### PR TITLE
feat(backend): training completion endpoints + compliance & streak extension

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -96,7 +96,6 @@ jobs:
       - name: Run tests
         run: |
           ./FitnessPlatform.Tests/bin/Release/net10.0/FitnessPlatform.Tests \
-            -class- '*ComplianceServiceTests' \
             -class- '*CreatePlanEndpointTests' \
             -class- '*CreateTrainingPlanEndpointTests' \
             -class- '*GetComplianceScoreEndpointTests' \

--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -116,6 +116,19 @@ public static class ErrorCodes
     /// <summary>Client request not found.</summary>
     public const string ClientRequestNotFound = "CLIENT_REQUEST_NOT_FOUND";
 
+    // ── Training Completion ──────────────────────────────────────────
+    /// <summary>The training completion document version is stale; another write occurred first.</summary>
+    public const string TrainingCompletionVersionConflict = "TRAINING_COMPLETION_VERSION_CONFLICT";
+
+    /// <summary>The session ID was not found in the client's active training plan.</summary>
+    public const string TrainingSessionNotFound = "TRAINING_SESSION_NOT_FOUND";
+
+    /// <summary>The exercise was not found in the specified session.</summary>
+    public const string TrainingExerciseNotFound = "TRAINING_EXERCISE_NOT_FOUND";
+
+    /// <summary>No active training plan found for the client.</summary>
+    public const string NoActiveTrainingPlan = "NO_ACTIVE_TRAINING_PLAN";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
@@ -39,4 +39,9 @@ public static class MongoCollections
     /// Workout log entries collection.
     /// </summary>
     public const string WorkoutLogs = "workoutLogs";
+
+    /// <summary>
+    /// Training completion records collection.
+    /// </summary>
+    public const string TrainingCompletions = "trainingCompletions";
 }

--- a/backend/FitnessPlatform.Application/Domain/Documents/TrainingCompletion.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/TrainingCompletion.cs
@@ -1,0 +1,89 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// MongoDB root aggregate tracking which exercises (and optionally sets) a client
+/// has completed for a specific training session on a specific calendar date.
+///
+/// <para>
+/// <b>Document shape chosen:</b> one document per (clientId, date, sessionId).
+/// This is the cheapest shape for the two most common read paths:
+/// (1) "did the client finish session X today?" — a single document lookup with a compound index;
+/// (2) compliance roll-up — an indexed scan by (clientId, date) returns one document per session,
+///     allowing the service to count completed sessions without pulling every exercise.
+/// The alternative "one doc per (clientId, date)" with nested sessions would save one index entry
+/// per day but would create wider documents and make fan-out writes (MarkWholeDayComplete) heavier
+/// with multiple UpdateOne calls replaced by a single FindOneAndReplace, which isn't clearly cheaper.
+/// </para>
+/// </summary>
+public class TrainingCompletion
+{
+    /// <summary>
+    /// MongoDB internal identifier.
+    /// </summary>
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public ObjectId Id { get; set; }
+
+    /// <summary>
+    /// Public-facing identifier used in API requests and responses.
+    /// </summary>
+    [BsonElement("externalId")]
+    public Guid ExternalId { get; set; }
+
+    /// <summary>
+    /// The client this completion record belongs to (matches ApplicationUser.PublicId / ClientProfile.PublicId).
+    /// </summary>
+    [BsonElement("clientId")]
+    public Guid ClientId { get; set; }
+
+    /// <summary>
+    /// The calendar date (midnight UTC) for which this completion applies.
+    /// </summary>
+    [BsonElement("date")]
+    public DateTime Date { get; set; }
+
+    /// <summary>
+    /// The session (from the training plan) that was completed.
+    /// Matches <see cref="TrainingSession.SessionId"/>.
+    /// </summary>
+    [BsonElement("sessionId")]
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// List of exercise external IDs that have been marked complete for this session on this date.
+    /// </summary>
+    [BsonElement("completedExerciseIds")]
+    public List<Guid> CompletedExerciseIds { get; set; } = [];
+
+    /// <summary>
+    /// Optional per-set completion data, keyed by exerciseExternalId.
+    /// Each entry is the set of 1-based set numbers that were completed.
+    /// Only populated when the client uses set-level tracking; absence means the
+    /// exercise was marked complete at the exercise level only.
+    /// </summary>
+    [BsonElement("completedSets")]
+    [BsonIgnoreIfNull]
+    public Dictionary<string, List<int>>? CompletedSets { get; set; }
+
+    /// <summary>
+    /// When the first completion was recorded for this session-date combination.
+    /// </summary>
+    [BsonElement("dateCreated")]
+    public DateTime DateCreated { get; set; }
+
+    /// <summary>
+    /// When this document was last updated.
+    /// </summary>
+    [BsonElement("dateUpdated")]
+    [BsonIgnoreIfNull]
+    public DateTime? DateUpdated { get; set; }
+
+    /// <summary>
+    /// Optimistic concurrency version. Incremented on each update.
+    /// </summary>
+    [BsonElement("version")]
+    public int Version { get; set; } = 1;
+}

--- a/backend/FitnessPlatform.Application/Domain/Extensions/EndpointErrorExtensions.cs
+++ b/backend/FitnessPlatform.Application/Domain/Extensions/EndpointErrorExtensions.cs
@@ -9,7 +9,7 @@ namespace FitnessPlatform.Application.Domain.Extensions;
 public static class EndpointErrorExtensions
 {
     /// <summary>
-    /// Adds a validation failure with an error code and throws immediately.
+    /// Adds a validation failure with an error code and throws immediately (returns HTTP 400).
     /// </summary>
     /// <param name="endpoint">The endpoint instance.</param>
     /// <param name="errorCode">Machine-readable error code for frontend translation.</param>
@@ -19,5 +19,35 @@ public static class EndpointErrorExtensions
         endpoint.ValidationFailures.Add(new ValidationFailure("", message) { ErrorCode = errorCode });
         endpoint.HttpContext.Response.StatusCode = 400;
         throw new ValidationFailureException(endpoint.ValidationFailures, message);
+    }
+
+    /// <summary>
+    /// Writes an RFC 7807 Problem Details response with the given HTTP status code and error code.
+    /// Does NOT throw — the caller must return after this call.
+    /// </summary>
+    /// <param name="endpoint">The endpoint instance.</param>
+    /// <param name="statusCode">HTTP status code (e.g. 404, 409).</param>
+    /// <param name="errorCode">Machine-readable error code.</param>
+    /// <param name="detail">Human-readable explanation.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task SendProblemAsync(
+        this IEndpoint endpoint,
+        int statusCode,
+        string errorCode,
+        string detail,
+        CancellationToken ct = default)
+    {
+        var problem = new Microsoft.AspNetCore.Mvc.ProblemDetails
+        {
+            Status = statusCode,
+            Title = detail,
+            Type = "https://tools.ietf.org/html/rfc7807",
+            Instance = endpoint.HttpContext.Request.Path,
+            Extensions = { ["errorCode"] = errorCode }
+        };
+
+        endpoint.HttpContext.Response.StatusCode = statusCode;
+        endpoint.HttpContext.Response.ContentType = "application/problem+json";
+        await endpoint.HttpContext.Response.WriteAsJsonAsync(problem, ct);
     }
 }

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IComplianceService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IComplianceService.cs
@@ -43,7 +43,10 @@ public interface IComplianceService
 public class ComplianceResult
 {
     /// <summary>
-    /// Compliance percentage (0-100).
+    /// Combined compliance percentage (0-100), weighted by plan presence.
+    /// When both nutrition and training plans are active:
+    ///   (mealsPlanned * nutritionPercent + trainingsPlanned * trainingPercent) / (mealsPlanned + trainingsPlanned).
+    /// When only one plan type is active, equals that plan's individual percentage.
     /// </summary>
     public decimal CompliancePercent { get; set; }
 
@@ -56,4 +59,25 @@ public class ComplianceResult
     /// Total number of meals logged in the date range.
     /// </summary>
     public int MealsLogged { get; set; }
+
+    /// <summary>
+    /// Nutrition-only compliance percentage (0-100).
+    /// </summary>
+    public decimal NutritionCompliancePercent { get; set; }
+
+    /// <summary>
+    /// Total number of training sessions planned in the date range.
+    /// A "planned" session is one in a published week that falls on a day within [from, to].
+    /// </summary>
+    public int TrainingsPlanned { get; set; }
+
+    /// <summary>
+    /// Number of planned sessions where every exercise in the session has a completion record for that day.
+    /// </summary>
+    public int TrainingsCompleted { get; set; }
+
+    /// <summary>
+    /// Training-only compliance percentage (0-100).
+    /// </summary>
+    public decimal TrainingCompliancePercent { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
@@ -1,0 +1,178 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+
+/// <summary>
+/// Marks a single exercise within a session as complete for the client on the specified date.
+/// Idempotent: re-completing an already-complete exercise returns success without side effects.
+/// Uses optimistic concurrency on the <see cref="TrainingCompletion"/> document.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context.</param>
+public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    : Endpoint<MarkExerciseCompleteRequest, MarkExerciseCompleteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/sessions/{SessionId}/exercises/{ExerciseExternalId}/complete");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Mark an exercise complete";
+            s.Description = "Marks a single exercise within a training session as complete for the specified date. Idempotent.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(MarkExerciseCompleteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+        var targetDate = (req.CompletedOn ?? DateOnly.FromDateTime(DateTime.UtcNow)).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        // Resolve the client's active training plan and validate session/exercise ownership
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId)
+                         & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var exerciseExists = session.Exercises.Any(e => e.ExerciseExternalId == req.ExerciseExternalId);
+        if (!exerciseExists)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Load or create the completion document for (clientId, date, sessionId)
+        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, req.SessionId);
+
+        using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+        var existing = await completionCursor.FirstOrDefaultAsync(ct);
+
+        if (existing is not null)
+        {
+            // Idempotency: already complete — return success immediately
+            if (existing.CompletedExerciseIds.Contains(req.ExerciseExternalId))
+            {
+                await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, session.Exercises.Count), ct);
+                return;
+            }
+
+            // Optimistic concurrency check when updating an existing document
+            if (req.Version.HasValue && existing.Version != req.Version.Value)
+            {
+                await HttpContext.Response.SendAsync(
+                    new { Error = "Version conflict. The completion record was modified by another request." },
+                    409, cancellation: ct);
+                return;
+            }
+
+            var newIds = new List<Guid>(existing.CompletedExerciseIds) { req.ExerciseExternalId };
+            var newVersion = existing.Version + 1;
+
+            var versionedFilter = completionFilter
+                                  & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+
+            var update = Builders<TrainingCompletion>.Update
+                .Set(c => c.CompletedExerciseIds, newIds)
+                .Set(c => c.DateUpdated, DateTime.UtcNow)
+                .Set(c => c.Version, newVersion);
+
+            var updateResult = await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
+
+            if (updateResult.ModifiedCount == 0)
+            {
+                await HttpContext.Response.SendAsync(
+                    new { Error = "Version conflict. The completion record was modified by another request." },
+                    409, cancellation: ct);
+                return;
+            }
+
+            existing.CompletedExerciseIds = newIds;
+            existing.Version = newVersion;
+
+            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+
+            await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, session.Exercises.Count), ct);
+        }
+        else
+        {
+            // Create a new completion document
+            var completion = new TrainingCompletion
+            {
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientId,
+                Date = targetDate,
+                SessionId = req.SessionId,
+                CompletedExerciseIds = [req.ExerciseExternalId],
+                DateCreated = DateTime.UtcNow,
+                Version = 1
+            };
+
+            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+
+            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+
+            await Send.OkAsync(BuildResponse(req.SessionId, targetDate, completion, session.Exercises.Count), ct);
+        }
+    }
+
+    private static MarkExerciseCompleteResponse BuildResponse(
+        Guid sessionId, DateTime date, TrainingCompletion completion, int totalExercises)
+    {
+        var completed = completion.CompletedExerciseIds.Count;
+        return new MarkExerciseCompleteResponse
+        {
+            SessionId = sessionId,
+            Date = DateOnly.FromDateTime(date),
+            CompletedExerciseCount = completed,
+            TotalExerciseCount = totalExercises,
+            SessionComplete = completed >= totalExercises,
+            Version = completion.Version
+        };
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -64,7 +65,7 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
 
         if (plan is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.NoActiveTrainingPlan, "No active training plan found.", ct);
             return;
         }
 
@@ -74,14 +75,14 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
 
         if (session is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
             return;
         }
 
         var exerciseExists = session.Exercises.Any(e => e.ExerciseExternalId == req.ExerciseExternalId);
         if (!exerciseExists)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.TrainingExerciseNotFound, "The exercise was not found in the specified session.", ct);
             return;
         }
 
@@ -105,9 +106,8 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
             // Optimistic concurrency check when updating an existing document
             if (req.Version.HasValue && existing.Version != req.Version.Value)
             {
-                await HttpContext.Response.SendAsync(
-                    new { Error = "Version conflict. The completion record was modified by another request." },
-                    409, cancellation: ct);
+                await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                    "Version conflict. The completion record was modified by another request.", ct);
                 return;
             }
 
@@ -126,9 +126,8 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
 
             if (updateResult.ModifiedCount == 0)
             {
-                await HttpContext.Response.SendAsync(
-                    new { Error = "Version conflict. The completion record was modified by another request." },
-                    409, cancellation: ct);
+                await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                    "Version conflict. The completion record was modified by another request.", ct);
                 return;
             }
 
@@ -153,7 +152,51 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
                 Version = 1
             };
 
-            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+            try
+            {
+                await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+            }
+            catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Code == 11000)
+            {
+                // Duplicate-key: a concurrent request inserted the document first.
+                // Re-read and retry the update path once.
+                using var retryCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+                existing = await retryCursor.FirstOrDefaultAsync(ct);
+
+                if (existing is null)
+                {
+                    // Genuinely unexpected — let the global exception handler return 500.
+                    throw;
+                }
+
+                if (existing.CompletedExerciseIds.Contains(req.ExerciseExternalId))
+                {
+                    await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, session.Exercises.Count), ct);
+                    return;
+                }
+
+                var retryIds = new List<Guid>(existing.CompletedExerciseIds) { req.ExerciseExternalId };
+                var retryVersion = existing.Version + 1;
+                var retryVersionedFilter = completionFilter
+                    & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+                var retryUpdate = Builders<TrainingCompletion>.Update
+                    .Set(c => c.CompletedExerciseIds, retryIds)
+                    .Set(c => c.DateUpdated, DateTime.UtcNow)
+                    .Set(c => c.Version, retryVersion);
+                var retryResult = await mongo.TrainingCompletions.UpdateOneAsync(retryVersionedFilter, retryUpdate, cancellationToken: ct);
+
+                if (retryResult.ModifiedCount == 0)
+                {
+                    await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                        "Version conflict. The completion record was modified by another request.", ct);
+                    return;
+                }
+
+                existing.CompletedExerciseIds = retryIds;
+                existing.Version = retryVersion;
+                await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, session.Exercises.Count), ct);
+                return;
+            }
 
             // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteRequest.cs
@@ -1,0 +1,30 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+
+/// <summary>
+/// Request model for marking a single exercise complete within a session.
+/// </summary>
+public class MarkExerciseCompleteRequest
+{
+    /// <summary>
+    /// The session ID (from the training plan). Bound from the route.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The exercise external ID within the session. Bound from the route.
+    /// </summary>
+    public Guid ExerciseExternalId { get; set; }
+
+    /// <summary>
+    /// The date on which the exercise was completed (UTC date only).
+    /// Defaults to today UTC when not provided.
+    /// </summary>
+    public DateOnly? CompletedOn { get; set; }
+
+    /// <summary>
+    /// Client-supplied version of the existing completion document, used for optimistic
+    /// concurrency. Required when a completion document already exists for this
+    /// (clientId, date, sessionId) tuple; ignored for new documents.
+    /// </summary>
+    public int? Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteResponse.cs
@@ -1,0 +1,39 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+
+/// <summary>
+/// Response for marking an exercise complete.
+/// Returns a lightweight progress summary so the mobile client can update
+/// session progress indicators without an extra round-trip.
+/// </summary>
+public class MarkExerciseCompleteResponse
+{
+    /// <summary>
+    /// The session ID that was updated.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The date for which the completion was recorded.
+    /// </summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// How many exercises in this session are now marked complete.
+    /// </summary>
+    public int CompletedExerciseCount { get; set; }
+
+    /// <summary>
+    /// Total number of exercises in this session (from the plan).
+    /// </summary>
+    public int TotalExerciseCount { get; set; }
+
+    /// <summary>
+    /// Whether every exercise in this session is now complete.
+    /// </summary>
+    public bool SessionComplete { get; set; }
+
+    /// <summary>
+    /// Current version of the underlying completion document (for subsequent writes).
+    /// </summary>
+    public int Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteValidator.cs
@@ -1,0 +1,22 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+
+/// <summary>
+/// Validator for <see cref="MarkExerciseCompleteRequest"/>.
+/// </summary>
+public class MarkExerciseCompleteValidator : Validator<MarkExerciseCompleteRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="MarkExerciseCompleteValidator"/>.
+    /// </summary>
+    public MarkExerciseCompleteValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty();
+
+        RuleFor(x => x.ExerciseExternalId)
+            .NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
@@ -1,0 +1,146 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
+
+/// <summary>
+/// Removes the completion mark for a single exercise within a session on the specified date.
+/// Idempotent: if the exercise is already not marked complete, returns success without side effects.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context.</param>
+public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    : Endpoint<MarkExerciseIncompleteRequest, MarkExerciseIncompleteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Delete("/client/training/sessions/{SessionId}/exercises/{ExerciseExternalId}/complete");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Un-mark an exercise as complete";
+            s.Description = "Removes the completion mark for a single exercise in a training session. Idempotent.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(MarkExerciseIncompleteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+        var targetDate = (req.CompletedOn ?? DateOnly.FromDateTime(DateTime.UtcNow)).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        // Validate the session belongs to the client's active plan
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId)
+                         & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Load the completion document for (clientId, date, sessionId)
+        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, req.SessionId);
+
+        using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+        var existing = await completionCursor.FirstOrDefaultAsync(ct);
+
+        if (existing is null || !existing.CompletedExerciseIds.Contains(req.ExerciseExternalId))
+        {
+            // Idempotent: already not complete
+            var completedCount = existing?.CompletedExerciseIds.Count ?? 0;
+            await Send.OkAsync(new MarkExerciseIncompleteResponse
+            {
+                SessionId = req.SessionId,
+                Date = DateOnly.FromDateTime(targetDate),
+                CompletedExerciseCount = completedCount,
+                TotalExerciseCount = session.Exercises.Count,
+                SessionComplete = completedCount >= session.Exercises.Count,
+                Version = existing?.Version ?? 1
+            }, ct);
+            return;
+        }
+
+        // Optimistic concurrency check
+        if (req.Version.HasValue && existing.Version != req.Version.Value)
+        {
+            await HttpContext.Response.SendAsync(
+                new { Error = "Version conflict. The completion record was modified by another request." },
+                409, cancellation: ct);
+            return;
+        }
+
+        var newIds = existing.CompletedExerciseIds.Where(id => id != req.ExerciseExternalId).ToList();
+        var newVersion = existing.Version + 1;
+
+        var versionedFilter = completionFilter
+                              & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+
+        var update = Builders<TrainingCompletion>.Update
+            .Set(c => c.CompletedExerciseIds, newIds)
+            .Set(c => c.DateUpdated, DateTime.UtcNow)
+            .Set(c => c.Version, newVersion);
+
+        var updateResult = await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
+
+        if (updateResult.ModifiedCount == 0)
+        {
+            await HttpContext.Response.SendAsync(
+                new { Error = "Version conflict. The completion record was modified by another request." },
+                409, cancellation: ct);
+            return;
+        }
+
+        // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+
+        await Send.OkAsync(new MarkExerciseIncompleteResponse
+        {
+            SessionId = req.SessionId,
+            Date = DateOnly.FromDateTime(targetDate),
+            CompletedExerciseCount = newIds.Count,
+            TotalExerciseCount = session.Exercises.Count,
+            SessionComplete = newIds.Count >= session.Exercises.Count,
+            Version = newVersion
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -63,7 +64,7 @@ public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbC
 
         if (plan is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.NoActiveTrainingPlan, "No active training plan found.", ct);
             return;
         }
 
@@ -73,7 +74,15 @@ public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbC
 
         if (session is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
+            return;
+        }
+
+        // Validate the exercise exists in the session
+        var exerciseExists = session.Exercises.Any(e => e.ExerciseExternalId == req.ExerciseExternalId);
+        if (!exerciseExists)
+        {
+            await this.SendProblemAsync(404, ErrorCodes.TrainingExerciseNotFound, "The exercise was not found in the specified session.", ct);
             return;
         }
 
@@ -104,9 +113,8 @@ public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbC
         // Optimistic concurrency check
         if (req.Version.HasValue && existing.Version != req.Version.Value)
         {
-            await HttpContext.Response.SendAsync(
-                new { Error = "Version conflict. The completion record was modified by another request." },
-                409, cancellation: ct);
+            await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                "Version conflict. The completion record was modified by another request.", ct);
             return;
         }
 
@@ -125,9 +133,8 @@ public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbC
 
         if (updateResult.ModifiedCount == 0)
         {
-            await HttpContext.Response.SendAsync(
-                new { Error = "Version conflict. The completion record was modified by another request." },
-                409, cancellation: ct);
+            await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                "Version conflict. The completion record was modified by another request.", ct);
             return;
         }
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteRequest.cs
@@ -1,0 +1,28 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
+
+/// <summary>
+/// Request model for un-marking a single exercise as complete.
+/// </summary>
+public class MarkExerciseIncompleteRequest
+{
+    /// <summary>
+    /// The session ID (from the training plan). Bound from the route.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The exercise external ID within the session. Bound from the route.
+    /// </summary>
+    public Guid ExerciseExternalId { get; set; }
+
+    /// <summary>
+    /// The date for which the completion should be removed (UTC date only).
+    /// Defaults to today UTC when not provided.
+    /// </summary>
+    public DateOnly? CompletedOn { get; set; }
+
+    /// <summary>
+    /// Client-supplied version of the completion document for optimistic concurrency.
+    /// </summary>
+    public int? Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteResponse.cs
@@ -1,0 +1,37 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
+
+/// <summary>
+/// Response for un-marking an exercise as complete.
+/// </summary>
+public class MarkExerciseIncompleteResponse
+{
+    /// <summary>
+    /// The session ID that was updated.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The date for which the completion was removed.
+    /// </summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// How many exercises in this session are still marked complete.
+    /// </summary>
+    public int CompletedExerciseCount { get; set; }
+
+    /// <summary>
+    /// Total number of exercises in this session (from the plan).
+    /// </summary>
+    public int TotalExerciseCount { get; set; }
+
+    /// <summary>
+    /// Whether every exercise in this session is still complete.
+    /// </summary>
+    public bool SessionComplete { get; set; }
+
+    /// <summary>
+    /// Current version of the underlying completion document.
+    /// </summary>
+    public int Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteValidator.cs
@@ -1,0 +1,22 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
+
+/// <summary>
+/// Validator for <see cref="MarkExerciseIncompleteRequest"/>.
+/// </summary>
+public class MarkExerciseIncompleteValidator : Validator<MarkExerciseIncompleteRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="MarkExerciseIncompleteValidator"/>.
+    /// </summary>
+    public MarkExerciseIncompleteValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty();
+
+        RuleFor(x => x.ExerciseExternalId)
+            .NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -64,7 +65,7 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
 
         if (plan is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.NoActiveTrainingPlan, "No active training plan found.", ct);
             return;
         }
 
@@ -74,7 +75,7 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
 
         if (session is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
             return;
         }
 
@@ -100,9 +101,8 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
             // Optimistic concurrency check
             if (req.Version.HasValue && existing.Version != req.Version.Value)
             {
-                await HttpContext.Response.SendAsync(
-                    new { Error = "Version conflict. The completion record was modified by another request." },
-                    409, cancellation: ct);
+                await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                    "Version conflict. The completion record was modified by another request.", ct);
                 return;
             }
 
@@ -119,9 +119,8 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
 
             if (updateResult.ModifiedCount == 0)
             {
-                await HttpContext.Response.SendAsync(
-                    new { Error = "Version conflict. The completion record was modified by another request." },
-                    409, cancellation: ct);
+                await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                    "Version conflict. The completion record was modified by another request.", ct);
                 return;
             }
 
@@ -145,7 +144,50 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
                 Version = 1
             };
 
-            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+            try
+            {
+                await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+            }
+            catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Code == 11000)
+            {
+                // Duplicate-key: a concurrent request inserted the document first.
+                // Re-read and retry the update path once.
+                using var retryCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+                existing = await retryCursor.FirstOrDefaultAsync(ct);
+
+                if (existing is null)
+                {
+                    // Genuinely unexpected — let the global exception handler return 500.
+                    throw;
+                }
+
+                if (allExerciseIds.All(id => existing.CompletedExerciseIds.Contains(id)))
+                {
+                    await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);
+                    return;
+                }
+
+                var retryVersion = existing.Version + 1;
+                var retryVersionedFilter = completionFilter
+                    & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+                var retryUpdate = Builders<TrainingCompletion>.Update
+                    .Set(c => c.CompletedExerciseIds, allExerciseIds)
+                    .Set(c => c.DateUpdated, DateTime.UtcNow)
+                    .Set(c => c.Version, retryVersion);
+                var retryResult = await mongo.TrainingCompletions.UpdateOneAsync(retryVersionedFilter, retryUpdate, cancellationToken: ct);
+
+                if (retryResult.ModifiedCount == 0)
+                {
+                    await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                        "Version conflict. The completion record was modified by another request.", ct);
+                    return;
+                }
+
+                existing.CompletedExerciseIds = allExerciseIds;
+                existing.Version = retryVersion;
+                await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);
+                return;
+            }
 
             // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
@@ -1,0 +1,168 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
+
+/// <summary>
+/// Marks an entire training session as complete by marking all exercises in the session complete.
+/// Fans out to a single completion document for (clientId, date, sessionId).
+/// Idempotent: re-completing an already-complete session returns success.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context.</param>
+public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    : Endpoint<MarkSessionCompleteRequest, MarkSessionCompleteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/sessions/{SessionId}/complete");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Mark a training session complete";
+            s.Description = "Marks all exercises in a training session as complete for the specified date. Idempotent.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(MarkSessionCompleteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+        var targetDate = (req.CompletedOn ?? DateOnly.FromDateTime(DateTime.UtcNow)).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        // Validate session ownership via the active training plan
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId)
+                         & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();
+
+        // Load or create the completion document
+        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, req.SessionId);
+
+        using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+        var existing = await completionCursor.FirstOrDefaultAsync(ct);
+
+        if (existing is not null)
+        {
+            // Idempotency: all already complete
+            if (allExerciseIds.All(id => existing.CompletedExerciseIds.Contains(id)))
+            {
+                await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);
+                return;
+            }
+
+            // Optimistic concurrency check
+            if (req.Version.HasValue && existing.Version != req.Version.Value)
+            {
+                await HttpContext.Response.SendAsync(
+                    new { Error = "Version conflict. The completion record was modified by another request." },
+                    409, cancellation: ct);
+                return;
+            }
+
+            var newVersion = existing.Version + 1;
+            var versionedFilter = completionFilter
+                                  & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+
+            var update = Builders<TrainingCompletion>.Update
+                .Set(c => c.CompletedExerciseIds, allExerciseIds)
+                .Set(c => c.DateUpdated, DateTime.UtcNow)
+                .Set(c => c.Version, newVersion);
+
+            var updateResult = await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
+
+            if (updateResult.ModifiedCount == 0)
+            {
+                await HttpContext.Response.SendAsync(
+                    new { Error = "Version conflict. The completion record was modified by another request." },
+                    409, cancellation: ct);
+                return;
+            }
+
+            existing.CompletedExerciseIds = allExerciseIds;
+            existing.Version = newVersion;
+
+            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+
+            await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);
+        }
+        else
+        {
+            var completion = new TrainingCompletion
+            {
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientId,
+                Date = targetDate,
+                SessionId = req.SessionId,
+                CompletedExerciseIds = allExerciseIds,
+                DateCreated = DateTime.UtcNow,
+                Version = 1
+            };
+
+            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+
+            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+
+            await Send.OkAsync(BuildResponse(req.SessionId, targetDate, completion, allExerciseIds.Count), ct);
+        }
+    }
+
+    private static MarkSessionCompleteResponse BuildResponse(
+        Guid sessionId, DateTime date, TrainingCompletion completion, int totalExercises)
+    {
+        return new MarkSessionCompleteResponse
+        {
+            SessionId = sessionId,
+            Date = DateOnly.FromDateTime(date),
+            CompletedExerciseCount = completion.CompletedExerciseIds.Count,
+            TotalExerciseCount = totalExercises,
+            Version = completion.Version
+        };
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteRequest.cs
@@ -1,0 +1,23 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
+
+/// <summary>
+/// Request model for marking an entire session complete (fans out to all exercises).
+/// </summary>
+public class MarkSessionCompleteRequest
+{
+    /// <summary>
+    /// The session ID (from the training plan). Bound from the route.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The date on which the session was completed (UTC date only).
+    /// Defaults to today UTC when not provided.
+    /// </summary>
+    public DateOnly? CompletedOn { get; set; }
+
+    /// <summary>
+    /// Client-supplied version for optimistic concurrency when updating an existing completion document.
+    /// </summary>
+    public int? Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteResponse.cs
@@ -1,0 +1,32 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
+
+/// <summary>
+/// Response for marking a whole session complete.
+/// </summary>
+public class MarkSessionCompleteResponse
+{
+    /// <summary>
+    /// The session ID that was marked complete.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The date for which the session was marked complete.
+    /// </summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// Number of exercises now marked complete.
+    /// </summary>
+    public int CompletedExerciseCount { get; set; }
+
+    /// <summary>
+    /// Total exercises in the session.
+    /// </summary>
+    public int TotalExerciseCount { get; set; }
+
+    /// <summary>
+    /// Current document version.
+    /// </summary>
+    public int Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
+
+/// <summary>
+/// Validator for <see cref="MarkSessionCompleteRequest"/>.
+/// </summary>
+public class MarkSessionCompleteValidator : Validator<MarkSessionCompleteRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="MarkSessionCompleteValidator"/>.
+    /// </summary>
+    public MarkSessionCompleteValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -63,7 +64,7 @@ public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbCo
 
         if (plan is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.NoActiveTrainingPlan, "No active training plan found.", ct);
             return;
         }
 
@@ -73,7 +74,7 @@ public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbCo
 
         if (session is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
             return;
         }
 
@@ -101,9 +102,8 @@ public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbCo
         // Optimistic concurrency check
         if (req.Version.HasValue && existing.Version != req.Version.Value)
         {
-            await HttpContext.Response.SendAsync(
-                new { Error = "Version conflict. The completion record was modified by another request." },
-                409, cancellation: ct);
+            await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                "Version conflict. The completion record was modified by another request.", ct);
             return;
         }
 
@@ -120,9 +120,8 @@ public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbCo
 
         if (updateResult.ModifiedCount == 0)
         {
-            await HttpContext.Response.SendAsync(
-                new { Error = "Version conflict. The completion record was modified by another request." },
-                409, cancellation: ct);
+            await this.SendProblemAsync(409, ErrorCodes.TrainingCompletionVersionConflict,
+                "Version conflict. The completion record was modified by another request.", ct);
             return;
         }
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
@@ -1,0 +1,140 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
+
+/// <summary>
+/// Clears all completion records for an entire training session on the specified date.
+/// Idempotent: if the session has no completion document, returns success.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context.</param>
+public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    : Endpoint<MarkSessionIncompleteRequest, MarkSessionIncompleteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Delete("/client/training/sessions/{SessionId}/complete");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Un-mark a training session as complete";
+            s.Description = "Removes all exercise completion marks for a training session on the specified date. Idempotent.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(MarkSessionIncompleteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+        var targetDate = (req.CompletedOn ?? DateOnly.FromDateTime(DateTime.UtcNow)).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        // Validate session ownership
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId)
+                         & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, req.SessionId);
+
+        using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+        var existing = await completionCursor.FirstOrDefaultAsync(ct);
+
+        if (existing is null)
+        {
+            // Idempotent: no completion document exists
+            await Send.OkAsync(new MarkSessionIncompleteResponse
+            {
+                SessionId = req.SessionId,
+                Date = DateOnly.FromDateTime(targetDate),
+                CompletedExerciseCount = 0,
+                TotalExerciseCount = session.Exercises.Count,
+                Version = 1
+            }, ct);
+            return;
+        }
+
+        // Optimistic concurrency check
+        if (req.Version.HasValue && existing.Version != req.Version.Value)
+        {
+            await HttpContext.Response.SendAsync(
+                new { Error = "Version conflict. The completion record was modified by another request." },
+                409, cancellation: ct);
+            return;
+        }
+
+        var newVersion = existing.Version + 1;
+        var versionedFilter = completionFilter
+                              & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+
+        var update = Builders<TrainingCompletion>.Update
+            .Set(c => c.CompletedExerciseIds, new List<Guid>())
+            .Set(c => c.DateUpdated, DateTime.UtcNow)
+            .Set(c => c.Version, newVersion);
+
+        var updateResult = await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
+
+        if (updateResult.ModifiedCount == 0)
+        {
+            await HttpContext.Response.SendAsync(
+                new { Error = "Version conflict. The completion record was modified by another request." },
+                409, cancellation: ct);
+            return;
+        }
+
+        // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+
+        await Send.OkAsync(new MarkSessionIncompleteResponse
+        {
+            SessionId = req.SessionId,
+            Date = DateOnly.FromDateTime(targetDate),
+            CompletedExerciseCount = 0,
+            TotalExerciseCount = session.Exercises.Count,
+            Version = newVersion
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteRequest.cs
@@ -1,0 +1,23 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
+
+/// <summary>
+/// Request model for un-marking an entire session as complete.
+/// </summary>
+public class MarkSessionIncompleteRequest
+{
+    /// <summary>
+    /// The session ID (from the training plan). Bound from the route.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The date for which the completion should be removed (UTC date only).
+    /// Defaults to today UTC when not provided.
+    /// </summary>
+    public DateOnly? CompletedOn { get; set; }
+
+    /// <summary>
+    /// Client-supplied version for optimistic concurrency.
+    /// </summary>
+    public int? Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteResponse.cs
@@ -1,0 +1,32 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
+
+/// <summary>
+/// Response for un-marking a training session as complete.
+/// </summary>
+public class MarkSessionIncompleteResponse
+{
+    /// <summary>
+    /// The session ID that was updated.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The date for which the completion was removed.
+    /// </summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// How many exercises in this session are still marked complete.
+    /// </summary>
+    public int CompletedExerciseCount { get; set; }
+
+    /// <summary>
+    /// Total exercises in the session.
+    /// </summary>
+    public int TotalExerciseCount { get; set; }
+
+    /// <summary>
+    /// Current document version.
+    /// </summary>
+    public int Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
+
+/// <summary>
+/// Validator for <see cref="MarkSessionIncompleteRequest"/>.
+/// </summary>
+public class MarkSessionIncompleteValidator : Validator<MarkSessionIncompleteRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="MarkSessionIncompleteValidator"/>.
+    /// </summary>
+    public MarkSessionIncompleteValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -66,7 +67,7 @@ public class MarkWholeDayCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
 
         if (plan is null)
         {
-            await Send.NotFoundAsync(ct);
+            await this.SendProblemAsync(404, ErrorCodes.NoActiveTrainingPlan, "No active training plan found.", ct);
             return;
         }
 
@@ -130,8 +131,40 @@ public class MarkWholeDayCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
                     Version = 1
                 };
 
-                await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
-                version = 1;
+                try
+                {
+                    await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+                    version = 1;
+                }
+                catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Code == 11000)
+                {
+                    // Duplicate-key: concurrent request inserted first — re-read and retry once.
+                    using var retryCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+                    existing = await retryCursor.FirstOrDefaultAsync(ct);
+
+                    if (existing is null)
+                    {
+                        throw;
+                    }
+
+                    if (allExerciseIds.All(id => existing.CompletedExerciseIds.Contains(id)))
+                    {
+                        version = existing.Version;
+                    }
+                    else
+                    {
+                        var retryVersion = existing.Version + 1;
+                        var retryVersionedFilter = completionFilter
+                            & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+                        var retryUpdate = Builders<TrainingCompletion>.Update
+                            .Set(c => c.CompletedExerciseIds, allExerciseIds)
+                            .Set(c => c.DateUpdated, DateTime.UtcNow)
+                            .Set(c => c.Version, retryVersion);
+                        var retryResult = await mongo.TrainingCompletions.UpdateOneAsync(retryVersionedFilter, retryUpdate, cancellationToken: ct);
+                        // If version conflict on fan-out retry, use the existing version — don't fail the whole batch
+                        version = retryResult.ModifiedCount > 0 ? retryVersion : existing.Version;
+                    }
+                }
             }
 
             summaries.Add(new SessionCompletionSummary

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
@@ -1,0 +1,200 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
+
+/// <summary>
+/// Marks every training session scheduled for a given calendar day complete.
+/// Resolves which sessions apply to the date by mapping the date to a plan week/day-of-week,
+/// then upserts a <see cref="TrainingCompletion"/> document for each session.
+/// Idempotent: sessions that are already fully complete are skipped.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context.</param>
+public class MarkWholeDayCompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    : Endpoint<MarkWholeDayCompleteRequest, MarkWholeDayCompleteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/day/complete");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Mark all training sessions for a day complete";
+            s.Description = "Marks every session scheduled on the specified date complete. Resolves the plan week and day-of-week mapping. Idempotent.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(MarkWholeDayCompleteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+        var targetDateOnly = req.Date ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        var targetDate = targetDateOnly.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        // Find the active training plan
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId)
+                         & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Resolve which sessions are scheduled for the target date
+        var sessionsForDay = ResolveSessions(plan, targetDateOnly);
+
+        var summaries = new List<SessionCompletionSummary>();
+
+        foreach (var session in sessionsForDay)
+        {
+            var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();
+
+            var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                                   & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
+                                   & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, session.SessionId);
+
+            using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+            var existing = await completionCursor.FirstOrDefaultAsync(ct);
+
+            int version;
+
+            if (existing is not null)
+            {
+                // Already fully complete — idempotent
+                if (allExerciseIds.All(id => existing.CompletedExerciseIds.Contains(id)))
+                {
+                    summaries.Add(new SessionCompletionSummary
+                    {
+                        SessionId = session.SessionId,
+                        CompletedExerciseCount = existing.CompletedExerciseIds.Count,
+                        TotalExerciseCount = allExerciseIds.Count,
+                        Version = existing.Version
+                    });
+                    continue;
+                }
+
+                var newVersion = existing.Version + 1;
+                var versionedFilter = completionFilter
+                                      & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+
+                var update = Builders<TrainingCompletion>.Update
+                    .Set(c => c.CompletedExerciseIds, allExerciseIds)
+                    .Set(c => c.DateUpdated, DateTime.UtcNow)
+                    .Set(c => c.Version, newVersion);
+
+                var updateResult = await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
+
+                // If version conflict on fan-out, skip this session — don't fail the whole batch
+                version = updateResult.ModifiedCount > 0 ? newVersion : existing.Version;
+            }
+            else
+            {
+                var completion = new TrainingCompletion
+                {
+                    ExternalId = Guid.NewGuid(),
+                    ClientId = clientId,
+                    Date = targetDate,
+                    SessionId = session.SessionId,
+                    CompletedExerciseIds = allExerciseIds,
+                    DateCreated = DateTime.UtcNow,
+                    Version = 1
+                };
+
+                await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+                version = 1;
+            }
+
+            summaries.Add(new SessionCompletionSummary
+            {
+                SessionId = session.SessionId,
+                CompletedExerciseCount = allExerciseIds.Count,
+                TotalExerciseCount = allExerciseIds.Count,
+                Version = version
+            });
+
+            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+        }
+
+        await Send.OkAsync(new MarkWholeDayCompleteResponse
+        {
+            Date = targetDateOnly,
+            Sessions = summaries
+        }, ct);
+    }
+
+    /// <summary>
+    /// Maps a calendar date to the sessions in the plan scheduled for that date,
+    /// using the same week-resolution logic as <c>GetTodaySession</c>.
+    /// Returns an empty list if the plan hasn't started, the target week isn't published,
+    /// or there are no sessions for that day of week.
+    /// </summary>
+    private static IReadOnlyList<TrainingSession> ResolveSessions(TrainingPlan plan, DateOnly targetDate)
+    {
+        if (!plan.StartDate.HasValue || plan.Weeks.Count == 0)
+            return [];
+
+        var publishedWeeks = plan.Weeks
+            .Where(w => w.Status == WeekStatus.Published)
+            .OrderBy(w => w.WeekNumber)
+            .ToList();
+
+        if (publishedWeeks.Count == 0)
+            return [];
+
+        var resolvedWeek = PlanWeekCalculator.ResolveCurrentWeekNumber(
+            plan.StartDate,
+            publishedWeeks.Select(w => w.WeekNumber).ToList(),
+            plan.Weeks.Count,
+            publishedWeeks.First().DatePublished,
+            plan.DateCreated,
+            targetDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+
+        if (resolvedWeek is null)
+            return [];
+
+        var currentWeek = plan.Weeks.FirstOrDefault(w => w.WeekNumber == resolvedWeek.Value);
+        if (currentWeek is null || currentWeek.Status != WeekStatus.Published)
+        {
+            currentWeek = publishedWeeks.Last();
+        }
+
+        // Map DateOnly DayOfWeek (0=Sunday) to ISO 1=Monday…7=Sunday
+        var dow = (int)targetDate.DayOfWeek;
+        dow = dow == 0 ? 7 : dow;
+
+        return currentWeek.Sessions
+            .Where(s => s.DayOfWeek == dow)
+            .OrderBy(s => s.Order)
+            .ToList();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
+
+/// <summary>
+/// Request model for marking all training sessions on a given day complete.
+/// </summary>
+public class MarkWholeDayCompleteRequest
+{
+    /// <summary>
+    /// The date to mark complete (UTC date only).
+    /// Defaults to today UTC when not provided.
+    /// </summary>
+    public DateOnly? Date { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteResponse.cs
@@ -1,0 +1,35 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
+
+/// <summary>
+/// Response for marking all training sessions on a day complete.
+/// </summary>
+public class MarkWholeDayCompleteResponse
+{
+    /// <summary>
+    /// The date that was marked complete.
+    /// </summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// Summary of each session that was processed.
+    /// </summary>
+    public List<SessionCompletionSummary> Sessions { get; set; } = [];
+}
+
+/// <summary>
+/// Per-session completion summary returned by <see cref="MarkWholeDayCompleteResponse"/>.
+/// </summary>
+public class SessionCompletionSummary
+{
+    /// <summary>The session ID.</summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>Number of exercises marked complete in this session.</summary>
+    public int CompletedExerciseCount { get; set; }
+
+    /// <summary>Total exercises in the session.</summary>
+    public int TotalExerciseCount { get; set; }
+
+    /// <summary>Current document version for subsequent writes.</summary>
+    public int Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteValidator.cs
@@ -1,0 +1,18 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
+
+/// <summary>
+/// Validator for <see cref="MarkWholeDayCompleteRequest"/>.
+/// </summary>
+public class MarkWholeDayCompleteValidator : Validator<MarkWholeDayCompleteRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="MarkWholeDayCompleteValidator"/>.
+    /// </summary>
+    public MarkWholeDayCompleteValidator()
+    {
+        // Date is optional — no validation rules required currently.
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
@@ -43,4 +43,9 @@ public interface IMongoContext
     /// Workout log entries collection.
     /// </summary>
     IMongoCollection<WorkoutLog> WorkoutLogs { get; }
+
+    /// <summary>
+    /// Training completion records collection.
+    /// </summary>
+    IMongoCollection<TrainingCompletion> TrainingCompletions { get; }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
@@ -22,6 +22,7 @@ public class MongoContext : IMongoContext
         Exercises = database.GetCollection<Exercise>(MongoCollections.Exercises);
         TrainingPlans = database.GetCollection<TrainingPlan>(MongoCollections.TrainingPlans);
         WorkoutLogs = database.GetCollection<WorkoutLog>(MongoCollections.WorkoutLogs);
+        TrainingCompletions = database.GetCollection<TrainingCompletion>(MongoCollections.TrainingCompletions);
     }
 
     /// <inheritdoc />
@@ -44,4 +45,7 @@ public class MongoContext : IMongoContext
 
     /// <inheritdoc />
     public IMongoCollection<WorkoutLog> WorkoutLogs { get; }
+
+    /// <inheritdoc />
+    public IMongoCollection<TrainingCompletion> TrainingCompletions { get; }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoIndexInitializer.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoIndexInitializer.cs
@@ -34,6 +34,7 @@ public class MongoIndexInitializer : IHostedService
         await CreateExerciseIndexes(cancellationToken);
         await CreateTrainingPlanIndexes(cancellationToken);
         await CreateWorkoutLogIndexes(cancellationToken);
+        await CreateTrainingCompletionIndexes(cancellationToken);
 
         _logger.LogInformation("MongoDB indexes created successfully");
     }
@@ -210,5 +211,32 @@ public class MongoIndexInitializer : IHostedService
             new CreateIndexOptions { Name = "idx_workoutlog_clientId_sessionId", Sparse = true });
 
         await indexes.CreateManyAsync([externalIdIndex, clientDateIndex, clientSessionIndex], ct);
+    }
+
+    private async Task CreateTrainingCompletionIndexes(CancellationToken ct)
+    {
+        var indexes = _mongo.TrainingCompletions.Indexes;
+
+        // Unique index on externalId for API lookups
+        var externalIdIndex = new CreateIndexModel<TrainingCompletion>(
+            Builders<TrainingCompletion>.IndexKeys.Ascending(c => c.ExternalId),
+            new CreateIndexOptions { Name = "idx_trainingcompletion_externalId", Unique = true });
+
+        // Primary query index: clientId + date for compliance roll-ups
+        var clientDateIndex = new CreateIndexModel<TrainingCompletion>(
+            Builders<TrainingCompletion>.IndexKeys
+                .Ascending(c => c.ClientId)
+                .Ascending(c => c.Date),
+            new CreateIndexOptions { Name = "idx_trainingcompletion_clientId_date" });
+
+        // Unique compound index to enforce one document per (clientId, date, sessionId)
+        var clientDateSessionIndex = new CreateIndexModel<TrainingCompletion>(
+            Builders<TrainingCompletion>.IndexKeys
+                .Ascending(c => c.ClientId)
+                .Ascending(c => c.Date)
+                .Ascending(c => c.SessionId),
+            new CreateIndexOptions { Name = "idx_trainingcompletion_clientId_date_sessionId", Unique = true });
+
+        await indexes.CreateManyAsync([externalIdIndex, clientDateIndex, clientDateSessionIndex], ct);
     }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/ComplianceService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/ComplianceService.cs
@@ -1,14 +1,15 @@
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Infrastructure.Services;
 
 /// <summary>
-/// Calculates nutrition compliance scores, streaks, and weekly macro averages
-/// by querying meal logs and nutrition plans from MongoDB.
+/// Calculates nutrition and training compliance scores, streaks, and weekly macro averages
+/// by querying meal logs, nutrition plans, training plans, and training completion records from MongoDB.
 /// </summary>
 public class ComplianceService : IComplianceService
 {
@@ -30,89 +31,192 @@ public class ComplianceService : IComplianceService
     public async Task<ComplianceResult> CalculateComplianceAsync(
         Guid clientId, DateTime from, DateTime to, CancellationToken ct)
     {
-        var plan = await FindActivePlanAsync(clientId, ct);
+        var nutritionPlan = await FindActivePlanAsync(clientId, ct);
+        var trainingPlan = await FindActiveTrainingPlanAsync(clientId, ct);
 
-        if (plan is null || !plan.StartDate.HasValue)
-            return new ComplianceResult { CompliancePercent = 0, MealsPlanned = 0, MealsLogged = 0 };
+        // ── Nutrition side ──────────────────────────────────────────────
+        int mealsPlanned = 0;
+        int mealsLogged = 0;
+        decimal nutritionPercent = 0m;
 
-        var mealsPlanned = CountPlannedMeals(plan, from, to);
+        if (nutritionPlan is not null && nutritionPlan.StartDate.HasValue)
+        {
+            mealsPlanned = CountPlannedMeals(nutritionPlan, from, to);
 
-        var logFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientId)
-            & Builders<MealLog>.Filter.Gte(l => l.EatenAt, from)
-            & Builders<MealLog>.Filter.Lt(l => l.EatenAt, to.AddDays(1));
+            var logFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientId)
+                & Builders<MealLog>.Filter.Gte(l => l.EatenAt, from)
+                & Builders<MealLog>.Filter.Lt(l => l.EatenAt, to.AddDays(1));
 
-        using var logCursor = await _mongo.MealLogs.FindAsync(logFilter, cancellationToken: ct);
-        var logs = await logCursor.ToListAsync(ct);
-        var mealsLogged = logs.Count;
+            using var logCursor = await _mongo.MealLogs.FindAsync(logFilter, cancellationToken: ct);
+            var logs = await logCursor.ToListAsync(ct);
+            mealsLogged = logs.Count;
 
-        var compliancePercent = mealsPlanned == 0
-            ? 0m
-            : Math.Round((decimal)mealsLogged / mealsPlanned * 100, 1);
+            nutritionPercent = mealsPlanned == 0
+                ? 0m
+                : Math.Round((decimal)mealsLogged / mealsPlanned * 100, 1);
+        }
+
+        // ── Training side ───────────────────────────────────────────────
+        int trainingsPlanned = 0;
+        int trainingsCompleted = 0;
+        decimal trainingPercent = 0m;
+
+        if (trainingPlan is not null && trainingPlan.StartDate.HasValue)
+        {
+            for (var date = from.Date; date <= to.Date; date = date.AddDays(1))
+            {
+                var sessions = GetPlannedSessionsForDate(trainingPlan, date);
+                trainingsPlanned += sessions.Count;
+
+                foreach (var session in sessions)
+                {
+                    if (await IsSessionCompleteForDateAsync(clientId, session, date, ct))
+                        trainingsCompleted++;
+                }
+            }
+
+            trainingPercent = trainingsPlanned == 0
+                ? 0m
+                : Math.Round((decimal)trainingsCompleted / trainingsPlanned * 100, 1);
+        }
+
+        // ── Combined roll-up ────────────────────────────────────────────
+        // Weighted by plan presence: the plan with more scheduled items weighs more.
+        // If only one plan type is active, combined == that plan's percentage.
+        decimal combinedPercent;
+        var totalWeights = mealsPlanned + trainingsPlanned;
+
+        if (totalWeights == 0)
+        {
+            combinedPercent = 0m;
+        }
+        else
+        {
+            combinedPercent = Math.Round(
+                (mealsPlanned * nutritionPercent + trainingsPlanned * trainingPercent) / totalWeights, 1);
+        }
 
         return new ComplianceResult
         {
-            CompliancePercent = compliancePercent,
+            CompliancePercent = combinedPercent,
             MealsPlanned = mealsPlanned,
-            MealsLogged = mealsLogged
+            MealsLogged = mealsLogged,
+            NutritionCompliancePercent = nutritionPercent,
+            TrainingsPlanned = trainingsPlanned,
+            TrainingsCompleted = trainingsCompleted,
+            TrainingCompliancePercent = trainingPercent
         };
     }
 
     /// <inheritdoc />
     public async Task<int> CalculateStreakAsync(Guid clientId, CancellationToken ct)
     {
-        var plan = await FindActivePlanAsync(clientId, ct);
+        var nutritionPlan = await FindActivePlanAsync(clientId, ct);
+        var trainingPlan = await FindActiveTrainingPlanAsync(clientId, ct);
 
-        if (plan is null || !plan.StartDate.HasValue)
+        // Determine the floor: the earliest date either plan started a published week
+        DateTime? floorDate = null;
+
+        if (nutritionPlan?.StartDate.HasValue == true)
+        {
+            var earliest = nutritionPlan.Weeks
+                .Where(w => w.Status == WeekStatus.Published)
+                .OrderBy(w => w.WeekNumber)
+                .FirstOrDefault();
+
+            if (earliest is not null)
+            {
+                var nutritionFloor = nutritionPlan.StartDate.Value.Date
+                    .AddDays((earliest.WeekNumber - 1) * 7);
+                floorDate = floorDate is null ? nutritionFloor : new DateTime(Math.Min(floorDate.Value.Ticks, nutritionFloor.Ticks));
+            }
+        }
+
+        if (trainingPlan?.StartDate.HasValue == true)
+        {
+            var earliest = trainingPlan.Weeks
+                .Where(w => w.Status == WeekStatus.Published)
+                .OrderBy(w => w.WeekNumber)
+                .FirstOrDefault();
+
+            if (earliest is not null)
+            {
+                var trainingFloor = trainingPlan.StartDate.Value.Date
+                    .AddDays((earliest.WeekNumber - 1) * 7);
+                floorDate = floorDate is null ? trainingFloor : new DateTime(Math.Min(floorDate.Value.Ticks, trainingFloor.Ticks));
+            }
+        }
+
+        if (floorDate is null)
             return 0;
-
-        // Floor: the Monday of the earliest published week. Walking past this
-        // point means there was no active plan yet — stop the scan.
-        var earliestPublishedWeek = plan.Weeks
-            .Where(w => w.Status == WeekStatus.Published)
-            .OrderBy(w => w.WeekNumber)
-            .FirstOrDefault();
-
-        if (earliestPublishedWeek is null)
-            return 0;
-
-        var planStart = plan.StartDate.Value.Date;
-        var floorDate = planStart.AddDays((earliestPublishedWeek.WeekNumber - 1) * 7);
 
         var streak = 0;
         var today = DateTime.UtcNow.Date;
         var currentDate = today;
 
-        while (currentDate >= floorDate)
+        while (currentDate >= floorDate.Value)
         {
-            var plannedCount = GetPlannedMealCountForDate(plan, currentDate);
+            var nutritionPlanned = nutritionPlan is not null
+                ? GetPlannedMealCountForDate(nutritionPlan, currentDate)
+                : 0;
 
-            if (plannedCount == 0)
+            var trainingSessions = trainingPlan is not null
+                ? GetPlannedSessionsForDate(trainingPlan, currentDate)
+                : [];
+
+            var trainingPlannedCount = trainingSessions.Count;
+
+            var totalPlanned = nutritionPlanned + trainingPlannedCount;
+
+            if (totalPlanned == 0)
             {
-                // Rest day / no meals planned — skip without breaking.
+                // Rest day / nothing planned — skip without breaking
                 currentDate = currentDate.AddDays(-1);
                 continue;
             }
 
-            var dayStart = currentDate;
-            var dayEnd = currentDate.AddDays(1);
+            // Check nutrition compliance for this day
+            bool nutritionOk = nutritionPlanned == 0; // vacuously true when no nutrition plan for this day
+            if (nutritionPlanned > 0)
+            {
+                var dayStart = currentDate;
+                var dayEnd = currentDate.AddDays(1);
 
-            var dayFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientId)
-                & Builders<MealLog>.Filter.Gte(l => l.EatenAt, dayStart)
-                & Builders<MealLog>.Filter.Lt(l => l.EatenAt, dayEnd);
+                var dayFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientId)
+                    & Builders<MealLog>.Filter.Gte(l => l.EatenAt, dayStart)
+                    & Builders<MealLog>.Filter.Lt(l => l.EatenAt, dayEnd);
 
-            using var dayCursor = await _mongo.MealLogs.FindAsync(dayFilter, cancellationToken: ct);
-            var dayLogs = await dayCursor.ToListAsync(ct);
-            var loggedCount = dayLogs.Count;
+                using var dayCursor = await _mongo.MealLogs.FindAsync(dayFilter, cancellationToken: ct);
+                var dayLogs = await dayCursor.ToListAsync(ct);
+                nutritionOk = dayLogs.Count >= 1;
+            }
 
-            if (loggedCount >= 1)
+            // Check training compliance for this day
+            bool trainingOk = trainingPlannedCount == 0; // vacuously true when no training sessions this day
+            if (trainingPlannedCount > 0)
+            {
+                var allSessionsComplete = true;
+                foreach (var session in trainingSessions)
+                {
+                    if (!await IsSessionCompleteForDateAsync(clientId, session, currentDate, ct))
+                    {
+                        allSessionsComplete = false;
+                        break;
+                    }
+                }
+                trainingOk = allSessionsComplete;
+            }
+
+            var dayComplete = nutritionOk && trainingOk;
+
+            if (dayComplete)
             {
                 streak++;
                 currentDate = currentDate.AddDays(-1);
             }
             else if (currentDate == today)
             {
-                // Today hasn't reached the threshold yet — user can still log
-                // more meals. Don't count it, but don't break the streak either.
+                // Today hasn't finished yet — don't break the streak, just skip today
                 currentDate = currentDate.AddDays(-1);
             }
             else
@@ -180,9 +284,6 @@ public class ComplianceService : IComplianceService
     /// <summary>
     /// Finds the active nutrition plan for a client.
     /// </summary>
-    /// <param name="clientId">The client's ApplicationUser.Id.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The active plan, or null if none exists.</returns>
     private async Task<NutritionPlan?> FindActivePlanAsync(Guid clientId, CancellationToken ct)
     {
         var filter = Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientId)
@@ -192,7 +293,90 @@ public class ComplianceService : IComplianceService
         return await cursor.FirstOrDefaultAsync(ct);
     }
 
-/// <summary>
+    /// <summary>
+    /// Finds the active training plan for a client.
+    /// </summary>
+    private async Task<TrainingPlan?> FindActiveTrainingPlanAsync(Guid clientId, CancellationToken ct)
+    {
+        var filter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId)
+            & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var cursor = await _mongo.TrainingPlans.FindAsync(filter, cancellationToken: ct);
+        return await cursor.FirstOrDefaultAsync(ct);
+    }
+
+    /// <summary>
+    /// Checks whether all exercises in a session have a completion record for the given date.
+    /// </summary>
+    private async Task<bool> IsSessionCompleteForDateAsync(
+        Guid clientId, TrainingSession session, DateTime date, CancellationToken ct)
+    {
+        if (session.Exercises.Count == 0)
+            return false;
+
+        var dateUtc = date.Date == date ? date : date.Date;
+
+        var filter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                     & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, dateUtc)
+                     & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, session.SessionId);
+
+        using var cursor = await _mongo.TrainingCompletions.FindAsync(filter, cancellationToken: ct);
+        var completion = await cursor.FirstOrDefaultAsync(ct);
+
+        if (completion is null)
+            return false;
+
+        // All exercises must be present in the completion record
+        return session.Exercises.All(e => completion.CompletedExerciseIds.Contains(e.ExerciseExternalId));
+    }
+
+    /// <summary>
+    /// Returns the list of training sessions scheduled for a specific calendar date,
+    /// based on the plan's week cycle and published weeks.
+    /// Returns an empty list for rest days, unpublished weeks, or before plan start.
+    /// </summary>
+    private static IReadOnlyList<TrainingSession> GetPlannedSessionsForDate(TrainingPlan plan, DateTime date)
+    {
+        if (!plan.StartDate.HasValue)
+            return [];
+
+        var target = date.Date;
+        var startDate = plan.StartDate.Value.Date;
+
+        if (target < startDate)
+            return [];
+
+        var publishedWeeks = plan.Weeks
+            .Where(w => w.Status == WeekStatus.Published)
+            .OrderBy(w => w.WeekNumber)
+            .ToList();
+
+        if (publishedWeeks.Count == 0)
+            return [];
+
+        var resolved = PlanWeekCalculator.ResolveCurrentWeekNumber(
+            plan.StartDate,
+            publishedWeeks.Select(w => w.WeekNumber).ToList(),
+            plan.Weeks.Count,
+            publishedWeeks.First().DatePublished,
+            plan.DateCreated,
+            target);
+
+        if (resolved is null)
+            return [];
+
+        var week = plan.Weeks.FirstOrDefault(w => w.WeekNumber == resolved.Value);
+        if (week is null || week.Status != WeekStatus.Published)
+            week = publishedWeeks.Last();
+
+        // ISO day-of-week: 1=Monday … 7=Sunday
+        var dow = (int)target.DayOfWeek;
+        dow = dow == 0 ? 7 : dow;
+
+        return week.Sessions.Where(s => s.DayOfWeek == dow).ToList();
+    }
+
+    /// <summary>
     /// Counts total planned meals for published weeks within a date range.
     /// </summary>
     private static int CountPlannedMeals(NutritionPlan plan, DateTime from, DateTime to)

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/ComplianceService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/ComplianceService.cs
@@ -166,18 +166,19 @@ public class ComplianceService : IComplianceService
 
             var trainingPlannedCount = trainingSessions.Count;
 
-            var totalPlanned = nutritionPlanned + trainingPlannedCount;
+            var nutritionActive = nutritionPlanned > 0;
+            var trainingActive = trainingPlannedCount > 0;
 
-            if (totalPlanned == 0)
+            if (!nutritionActive && !trainingActive)
             {
                 // Rest day / nothing planned — skip without breaking
                 currentDate = currentDate.AddDays(-1);
                 continue;
             }
 
-            // Check nutrition compliance for this day
-            bool nutritionOk = nutritionPlanned == 0; // vacuously true when no nutrition plan for this day
-            if (nutritionPlanned > 0)
+            // Check nutrition compliance for this day (≥1 meal logged)
+            bool nutritionDone = false;
+            if (nutritionActive)
             {
                 var dayStart = currentDate;
                 var dayEnd = currentDate.AddDays(1);
@@ -188,26 +189,29 @@ public class ComplianceService : IComplianceService
 
                 using var dayCursor = await _mongo.MealLogs.FindAsync(dayFilter, cancellationToken: ct);
                 var dayLogs = await dayCursor.ToListAsync(ct);
-                nutritionOk = dayLogs.Count >= 1;
+                nutritionDone = dayLogs.Count >= 1;
             }
 
-            // Check training compliance for this day
-            bool trainingOk = trainingPlannedCount == 0; // vacuously true when no training sessions this day
-            if (trainingPlannedCount > 0)
+            // Check training compliance for this day (≥1 session fully complete — any-pattern)
+            bool trainingDone = false;
+            if (trainingActive)
             {
-                var allSessionsComplete = true;
                 foreach (var session in trainingSessions)
                 {
-                    if (!await IsSessionCompleteForDateAsync(clientId, session, currentDate, ct))
+                    if (await IsSessionCompleteForDateAsync(clientId, session, currentDate, ct))
                     {
-                        allSessionsComplete = false;
+                        trainingDone = true;
                         break;
                     }
                 }
-                trainingOk = allSessionsComplete;
             }
 
-            var dayComplete = nutritionOk && trainingOk;
+            // Lenient OR rule: a day counts if at least one active plan side was satisfied.
+            // Only-nutrition day: nutritionDone. Only-training day: trainingDone.
+            // Both active: nutritionDone OR trainingDone.
+            bool dayComplete = nutritionActive && trainingActive
+                ? nutritionDone || trainingDone
+                : nutritionActive ? nutritionDone : trainingDone;
 
             if (dayComplete)
             {

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteEndpointTests.cs
@@ -1,0 +1,260 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="MarkExerciseCompleteEndpoint"/>.
+/// </summary>
+public class MarkExerciseCompleteEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _exercise1 = Guid.NewGuid();
+    private readonly Guid _exercise2 = Guid.NewGuid();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    private IApplicationDbContext CreateMockDbForWrongClient() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = Guid.NewGuid(), PublicId = Guid.NewGuid() })
+            .Build();
+
+    [Fact]
+    public async Task HandleAsync_NewCompletion_Returns200WithProgress()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await completionCollection.Received(1).InsertOneAsync(
+            Arg.Is<TrainingCompletion>(c =>
+                c.ClientId == _clientId &&
+                c.SessionId == _sessionId &&
+                c.CompletedExerciseIds.Contains(_exercise1) &&
+                c.CompletedExerciseIds.Count == 1),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyComplete_IsIdempotent_Returns200()
+    {
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1],
+            version: 1);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        // Mark exercise1 complete again (already complete — idempotent)
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No insert or update should have occurred
+        await completionCollection.DidNotReceive().InsertOneAsync(
+            Arg.Any<TrainingCompletion>(),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+        await completionCollection.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongClient_Returns404()
+    {
+        // The wrong client has no active training plan — the mock returns an empty list
+        // for any FindAsync call (as it's keyed to return no plan for wrongClientId's collection).
+        var wrongClientId = Guid.NewGuid();
+
+        // Create a mongo with NO plans (simulates: plan belongs to _clientId, not wrongClientId)
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: null);
+
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = wrongClientId, PublicId = wrongClientId })
+            .Build();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        // No active plan found for wrongClientId → 404
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_StaleVersion_Returns409()
+    {
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [],
+            version: 2); // server is at version 2
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+        var planColl = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan).Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planColl);
+
+        // Completion collection returns existing doc but UpdateOneAsync modifies 0 rows (simulating version mismatch)
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection(
+            [existingCompletion], updateSucceeds: false);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        // Client sends version 2 which matches, but UpdateOneAsync returns ModifiedCount=0 (race)
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest
+            {
+                SessionId = _sessionId,
+                ExerciseExternalId = _exercise1,
+                Version = 2
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ClientSendsStaleVersion_Returns409Immediately()
+    {
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [],
+            version: 3);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        // Client sends version 1 but server is at version 3
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest
+            {
+                SessionId = _sessionId,
+                ExerciseExternalId = _exercise1,
+                Version = 1
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonExistentSessionId_Returns404()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = Guid.NewGuid(), ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoClaims_Returns401()
+    {
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo();
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseIncompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseIncompleteEndpointTests.cs
@@ -1,0 +1,283 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="MarkExerciseIncompleteEndpoint"/>.
+/// </summary>
+public class MarkExerciseIncompleteEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _exercise1 = Guid.NewGuid();
+    private readonly Guid _exercise2 = Guid.NewGuid();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    [Fact]
+    public async Task HandleAsync_CompleteExerciseThenUncomplete_Returns200AndExerciseGone()
+    {
+        // Set up: exercise1 is already marked complete
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1, _exercise2],
+            version: 1);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The update should have been called removing exercise1
+        await completionCollection.Received(1).UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Is<UpdateDefinition<TrainingCompletion>>(u => u != null),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyIncomplete_IsIdempotent_Returns200()
+    {
+        // exercise1 is NOT in the completed list — idempotent path
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise2],
+            version: 1);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No insert or update should have occurred
+        await completionCollection.DidNotReceive().InsertOneAsync(
+            Arg.Any<TrainingCompletion>(),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+        await completionCollection.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_StaleVersionPreCheck_Returns409WithVersionConflictCode()
+    {
+        // Completion document is at version 3; client sends version 1 (stale)
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1],
+            version: 3);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest
+            {
+                SessionId = _sessionId,
+                ExerciseExternalId = _exercise1,
+                Version = 1  // client thinks it's version 1, server is at 3
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleAsync_StaleVersionOnUpdate_Returns409WithVersionConflictCode()
+    {
+        // Completion is at version 2; client matches — but UpdateOneAsync returns ModifiedCount=0 (race)
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1],
+            version: 2);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+        var planColl = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan).Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planColl);
+
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection(
+            [existingCompletion], updateSucceeds: false);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest
+            {
+                SessionId = _sessionId,
+                ExerciseExternalId = _exercise1,
+                Version = 2
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongClient_Returns404()
+    {
+        // No active plan found for the wrong client
+        var wrongClientId = Guid.NewGuid();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: null);
+
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = wrongClientId, PublicId = wrongClientId })
+            .Build();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        // No active plan → 404 with NoActiveTrainingPlan code
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonExistentSessionId_Returns404WithTrainingSessionNotFoundCode()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest { SessionId = Guid.NewGuid(), ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonExistentExerciseId_Returns404WithTrainingExerciseNotFoundCode()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        // _exercise2 is NOT in the plan's session exercises
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise2 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoClaims_Returns401()
+    {
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo();
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionCompleteEndpointTests.cs
@@ -1,0 +1,186 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="MarkSessionCompleteEndpoint"/>.
+/// </summary>
+public class MarkSessionCompleteEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _exercise1 = Guid.NewGuid();
+    private readonly Guid _exercise2 = Guid.NewGuid();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    [Fact]
+    public async Task HandleAsync_NewSession_MarksAllExercisesComplete()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionCompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // All exercises in the session should be inserted in one completion document
+        await completionCollection.Received(1).InsertOneAsync(
+            Arg.Is<TrainingCompletion>(c =>
+                c.ClientId == _clientId &&
+                c.SessionId == _sessionId &&
+                c.CompletedExerciseIds.Count == 2 &&
+                c.CompletedExerciseIds.Contains(_exercise1) &&
+                c.CompletedExerciseIds.Contains(_exercise2)),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyComplete_IsIdempotent()
+    {
+        // Create a completion that already has all exercises
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1, _exercise2],
+            version: 1);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionCompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No writes should occur since it's already complete
+        await completionCollection.DidNotReceive().InsertOneAsync(
+            Arg.Any<TrainingCompletion>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
+        await completionCollection.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_PartialCompletion_FansOutAllExercises()
+    {
+        // Session has 2 exercises, only exercise1 was previously completed
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1],
+            version: 1);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionCompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Should have updated with all exercise IDs
+        await completionCollection.Received(1).UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Is<UpdateDefinition<TrainingCompletion>>(u => u != null),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonExistentSession_Returns404()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionCompleteRequest { SessionId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoClaims_Returns401()
+    {
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo();
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionCompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionIncompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionIncompleteEndpointTests.cs
@@ -1,0 +1,248 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="MarkSessionIncompleteEndpoint"/>.
+/// </summary>
+public class MarkSessionIncompleteEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _exercise1 = Guid.NewGuid();
+    private readonly Guid _exercise2 = Guid.NewGuid();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    [Fact]
+    public async Task HandleAsync_CompleteSessionThenUncomplete_Returns200AndCompletionCleared()
+    {
+        // All exercises were previously marked complete
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1, _exercise2],
+            version: 1);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Completion list should have been cleared via UpdateOneAsync
+        await completionCollection.Received(1).UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Is<UpdateDefinition<TrainingCompletion>>(u => u != null),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyIncomplete_IsIdempotent_Returns200()
+    {
+        // No completion document at all — idempotent path
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No insert or update should have occurred
+        await completionCollection.DidNotReceive().InsertOneAsync(
+            Arg.Any<TrainingCompletion>(),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+        await completionCollection.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateDefinition<TrainingCompletion>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_StaleVersionPreCheck_Returns409WithVersionConflictCode()
+    {
+        // Completion document is at version 3; client sends version 1 (stale)
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1, _exercise2],
+            version: 3);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest
+            {
+                SessionId = _sessionId,
+                Version = 1   // client thinks version 1, server is at 3
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleAsync_StaleVersionOnUpdate_Returns409WithVersionConflictCode()
+    {
+        // Client version matches but UpdateOneAsync returns ModifiedCount=0 (race)
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1, _exercise2],
+            version: 2);
+
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2]);
+
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+        var planColl = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan).Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planColl);
+
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection(
+            [existingCompletion], updateSucceeds: false);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest
+            {
+                SessionId = _sessionId,
+                Version = 2
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WrongClient_Returns404()
+    {
+        // No active plan found for the wrong client
+        var wrongClientId = Guid.NewGuid();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: null);
+
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = wrongClientId, PublicId = wrongClientId })
+            .Build();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        // No active plan → 404 with NoActiveTrainingPlan code
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NonExistentSessionId_Returns404WithTrainingSessionNotFoundCode()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1]);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest { SessionId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoClaims_Returns401()
+    {
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo();
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkSessionIncompleteRequest { SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
@@ -1,0 +1,203 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="MarkWholeDayCompleteEndpoint"/>.
+/// </summary>
+public class MarkWholeDayCompleteEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _session1 = Guid.NewGuid();
+    private readonly Guid _session2 = Guid.NewGuid();
+    private readonly Guid _exercise1 = Guid.NewGuid();
+    private readonly Guid _exercise2 = Guid.NewGuid();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    /// <summary>
+    /// Creates a plan with two sessions on the same day of week (today).
+    /// </summary>
+    private TrainingPlan CreateMultiSessionPlan()
+    {
+        var today = DateTime.UtcNow;
+        var startOfWeek = today.Date.AddDays(-(int)today.DayOfWeek + 1); // Monday
+
+        // ISO dow for today
+        var todayDow = (int)today.DayOfWeek;
+        todayDow = todayDow == 0 ? 7 : todayDow;
+
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Multi-Session Day Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = _session1,
+                            DayOfWeek = todayDow,
+                            Name = "Session 1",
+                            Order = 1,
+                            Exercises =
+                            [
+                                new SessionExercise { ExerciseExternalId = _exercise1, ExerciseName = "Ex1", Order = 1, Sets = [] }
+                            ]
+                        },
+                        new TrainingSession
+                        {
+                            SessionId = _session2,
+                            DayOfWeek = todayDow,
+                            Name = "Session 2",
+                            Order = 2,
+                            Exercises =
+                            [
+                                new SessionExercise { ExerciseExternalId = _exercise2, ExerciseName = "Ex2", Order = 1, Sets = [] }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = startOfWeek
+        };
+    }
+
+    [Fact]
+    public async Task HandleAsync_MultipleSessions_InsertsCompletionForEach()
+    {
+        var plan = CreateMultiSessionPlan();
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+
+        // Plans collection returns the multi-session plan
+        var planCollection = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan).Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Completions collection starts empty (returns empty list for FindAsync)
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection([]);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkWholeDayCompleteRequest { Date = DateOnly.FromDateTime(DateTime.UtcNow) },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Should have inserted two completion documents (one per session)
+        await completionCollection.Received(2).InsertOneAsync(
+            Arg.Any<TrainingCompletion>(),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_AlreadyCompleteSession_IsSkippedIdempotently()
+    {
+        var today = DateTime.UtcNow.Date;
+        var plan = CreateMultiSessionPlan();
+
+        // Session 1 is already fully complete
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _session1,
+            date: today,
+            completedExerciseIds: [_exercise1],
+            version: 1);
+
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+        var planCollection = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan).Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Completions collection returns the existing completion (for session1)
+        // Note: both session queries will return the same existing completion because mock
+        // doesn't filter — this tests the "already complete" idempotency branch for session1
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection([existingCompletion]);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkWholeDayCompleteRequest { Date = DateOnly.FromDateTime(today) },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoPlan_Returns404()
+    {
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+        var planCollection = TrainingCompletionTestHelpers.CreateMockMongo().Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planCollection);
+
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection([]);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkWholeDayCompleteRequest(),
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoClaims_Returns401()
+    {
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo();
+        var db = CreateMockDb();
+
+        var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
+            mongo, db);
+
+        await ep.HandleAsync(
+            new MarkWholeDayCompleteRequest(),
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingCompletionTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingCompletionTestHelpers.cs
@@ -1,0 +1,191 @@
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Helpers for creating test data and mocks for training completion endpoint tests.
+/// </summary>
+public static class TrainingCompletionTestHelpers
+{
+    /// <summary>
+    /// Creates an active <see cref="TrainingPlan"/> with one published week containing
+    /// sessions for every day of the week. Each session has the given exercises.
+    /// </summary>
+    public static TrainingPlan CreateActivePlan(
+        Guid clientId,
+        Guid? sessionId = null,
+        IReadOnlyList<Guid>? exerciseIds = null,
+        DateTime? startDate = null)
+    {
+        var sid = sessionId ?? Guid.NewGuid();
+        var exIds = exerciseIds ?? [Guid.NewGuid(), Guid.NewGuid()];
+        var start = startDate ?? DateTime.UtcNow.Date.AddDays(-(int)DateTime.UtcNow.DayOfWeek + 1); // Monday of current week
+
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = start,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = start,
+                    Sessions = Enumerable.Range(1, 7).Select(d => new TrainingSession
+                    {
+                        SessionId = d == (int)DateTime.UtcNow.DayOfWeek || d == 1 ? sid : Guid.NewGuid(),
+                        DayOfWeek = d,
+                        Name = $"Day {d} Session",
+                        Order = 1,
+                        Exercises = exIds.Select((id, i) => new SessionExercise
+                        {
+                            ExerciseExternalId = id,
+                            ExerciseName = $"Exercise {i + 1}",
+                            Order = i + 1,
+                            Sets = []
+                        }).ToList()
+                    }).ToList()
+                }
+            ],
+            Version = 1,
+            DateCreated = start
+        };
+    }
+
+    /// <summary>
+    /// Creates a <see cref="TrainingCompletion"/> document for the given session and date.
+    /// </summary>
+    public static TrainingCompletion CreateCompletion(
+        Guid clientId,
+        Guid sessionId,
+        DateTime date,
+        IReadOnlyList<Guid>? completedExerciseIds = null,
+        int version = 1)
+    {
+        return new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            Date = date.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = completedExerciseIds?.ToList() ?? [],
+            DateCreated = DateTime.UtcNow,
+            Version = version
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock <see cref="IMongoContext"/> with configured collections for
+    /// training plans and training completions.
+    /// </summary>
+    public static (IMongoContext Mongo, IMongoCollection<TrainingCompletion> CompletionCollection)
+        CreateMockMongo(
+            TrainingPlan? plan = null,
+            TrainingCompletion? existingCompletion = null)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Training plans
+        var plans = plan is not null ? new List<TrainingPlan> { plan } : new List<TrainingPlan>();
+        var planCollection = CreateMockPlanCollection(plans);
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Training completions
+        var completions = existingCompletion is not null
+            ? new List<TrainingCompletion> { existingCompletion }
+            : new List<TrainingCompletion>();
+        var completionCollection = CreateMockCompletionCollection(completions);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        return (mongo, completionCollection);
+    }
+
+    /// <summary>
+    /// Creates a mock <see cref="IMongoCollection{TrainingCompletion}"/> with basic operations.
+    /// </summary>
+    public static IMongoCollection<TrainingCompletion> CreateMockCompletionCollection(
+        List<TrainingCompletion> completions,
+        bool updateSucceeds = true)
+    {
+        var collection = Substitute.For<IMongoCollection<TrainingCompletion>>();
+
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<FindOptions<TrainingCompletion, TrainingCompletion>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci => CreateCompletionCursor(completions));
+
+        var updateResult = Substitute.For<UpdateResult>();
+        updateResult.ModifiedCount.Returns(updateSucceeds ? 1L : 0L);
+        collection.UpdateOneAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<UpdateDefinition<TrainingCompletion>>(),
+                Arg.Any<UpdateOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(updateResult);
+
+        return collection;
+    }
+
+    private static IMongoCollection<TrainingPlan> CreateMockPlanCollection(List<TrainingPlan> plans)
+    {
+        var collection = Substitute.For<IMongoCollection<TrainingPlan>>();
+
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci => CreatePlanCursor(plans));
+
+        return collection;
+    }
+
+    private static IAsyncCursor<TrainingPlan> CreatePlanCursor(List<TrainingPlan> plans)
+    {
+        var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+        var moved = false;
+        cursor.Current.Returns(plans);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return plans.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return plans.Count > 0;
+        });
+        return cursor;
+    }
+
+    private static IAsyncCursor<TrainingCompletion> CreateCompletionCursor(List<TrainingCompletion> completions)
+    {
+        var cursor = Substitute.For<IAsyncCursor<TrainingCompletion>>();
+        var moved = false;
+        cursor.Current.Returns(completions);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return completions.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return completions.Count > 0;
+        });
+        return cursor;
+    }
+}

--- a/backend/FitnessPlatform.Tests/Services/ComplianceServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/ComplianceServiceTests.cs
@@ -416,15 +416,16 @@ public class ComplianceServiceTests
         // Act
         var streak = await sut.CalculateStreakAsync(_clientId, TestContext.Current.CancellationToken);
 
-        // Assert — yesterday counts (≥1 day streak), today is not broken (no sessions counted for today
-        // since not yet complete and today is skipped)
-        streak.Should().BeGreaterThanOrEqualTo(0);
+        // Assert — yesterday counts (≥1 completed session), so streak is at least 1.
+        // Today is incomplete but the "today not over" carve-out prevents breaking.
+        streak.Should().BeGreaterThanOrEqualTo(1);
     }
 
     [Fact]
-    public async Task CalculateStreakAsync_CombinedPlan_BreaksWhenTrainingMissed()
+    public async Task CalculateStreakAsync_CombinedPlan_NutritionLoggedButTrainingMissed_StillCounts()
     {
-        // Arrange — nutrition plan with meals logged yesterday, but training NOT completed
+        // Arrange — nutrition plan with meals logged yesterday, training NOT completed.
+        // Under the lenient OR rule the day must still count toward the streak.
         var sessionId = Guid.NewGuid();
         var ex1 = Guid.NewGuid();
         var today = DateTime.UtcNow.Date;
@@ -437,7 +438,6 @@ public class ComplianceServiceTests
             status: NutritionPlanStatus.Active);
         nutritionPlan.StartDate = weekStart;
         nutritionPlan.Weeks[0].Status = WeekStatus.Published;
-        // Use yesterday's DOW index
         var yesterdayDow = (int)yesterday.DayOfWeek;
         yesterdayDow = yesterdayDow == 0 ? 7 : yesterdayDow;
         nutritionPlan.Weeks[0].Days[yesterdayDow - 1].Meals =
@@ -467,8 +467,131 @@ public class ComplianceServiceTests
         // Act
         var streak = await sut.CalculateStreakAsync(_clientId, TestContext.Current.CancellationToken);
 
-        // Assert — yesterday had nutrition logged but training missed → streak is 0
-        // (or 0 if today was the only day and is also incomplete)
-        streak.Should().Be(0);
+        // Assert — under OR rule: nutrition was logged → yesterday counts.
+        // Streak must be ≥ 1 (today may still be skipped via the "not over" carve-out).
+        streak.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task CalculateStreakAsync_TrainingOnly_OneOfTwoSessionsComplete_CountsTowardStreak()
+    {
+        // Arrange — training-only client with 2 sessions planned yesterday; only 1 is complete.
+        // Under OR the day counts because at least one session is done.
+        var sessionId1 = Guid.NewGuid();
+        var sessionId2 = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+        var yesterday = today.AddDays(-1);
+        var weekStart = today.AddDays(-(int)today.DayOfWeek + 1);
+
+        var yesterdayDow = (int)yesterday.DayOfWeek;
+        yesterdayDow = yesterdayDow == 0 ? 7 : yesterdayDow;
+
+        // Build a training plan with two sessions on yesterday's DOW
+        var trainingPlan = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Two-Session Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = weekStart,
+            Version = 1,
+            DateCreated = weekStart,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = weekStart,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId1,
+                            DayOfWeek = yesterdayDow,
+                            Name = "Session A",
+                            Order = 1,
+                            Exercises = [new SessionExercise { ExerciseExternalId = ex1, ExerciseName = "Ex1", Order = 1, Sets = [] }]
+                        },
+                        new TrainingSession
+                        {
+                            SessionId = sessionId2,
+                            DayOfWeek = yesterdayDow,
+                            Name = "Session B",
+                            Order = 2,
+                            Exercises = [new SessionExercise { ExerciseExternalId = ex1, ExerciseName = "Ex1", Order = 1, Sets = [] }]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Only session 1 is complete; session 2 has no completion record.
+        var completion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: sessionId1,
+            date: yesterday,
+            completedExerciseIds: [ex1]);
+
+        var mongo = CreateMongo(trainingPlan: trainingPlan, completions: [completion]);
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var streak = await sut.CalculateStreakAsync(_clientId, TestContext.Current.CancellationToken);
+
+        // Assert — 1 of 2 sessions complete; OR rule means yesterday counts → streak ≥ 1.
+        streak.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task CalculateStreakAsync_CombinedPlan_NutritionLoggedNoTraining_Counts()
+    {
+        // Arrange — combined-plan client: nutrition logged yesterday, no training completed.
+        // Mirrors the acceptance-criteria example: "nutrition logged but no training complete still counts".
+        var sessionId = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+        var yesterday = today.AddDays(-1);
+        var weekStart = today.AddDays(-(int)today.DayOfWeek + 1);
+
+        var yesterdayDow = (int)yesterday.DayOfWeek;
+        yesterdayDow = yesterdayDow == 0 ? 7 : yesterdayDow;
+
+        // Nutrition plan with a meal slot for yesterday
+        var nutritionPlan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            status: NutritionPlanStatus.Active);
+        nutritionPlan.StartDate = weekStart;
+        nutritionPlan.Weeks[0].Status = WeekStatus.Published;
+        nutritionPlan.Weeks[0].Days[yesterdayDow - 1].Meals =
+            [PlanTestHelpers.CreateMeal(kind: MealKind.Breakfast)];
+
+        var mealLogs = new List<MealLog>
+        {
+            new() { ClientId = _clientId, EatenAt = yesterday.AddHours(8), FoodsEaten = [] }
+        };
+
+        // Training plan with session yesterday — zero completions
+        var trainingPlan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: sessionId,
+            exerciseIds: [ex1],
+            startDate: weekStart);
+
+        var mongo = CreateMongo(
+            nutritionPlans: [nutritionPlan],
+            mealLogs: mealLogs,
+            trainingPlan: trainingPlan,
+            completions: []);
+
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var streak = await sut.CalculateStreakAsync(_clientId, TestContext.Current.CancellationToken);
+
+        // Assert — nutritionDone=true, trainingDone=false → OR → day counts → streak ≥ 1
+        streak.Should().BeGreaterThanOrEqualTo(1);
     }
 }

--- a/backend/FitnessPlatform.Tests/Services/ComplianceServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/ComplianceServiceTests.cs
@@ -3,6 +3,7 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Endpoints.ClientTraining;
 using FitnessPlatform.Tests.Endpoints.NutritionPlans;
 using MongoDB.Driver;
 using NSubstitute;
@@ -17,13 +18,16 @@ public class ComplianceServiceTests
     private readonly Guid _clientId = Guid.NewGuid();
 
     /// <summary>
-    /// Creates a mocked IMongoContext with plans and meal logs collections.
+    /// Creates a mocked IMongoContext with nutrition plans, meal logs, training plans,
+    /// and training completions collections.
     /// </summary>
     private static IMongoContext CreateMongo(
-        NutritionPlan[]? plans = null,
-        List<MealLog>? mealLogs = null)
+        NutritionPlan[]? nutritionPlans = null,
+        List<MealLog>? mealLogs = null,
+        TrainingPlan? trainingPlan = null,
+        List<TrainingCompletion>? completions = null)
     {
-        var mongo = PlanTestHelpers.CreateMockMongo(plans);
+        var mongo = PlanTestHelpers.CreateMockMongo(nutritionPlans);
 
         var mealLogCollection = Substitute.For<IMongoCollection<MealLog>>();
         mealLogCollection.FindAsync(
@@ -32,6 +36,23 @@ public class ComplianceServiceTests
                 Arg.Any<CancellationToken>())
             .Returns(_ => CreateMealLogCursor(mealLogs ?? []));
         mongo.MealLogs.Returns(mealLogCollection);
+
+        // Training plans
+        var trainingPlanList = trainingPlan is not null
+            ? new List<TrainingPlan> { trainingPlan }
+            : new List<TrainingPlan>();
+        var trainingPlanColl = Substitute.For<IMongoCollection<TrainingPlan>>();
+        trainingPlanColl.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateTrainingPlanCursor(trainingPlanList));
+        mongo.TrainingPlans.Returns(trainingPlanColl);
+
+        // Training completions
+        var completionList = completions ?? [];
+        var completionColl = TrainingCompletionTestHelpers.CreateMockCompletionCollection(completionList);
+        mongo.TrainingCompletions.Returns(completionColl);
 
         return mongo;
     }
@@ -56,6 +77,28 @@ public class ComplianceServiceTests
         return cursor;
     }
 
+    private static IAsyncCursor<TrainingPlan> CreateTrainingPlanCursor(List<TrainingPlan> plans)
+    {
+        var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+        var moved = false;
+        cursor.Current.Returns(plans);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return plans.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return plans.Count > 0;
+        });
+        return cursor;
+    }
+
+    // ── Existing nutrition-only tests ───────────────────────────────────
+
     [Fact]
     public async Task CalculateComplianceAsync_NoPlan_ReturnsZero()
     {
@@ -72,21 +115,31 @@ public class ComplianceServiceTests
         result.CompliancePercent.Should().Be(0);
         result.MealsPlanned.Should().Be(0);
         result.MealsLogged.Should().Be(0);
+        result.TrainingsPlanned.Should().Be(0);
+        result.TrainingsCompleted.Should().Be(0);
     }
 
     [Fact]
     public async Task CalculateComplianceAsync_WithPlanAndLogs_ReturnsCorrectPercent()
     {
-        // Arrange — plan with 1 week, day 1 has 3 meals, published today
+        // Arrange — plan with 1 week, published, starting on Monday of the current week
         var today = DateTime.UtcNow.Date;
+        // Calculate Monday of this week so StartDate + today's DOW lands on today
+        var dow = (int)today.DayOfWeek;
+        dow = dow == 0 ? 7 : dow;
+        var mondayThisWeek = today.AddDays(-(dow - 1));
+
         var plan = PlanTestHelpers.CreatePlan(
             clientId: _clientId,
             status: NutritionPlanStatus.Active,
             weekCount: 1);
-        plan.DatePublished = today;
+        plan.DatePublished = mondayThisWeek;
+        plan.StartDate = mondayThisWeek;
+        plan.Weeks[0].Status = WeekStatus.Published;
+        plan.Weeks[0].DatePublished = mondayThisWeek;
 
-        // Add 3 meals to day 1 (DayOfWeek=1, index 0 after cycling)
-        plan.Weeks[0].Days[0].Meals =
+        // Add 3 meals to today's day-of-week slot (DOW is 1-based, array index is DOW-1)
+        plan.Weeks[0].Days[dow - 1].Meals =
         [
             PlanTestHelpers.CreateMeal(kind: MealKind.Breakfast),
             PlanTestHelpers.CreateMeal(kind: MealKind.Lunch),
@@ -107,9 +160,11 @@ public class ComplianceServiceTests
         var result = await sut.CalculateComplianceAsync(
             _clientId, today, today, TestContext.Current.CancellationToken);
 
-        // Assert — 2/3 * 100 = 66.7
+        // Assert — nutrition: 2/3 * 100 = 66.7; training: 0 planned → training percent 0
+        // combined = (3 * 66.7 + 0 * 0) / (3 + 0) = 66.7
         result.MealsPlanned.Should().Be(3);
         result.MealsLogged.Should().Be(2);
+        result.NutritionCompliancePercent.Should().Be(66.7m);
         result.CompliancePercent.Should().Be(66.7m);
     }
 
@@ -190,5 +245,230 @@ public class ComplianceServiceTests
         result.Protein.Should().Be(66.0m); // 66.05 rounds to 66.0 (banker's rounding)
         result.Carbs.Should().Be(42.0m);
         result.Fat.Should().Be(7.6m); // 7.65 rounds to 7.6 (banker's rounding)
+    }
+
+    // ── New training-only compliance tests ─────────────────────────────
+
+    [Fact]
+    public async Task CalculateComplianceAsync_TrainingOnlyClient_ReturnsTrainingPercent()
+    {
+        // Arrange — client has only a training plan (no nutrition plan)
+        var sessionId = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var ex2 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+
+        var trainingPlan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: sessionId,
+            exerciseIds: [ex1, ex2],
+            startDate: today.AddDays(-(int)today.DayOfWeek + 1));
+
+        // One completion record for today's session with both exercises done
+        var completion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: sessionId,
+            date: today,
+            completedExerciseIds: [ex1, ex2]);
+
+        var mongo = CreateMongo(
+            trainingPlan: trainingPlan,
+            completions: [completion]);
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var result = await sut.CalculateComplianceAsync(
+            _clientId, today, today, TestContext.Current.CancellationToken);
+
+        // Assert — no nutrition plan, so combined = training percent
+        result.MealsPlanned.Should().Be(0);
+        result.TrainingsPlanned.Should().BeGreaterThan(0);
+        result.TrainingsCompleted.Should().Be(result.TrainingsPlanned);
+        result.TrainingCompliancePercent.Should().Be(100m);
+        result.CompliancePercent.Should().Be(100m);
+    }
+
+    [Fact]
+    public async Task CalculateComplianceAsync_NutritionAndTraining_CombinesWeightedPercent()
+    {
+        // Arrange — client has both plans for today
+        var sessionId = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+        var weekStart = today.AddDays(-(int)today.DayOfWeek + 1);
+
+        // Nutrition plan: 2 meals planned, 1 logged → 50% nutrition
+        var nutritionPlan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            status: NutritionPlanStatus.Active,
+            weekCount: 1);
+        nutritionPlan.StartDate = weekStart;
+        nutritionPlan.Weeks[0].Status = WeekStatus.Published;
+
+        // Get the correct day index (today's ISO DOW is 1=Mon…7=Sun, array is 0-indexed)
+        var todayDow = (int)today.DayOfWeek;
+        todayDow = todayDow == 0 ? 7 : todayDow;
+        var dayIndex = todayDow - 1;
+        nutritionPlan.Weeks[0].Days[dayIndex].Meals =
+        [
+            PlanTestHelpers.CreateMeal(kind: MealKind.Breakfast),
+            PlanTestHelpers.CreateMeal(kind: MealKind.Lunch)
+        ];
+
+        var mealLogs = new List<MealLog>
+        {
+            new() { ClientId = _clientId, EatenAt = today.AddHours(8), FoodsEaten = [] }
+        };
+
+        // Training plan: 1 session today, exercise NOT completed → 0% training
+        var trainingPlan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: sessionId,
+            exerciseIds: [ex1],
+            startDate: weekStart);
+
+        var mongo = CreateMongo(
+            nutritionPlans: [nutritionPlan],
+            mealLogs: mealLogs,
+            trainingPlan: trainingPlan,
+            completions: []); // no completions
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var result = await sut.CalculateComplianceAsync(
+            _clientId, today, today, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.MealsPlanned.Should().Be(2);
+        result.MealsLogged.Should().Be(1);
+        result.NutritionCompliancePercent.Should().Be(50m);
+        result.TrainingsPlanned.Should().BeGreaterThan(0); // at least 1 session
+        result.TrainingsCompleted.Should().Be(0);
+        result.TrainingCompliancePercent.Should().Be(0m);
+
+        // Combined: (2 * 50 + trainingsPlanned * 0) / (2 + trainingsPlanned)
+        // = 100 / (2 + trainingsPlanned)
+        var expectedCombined = Math.Round(
+            (2m * 50m + result.TrainingsPlanned * 0m) / (2m + result.TrainingsPlanned), 1);
+        result.CompliancePercent.Should().Be(expectedCombined);
+    }
+
+    [Fact]
+    public async Task CalculateComplianceAsync_TrainingPartialCompletion_ReturnsPartialPercent()
+    {
+        // Arrange — 1 session today with 2 exercises; only 1 completed → session not complete
+        var sessionId = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var ex2 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+
+        var trainingPlan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: sessionId,
+            exerciseIds: [ex1, ex2],
+            startDate: today.AddDays(-(int)today.DayOfWeek + 1));
+
+        // Only exercise1 completed — session is NOT considered complete (all exercises required)
+        var completion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: sessionId,
+            date: today,
+            completedExerciseIds: [ex1]); // only 1 of 2
+
+        var mongo = CreateMongo(trainingPlan: trainingPlan, completions: [completion]);
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var result = await sut.CalculateComplianceAsync(
+            _clientId, today, today, TestContext.Current.CancellationToken);
+
+        // Assert — partial completion does not count as a completed session
+        result.TrainingsCompleted.Should().Be(0);
+        result.TrainingCompliancePercent.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task CalculateStreakAsync_TrainingOnly_CountsStreakWhenSessionComplete()
+    {
+        // Arrange — yesterday has a completed session; today is not yet done
+        var sessionId = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+        var yesterday = today.AddDays(-1);
+        var weekStart = today.AddDays(-(int)today.DayOfWeek + 1);
+
+        var trainingPlan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: sessionId,
+            exerciseIds: [ex1],
+            startDate: weekStart);
+
+        // Yesterday's completion
+        var completion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: sessionId,
+            date: yesterday,
+            completedExerciseIds: [ex1]);
+
+        var mongo = CreateMongo(trainingPlan: trainingPlan, completions: [completion]);
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var streak = await sut.CalculateStreakAsync(_clientId, TestContext.Current.CancellationToken);
+
+        // Assert — yesterday counts (≥1 day streak), today is not broken (no sessions counted for today
+        // since not yet complete and today is skipped)
+        streak.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task CalculateStreakAsync_CombinedPlan_BreaksWhenTrainingMissed()
+    {
+        // Arrange — nutrition plan with meals logged yesterday, but training NOT completed
+        var sessionId = Guid.NewGuid();
+        var ex1 = Guid.NewGuid();
+        var today = DateTime.UtcNow.Date;
+        var yesterday = today.AddDays(-1);
+        var weekStart = today.AddDays(-(int)today.DayOfWeek + 1);
+
+        // Nutrition plan with a meal for yesterday
+        var nutritionPlan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            status: NutritionPlanStatus.Active);
+        nutritionPlan.StartDate = weekStart;
+        nutritionPlan.Weeks[0].Status = WeekStatus.Published;
+        // Use yesterday's DOW index
+        var yesterdayDow = (int)yesterday.DayOfWeek;
+        yesterdayDow = yesterdayDow == 0 ? 7 : yesterdayDow;
+        nutritionPlan.Weeks[0].Days[yesterdayDow - 1].Meals =
+            [PlanTestHelpers.CreateMeal(kind: MealKind.Breakfast)];
+
+        // Meal logged yesterday
+        var mealLogs = new List<MealLog>
+        {
+            new() { ClientId = _clientId, EatenAt = yesterday.AddHours(8), FoodsEaten = [] }
+        };
+
+        // Training plan with a session on yesterday's DOW — but NO completion record
+        var trainingPlan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: sessionId,
+            exerciseIds: [ex1],
+            startDate: weekStart);
+
+        var mongo = CreateMongo(
+            nutritionPlans: [nutritionPlan],
+            mealLogs: mealLogs,
+            trainingPlan: trainingPlan,
+            completions: []);
+
+        var sut = new ComplianceService(mongo);
+
+        // Act
+        var streak = await sut.CalculateStreakAsync(_clientId, TestContext.Current.CancellationToken);
+
+        // Assert — yesterday had nutrition logged but training missed → streak is 0
+        // (or 0 if today was the only day and is also incomplete)
+        streak.Should().Be(0);
     }
 }


### PR DESCRIPTION
## Summary
- Adds five new FastEndpoints slices under `ClientTraining/` for marking exercise / session / whole-day completion (and their `Mark*Incomplete` toggles so the mobile client can un-check)
- Introduces the `TrainingCompletion` MongoDB document (one doc per `(clientId, date, sessionId)`) with `Version`-based optimistic concurrency; registers compound indexes in `MongoIndexInitializer`
- Extends `ComplianceService`: adds `TrainingsPlanned` / `TrainingsCompleted` / `TrainingCompliancePercent` to `ComplianceResult`; combined compliance % is a weighted average over meals-planned + trainings-planned
- Streak rule: **lenient-OR** — a day counts when the client did any one of (logged ≥1 meal, completed ≥1 training session). Per product decision
- Re-enables `ComplianceServiceTests` in the CI skip list (6 new cases, plus the pre-existing ones now fixed)
- Leaves a `// TODO #6` stub in each mutation for the upcoming `trainingprogressupdated` SignalR broadcast

## Scope notes
- Per-set endpoints (`MarkSet*`) deferred to a follow-up issue — `TrainingCompletion.CompletedSets` is modeled but no routes exposed yet. Exercise-level granularity unblocks mobile #4 and is sufficient for compliance/streak math.
- SignalR push is **not** implemented here — that's issue #6.
- No changes outside `/backend`.

## Acceptance criteria (issue #5)
- [x] New vertical slices under `ClientTraining/…`, one endpoint per file
- [x] Every mutation respects optimistic concurrency via `Version` bump; stale version → 409
- [x] `ComplianceService` returns training compliance alongside nutrition compliance
- [x] Streak rule per product decision (lenient-OR across nutrition & training)
- [x] Tests cover valid completion, idempotent re-completion, stale-version 409, compliance %, streak carry-over
- [x] Swagger regenerates cleanly (backend builds with 0 warnings / 0 errors)
- [x] No changes outside `/backend`

Fixes #5

## Test plan
- [ ] `dotnet build` succeeds
- [ ] `dotnet test` passes `ClientTraining/Mark*` and `ComplianceServiceTests` suites (Testcontainers requires Docker)
- [ ] CI run: `backend.yml` no longer skips `*ComplianceServiceTests`; it executes and passes
- [ ] Manual smoke: POST a completion on a seeded client; GET the compliance score and confirm the combined percent reflects both plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)