### PR TITLE
fix(mobile): stop auto-marking notifications read on sheet close

### DIFF
--- a/mobile/app/(client)/(tabs)/index.tsx
+++ b/mobile/app/(client)/(tabs)/index.tsx
@@ -178,7 +178,7 @@ export default function TodayScreen() {
 
       <NotificationSheet
         visible={sheetOpen}
-        onClose={() => { setSheetOpen(false); markAllRead(); }}
+        onClose={() => setSheetOpen(false)}
         notifications={notifications}
         onMarkAllRead={markAllRead}
         onAction={handleNotificationAction}


### PR DESCRIPTION
## Summary
- Remove `markAllRead()` side effect from the notification sheet's `onClose` handler in `mobile/app/(client)/(tabs)/index.tsx`
- The existing "Mark all as read" header button remains the only entry point for the batch mark-read action
- Per-row taps continue to call `markRead(n.id)`, which applies an optimistic `read: true` update synchronously via `queryClient.setQueryData`

Fixes #2

## Test plan
- [ ] Receive ≥2 notifications on the client app
- [ ] Open the notification sheet from the Today header
- [ ] Tap a single notification → only that row becomes read
- [ ] Close the sheet, reopen it → other notifications remain unread
- [ ] Tap "Mark all as read" in the header → all rows become read

🤖 Generated with [Claude Code](https://claude.com/claude-code)