### PR TITLE
feat(backend+web): trainingprogressupdated SignalR event + dashboard listener

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
@@ -4,9 +4,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
@@ -18,7 +20,15 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComple
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
+/// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="logger">Logger.</param>
+public class MarkExerciseCompleteEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    IComplianceService compliance,
+    ILogger<MarkExerciseCompleteEndpoint> logger)
     : Endpoint<MarkExerciseCompleteRequest, MarkExerciseCompleteResponse>
 {
     /// <inheritdoc />
@@ -134,7 +144,11 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
             existing.CompletedExerciseIds = newIds;
             existing.Version = newVersion;
 
-            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+            await TrainingProgressBroadcaster.BroadcastSessionAsync(
+                notifier, compliance, mongo, plan, clientId,
+                req.SessionId, DateOnly.FromDateTime(targetDate),
+                newIds.Count, session.Exercises.Count,
+                logger, ct);
 
             await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, session.Exercises.Count), ct);
         }
@@ -198,7 +212,11 @@ public class MarkExerciseCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
                 return;
             }
 
-            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+            await TrainingProgressBroadcaster.BroadcastSessionAsync(
+                notifier, compliance, mongo, plan, clientId,
+                req.SessionId, DateOnly.FromDateTime(targetDate),
+                completion.CompletedExerciseIds.Count, session.Exercises.Count,
+                logger, ct);
 
             await Send.OkAsync(BuildResponse(req.SessionId, targetDate, completion, session.Exercises.Count), ct);
         }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
@@ -4,9 +4,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
@@ -17,7 +19,15 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomp
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
+/// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="logger">Logger.</param>
+public class MarkExerciseIncompleteEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    IComplianceService compliance,
+    ILogger<MarkExerciseIncompleteEndpoint> logger)
     : Endpoint<MarkExerciseIncompleteRequest, MarkExerciseIncompleteResponse>
 {
     /// <inheritdoc />
@@ -138,7 +148,11 @@ public class MarkExerciseIncompleteEndpoint(IMongoContext mongo, IApplicationDbC
             return;
         }
 
-        // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+        await TrainingProgressBroadcaster.BroadcastSessionAsync(
+            notifier, compliance, mongo, plan, clientId,
+            req.SessionId, DateOnly.FromDateTime(targetDate),
+            newIds.Count, session.Exercises.Count,
+            logger, ct);
 
         await Send.OkAsync(new MarkExerciseIncompleteResponse
         {

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
@@ -4,9 +4,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
@@ -18,7 +20,15 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplet
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
+/// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="logger">Logger.</param>
+public class MarkSessionCompleteEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    IComplianceService compliance,
+    ILogger<MarkSessionCompleteEndpoint> logger)
     : Endpoint<MarkSessionCompleteRequest, MarkSessionCompleteResponse>
 {
     /// <inheritdoc />
@@ -127,7 +137,11 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
             existing.CompletedExerciseIds = allExerciseIds;
             existing.Version = newVersion;
 
-            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+            await TrainingProgressBroadcaster.BroadcastSessionAsync(
+                notifier, compliance, mongo, plan, clientId,
+                req.SessionId, DateOnly.FromDateTime(targetDate),
+                allExerciseIds.Count, allExerciseIds.Count,
+                logger, ct);
 
             await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);
         }
@@ -189,7 +203,11 @@ public class MarkSessionCompleteEndpoint(IMongoContext mongo, IApplicationDbCont
                 return;
             }
 
-            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+            await TrainingProgressBroadcaster.BroadcastSessionAsync(
+                notifier, compliance, mongo, plan, clientId,
+                req.SessionId, DateOnly.FromDateTime(targetDate),
+                allExerciseIds.Count, allExerciseIds.Count,
+                logger, ct);
 
             await Send.OkAsync(BuildResponse(req.SessionId, targetDate, completion, allExerciseIds.Count), ct);
         }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
@@ -4,9 +4,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
@@ -17,7 +19,15 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncompl
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
+/// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="logger">Logger.</param>
+public class MarkSessionIncompleteEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    IComplianceService compliance,
+    ILogger<MarkSessionIncompleteEndpoint> logger)
     : Endpoint<MarkSessionIncompleteRequest, MarkSessionIncompleteResponse>
 {
     /// <inheritdoc />
@@ -125,7 +135,11 @@ public class MarkSessionIncompleteEndpoint(IMongoContext mongo, IApplicationDbCo
             return;
         }
 
-        // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+        await TrainingProgressBroadcaster.BroadcastSessionAsync(
+            notifier, compliance, mongo, plan, clientId,
+            req.SessionId, DateOnly.FromDateTime(targetDate),
+            0, session.Exercises.Count,
+            logger, ct);
 
         await Send.OkAsync(new MarkSessionIncompleteResponse
         {

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
@@ -4,9 +4,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
@@ -19,7 +21,15 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComple
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class MarkWholeDayCompleteEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
+/// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="logger">Logger.</param>
+public class MarkWholeDayCompleteEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    IComplianceService compliance,
+    ILogger<MarkWholeDayCompleteEndpoint> logger)
     : Endpoint<MarkWholeDayCompleteRequest, MarkWholeDayCompleteResponse>
 {
     /// <inheritdoc />
@@ -174,8 +184,18 @@ public class MarkWholeDayCompleteEndpoint(IMongoContext mongo, IApplicationDbCon
                 TotalExerciseCount = allExerciseIds.Count,
                 Version = version
             });
+        }
 
-            // TODO #6: publish trainingprogressupdated to trainer via IRealtimeNotifier
+        // Broadcast once for all sessions updated in this request
+        if (summaries.Count > 0)
+        {
+            var aggregateCompleted = summaries.Sum(s => s.CompletedExerciseCount);
+            var aggregateTotal = summaries.Sum(s => s.TotalExerciseCount);
+
+            await TrainingProgressBroadcaster.BroadcastWholeDayAsync(
+                notifier, compliance, mongo, plan, clientId,
+                targetDateOnly, aggregateCompleted, aggregateTotal,
+                logger, ct);
         }
 
         await Send.OkAsync(new MarkWholeDayCompleteResponse

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressBroadcaster.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressBroadcaster.cs
@@ -1,0 +1,258 @@
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining;
+
+/// <summary>
+/// Shared helper that builds and broadcasts the <c>trainingprogressupdated</c>
+/// SignalR event to the trainer who owns the completing client.
+/// Called by all five Mark*Complete / Mark*Incomplete endpoints after a successful Mongo write.
+///
+/// Design notes:
+/// - The trainer's UserId is read from <see cref="TrainingPlan.TrainerId"/>, which is set when
+///   the plan is created and always equals the trainer's <c>ApplicationUser.Id</c>.
+/// - If no trainer is linked (TrainerId is empty) the broadcast is silently skipped.
+/// - Any exception from the notifier is caught and logged so the primary mutation always
+///   succeeds even if the SignalR channel is unavailable.
+/// </summary>
+internal static class TrainingProgressBroadcaster
+{
+    internal const string EventName = "trainingprogressupdated";
+
+    /// <summary>
+    /// Broadcasts <c>trainingprogressupdated</c> to the trainer after a single-session mutation.
+    /// </summary>
+    /// <param name="notifier">Realtime notifier.</param>
+    /// <param name="compliance">Compliance service for computing today's compliance and streak.</param>
+    /// <param name="mongo">Mongo context for counting today's session completions.</param>
+    /// <param name="plan">The client's active training plan.</param>
+    /// <param name="clientId">The client's public Guid (MongoDB clientId).</param>
+    /// <param name="sessionId">The session that was mutated.</param>
+    /// <param name="date">The date for which the mutation occurred.</param>
+    /// <param name="completedExerciseCount">Completed exercises in the session after mutation.</param>
+    /// <param name="totalExerciseCount">Total exercises in the session.</param>
+    /// <param name="logger">Logger for swallowing broadcast errors.</param>
+    /// <param name="ct">Cancellation token.</param>
+    internal static async Task BroadcastSessionAsync(
+        IRealtimeNotifier notifier,
+        IComplianceService compliance,
+        IMongoContext mongo,
+        TrainingPlan plan,
+        Guid clientId,
+        Guid sessionId,
+        DateOnly date,
+        int completedExerciseCount,
+        int totalExerciseCount,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var trainerId = plan.TrainerId;
+        if (trainerId == Guid.Empty)
+            return;
+
+        try
+        {
+            var (compliancePercent, streak, sessionsCompleted, sessionsPlanned) =
+                await ComputeMetricsAsync(compliance, mongo, plan, clientId, date, ct);
+
+            var payload = new TrainingProgressUpdatedEvent
+            {
+                ClientId = clientId,
+                SessionId = sessionId,
+                Date = date,
+                CompletedExerciseCount = completedExerciseCount,
+                TotalExerciseCount = totalExerciseCount,
+                SessionComplete = completedExerciseCount >= totalExerciseCount,
+                NewCompliancePercent = compliancePercent,
+                NewStreak = streak,
+                SessionsCompletedToday = sessionsCompleted,
+                SessionsPlannedToday = sessionsPlanned
+            };
+
+            await notifier.NotifyAsync(trainerId, EventName, payload, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to broadcast {Event} for client {ClientId} to trainer {TrainerId}. The mutation succeeded.",
+                EventName, clientId, trainerId);
+        }
+    }
+
+    /// <summary>
+    /// Broadcasts <c>trainingprogressupdated</c> to the trainer after a whole-day mutation
+    /// that may have touched multiple sessions.
+    /// </summary>
+    /// <param name="notifier">Realtime notifier.</param>
+    /// <param name="compliance">Compliance service for computing today's compliance and streak.</param>
+    /// <param name="mongo">Mongo context for counting today's session completions.</param>
+    /// <param name="plan">The client's active training plan.</param>
+    /// <param name="clientId">The client's public Guid (MongoDB clientId).</param>
+    /// <param name="date">The date for which the mutation occurred.</param>
+    /// <param name="aggregateCompletedExercises">Sum of completed exercises across all updated sessions.</param>
+    /// <param name="aggregateTotalExercises">Sum of total exercises across all updated sessions.</param>
+    /// <param name="logger">Logger for swallowing broadcast errors.</param>
+    /// <param name="ct">Cancellation token.</param>
+    internal static async Task BroadcastWholeDayAsync(
+        IRealtimeNotifier notifier,
+        IComplianceService compliance,
+        IMongoContext mongo,
+        TrainingPlan plan,
+        Guid clientId,
+        DateOnly date,
+        int aggregateCompletedExercises,
+        int aggregateTotalExercises,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var trainerId = plan.TrainerId;
+        if (trainerId == Guid.Empty)
+            return;
+
+        try
+        {
+            var (compliancePercent, streak, sessionsCompleted, sessionsPlanned) =
+                await ComputeMetricsAsync(compliance, mongo, plan, clientId, date, ct);
+
+            var payload = new TrainingProgressUpdatedEvent
+            {
+                ClientId = clientId,
+                SessionId = null,
+                Date = date,
+                CompletedExerciseCount = aggregateCompletedExercises,
+                TotalExerciseCount = aggregateTotalExercises,
+                SessionComplete = aggregateTotalExercises > 0 && aggregateCompletedExercises >= aggregateTotalExercises,
+                NewCompliancePercent = compliancePercent,
+                NewStreak = streak,
+                SessionsCompletedToday = sessionsCompleted,
+                SessionsPlannedToday = sessionsPlanned
+            };
+
+            await notifier.NotifyAsync(trainerId, EventName, payload, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to broadcast {Event} (whole-day) for client {ClientId} to trainer {TrainerId}. The mutation succeeded.",
+                EventName, clientId, trainerId);
+        }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Computes today's compliance, streak, and session counts in parallel.
+    /// </summary>
+    private static async Task<(decimal CompliancePercent, int Streak, int SessionsCompleted, int SessionsPlanned)>
+        ComputeMetricsAsync(
+            IComplianceService compliance,
+            IMongoContext mongo,
+            TrainingPlan plan,
+            Guid clientId,
+            DateOnly date,
+            CancellationToken ct)
+    {
+        var todayStart = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var todayEnd = todayStart.AddDays(1);
+
+        // Run compliance + streak concurrently
+        var complianceTask = compliance.CalculateComplianceAsync(clientId, todayStart, todayStart, ct);
+        var streakTask = compliance.CalculateStreakAsync(clientId, ct);
+
+        await Task.WhenAll(complianceTask, streakTask);
+
+        var complianceResult = await complianceTask;
+        var streak = await streakTask;
+
+        // Count sessions planned and completed today from the plan
+        var sessionsPlanned = GetPlannedSessionsForDate(plan, date);
+        var sessionsCompleted = await CountCompletedSessionsAsync(mongo, clientId, plan, date, sessionsPlanned, ct);
+
+        return (complianceResult.CompliancePercent, streak, sessionsCompleted, sessionsPlanned.Count);
+    }
+
+    /// <summary>
+    /// Returns the sessions scheduled for a specific date based on the plan's published weeks.
+    /// Delegates to the same logic used in the MarkWholeDayCompleteEndpoint.
+    /// </summary>
+    private static IReadOnlyList<TrainingSession> GetPlannedSessionsForDate(TrainingPlan plan, DateOnly date)
+    {
+        if (!plan.StartDate.HasValue || plan.Weeks.Count == 0)
+            return [];
+
+        var publishedWeeks = plan.Weeks
+            .Where(w => w.Status == WeekStatus.Published)
+            .OrderBy(w => w.WeekNumber)
+            .ToList();
+
+        if (publishedWeeks.Count == 0)
+            return [];
+
+        var resolved = PlanWeekCalculator.ResolveCurrentWeekNumber(
+            plan.StartDate,
+            publishedWeeks.Select(w => w.WeekNumber).ToList(),
+            plan.Weeks.Count,
+            publishedWeeks.First().DatePublished,
+            plan.DateCreated,
+            date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+
+        if (resolved is null)
+            return [];
+
+        var week = plan.Weeks.FirstOrDefault(w => w.WeekNumber == resolved.Value);
+        if (week is null || week.Status != WeekStatus.Published)
+            week = publishedWeeks.Last();
+
+        var dow = (int)date.DayOfWeek;
+        dow = dow == 0 ? 7 : dow;
+
+        return week.Sessions.Where(s => s.DayOfWeek == dow).OrderBy(s => s.Order).ToList();
+    }
+
+    /// <summary>
+    /// Counts how many of today's planned sessions are fully complete.
+    /// A session is "complete" when its completion document contains all exercise IDs.
+    /// </summary>
+    private static async Task<int> CountCompletedSessionsAsync(
+        IMongoContext mongo,
+        Guid clientId,
+        TrainingPlan plan,
+        DateOnly date,
+        IReadOnlyList<TrainingSession> plannedSessions,
+        CancellationToken ct)
+    {
+        if (plannedSessions.Count == 0)
+            return 0;
+
+        var targetDate = date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var sessionIds = plannedSessions.Select(s => s.SessionId).ToList();
+
+        var filter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                     & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
+                     & Builders<TrainingCompletion>.Filter.In(c => c.SessionId, sessionIds);
+
+        using var cursor = await mongo.TrainingCompletions.FindAsync(filter, cancellationToken: ct);
+        var completions = await cursor.ToListAsync(ct);
+
+        var completionMap = completions.ToDictionary(c => c.SessionId, c => c.CompletedExerciseIds);
+
+        var count = 0;
+        foreach (var session in plannedSessions)
+        {
+            if (session.Exercises.Count == 0)
+                continue;
+
+            if (completionMap.TryGetValue(session.SessionId, out var completedIds))
+            {
+                if (session.Exercises.All(e => completedIds.Contains(e.ExerciseExternalId)))
+                    count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressUpdatedEvent.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressUpdatedEvent.cs
@@ -1,0 +1,63 @@
+namespace FitnessPlatform.Application.Features.ClientTraining;
+
+/// <summary>
+/// Payload for the <c>trainingprogressupdated</c> SignalR event broadcast to the client's trainer
+/// whenever the client marks an exercise or session complete or incomplete.
+/// </summary>
+public class TrainingProgressUpdatedEvent
+{
+    /// <summary>
+    /// The client's public identifier (MongoDB clientId / ApplicationUser.Id).
+    /// </summary>
+    public Guid ClientId { get; set; }
+
+    /// <summary>
+    /// The session that was mutated.
+    /// Null for <c>MarkWholeDayComplete</c> where multiple sessions may have been updated.
+    /// </summary>
+    public Guid? SessionId { get; set; }
+
+    /// <summary>
+    /// The calendar date for which the completion was recorded.
+    /// </summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// How many exercises in the session are now marked complete.
+    /// For multi-session operations (MarkWholeDayComplete) this reflects the
+    /// aggregate count across all sessions updated in the request.
+    /// </summary>
+    public int CompletedExerciseCount { get; set; }
+
+    /// <summary>
+    /// Total number of exercises in the session (from the plan).
+    /// For multi-session operations this reflects the aggregate total.
+    /// </summary>
+    public int TotalExerciseCount { get; set; }
+
+    /// <summary>
+    /// Whether every exercise in the session is now complete.
+    /// For multi-session operations this is true only when all sessions are fully complete.
+    /// </summary>
+    public bool SessionComplete { get; set; }
+
+    /// <summary>
+    /// Combined compliance percentage for the client today (training + nutrition weighted).
+    /// </summary>
+    public decimal NewCompliancePercent { get; set; }
+
+    /// <summary>
+    /// Current consecutive-day streak for the client.
+    /// </summary>
+    public int NewStreak { get; set; }
+
+    /// <summary>
+    /// Number of training sessions the client has fully completed today.
+    /// </summary>
+    public int SessionsCompletedToday { get; set; }
+
+    /// <summary>
+    /// Number of training sessions planned for the client today.
+    /// </summary>
+    public int SessionsPlannedToday { get; set; }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteBroadcastTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteBroadcastTests.cs
@@ -1,0 +1,311 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining;
+using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests that verify the <c>trainingprogressupdated</c> SignalR broadcast
+/// behaviour of <see cref="MarkExerciseCompleteEndpoint"/>.
+/// One solid suite on this endpoint is sufficient; the broadcaster helper
+/// is shared by all five Mark* endpoints.
+/// </summary>
+public class MarkExerciseCompleteBroadcastTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _exercise1 = Guid.NewGuid();
+    private readonly Guid _exercise2 = Guid.NewGuid();
+
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ILogger<MarkExerciseCompleteEndpoint> _logger =
+        Substitute.For<ILogger<MarkExerciseCompleteEndpoint>>();
+
+    private IApplicationDbContext CreateMockDb(Guid clientUserId, Guid clientPublicId) =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = clientUserId, PublicId = clientPublicId })
+            .Build();
+
+    private TrainingPlan CreateActivePlan(Guid? trainerId = null) =>
+        TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2],
+            trainerId: trainerId ?? _trainerId);
+
+    // ── Broadcast is sent once on a successful new completion ────────────
+
+    [Fact]
+    public async Task HandleAsync_NewCompletion_BroadcastsExactlyOnce()
+    {
+        var plan = CreateActivePlan();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Exactly one notification to the trainer's user id
+        await _notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "trainingprogressupdated",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Broadcast payload has correct clientId and SessionId ─────────────
+
+    [Fact]
+    public async Task HandleAsync_NewCompletion_PayloadHasCorrectClientIdAndSessionId()
+    {
+        var plan = CreateActivePlan();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        await _notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "trainingprogressupdated",
+            Arg.Is<TrainingProgressUpdatedEvent>(p =>
+                p.ClientId == _clientId &&
+                p.SessionId == _sessionId),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── SessionComplete flag is set when all exercises are done ──────────
+
+    [Fact]
+    public async Task HandleAsync_AllExercisesCompleted_PayloadSessionCompleteIsTrue()
+    {
+        // One exercise in the session; marking it complete makes the session complete.
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1],
+            trainerId: _trainerId);
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        await _notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "trainingprogressupdated",
+            Arg.Is<TrainingProgressUpdatedEvent>(p => p.SessionComplete),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Notification is sent to the trainer, not the client ──────────────
+
+    [Fact]
+    public async Task HandleAsync_NewCompletion_NotifiesTrainerNotClient()
+    {
+        var plan = CreateActivePlan();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        // Must be sent to trainer, not the client
+        await _notifier.DidNotReceive().NotifyAsync(
+            _clientId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+
+        await _notifier.Received(1).NotifyAsync(
+            _trainerId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Idempotent path (already complete) → no broadcast ────────────────
+
+    [Fact]
+    public async Task HandleAsync_AlreadyComplete_NoBroadcast()
+    {
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [_exercise1],
+            version: 1);
+
+        var plan = CreateActivePlan();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(
+            plan: plan,
+            existingCompletion: existingCompletion);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        // exercise1 is already complete — idempotent no-op
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No broadcast on the idempotent path
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── No broadcast when client has no trainer (TrainerId = Guid.Empty) ─
+
+    [Fact]
+    public async Task HandleAsync_ClientHasNoTrainer_NoBroadcast()
+    {
+        var plan = TrainingCompletionTestHelpers.CreateActivePlan(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            exerciseIds: [_exercise1, _exercise2],
+            trainerId: Guid.Empty); // no trainer linked
+
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Version-conflict 409 → no broadcast ──────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_VersionConflict409_NoBroadcast()
+    {
+        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
+            clientId: _clientId,
+            sessionId: _sessionId,
+            date: DateTime.UtcNow.Date,
+            completedExerciseIds: [],
+            version: 2); // server is at version 2
+
+        var plan = CreateActivePlan();
+
+        var mongo = Substitute.For<FitnessPlatform.Application.Infrastructure.Data.MongoDb.IMongoContext>();
+        var planColl = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan).Mongo.TrainingPlans;
+        mongo.TrainingPlans.Returns(planColl);
+
+        // UpdateOneAsync returns ModifiedCount=0 → version conflict
+        var completionCollection = TrainingCompletionTestHelpers.CreateMockCompletionCollection(
+            [existingCompletion], updateSucceeds: false);
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        await ep.HandleAsync(
+            new MarkExerciseCompleteRequest
+            {
+                SessionId = _sessionId,
+                ExerciseExternalId = _exercise1,
+                Version = 2
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+
+        // No broadcast on error paths
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Broadcast failure does NOT fail the mutation (log-and-continue) ──
+
+    [Fact]
+    public async Task HandleAsync_BroadcastThrows_MutationStillSucceeds()
+    {
+        _notifier
+            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("SignalR hub unavailable")));
+
+        var plan = CreateActivePlan();
+        var (mongo, _) = TrainingCompletionTestHelpers.CreateMockMongo(plan: plan);
+        var db = CreateMockDb(_clientId, _clientId);
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _compliance, _logger);
+
+        // Should NOT throw; the broadcast exception is swallowed
+        var act = async () => await ep.HandleAsync(
+            new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
+            TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteEndpointTests.cs
@@ -5,9 +5,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -22,6 +24,9 @@ public class MarkExerciseCompleteEndpointTests
     private readonly Guid _sessionId = Guid.NewGuid();
     private readonly Guid _exercise1 = Guid.NewGuid();
     private readonly Guid _exercise2 = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
+    private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ILogger<MarkExerciseCompleteEndpoint> _logger = Substitute.For<ILogger<MarkExerciseCompleteEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -47,7 +52,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
@@ -88,7 +93,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         // Mark exercise1 complete again (already complete — idempotent)
         await ep.HandleAsync(
@@ -126,7 +131,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
@@ -165,7 +170,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         // Client sends version 2 which matches, but UpdateOneAsync returns ModifiedCount=0 (race)
         await ep.HandleAsync(
@@ -203,7 +208,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         // Client sends version 1 but server is at version 3
         await ep.HandleAsync(
@@ -232,7 +237,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = Guid.NewGuid(), ExerciseExternalId = _exercise1 },
@@ -249,7 +254,7 @@ public class MarkExerciseCompleteEndpointTests
 
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseIncompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseIncompleteEndpointTests.cs
@@ -5,9 +5,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseIncomplete;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -22,6 +24,9 @@ public class MarkExerciseIncompleteEndpointTests
     private readonly Guid _sessionId = Guid.NewGuid();
     private readonly Guid _exercise1 = Guid.NewGuid();
     private readonly Guid _exercise2 = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
+    private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ILogger<MarkExerciseIncompleteEndpoint> _logger = Substitute.For<ILogger<MarkExerciseIncompleteEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -52,7 +57,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
@@ -92,7 +97,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
@@ -136,7 +141,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest
@@ -179,7 +184,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest
@@ -207,7 +212,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },
@@ -231,7 +236,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest { SessionId = Guid.NewGuid(), ExerciseExternalId = _exercise1 },
@@ -254,7 +259,7 @@ public class MarkExerciseIncompleteEndpointTests
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         // _exercise2 is NOT in the plan's session exercises
         await ep.HandleAsync(
@@ -272,7 +277,7 @@ public class MarkExerciseIncompleteEndpointTests
 
         var ep = Factory.Create<MarkExerciseIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseIncompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1 },

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionCompleteEndpointTests.cs
@@ -5,9 +5,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -22,6 +24,9 @@ public class MarkSessionCompleteEndpointTests
     private readonly Guid _sessionId = Guid.NewGuid();
     private readonly Guid _exercise1 = Guid.NewGuid();
     private readonly Guid _exercise2 = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
+    private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ILogger<MarkSessionCompleteEndpoint> _logger = Substitute.For<ILogger<MarkSessionCompleteEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -42,7 +47,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -86,7 +91,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -128,7 +133,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -158,7 +163,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = Guid.NewGuid() },
@@ -175,7 +180,7 @@ public class MarkSessionCompleteEndpointTests
 
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionIncompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionIncompleteEndpointTests.cs
@@ -5,9 +5,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkSessionIncomplete;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -22,6 +24,9 @@ public class MarkSessionIncompleteEndpointTests
     private readonly Guid _sessionId = Guid.NewGuid();
     private readonly Guid _exercise1 = Guid.NewGuid();
     private readonly Guid _exercise2 = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
+    private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ILogger<MarkSessionIncompleteEndpoint> _logger = Substitute.For<ILogger<MarkSessionIncompleteEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -52,7 +57,7 @@ public class MarkSessionIncompleteEndpointTests
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest { SessionId = _sessionId },
@@ -83,7 +88,7 @@ public class MarkSessionIncompleteEndpointTests
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest { SessionId = _sessionId },
@@ -127,7 +132,7 @@ public class MarkSessionIncompleteEndpointTests
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest
@@ -169,7 +174,7 @@ public class MarkSessionIncompleteEndpointTests
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest
@@ -196,7 +201,7 @@ public class MarkSessionIncompleteEndpointTests
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest { SessionId = _sessionId },
@@ -220,7 +225,7 @@ public class MarkSessionIncompleteEndpointTests
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest { SessionId = Guid.NewGuid() },
@@ -237,7 +242,7 @@ public class MarkSessionIncompleteEndpointTests
 
         var ep = Factory.Create<MarkSessionIncompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkSessionIncompleteRequest { SessionId = _sessionId },

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
@@ -5,9 +5,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -23,6 +25,9 @@ public class MarkWholeDayCompleteEndpointTests
     private readonly Guid _session2 = Guid.NewGuid();
     private readonly Guid _exercise1 = Guid.NewGuid();
     private readonly Guid _exercise2 = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
+    private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ILogger<MarkWholeDayCompleteEndpoint> _logger = Substitute.For<ILogger<MarkWholeDayCompleteEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -107,7 +112,7 @@ public class MarkWholeDayCompleteEndpointTests
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest { Date = DateOnly.FromDateTime(DateTime.UtcNow) },
@@ -151,7 +156,7 @@ public class MarkWholeDayCompleteEndpointTests
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest { Date = DateOnly.FromDateTime(today) },
@@ -175,7 +180,7 @@ public class MarkWholeDayCompleteEndpointTests
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest(),
@@ -192,7 +197,7 @@ public class MarkWholeDayCompleteEndpointTests
 
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db);
+            mongo, db, _notifier, _compliance, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest(),

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingCompletionTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingCompletionTestHelpers.cs
@@ -1,5 +1,6 @@
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using MongoDB.Driver;
 using NSubstitute;
@@ -19,7 +20,8 @@ public static class TrainingCompletionTestHelpers
         Guid clientId,
         Guid? sessionId = null,
         IReadOnlyList<Guid>? exerciseIds = null,
-        DateTime? startDate = null)
+        DateTime? startDate = null,
+        Guid? trainerId = null)
     {
         var sid = sessionId ?? Guid.NewGuid();
         var exIds = exerciseIds ?? [Guid.NewGuid(), Guid.NewGuid()];
@@ -29,7 +31,7 @@ public static class TrainingCompletionTestHelpers
         {
             ExternalId = Guid.NewGuid(),
             ClientId = clientId,
-            TrainerId = Guid.NewGuid(),
+            TrainerId = trainerId ?? Guid.NewGuid(),
             Name = "Test Plan",
             Status = TrainingPlanStatus.Active,
             StartDate = start,
@@ -167,6 +169,29 @@ public static class TrainingCompletionTestHelpers
             return plans.Count > 0;
         });
         return cursor;
+    }
+
+    /// <summary>
+    /// Creates a no-op <see cref="IRealtimeNotifier"/> substitute for tests that don't care about broadcasts.
+    /// </summary>
+    public static IRealtimeNotifier CreateStubNotifier()
+    {
+        return Substitute.For<IRealtimeNotifier>();
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IComplianceService"/> substitute that returns neutral defaults
+    /// (0% compliance, 0 streak) for tests that don't care about broadcast payload values.
+    /// </summary>
+    public static IComplianceService CreateStubComplianceService()
+    {
+        var svc = Substitute.For<IComplianceService>();
+        svc.CalculateComplianceAsync(
+                Arg.Any<Guid>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new ComplianceResult { CompliancePercent = 0m });
+        svc.CalculateStreakAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+        return svc;
     }
 
     private static IAsyncCursor<TrainingCompletion> CreateCompletionCursor(List<TrainingCompletion> completions)

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -6046,6 +6046,385 @@ export class ApiClient {
     }
 
     /**
+     * Mark all training sessions for a day complete
+     * @return Success
+     */
+    markWholeDayCompleteEndpoint(markWholeDayCompleteRequest: MarkWholeDayCompleteRequest, signal?: AbortSignal): Promise<MarkWholeDayCompleteResponse> {
+        let url_ = this.baseUrl + "/client/training/day/complete";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(markWholeDayCompleteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMarkWholeDayCompleteEndpoint(_response);
+        });
+    }
+
+    protected processMarkWholeDayCompleteEndpoint(response: AxiosResponse): Promise<MarkWholeDayCompleteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<MarkWholeDayCompleteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MarkWholeDayCompleteResponse>(null as any);
+    }
+
+    /**
+     * Un-mark a training session as complete
+     * @param sessionId The session ID (from the training plan). Bound from the route.
+     * @return Success
+     */
+    markSessionIncompleteEndpoint(sessionId: string, markSessionIncompleteRequest: MarkSessionIncompleteRequest, signal?: AbortSignal): Promise<MarkSessionIncompleteResponse> {
+        let url_ = this.baseUrl + "/client/training/sessions/{sessionId}/complete";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(markSessionIncompleteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "DELETE",
+            url: url_,
+            headers: {
+                "Content-Type": "*/*",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMarkSessionIncompleteEndpoint(_response);
+        });
+    }
+
+    protected processMarkSessionIncompleteEndpoint(response: AxiosResponse): Promise<MarkSessionIncompleteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<MarkSessionIncompleteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MarkSessionIncompleteResponse>(null as any);
+    }
+
+    /**
+     * Mark a training session complete
+     * @param sessionId The session ID (from the training plan). Bound from the route.
+     * @return Success
+     */
+    markSessionCompleteEndpoint(sessionId: string, markSessionCompleteRequest: MarkSessionCompleteRequest, signal?: AbortSignal): Promise<MarkSessionCompleteResponse> {
+        let url_ = this.baseUrl + "/client/training/sessions/{sessionId}/complete";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(markSessionCompleteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMarkSessionCompleteEndpoint(_response);
+        });
+    }
+
+    protected processMarkSessionCompleteEndpoint(response: AxiosResponse): Promise<MarkSessionCompleteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<MarkSessionCompleteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MarkSessionCompleteResponse>(null as any);
+    }
+
+    /**
+     * Un-mark an exercise as complete
+     * @param sessionId The session ID (from the training plan). Bound from the route.
+     * @param exerciseExternalId The exercise external ID within the session. Bound from the route.
+     * @return Success
+     */
+    markExerciseIncompleteEndpoint(sessionId: string, exerciseExternalId: string, markExerciseIncompleteRequest: MarkExerciseIncompleteRequest, signal?: AbortSignal): Promise<MarkExerciseIncompleteResponse> {
+        let url_ = this.baseUrl + "/client/training/sessions/{sessionId}/exercises/{exerciseExternalId}/complete";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        if (exerciseExternalId === undefined || exerciseExternalId === null)
+            throw new globalThis.Error("The parameter 'exerciseExternalId' must be defined.");
+        url_ = url_.replace("{exerciseExternalId}", encodeURIComponent("" + exerciseExternalId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(markExerciseIncompleteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "DELETE",
+            url: url_,
+            headers: {
+                "Content-Type": "*/*",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMarkExerciseIncompleteEndpoint(_response);
+        });
+    }
+
+    protected processMarkExerciseIncompleteEndpoint(response: AxiosResponse): Promise<MarkExerciseIncompleteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<MarkExerciseIncompleteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MarkExerciseIncompleteResponse>(null as any);
+    }
+
+    /**
+     * Mark an exercise complete
+     * @param sessionId The session ID (from the training plan). Bound from the route.
+     * @param exerciseExternalId The exercise external ID within the session. Bound from the route.
+     * @return Success
+     */
+    markExerciseCompleteEndpoint(sessionId: string, exerciseExternalId: string, markExerciseCompleteRequest: MarkExerciseCompleteRequest, signal?: AbortSignal): Promise<MarkExerciseCompleteResponse> {
+        let url_ = this.baseUrl + "/client/training/sessions/{sessionId}/exercises/{exerciseExternalId}/complete";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        if (exerciseExternalId === undefined || exerciseExternalId === null)
+            throw new globalThis.Error("The parameter 'exerciseExternalId' must be defined.");
+        url_ = url_.replace("{exerciseExternalId}", encodeURIComponent("" + exerciseExternalId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(markExerciseCompleteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMarkExerciseCompleteEndpoint(_response);
+        });
+    }
+
+    protected processMarkExerciseCompleteEndpoint(response: AxiosResponse): Promise<MarkExerciseCompleteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<MarkExerciseCompleteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MarkExerciseCompleteResponse>(null as any);
+    }
+
+    /**
      * Get today's training session
      * @return Success
      */
@@ -9698,9 +10077,9 @@ export interface UpdateRecipeRequest {
     note?: string | undefined;
     /** Updated list of food items in the recipe. */
     foods: RecipeFoodDto[];
-    /** Updated visibility. Defaults to Public when omitted.
+    /** Updated visibility. When omitted, the recipe's existing visibility is preserved.
 Only the recipe's creator can change this value. */
-    visibility?: RecipeVisibility;
+    visibility?: RecipeVisibility | undefined;
 }
 
 /** Input DTO representing a food item to include in a recipe. */
@@ -10522,9 +10901,9 @@ export interface UpdateFoodRequest {
     nutrientValue?: NutrientValueDto;
     /** Updated food category. */
     category?: FoodCategory;
-    /** Updated visibility. Defaults to Public when omitted.
+    /** Updated visibility. When omitted, the food's existing visibility is preserved.
 Only the food's creator can change this value. */
-    visibility?: FoodVisibility;
+    visibility?: FoodVisibility | undefined;
     /** Updated user note. */
     note?: string | undefined;
     /** Updated allergen identifiers. */
@@ -10807,6 +11186,131 @@ export interface CreateExerciseRequest {
     difficulty?: ExerciseDifficulty;
     /** Technique notes in Markdown format. */
     techniqueNotes?: string | undefined;
+}
+
+/** Response for marking all training sessions on a day complete. */
+export interface MarkWholeDayCompleteResponse {
+    /** The date that was marked complete. */
+    date?: string;
+    /** Summary of each session that was processed. */
+    sessions?: SessionCompletionSummary[];
+}
+
+/** Per-session completion summary returned by MarkWholeDayCompleteResponse. */
+export interface SessionCompletionSummary {
+    /** The session ID. */
+    sessionId?: string;
+    /** Number of exercises marked complete in this session. */
+    completedExerciseCount?: number;
+    /** Total exercises in the session. */
+    totalExerciseCount?: number;
+    /** Current document version for subsequent writes. */
+    version?: number;
+}
+
+/** Request model for marking all training sessions on a given day complete. */
+export interface MarkWholeDayCompleteRequest {
+    /** The date to mark complete (UTC date only).
+Defaults to today UTC when not provided. */
+    date?: string | undefined;
+}
+
+/** Response for un-marking a training session as complete. */
+export interface MarkSessionIncompleteResponse {
+    /** The session ID that was updated. */
+    sessionId?: string;
+    /** The date for which the completion was removed. */
+    date?: string;
+    /** How many exercises in this session are still marked complete. */
+    completedExerciseCount?: number;
+    /** Total exercises in the session. */
+    totalExerciseCount?: number;
+    /** Current document version. */
+    version?: number;
+}
+
+/** Request model for un-marking an entire session as complete. */
+export interface MarkSessionIncompleteRequest {
+    /** The date for which the completion should be removed (UTC date only).
+Defaults to today UTC when not provided. */
+    completedOn?: string | undefined;
+    /** Client-supplied version for optimistic concurrency. */
+    version?: number | undefined;
+}
+
+/** Response for marking a whole session complete. */
+export interface MarkSessionCompleteResponse {
+    /** The session ID that was marked complete. */
+    sessionId?: string;
+    /** The date for which the session was marked complete. */
+    date?: string;
+    /** Number of exercises now marked complete. */
+    completedExerciseCount?: number;
+    /** Total exercises in the session. */
+    totalExerciseCount?: number;
+    /** Current document version. */
+    version?: number;
+}
+
+/** Request model for marking an entire session complete (fans out to all exercises). */
+export interface MarkSessionCompleteRequest {
+    /** The date on which the session was completed (UTC date only).
+Defaults to today UTC when not provided. */
+    completedOn?: string | undefined;
+    /** Client-supplied version for optimistic concurrency when updating an existing completion document. */
+    version?: number | undefined;
+}
+
+/** Response for un-marking an exercise as complete. */
+export interface MarkExerciseIncompleteResponse {
+    /** The session ID that was updated. */
+    sessionId?: string;
+    /** The date for which the completion was removed. */
+    date?: string;
+    /** How many exercises in this session are still marked complete. */
+    completedExerciseCount?: number;
+    /** Total number of exercises in this session (from the plan). */
+    totalExerciseCount?: number;
+    /** Whether every exercise in this session is still complete. */
+    sessionComplete?: boolean;
+    /** Current version of the underlying completion document. */
+    version?: number;
+}
+
+/** Request model for un-marking a single exercise as complete. */
+export interface MarkExerciseIncompleteRequest {
+    /** The date for which the completion should be removed (UTC date only).
+Defaults to today UTC when not provided. */
+    completedOn?: string | undefined;
+    /** Client-supplied version of the completion document for optimistic concurrency. */
+    version?: number | undefined;
+}
+
+/** Response for marking an exercise complete. Returns a lightweight progress summary so the mobile client can update session progress indicators without an extra round-trip. */
+export interface MarkExerciseCompleteResponse {
+    /** The session ID that was updated. */
+    sessionId?: string;
+    /** The date for which the completion was recorded. */
+    date?: string;
+    /** How many exercises in this session are now marked complete. */
+    completedExerciseCount?: number;
+    /** Total number of exercises in this session (from the plan). */
+    totalExerciseCount?: number;
+    /** Whether every exercise in this session is now complete. */
+    sessionComplete?: boolean;
+    /** Current version of the underlying completion document (for subsequent writes). */
+    version?: number;
+}
+
+/** Request model for marking a single exercise complete within a session. */
+export interface MarkExerciseCompleteRequest {
+    /** The date on which the exercise was completed (UTC date only).
+Defaults to today UTC when not provided. */
+    completedOn?: string | undefined;
+    /** Client-supplied version of the existing completion document, used for optimistic
+concurrency. Required when a completion document already exists for this
+(clientId, date, sessionId) tuple; ignored for new documents. */
+    version?: number | undefined;
 }
 
 /** Response with today's planned training session. */

--- a/web/src/api/trainingProgressEvent.ts
+++ b/web/src/api/trainingProgressEvent.ts
@@ -55,3 +55,28 @@ export interface TrainingProgressUpdatedEvent {
   /** Number of training sessions planned for the client today. */
   sessionsPlannedToday: number;
 }
+
+/**
+ * Runtime type guard for `TrainingProgressUpdatedEvent`.
+ *
+ * Use this whenever consuming the raw SignalR payload to catch backend shape
+ * drift early and avoid silent `undefined` access.
+ */
+export function isTrainingProgressUpdatedEvent(
+  payload: unknown,
+): payload is TrainingProgressUpdatedEvent {
+  if (typeof payload !== 'object' || payload === null) return false;
+  const p = payload as Partial<Record<keyof TrainingProgressUpdatedEvent, unknown>>;
+  return (
+    typeof p.clientId === 'string' &&
+    (p.sessionId === null || typeof p.sessionId === 'string') &&
+    typeof p.date === 'string' &&
+    typeof p.completedExerciseCount === 'number' &&
+    typeof p.totalExerciseCount === 'number' &&
+    typeof p.sessionComplete === 'boolean' &&
+    typeof p.newCompliancePercent === 'number' &&
+    typeof p.newStreak === 'number' &&
+    typeof p.sessionsCompletedToday === 'number' &&
+    typeof p.sessionsPlannedToday === 'number'
+  );
+}

--- a/web/src/api/trainingProgressEvent.ts
+++ b/web/src/api/trainingProgressEvent.ts
@@ -1,0 +1,57 @@
+/**
+ * Hand-written TypeScript mirror of the C# TrainingProgressUpdatedEvent DTO.
+ *
+ * This event is broadcast over SignalR only (no REST endpoint), so it will not
+ * appear in generated.ts.  Do NOT move these types into generated.ts — it is
+ * auto-generated and write-locked.
+ *
+ * Source of truth:
+ *   backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressUpdatedEvent.cs
+ *
+ * SignalR event name: "trainingprogressupdated"  (hub convention: lowercase)
+ */
+
+export interface TrainingProgressUpdatedEvent {
+  /** The client's public identifier (MongoDB clientId / ApplicationUser.Id as a string). */
+  clientId: string;
+
+  /**
+   * The session that was mutated.
+   * null for MarkWholeDayComplete where multiple sessions may have been updated.
+   */
+  sessionId: string | null;
+
+  /** The calendar date for which the completion was recorded (ISO date YYYY-MM-DD). */
+  date: string;
+
+  /**
+   * How many exercises in the session are now marked complete.
+   * For multi-session operations (MarkWholeDayComplete) this reflects the
+   * aggregate count across all sessions updated in the request.
+   */
+  completedExerciseCount: number;
+
+  /**
+   * Total number of exercises in the session (from the plan).
+   * For multi-session operations this reflects the aggregate total.
+   */
+  totalExerciseCount: number;
+
+  /**
+   * Whether every exercise in the session is now complete.
+   * For multi-session operations this is true only when all sessions are fully complete.
+   */
+  sessionComplete: boolean;
+
+  /** Combined compliance percentage for the client today (training + nutrition weighted). */
+  newCompliancePercent: number;
+
+  /** Current consecutive-day streak for the client. */
+  newStreak: number;
+
+  /** Number of training sessions the client has fully completed today. */
+  sessionsCompletedToday: number;
+
+  /** Number of training sessions planned for the client today. */
+  sessionsPlannedToday: number;
+}

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Sidebar } from './Sidebar';
 import { useSignalR } from '@/hooks/useSignalR';
 import { useToastStore } from '@/stores/toast';
-import type { TrainingProgressUpdatedEvent } from '@/api/trainingProgressEvent';
+import { isTrainingProgressUpdatedEvent } from '@/api/trainingProgressEvent';
 
 const DARK_MODE_KEY = 'gf-dark-mode';
 
@@ -136,9 +136,16 @@ export function AppShell() {
       if (import.meta.env.DEV) {
         console.debug('trainingprogressupdated', payload);
       }
-      const data = payload as TrainingProgressUpdatedEvent | undefined;
-      const clientId = data?.clientId;
+      if (!isTrainingProgressUpdatedEvent(payload)) {
+        if (import.meta.env.DEV) {
+          console.warn('trainingprogressupdated: invalid payload shape', payload);
+        }
+        return;
+      }
+      const clientId = payload.clientId;
 
+      // `sessionId` may be null (whole-day broadcast aggregates across sessions);
+      // handler is intentionally sessionId-agnostic — we invalidate the same keys either way.
       // Refresh the main dashboard table — drives avg compliance pill,
       // low-compliance alert count, per-client compliance/streak cells,
       // and the low-compliance callouts.  All of these are derived from

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Sidebar } from './Sidebar';
 import { useSignalR } from '@/hooks/useSignalR';
 import { useToastStore } from '@/stores/toast';
+import type { TrainingProgressUpdatedEvent } from '@/api/trainingProgressEvent';
 
 const DARK_MODE_KEY = 'gf-dark-mode';
 
@@ -128,6 +129,28 @@ export function AppShell() {
       queryClient.invalidateQueries({ queryKey: ['client-timeline', clientId] });
       // Main dashboard table — refresh calories, compliance, streak.
       queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
+    },
+    trainingprogressupdated: (payload: unknown) => {
+      // The backend broadcasts this event only to the trainer who owns the client
+      // (per-user SignalR group), so no client-id filtering is needed here.
+      if (import.meta.env.DEV) {
+        console.debug('trainingprogressupdated', payload);
+      }
+      const data = payload as TrainingProgressUpdatedEvent | undefined;
+      const clientId = data?.clientId;
+
+      // Refresh the main dashboard table — drives avg compliance pill,
+      // low-compliance alert count, per-client compliance/streak cells,
+      // and the low-compliance callouts.  All of these are derived from
+      // the single ['dashboard-summary'] query (DashboardPage.tsx line 87-91).
+      queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
+
+      // If the trainer has the per-client detail page open, refresh its
+      // stats panel and activity timeline as well.
+      if (clientId) {
+        queryClient.invalidateQueries({ queryKey: ['client-dashboard', clientId] });
+        queryClient.invalidateQueries({ queryKey: ['client-timeline', clientId] });
+      }
     },
     typing: (payload: unknown) => {
       const data = payload as { conversationId?: string; senderId?: string } | undefined;


### PR DESCRIPTION
## Summary
- **Backend**: new `TrainingProgressUpdatedEvent` DTO + `TrainingProgressBroadcaster` helper; all five `ClientTraining/Mark*` endpoints now broadcast `trainingprogressupdated` to the owning trainer's SignalR group after a successful Mongo write (scoped, not global). Broadcast is try/catch-wrapped so a SignalR hiccup never fails the completion mutation. The `// TODO #6` stubs left behind by #5 are gone.
- **Web**: hand-written `TrainingProgressUpdatedEvent` TS interface (SignalR payloads aren't in Swagger) + handler in `AppShell.tsx` that invalidates `['dashboard-summary']`, `['client-dashboard', clientId]`, and `['client-timeline', clientId]`. No polling; dashboard tiles refresh on event receipt.
- **Web regen-api**: also picked up two REST endpoints PR #24 had added but web hadn't regenerated (`markWholeDayComplete`, `markSessionIncomplete`) — separate chore commit.
- 7 backend broadcast tests added — exactly-once per mutation, correct target (trainer not client), no-broadcast on idempotent repeat / 409 / missing trainer, mutation still succeeds if broadcast throws.

## Closes loop for epic #7
This is the last sub-issue. Full loop: client marks session done on mobile → backend persists + broadcasts → trainer's dashboard refreshes in ~1 s without refresh. No polling anywhere.

## Scope notes
- Event name is lowercase `trainingprogressupdated` per repo convention
- Payload DTO is not in Swagger (SignalR lives outside OpenAPI); web ships a hand-written mirror. If we later standardize a shared-types mechanism, this file is the first candidate to migrate.
- No toast on the dashboard — the event fires per exercise completion and a refreshing table is a non-intrusive signal

## Acceptance criteria (issue #6)
- [x] `trainingprogressupdated` registered in `NotificationHub` and broadcast from the 5 completion endpoints
- [x] Event payload typed on the web client (hand-written TS matches C# DTO field-for-field)
- [x] Web dashboard listens and invalidates the right query keys; no polling introduced
- [x] Event scoped to the trainer who owns the client; other trainers don't receive it
- [x] Integration test covers broadcast happening exactly once per completion

Fixes #6

## Test plan
- [ ] Backend: `dotnet test` passes `ClientTraining/Mark*` + `MarkExerciseCompleteBroadcastTests` + `ComplianceServiceTests` (Testcontainers requires Docker)
- [ ] Web: `npx tsc --noEmit` passes (verified)
- [ ] Manual E2E: trainer dashboard open + client marks one exercise done on mobile → dashboard row updates compliance + streak within ~1 s, no manual refresh
- [ ] With per-client detail page open, confirm stats panel + timeline also refresh on the same event
- [ ] DevTools Network tab: only one `/trainer/dashboard-summary` request fires after the event (no polling)
- [ ] `trainingprogressupdated` logs in DEV builds only; silent in `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)