### PR TITLE
feat(mobile): handle personalrecordachieved SignalR event (#15)

### DIFF
--- a/mobile/app/(client)/(tabs)/_layout.tsx
+++ b/mobile/app/(client)/(tabs)/_layout.tsx
@@ -34,6 +34,15 @@ interface NotificationPayload {
   startDate?: string
 }
 
+interface PersonalRecordAchievedPayload {
+  clientId: string;
+  exerciseExternalId: string;
+  exerciseName: string;
+  weightKg: number;
+  reps: number;
+  achievedAt: string;
+}
+
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     // shouldShowAlert: true,
@@ -234,6 +243,12 @@ export default function ClientTabLayout() {
           queryClient.invalidateQueries({ queryKey: ['conversations'] });
           queryClient.invalidateQueries({ queryKey: ['archived-conversations'] });
         }
+      }),
+      onEvent('personalrecordachieved', (raw: unknown) => {
+        const _p = raw as PersonalRecordAchievedPayload;
+        void _p; // payload received; invalidate PR queries so cards refresh
+        queryClient.invalidateQueries({ queryKey: ['personal-records-latest'] });
+        queryClient.invalidateQueries({ queryKey: ['personal-records-all'] });
       }),
     ];
 

--- a/mobile/src/api/signalr.ts
+++ b/mobile/src/api/signalr.ts
@@ -15,6 +15,7 @@ const KNOWN_EVENTS = [
   'invitationcancelled',
   'clientrequestaccepted',
   'clientrequestrejected',
+  'personalrecordachieved',
   'questionnaireassigned',
   'nutritionplanpublished',
   'nutritionplanupdated',


### PR DESCRIPTION
## Summary

- Register `'personalrecordachieved'` in `KNOWN_EVENTS` (`mobile/src/api/signalr.ts`) so the lowercase event name is pre-wired as a no-op and passes through the SignalR warning filter.
- Subscribe in `mobile/app/(client)/(tabs)/_layout.tsx` via `onEvent('personalrecordachieved', …)` using the existing `unsubs` array — cleanup is automatic when the tabs layout unmounts (`unsubs.forEach((unsub) => unsub())`).
- Handler casts the payload to a hand-written `PersonalRecordAchievedPayload` type and invalidates `['personal-records-latest']` + `['personal-records-all']` — the exact keys used by `PersonalRecordsCard` and `PersonalRecordsSheet`. No data fetching inside the handler.

## AC checklist

- [x] `'personalrecordachieved'` added to `KNOWN_EVENTS`.
- [x] `onEvent` subscription returns unsubscribe, added to the existing `unsubs` cleanup block.
- [x] Payload cast uses a named interface (`PersonalRecordAchievedPayload`) — no `any`.
- [x] Invalidates `['personal-records-latest']` (PersonalRecordsCard at line 114) and `['personal-records-all']` (PersonalRecordsSheet at line 84).
- [x] Handler only calls `invalidateQueries` — no fetching or side-effect logic.
- [x] `npx tsc --noEmit` clean; `npm test` 79/79 green.

## Test plan

- [x] `cd mobile && npx tsc --noEmit` — no errors.
- [x] `cd mobile && npm test -- --watchAll=false` — 79/79 pass (4 suites).
- [x] `grep` confirms the invalidation keys match real query subscribers in `PersonalRecordsCard.tsx` and `PersonalRecordsSheet.tsx`.

## Notes

- The payload shape (`PersonalRecordAchievedPayload`) is hand-written locally because the SignalR event isn't surfaced in Swagger — there's no generated type to import. The fields mirror the backend DTO broadcast in PR #42 (merged).
- Sibling web handler is in the parallel PR off `feature/15b-web-pr-event`.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)