### PR TITLE
feat(backend): broadcast personalrecordachieved on PR detection (#15)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -112,6 +112,7 @@ jobs:
             -class- '*GetClientPlansIntegrationTests' \
             -class- '*GetFullTrainingPlanIntegrationTests' \
             -class- '*PersonalRecordDetectionTests' \
+            -class- '*PersonalRecordBroadcastTests' \
             -class- '*GetClientRecordsEndpointTests' \
             -class- '*GetClientTimelineEndpointTests'
         env:

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
@@ -2,8 +2,11 @@ using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
+using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.WorkoutLogs.UpdateWorkout;
@@ -17,9 +20,13 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.UpdateWorkout;
 /// corresponding <see cref="WorkoutSet.IsPR"/> flag on the log.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
+/// <param name="db">PostgreSQL context (used for trainer-link lookup).</param>
+/// <param name="notifier">SignalR notifier for broadcasting PR events.</param>
 /// <param name="logger">Logger for best-effort PR warning messages.</param>
 public class UpdateWorkoutEndpoint(
     IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
     ILogger<UpdateWorkoutEndpoint> logger) : Endpoint<UpdateWorkoutRequest, WorkoutLogDetail>
 {
     /// <inheritdoc />
@@ -100,7 +107,7 @@ public class UpdateWorkoutEndpoint(
         try
         {
             var prFlagsChanged = await DetectAndPersistPRsAsync(
-                log, clientId, previouslyCompleted, ct);
+                log, clientId, previouslyCompleted, notifier, ct);
 
             // If any IsPR flags were set on the in-memory log object, persist them
             // back with a second replace so the response and DB stay consistent.
@@ -131,6 +138,7 @@ public class UpdateWorkoutEndpoint(
         WorkoutLog log,
         Guid clientId,
         HashSet<(Guid ExerciseExternalId, int SetNumber)> previouslyCompleted,
+        IRealtimeNotifier realtimeNotifier,
         CancellationToken ct)
     {
         // Collect newly-completed sets (CompletedAt moved null → non-null),
@@ -283,9 +291,72 @@ public class UpdateWorkoutEndpoint(
                 anyPrFlagged = true;
                 runningBestWeight = setWeight;
                 runningBestReps = setReps;
+
+                // ── Broadcast personalrecordachieved to client + active trainers ───────
+                // Best-effort: failure must NOT surface as a request error.
+                // The insert already committed above — we broadcast exactly once
+                // per newly-inserted PR. Idempotency-skipped PRs do NOT reach here.
+                await BroadcastPrAchievedAsync(pr, realtimeNotifier, ct);
             }
         }
 
         return anyPrFlagged;
+    }
+
+    private async Task BroadcastPrAchievedAsync(
+        PersonalRecord pr,
+        IRealtimeNotifier realtimeNotifier,
+        CancellationToken ct)
+    {
+        var payload = new
+        {
+            ClientId = pr.ClientId,
+            ExerciseExternalId = pr.ExerciseExternalId,
+            ExerciseName = pr.ExerciseName,
+            WeightKg = pr.WeightKg,
+            Reps = pr.Reps,
+            AchievedAt = pr.AchievedAt
+        };
+
+        try
+        {
+            // Notify the client themselves.
+            await realtimeNotifier.NotifyAsync(pr.ClientId, "personalrecordachieved", payload, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to broadcast personalrecordachieved to client {ClientId}.", pr.ClientId);
+        }
+
+        // Notify each active trainer linked to this client.
+        List<Guid> trainerUserIds;
+        try
+        {
+            trainerUserIds = await db.ClientProfessionalLinks
+                .AsNoTracking()
+                .Where(l => l.ClientProfile.UserId == pr.ClientId && l.IsActive)
+                .Select(l => l.ProfessionalProfile.UserId)
+                .ToListAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to look up active trainers for client {ClientId} during PR broadcast.", pr.ClientId);
+            return;
+        }
+
+        foreach (var trainerId in trainerUserIds)
+        {
+            try
+            {
+                await realtimeNotifier.NotifyAsync(trainerId, "personalrecordachieved", payload, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to broadcast personalrecordachieved to trainer {TrainerId}.", trainerId);
+            }
+        }
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/PersonalRecordBroadcastTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/PersonalRecordBroadcastTests.cs
@@ -1,0 +1,394 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Integration tests verifying the <c>personalrecordachieved</c> SignalR broadcast
+/// wired into <c>PUT /client/training/logs/{LogId}</c>.
+///
+/// Uses real PostgreSQL (for trainer-link lookups) and real MongoDB (for PR detection)
+/// via Testcontainers. The <see cref="IRealtimeNotifier"/> is replaced with
+/// <see cref="FakeRealtimeNotifier"/> in <see cref="FitnessApiFactory"/>.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class PersonalRecordBroadcastTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail() => $"{Guid.NewGuid():N}@pr-broadcast-test.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    // ── helpers ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Registers and logs in a client, returns Http client (with token), UserId, and a started log id.
+    /// </summary>
+    private async Task<(HttpClient Http, Guid UserId, Guid LogId)> SetupClientWithLogAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "PR", "BroadcastClient", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        Guid userId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == email,
+                TestContext.Current.CancellationToken);
+            userId = user.Id;
+        }
+
+        var startResponse = await http.PostAsJsonAsync(
+            "/client/training/logs",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        startResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var startBody = await startResponse.Content.ReadFromJsonAsync<LogResponse>(
+            JsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        return (http, userId, startBody!.LogId);
+    }
+
+    /// <summary>
+    /// Registers a trainer and returns their UserId and ClientProfile/ProfessionalProfile IDs.
+    /// </summary>
+    private async Task<(Guid TrainerUserId, long ProfessionalProfileId)> SetupTrainerAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "PR", "BroadcastTrainer", "Trainer");
+
+        Guid trainerUserId;
+        long professionalProfileId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == email,
+                TestContext.Current.CancellationToken);
+            trainerUserId = user.Id;
+
+            var profile = await db.ProfessionalProfiles.FirstAsync(
+                p => p.UserId == trainerUserId,
+                TestContext.Current.CancellationToken);
+            professionalProfileId = profile.Id;
+        }
+
+        return (trainerUserId, professionalProfileId);
+    }
+
+    /// <summary>
+    /// Creates an active <see cref="ClientProfessionalLink"/> between an existing client and trainer
+    /// by seeding directly into Postgres.
+    /// </summary>
+    private async Task LinkTrainerToClientAsync(Guid clientUserId, long professionalProfileId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var clientProfile = await db.ClientProfiles.FirstAsync(
+            p => p.UserId == clientUserId,
+            TestContext.Current.CancellationToken);
+
+        db.ClientProfessionalLinks.Add(new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = professionalProfileId,
+            ProfessionalRole = UserRole.Trainer,
+            IsActive = true,
+            CanViewTrainingPlans = true,
+            CanViewNutritionPlans = false,
+            DateCreated = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static object BuildUpdateRequest(
+        Guid exerciseId,
+        string exerciseName,
+        decimal weight,
+        int reps,
+        int setNumber = 1)
+    {
+        return new
+        {
+            Exercises = new[]
+            {
+                new
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = exerciseName,
+                    Sets = new[]
+                    {
+                        new
+                        {
+                            SetNumber = setNumber,
+                            Reps = reps,
+                            WeightKg = weight,
+                            CompletedAt = DateTime.UtcNow
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private FakeRealtimeNotifier GetNotifier()
+    {
+        using var scope = factory.Services.CreateScope();
+        // FakeRealtimeNotifier is a singleton — resolve it once and return the singleton.
+        return factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+    }
+
+    // ── test cases ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Test 1: First PR with one linked trainer → exactly 2 events: one to client, one to trainer.
+    /// </summary>
+    [Fact]
+    public async Task FirstPR_WithLinkedTrainer_BroadcastsToClientAndTrainer()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (http, clientId, logId) = await SetupClientWithLogAsync();
+        var (trainerUserId, profProfileId) = await SetupTrainerAsync();
+        await LinkTrainerToClientAsync(clientId, profProfileId);
+
+        var exerciseId = Guid.NewGuid();
+        var response = await http.PutAsJsonAsync(
+            $"/client/training/logs/{logId}",
+            BuildUpdateRequest(exerciseId, "Squat", weight: 100m, reps: 5),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "personalrecordachieved")
+            .ToList();
+
+        calls.Should().HaveCount(2,
+            "one event to the client and one to the linked trainer");
+
+        calls.Should().Contain(c => c.UserId == clientId,
+            "client must receive the personalrecordachieved event");
+
+        calls.Should().Contain(c => c.UserId == trainerUserId,
+            "trainer must receive the personalrecordachieved event");
+    }
+
+    /// <summary>
+    /// Test 2: Idempotent re-submit — no re-broadcast on the second call.
+    /// </summary>
+    [Fact]
+    public async Task IdempotentReSubmit_NoAdditionalBroadcast()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (http, clientId, logId) = await SetupClientWithLogAsync();
+        var (_, profProfileId) = await SetupTrainerAsync();
+        await LinkTrainerToClientAsync(clientId, profProfileId);
+
+        var exerciseId = Guid.NewGuid();
+        var body = BuildUpdateRequest(exerciseId, "Bench Press", weight: 80m, reps: 8);
+
+        // First call — PR detected, 2 events fired
+        var first = await http.PutAsJsonAsync(
+            $"/client/training/logs/{logId}",
+            body,
+            TestContext.Current.CancellationToken);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var countAfterFirst = notifier.Calls.Count(c => c.EventType == "personalrecordachieved");
+        countAfterFirst.Should().Be(2, "first call: client + trainer");
+
+        notifier.Reset();
+
+        // Second call with identical payload — idempotent, no new PR, no new broadcast
+        var second = await http.PutAsJsonAsync(
+            $"/client/training/logs/{logId}",
+            body,
+            TestContext.Current.CancellationToken);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var countAfterSecond = notifier.Calls.Count(c => c.EventType == "personalrecordachieved");
+        countAfterSecond.Should().Be(0,
+            "re-submitting the same sets must not fire additional PR broadcasts");
+    }
+
+    /// <summary>
+    /// Test 3: Two exercises each at new max → 4 broadcasts (2 PRs × 2 audience members).
+    /// </summary>
+    [Fact]
+    public async Task MultiplePRsInOneUpdate_BroadcastsOncePerPrPerAudienceMember()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (http, clientId, logId) = await SetupClientWithLogAsync();
+        var (trainerUserId, profProfileId) = await SetupTrainerAsync();
+        await LinkTrainerToClientAsync(clientId, profProfileId);
+
+        var exerciseAId = Guid.NewGuid();
+        var exerciseBId = Guid.NewGuid();
+
+        var body = new
+        {
+            Exercises = new[]
+            {
+                new
+                {
+                    ExerciseExternalId = exerciseAId,
+                    ExerciseName = "Overhead Press",
+                    Sets = new[]
+                    {
+                        new { SetNumber = 1, Reps = 6, WeightKg = 60m, CompletedAt = DateTime.UtcNow }
+                    }
+                },
+                new
+                {
+                    ExerciseExternalId = exerciseBId,
+                    ExerciseName = "Pull-up",
+                    Sets = new[]
+                    {
+                        new { SetNumber = 1, Reps = 10, WeightKg = 10m, CompletedAt = DateTime.UtcNow }
+                    }
+                }
+            }
+        };
+
+        var response = await http.PutAsJsonAsync(
+            $"/client/training/logs/{logId}",
+            body,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "personalrecordachieved")
+            .ToList();
+
+        calls.Should().HaveCount(4,
+            "2 PRs × 2 audience members (client + trainer) = 4 events");
+
+        // Both client and trainer receive two events each
+        calls.Count(c => c.UserId == clientId).Should().Be(2,
+            "client receives one event per PR");
+        calls.Count(c => c.UserId == trainerUserId).Should().Be(2,
+            "trainer receives one event per PR");
+    }
+
+    /// <summary>
+    /// Test 4: No linked trainer → only the client receives the event (1 event total).
+    /// </summary>
+    [Fact]
+    public async Task NoProfessionalLinked_OnlyClientReceivesBroadcast()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (http, clientId, logId) = await SetupClientWithLogAsync();
+        // Deliberately do NOT link any trainer
+
+        var exerciseId = Guid.NewGuid();
+        var response = await http.PutAsJsonAsync(
+            $"/client/training/logs/{logId}",
+            BuildUpdateRequest(exerciseId, "Deadlift", weight: 120m, reps: 3),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "personalrecordachieved")
+            .ToList();
+
+        calls.Should().HaveCount(1,
+            "with no trainer linked, only the client receives the event");
+
+        calls[0].UserId.Should().Be(clientId,
+            "the single event must be addressed to the client");
+    }
+
+    /// <summary>
+    /// Test 5: Two trainers linked → 3 events per PR (1 client + 2 trainers).
+    /// </summary>
+    [Fact]
+    public async Task TwoTrainersLinked_AllThreeAudienceMembersReceiveEvent()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (http, clientId, logId) = await SetupClientWithLogAsync();
+        var (trainer1UserId, profProfileId1) = await SetupTrainerAsync();
+        var (trainer2UserId, profProfileId2) = await SetupTrainerAsync();
+        await LinkTrainerToClientAsync(clientId, profProfileId1);
+        await LinkTrainerToClientAsync(clientId, profProfileId2);
+
+        var exerciseId = Guid.NewGuid();
+        var response = await http.PutAsJsonAsync(
+            $"/client/training/logs/{logId}",
+            BuildUpdateRequest(exerciseId, "Romanian Deadlift", weight: 90m, reps: 8),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "personalrecordachieved")
+            .ToList();
+
+        calls.Should().HaveCount(3,
+            "1 PR × 3 audience members (client + 2 trainers) = 3 events");
+
+        calls.Should().Contain(c => c.UserId == clientId,
+            "client must receive the event");
+        calls.Should().Contain(c => c.UserId == trainer1UserId,
+            "trainer 1 must receive the event");
+        calls.Should().Contain(c => c.UserId == trainer2UserId,
+            "trainer 2 must receive the event");
+    }
+
+    // ── local response DTOs ───────────────────────────────────────────────────────
+
+    private record LogResponse(
+        Guid LogId,
+        Guid ClientId,
+        bool IsCompleted,
+        bool HasPR,
+        List<ExerciseResponse> Exercises);
+
+    private record ExerciseResponse(
+        Guid ExerciseExternalId,
+        string ExerciseName,
+        List<SetResponse> Sets);
+
+    private record SetResponse(
+        int SetNumber,
+        bool IsPR,
+        decimal? WeightKg,
+        int? Reps,
+        DateTime? CompletedAt);
+}

--- a/backend/FitnessPlatform.Tests/Infrastructure/FakeRealtimeNotifier.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FakeRealtimeNotifier.cs
@@ -1,0 +1,48 @@
+using FitnessPlatform.Application.Domain.Interfaces;
+
+namespace FitnessPlatform.Tests.Infrastructure;
+
+/// <summary>
+/// Thread-safe fake implementation of <see cref="IRealtimeNotifier"/> for integration tests.
+/// Records all <c>NotifyAsync</c> calls so tests can assert on event names, recipients, and payloads.
+/// </summary>
+public class FakeRealtimeNotifier : IRealtimeNotifier
+{
+    private readonly List<NotifyCall> _calls = [];
+    private readonly Lock _lock = new();
+
+    /// <summary>
+    /// Returns a snapshot of all recorded <c>NotifyAsync</c> invocations.
+    /// </summary>
+    public IReadOnlyList<NotifyCall> Calls
+    {
+        get
+        {
+            lock (_lock) return _calls.ToList();
+        }
+    }
+
+    /// <inheritdoc />
+    public Task NotifyAsync(Guid userId, string eventType, object payload, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            _calls.Add(new NotifyCall(userId, eventType, payload));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Clears all recorded calls. Call between tests if the notifier is shared.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_lock) _calls.Clear();
+    }
+
+    /// <summary>
+    /// A single recorded invocation of <c>NotifyAsync</c>.
+    /// </summary>
+    public record NotifyCall(Guid UserId, string EventType, object Payload);
+}

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
@@ -71,6 +71,15 @@ public class FitnessApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
                 services.Remove(emailDescriptor);
 
             services.AddScoped<IEmailService, FakeEmailService>();
+
+            // Replace realtime notifier with in-memory fake so tests can assert broadcasts
+            var notifierDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(IRealtimeNotifier));
+            if (notifierDescriptor is not null)
+                services.Remove(notifierDescriptor);
+
+            services.AddSingleton<FakeRealtimeNotifier>();
+            services.AddSingleton<IRealtimeNotifier>(sp => sp.GetRequiredService<FakeRealtimeNotifier>());
         });
 
         builder.UseEnvironment("Development");


### PR DESCRIPTION
## Summary
- Broadcasts `personalrecordachieved` via `IRealtimeNotifier` immediately after each successful `PersonalRecord.InsertOneAsync` in `UpdateWorkoutEndpoint` (best-effort, failures logged but never surface to the caller).
- Audience is the client themselves plus every active `ClientProfessionalLink` trainer — no cross-trainer leakage.
- Idempotency-skipped PRs (existing `(WorkoutLogId, ExerciseExternalId, SetNumber)` row) do **not** re-broadcast — the broadcast sits after the insert, in the non-duplicate path only.
- Wires a `FakeRealtimeNotifier` into `FitnessApiFactory` (mirrors the `FakeEmailService` pattern) so integration tests can assert on event names, recipients, and counts.
- 5 new integration tests in `PersonalRecordBroadcastTests` cover first PR + linked trainer, idempotent re-submit, multi-PR in one request, no linked trainer, and two linked trainers.
- `.github/workflows/backend.yml` allowlists `*PersonalRecordBroadcastTests` so the suite runs in CI.

## AC checklist
- [x] Event broadcast via `IRealtimeNotifier` with name `personalrecordachieved` (lowercase literal).
- [x] Fires exactly once per newly-detected PR (idempotent re-submits do not re-broadcast).
- [x] Scoped to the client + owning trainer(s); no cross-trainer leakage.
- [x] Integration test asserts exactly-once broadcast per PR and the client+trainer audience.
- [x] Request contract of `PUT /client/training/logs/{LogId}` unchanged.
- [x] Broadcast failures don't fail the request (best-effort, wrapped try/catch per recipient).

## Test plan
- [x] `dotnet build` — clean (4 NU1902 MailKit advisory warnings only, pre-existing).
- [x] `PersonalRecordBroadcastTests` — 5/5 pass.
- [x] `PersonalRecordDetectionTests` regression — 5/5 pass.
- [x] `GetClientRecordsEndpointTests` regression — 6/6 pass.
- [x] `GetClientTimelineEndpointTests` regression — 5/5 pass.

## Notes
Web and mobile listeners (query-invalidation + toast/sheet UX) land in sibling PRs — parts b and c of #15.

Related to #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)