### PR TITLE
feat(web): wire personalrecordachieved SignalR event (#15)

### DIFF
--- a/web/src/api/personalRecordEvent.ts
+++ b/web/src/api/personalRecordEvent.ts
@@ -1,0 +1,55 @@
+/**
+ * Hand-written TypeScript mirror of the C# PersonalRecordAchievedEvent DTO.
+ *
+ * This event is broadcast over SignalR only (no REST endpoint), so it will not
+ * appear in generated.ts.  Do NOT move these types into generated.ts — it is
+ * auto-generated and write-locked.
+ *
+ * Source of truth:
+ *   backend/FitnessPlatform.Application/Features/ClientTraining/PersonalRecordAchievedEvent.cs
+ *
+ * SignalR event name: "personalrecordachieved"  (hub convention: lowercase)
+ *
+ * Payload fields are camelCased on the wire (System.Text.Json default).
+ */
+
+export interface PersonalRecordAchievedEvent {
+  /** The client's public identifier (ApplicationUser.Id as a string). */
+  clientId: string;
+
+  /** The exercise's external/public identifier. */
+  exerciseExternalId: string;
+
+  /** Localised display name of the exercise. */
+  exerciseName: string;
+
+  /** Weight lifted in kilograms. */
+  weightKg: number;
+
+  /** Number of repetitions performed. */
+  reps: number;
+
+  /** ISO 8601 timestamp when the record was set. */
+  achievedAt: string;
+}
+
+/**
+ * Runtime type guard for `PersonalRecordAchievedEvent`.
+ *
+ * Use this whenever consuming the raw SignalR payload to catch backend shape
+ * drift early and avoid silent `undefined` access.
+ */
+export function isPersonalRecordAchievedEvent(
+  payload: unknown,
+): payload is PersonalRecordAchievedEvent {
+  if (typeof payload !== 'object' || payload === null) return false;
+  const p = payload as Partial<Record<keyof PersonalRecordAchievedEvent, unknown>>;
+  return (
+    typeof p.clientId === 'string' &&
+    typeof p.exerciseExternalId === 'string' &&
+    typeof p.exerciseName === 'string' &&
+    typeof p.weightKg === 'number' &&
+    typeof p.reps === 'number' &&
+    typeof p.achievedAt === 'string'
+  );
+}

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from './Sidebar';
 import { useSignalR } from '@/hooks/useSignalR';
 import { useToastStore } from '@/stores/toast';
 import { isTrainingProgressUpdatedEvent } from '@/api/trainingProgressEvent';
+import { isPersonalRecordAchievedEvent } from '@/api/personalRecordEvent';
 
 const DARK_MODE_KEY = 'gf-dark-mode';
 
@@ -158,6 +159,38 @@ export function AppShell() {
         queryClient.invalidateQueries({ queryKey: ['client-dashboard', clientId] });
         queryClient.invalidateQueries({ queryKey: ['client-timeline', clientId] });
       }
+    },
+    personalrecordachieved: (payload: unknown) => {
+      if (import.meta.env.DEV) {
+        console.debug('personalrecordachieved', payload);
+      }
+      if (!isPersonalRecordAchievedEvent(payload)) {
+        if (import.meta.env.DEV) {
+          console.warn('personalrecordachieved: invalid payload shape', payload);
+        }
+        return;
+      }
+      const { clientId, exerciseName } = payload;
+
+      // Toast notification so the trainer sees the PR regardless of which page they are on.
+      addToast(
+        t('notifications.personalRecordAchieved', { exerciseName }),
+        'success',
+      );
+
+      // Invalidate the client's activity timeline — the new personal_record entry
+      // will appear there once the query refetches.
+      // Key shape verified: ClientDetailPage.tsx line 31 uses ['client-timeline', id].
+      queryClient.invalidateQueries({ queryKey: ['client-timeline', clientId] });
+
+      // Invalidate the per-client stats panel (streak, compliance, etc.).
+      // Key shape verified: ClientDetailPage.tsx line 25 uses ['client-dashboard', id].
+      queryClient.invalidateQueries({ queryKey: ['client-dashboard', clientId] });
+
+      // Invalidate the trainer's dashboard summary — the PR represents a completed
+      // workout that may update streak / training count cells in the client table.
+      // Key shape verified: DashboardPage.tsx line 88 uses ['dashboard-summary'].
+      queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
     },
     typing: (payload: unknown) => {
       const data = payload as { conversationId?: string; senderId?: string } | undefined;

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1161,6 +1161,7 @@
     "inviteRevokedGeneric": "Klient zrušil svou pozvánku",
     "collaborationEnded": "{{name}} ukončil/a spolupráci",
     "collaborationEndedGeneric": "Klient ukončil spolupráci",
+    "personalRecordAchieved": "Nový osobní rekord – {{exerciseName}}",
     "title": "Oznámení",
     "markAllRead": "Označit vše jako přečtené",
     "empty": "Žádná oznámení",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1161,6 +1161,7 @@
     "inviteRevokedGeneric": "Ein Klient hat seine Einladung zurückgezogen",
     "collaborationEnded": "{{name}} hat die Zusammenarbeit beendet",
     "collaborationEndedGeneric": "Ein Klient hat die Zusammenarbeit beendet",
+    "personalRecordAchieved": "Neuer persönlicher Rekord – {{exerciseName}}",
     "title": "Benachrichtigungen",
     "markAllRead": "Alle als gelesen markieren",
     "empty": "Keine Benachrichtigungen",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1162,6 +1162,7 @@
     "inviteRevokedGeneric": "A client revoked their invitation",
     "collaborationEnded": "{{name}} ended the collaboration",
     "collaborationEndedGeneric": "A client ended the collaboration",
+    "personalRecordAchieved": "New personal record – {{exerciseName}}",
     "title": "Notifications",
     "markAllRead": "Mark all as read",
     "empty": "No notifications",


### PR DESCRIPTION
## Summary

- Listen for the `personalrecordachieved` SignalR event in `AppShell.tsx` (lowercase hub convention) and narrow the raw payload through a hand-written `isPersonalRecordAchievedEvent` type guard before touching it — no `any`, no silent undefined access.
- Invalidate three real TanStack Query keys so the trainer sees the PR live without polling: `['client-timeline', clientId]` (per-client timeline), `['client-dashboard', clientId]` (per-client stats panel), and `['dashboard-summary']` (main dashboard table).
- Fire a success toast via the existing store with an i18n-bound copy that includes the exercise name (`notifications.personalRecordAchieved`), shipped in cs/en/de.

## AC checklist

- [x] Handler listens on the exact lowercase event name `personalrecordachieved`.
- [x] Payload narrowed through a runtime type guard — no `any` in the new file, no silent access.
- [x] Invalidates real query keys (grep-verified against `ClientDetailPage.tsx` and `DashboardPage.tsx`).
- [x] No data fetching inside the handler — only `addToast` and `invalidateQueries`.
- [x] Toast copy via `t('notifications.personalRecordAchieved')`; cs/en/de parity.
- [x] No hardcoded colors, spacing, or fonts in the new code.
- [x] `npx tsc --noEmit` clean; `npm run build` clean.

## Test plan

- [x] `npx tsc --noEmit` clean (exit 0).
- [x] `npm run build` clean (exit 0).
- [ ] Runtime verification deferred to a live PR event against the deployed backend — the realtime contract is locked in by the backend slice (#15a, merged as PR #42) and the shared event-name convention.

## Notes

The `PersonalRecordAchievedEvent` type is hand-written in `web/src/api/personalRecordEvent.ts` rather than generated. SignalR events do not appear in the Swagger surface that NSwag regenerates, so the DTO mirror is intentional and documented at the top of the file — do not move it into `generated.ts` (that file is auto-generated and write-locked).

Related to #15. Backend slice merged as PR #42; mobile handler tracked in a sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)