### PR TITLE
feat(backend): weekly check-in scheduler + client response flow (#34)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -120,7 +120,13 @@ jobs:
             -class- '*PutSettingsEndpointTests' \
             -class- '*GetOverridesEndpointTests' \
             -class- '*PutOverrideEndpointTests' \
-            -class- '*DeleteOverrideEndpointTests'
+            -class- '*DeleteOverrideEndpointTests' \
+            -class- '*GetCurrentClientCheckInsEndpointTests' \
+            -class- '*RespondToCheckInEndpointTests' \
+            -class- '*DismissCheckInEndpointTests' \
+            -class- '*MarkCheckInReviewedEndpointTests' \
+            -class- '*GetTrainerCheckInsEndpointTests' \
+            -class- '*WeeklyCheckInSchedulerTests'
         env:
           POSTGRES_PASSWORD: test_password
           MONGO_PASSWORD: test_password

--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -142,6 +142,15 @@ public static class ErrorCodes
     /// <summary>The trainer is not linked to the specified client.</summary>
     public const string NotLinkedToClient = "NOT_LINKED_TO_CLIENT";
 
+    /// <summary>The weekly check-in was not found or does not belong to the caller.</summary>
+    public const string CheckInNotFound = "CHECK_IN_NOT_FOUND";
+
+    /// <summary>The trainer already reviewed this check-in; the client can no longer modify it.</summary>
+    public const string CheckInAlreadyReviewed = "CHECK_IN_ALREADY_REVIEWED";
+
+    /// <summary>The weekly check-in belongs to another professional.</summary>
+    public const string CheckInNotOwned = "CHECK_IN_NOT_OWNED";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Domain/Entities/WeeklyCheckIn.cs
+++ b/backend/FitnessPlatform.Application/Domain/Entities/WeeklyCheckIn.cs
@@ -1,0 +1,73 @@
+using System.ComponentModel.DataAnnotations;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Entities;
+
+/// <summary>
+/// Represents one weekly check-in lifecycle — from scheduler dispatch through client response
+/// to trainer review.
+/// One row per (ClientUserId, ProfessionalUserId, Profession, WeekStartDate) — enforced by unique index.
+/// </summary>
+public class WeeklyCheckIn
+{
+    /// <summary>Primary key.</summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// The client who receives this check-in.
+    /// Foreign key → <see cref="ApplicationUser"/>.
+    /// </summary>
+    public Guid ClientUserId { get; set; }
+
+    /// <summary>
+    /// The professional (trainer or nutritionist) who owns this check-in.
+    /// Foreign key → <see cref="ApplicationUser"/>.
+    /// </summary>
+    public Guid ProfessionalUserId { get; set; }
+
+    /// <summary>
+    /// The professional capacity this check-in applies to (Training or Nutrition).
+    /// </summary>
+    public Profession Profession { get; set; }
+
+    /// <summary>
+    /// ISO-week Monday of the week being planned. Always a Monday.
+    /// </summary>
+    public DateOnly WeekStartDate { get; set; }
+
+    /// <summary>
+    /// Flags selected by the client when responding. Stored as a jsonb array of strings.
+    /// Empty list = no flags selected (valid response).
+    /// </summary>
+    public List<CheckInFlag> Flags { get; set; } = [];
+
+    /// <summary>
+    /// Optional free-text note from the client. ≤ 500 characters.
+    /// </summary>
+    [MaxLength(500)]
+    public string? Note { get; set; }
+
+    /// <summary>UTC timestamp when the scheduler sent this check-in.</summary>
+    public DateTime SentAt { get; set; }
+
+    /// <summary>UTC timestamp when the client submitted a response. Null until responded.</summary>
+    public DateTime? RespondedAt { get; set; }
+
+    /// <summary>UTC timestamp when the client dismissed this check-in for the week. Null until dismissed.</summary>
+    public DateTime? DismissedByClientAt { get; set; }
+
+    /// <summary>UTC timestamp when the professional marked this check-in as reviewed. Null until reviewed.</summary>
+    public DateTime? ReviewedByTrainerAt { get; set; }
+
+    /// <summary>UTC timestamp of row creation.</summary>
+    public DateTime DateCreated { get; set; }
+
+    /// <summary>UTC timestamp of last modification.</summary>
+    public DateTime DateModified { get; set; }
+
+    /// <summary>Navigation property to the client user.</summary>
+    public ApplicationUser ClientUser { get; set; } = null!;
+
+    /// <summary>Navigation property to the professional user.</summary>
+    public ApplicationUser ProfessionalUser { get; set; } = null!;
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/CheckInFlag.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/CheckInFlag.cs
@@ -1,0 +1,26 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Flags a client can select when responding to a weekly check-in reminder,
+/// indicating events or circumstances that may affect the upcoming week's plan.
+/// </summary>
+public enum CheckInFlag
+{
+    /// <summary>Client will be traveling during the upcoming week.</summary>
+    Traveling,
+
+    /// <summary>Client has a notable event or celebration during the upcoming week.</summary>
+    EventOrCelebration,
+
+    /// <summary>Client is feeling sick or has low energy.</summary>
+    SickOrLowEnergy,
+
+    /// <summary>Client is dealing with an injury or pain.</summary>
+    InjuryOrPain,
+
+    /// <summary>Client has more time than usual available for training or nutrition adherence.</summary>
+    MoreTimeAvailable,
+
+    /// <summary>Client has less time than usual available.</summary>
+    LessTimeAvailable
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/NotificationType.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/NotificationType.cs
@@ -39,5 +39,11 @@ public enum NotificationType
     InvitationDeclined,
 
     /// <summary>A pending invite was auto-cancelled because another professional of the same role was accepted.</summary>
-    InvitationCancelled
+    InvitationCancelled,
+
+    /// <summary>A weekly check-in reminder was sent to a client by the scheduler.</summary>
+    WeeklyCheckInRequested,
+
+    /// <summary>A client responded to a weekly check-in reminder; delivered to the professional.</summary>
+    WeeklyCheckInResponded
 }

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/DismissCheckIn/DismissCheckInEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/DismissCheckIn/DismissCheckInEndpoint.cs
@@ -1,0 +1,78 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.DismissCheckIn;
+
+/// <summary>
+/// Client dismisses a weekly check-in for the week.
+/// No trainer notification is created. A <c>weeklycheckinupdated</c> event is broadcast
+/// so the client's open tab can remove the banner immediately.
+/// </summary>
+public class DismissCheckInEndpoint(
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier)
+    : Endpoint<DismissCheckInRequest, DismissCheckInResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/weekly-check-ins/{id}/dismiss");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Dismiss a weekly check-in";
+            s.Description =
+                "Marks the weekly check-in as dismissed by the client. " +
+                "No trainer notification is created.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(DismissCheckInRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientUserId = Guid.Parse(userId);
+
+        var checkIn = await db.WeeklyCheckIns
+            .FirstOrDefaultAsync(c => c.Id == req.Id, ct);
+
+        if (checkIn is null || checkIn.ClientUserId != clientUserId)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        checkIn.DismissedByClientAt = now;
+        checkIn.DateModified = now;
+
+        await db.SaveChangesAsync(ct);
+
+        // Broadcast to the client (and to the professional in case they're watching).
+        var broadcastPayload = new
+        {
+            id = checkIn.Id,
+            dismissedAt = checkIn.DismissedByClientAt
+        };
+
+        await notifier.NotifyAsync(clientUserId, "weeklycheckinupdated", broadcastPayload, ct);
+        await notifier.NotifyAsync(checkIn.ProfessionalUserId, "weeklycheckinupdated", broadcastPayload, ct);
+
+        await Send.OkAsync(new DismissCheckInResponse
+        {
+            Id = checkIn.Id,
+            DismissedAt = checkIn.DismissedByClientAt.Value
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/DismissCheckIn/DismissCheckInRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/DismissCheckIn/DismissCheckInRequest.cs
@@ -1,0 +1,10 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.DismissCheckIn;
+
+/// <summary>
+/// Request for POST /client/weekly-check-ins/{id}/dismiss.
+/// </summary>
+public class DismissCheckInRequest
+{
+    /// <summary>Route parameter — check-in identifier.</summary>
+    public Guid Id { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/DismissCheckIn/DismissCheckInResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/DismissCheckIn/DismissCheckInResponse.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.DismissCheckIn;
+
+/// <summary>
+/// Response for POST /client/weekly-check-ins/{id}/dismiss.
+/// </summary>
+public class DismissCheckInResponse
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>When the check-in was dismissed (UTC).</summary>
+    public DateTime DismissedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCheckInDetail/GetCheckInDetailEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCheckInDetail/GetCheckInDetailEndpoint.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetCheckInDetail;
+
+/// <summary>
+/// Returns full detail for a single check-in.
+/// Returns 404 if the record doesn't exist; 403 if it belongs to a different professional.
+/// </summary>
+public class GetCheckInDetailEndpoint(IApplicationDbContext db)
+    : Endpoint<GetCheckInDetailRequest, GetCheckInDetailResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/weekly-check-ins/{id}");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Get check-in detail (trainer)";
+            s.Description = "Returns full detail for a single weekly check-in. 404 if not found; 403 if owned by another professional.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetCheckInDetailRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var professionalUserId = Guid.Parse(userId);
+
+        var checkIn = await db.WeeklyCheckIns
+            .AsNoTracking()
+            .Include(c => c.ClientUser)
+            .FirstOrDefaultAsync(c => c.Id == req.Id, ct);
+
+        if (checkIn is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (checkIn.ProfessionalUserId != professionalUserId)
+        {
+            await Send.ForbiddenAsync(ct);
+            return;
+        }
+
+        await Send.OkAsync(new GetCheckInDetailResponse
+        {
+            Id = checkIn.Id,
+            ClientUserId = checkIn.ClientUserId,
+            ClientName = $"{checkIn.ClientUser.FirstName} {checkIn.ClientUser.LastName}",
+            ProfessionalUserId = checkIn.ProfessionalUserId,
+            Profession = checkIn.Profession.ToString(),
+            WeekStartDate = checkIn.WeekStartDate,
+            Flags = checkIn.Flags,
+            Note = checkIn.Note,
+            SentAt = checkIn.SentAt,
+            RespondedAt = checkIn.RespondedAt,
+            DismissedByClientAt = checkIn.DismissedByClientAt,
+            ReviewedByTrainerAt = checkIn.ReviewedByTrainerAt
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCheckInDetail/GetCheckInDetailRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCheckInDetail/GetCheckInDetailRequest.cs
@@ -1,0 +1,10 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetCheckInDetail;
+
+/// <summary>
+/// Request for GET /trainer/weekly-check-ins/{id}.
+/// </summary>
+public class GetCheckInDetailRequest
+{
+    /// <summary>Check-in identifier (route parameter).</summary>
+    public Guid Id { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCheckInDetail/GetCheckInDetailResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCheckInDetail/GetCheckInDetailResponse.cs
@@ -1,0 +1,45 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetCheckInDetail;
+
+/// <summary>
+/// Response for GET /trainer/weekly-check-ins/{id}.
+/// </summary>
+public class GetCheckInDetailResponse
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Client's ApplicationUser.Id.</summary>
+    public Guid ClientUserId { get; set; }
+
+    /// <summary>Client's display name.</summary>
+    public string ClientName { get; set; } = string.Empty;
+
+    /// <summary>Professional's ApplicationUser.Id.</summary>
+    public Guid ProfessionalUserId { get; set; }
+
+    /// <summary>Profession context.</summary>
+    public string Profession { get; set; } = string.Empty;
+
+    /// <summary>ISO-week Monday being planned.</summary>
+    public DateOnly WeekStartDate { get; set; }
+
+    /// <summary>Flags selected by the client.</summary>
+    public List<CheckInFlag> Flags { get; set; } = [];
+
+    /// <summary>Client's optional note.</summary>
+    public string? Note { get; set; }
+
+    /// <summary>When the scheduler sent this check-in.</summary>
+    public DateTime SentAt { get; set; }
+
+    /// <summary>When the client responded. Null if not yet responded.</summary>
+    public DateTime? RespondedAt { get; set; }
+
+    /// <summary>When the client dismissed. Null if not dismissed.</summary>
+    public DateTime? DismissedByClientAt { get; set; }
+
+    /// <summary>When the trainer marked this reviewed. Null if not reviewed.</summary>
+    public DateTime? ReviewedByTrainerAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetClientCurrentCheckIn/GetClientCurrentCheckInEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetClientCurrentCheckIn/GetClientCurrentCheckInEndpoint.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetClientCurrentCheckIn;
+
+/// <summary>
+/// Returns the latest check-in(s) for a specific client in the current ISO week.
+/// Used by the plan-editor banner to decide which state to render.
+/// Only returns check-ins that belong to the authenticated professional.
+/// </summary>
+public class GetClientCurrentCheckInEndpoint(IApplicationDbContext db)
+    : Endpoint<GetClientCurrentCheckInRequest, GetClientCurrentCheckInResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/clients/{clientUserId}/weekly-check-ins/current");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Get current week's check-in for a client (trainer)";
+            s.Description =
+                "Returns the check-in(s) for the given client in the current ISO week, " +
+                "filtered to the authenticated professional. Optionally filter by profession.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetClientCurrentCheckInRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var professionalUserId = Guid.Parse(userId);
+
+        // Compute ISO-week Monday of the current week.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var daysFromMonday = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var weekMonday = today.AddDays(-daysFromMonday);
+
+        var query = db.WeeklyCheckIns
+            .AsNoTracking()
+            .Where(c =>
+                c.ClientUserId == req.ClientUserId &&
+                c.ProfessionalUserId == professionalUserId &&
+                c.WeekStartDate == weekMonday);
+
+        if (!string.IsNullOrWhiteSpace(req.Profession) &&
+            Enum.TryParse<Profession>(req.Profession, ignoreCase: true, out var professionFilter))
+        {
+            query = query.Where(c => c.Profession == professionFilter);
+        }
+
+        var checkIns = await query
+            .OrderBy(c => c.Profession)
+            .Select(c => new ClientCheckInDto
+            {
+                Id = c.Id,
+                Profession = c.Profession.ToString(),
+                WeekStartDate = c.WeekStartDate,
+                Flags = c.Flags,
+                Note = c.Note,
+                SentAt = c.SentAt,
+                RespondedAt = c.RespondedAt,
+                DismissedByClientAt = c.DismissedByClientAt,
+                ReviewedByTrainerAt = c.ReviewedByTrainerAt
+            })
+            .ToListAsync(ct);
+
+        await Send.OkAsync(new GetClientCurrentCheckInResponse { CheckIns = checkIns }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetClientCurrentCheckIn/GetClientCurrentCheckInRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetClientCurrentCheckIn/GetClientCurrentCheckInRequest.cs
@@ -1,0 +1,16 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetClientCurrentCheckIn;
+
+/// <summary>
+/// Request for GET /trainer/clients/{clientUserId}/weekly-check-ins/current.
+/// </summary>
+public class GetClientCurrentCheckInRequest
+{
+    /// <summary>Client's ApplicationUser.Id (route parameter).</summary>
+    public Guid ClientUserId { get; set; }
+
+    /// <summary>
+    /// Profession to filter by ("Training" or "Nutrition"). Optional.
+    /// When omitted, returns check-ins for all professions.
+    /// </summary>
+    public string? Profession { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetClientCurrentCheckIn/GetClientCurrentCheckInResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetClientCurrentCheckIn/GetClientCurrentCheckInResponse.cs
@@ -1,0 +1,46 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetClientCurrentCheckIn;
+
+/// <summary>
+/// Response for GET /trainer/clients/{clientUserId}/weekly-check-ins/current.
+/// </summary>
+public class GetClientCurrentCheckInResponse
+{
+    /// <summary>
+    /// Latest check-in(s) for the current ISO week and the given client.
+    /// Typically 0–2 items (one per profession).
+    /// </summary>
+    public List<ClientCheckInDto> CheckIns { get; set; } = [];
+}
+
+/// <summary>A single check-in as seen from the plan-editor banner.</summary>
+public class ClientCheckInDto
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Profession context.</summary>
+    public string Profession { get; set; } = string.Empty;
+
+    /// <summary>ISO-week Monday.</summary>
+    public DateOnly WeekStartDate { get; set; }
+
+    /// <summary>Flags selected by the client.</summary>
+    public List<CheckInFlag> Flags { get; set; } = [];
+
+    /// <summary>Client's note.</summary>
+    public string? Note { get; set; }
+
+    /// <summary>When the scheduler sent this.</summary>
+    public DateTime SentAt { get; set; }
+
+    /// <summary>When the client responded. Null if pending.</summary>
+    public DateTime? RespondedAt { get; set; }
+
+    /// <summary>When the client dismissed. Null if not dismissed.</summary>
+    public DateTime? DismissedByClientAt { get; set; }
+
+    /// <summary>When the trainer marked this reviewed.</summary>
+    public DateTime? ReviewedByTrainerAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCurrentClientCheckIns/GetCurrentClientCheckInsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCurrentClientCheckIns/GetCurrentClientCheckInsEndpoint.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetCurrentClientCheckIns;
+
+/// <summary>
+/// Returns the active (not yet responded, not dismissed) weekly check-ins for the
+/// authenticated client in the current ISO week. Maximum 2 items (one per profession).
+/// </summary>
+public class GetCurrentClientCheckInsEndpoint(IApplicationDbContext db)
+    : Endpoint<GetCurrentClientCheckInsRequest, GetCurrentClientCheckInsResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/client/weekly-check-ins/current");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Get current week's active check-ins (client)";
+            s.Description =
+                "Returns up to 2 active weekly check-ins (not responded, not dismissed) " +
+                "for the authenticated client in the current ISO week.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetCurrentClientCheckInsRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientUserId = Guid.Parse(userId);
+
+        // Compute ISO-week Monday of the current week.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var daysFromMonday = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var weekMonday = today.AddDays(-daysFromMonday);
+
+        var checkIns = await db.WeeklyCheckIns
+            .AsNoTracking()
+            .Where(c =>
+                c.ClientUserId == clientUserId &&
+                c.WeekStartDate == weekMonday &&
+                c.RespondedAt == null &&
+                c.DismissedByClientAt == null)
+            .Include(c => c.ProfessionalUser)
+            .OrderBy(c => c.Profession)
+            .Select(c => new CheckInSummary
+            {
+                Id = c.Id,
+                ProfessionalUserId = c.ProfessionalUserId,
+                ProfessionalName = c.ProfessionalUser.FirstName + " " + c.ProfessionalUser.LastName,
+                Profession = c.Profession.ToString(),
+                WeekStartDate = c.WeekStartDate,
+                SentAt = c.SentAt
+            })
+            .ToListAsync(ct);
+
+        await Send.OkAsync(new GetCurrentClientCheckInsResponse { CheckIns = checkIns }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCurrentClientCheckIns/GetCurrentClientCheckInsRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCurrentClientCheckIns/GetCurrentClientCheckInsRequest.cs
@@ -1,0 +1,7 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetCurrentClientCheckIns;
+
+/// <summary>
+/// Request marker for GET /client/weekly-check-ins/current.
+/// No query parameters — the ISO week is derived from the server's current date.
+/// </summary>
+public class GetCurrentClientCheckInsRequest { }

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCurrentClientCheckIns/GetCurrentClientCheckInsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetCurrentClientCheckIns/GetCurrentClientCheckInsResponse.cs
@@ -1,0 +1,33 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetCurrentClientCheckIns;
+
+/// <summary>
+/// Response for GET /client/weekly-check-ins/current.
+/// Returns 0–2 active (not responded, not dismissed) check-ins for the current ISO week.
+/// </summary>
+public class GetCurrentClientCheckInsResponse
+{
+    /// <summary>Active check-ins for the current ISO week.</summary>
+    public List<CheckInSummary> CheckIns { get; set; } = [];
+}
+
+/// <summary>Summary of a single active check-in.</summary>
+public class CheckInSummary
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Professional who sent the check-in.</summary>
+    public Guid ProfessionalUserId { get; set; }
+
+    /// <summary>Professional's display name.</summary>
+    public string ProfessionalName { get; set; } = string.Empty;
+
+    /// <summary>Profession type (Training or Nutrition).</summary>
+    public string Profession { get; set; } = string.Empty;
+
+    /// <summary>ISO-week Monday being planned.</summary>
+    public DateOnly WeekStartDate { get; set; }
+
+    /// <summary>When the scheduler sent this check-in.</summary>
+    public DateTime SentAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetTrainerCheckIns/GetTrainerCheckInsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetTrainerCheckIns/GetTrainerCheckInsEndpoint.cs
@@ -1,0 +1,69 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetTrainerCheckIns;
+
+/// <summary>
+/// Returns all responded and pending (not dismissed) check-ins for the caller's clients
+/// for the specified ISO week.
+/// </summary>
+public class GetTrainerCheckInsEndpoint(IApplicationDbContext db)
+    : Endpoint<GetTrainerCheckInsRequest, GetTrainerCheckInsResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/weekly-check-ins");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "List check-ins for a week (trainer)";
+            s.Description =
+                "Returns responded and pending (not dismissed) check-ins for the authenticated " +
+                "trainer's clients for the given week. Pass weekStartDate as YYYY-MM-DD (must be a Monday).";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetTrainerCheckInsRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var professionalUserId = Guid.Parse(userId);
+
+        var checkIns = await db.WeeklyCheckIns
+            .AsNoTracking()
+            .Where(c =>
+                c.ProfessionalUserId == professionalUserId &&
+                c.WeekStartDate == req.WeekStartDate &&
+                c.DismissedByClientAt == null)
+            .Include(c => c.ClientUser)
+            .OrderBy(c => c.ClientUser.LastName)
+                .ThenBy(c => c.ClientUser.FirstName)
+            .Select(c => new TrainerCheckInDto
+            {
+                Id = c.Id,
+                ClientUserId = c.ClientUserId,
+                ClientName = c.ClientUser.FirstName + " " + c.ClientUser.LastName,
+                Profession = c.Profession.ToString(),
+                WeekStartDate = c.WeekStartDate,
+                Flags = c.Flags,
+                Note = c.Note,
+                SentAt = c.SentAt,
+                RespondedAt = c.RespondedAt,
+                DismissedByClientAt = c.DismissedByClientAt,
+                ReviewedByTrainerAt = c.ReviewedByTrainerAt
+            })
+            .ToListAsync(ct);
+
+        await Send.OkAsync(new GetTrainerCheckInsResponse { CheckIns = checkIns }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetTrainerCheckIns/GetTrainerCheckInsRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetTrainerCheckIns/GetTrainerCheckInsRequest.cs
@@ -1,0 +1,12 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetTrainerCheckIns;
+
+/// <summary>
+/// Query parameters for GET /trainer/weekly-check-ins.
+/// </summary>
+public class GetTrainerCheckInsRequest
+{
+    /// <summary>
+    /// ISO-week Monday to filter by (YYYY-MM-DD). Required.
+    /// </summary>
+    public DateOnly WeekStartDate { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetTrainerCheckIns/GetTrainerCheckInsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetTrainerCheckIns/GetTrainerCheckInsResponse.cs
@@ -1,0 +1,49 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.GetTrainerCheckIns;
+
+/// <summary>
+/// Response for GET /trainer/weekly-check-ins.
+/// </summary>
+public class GetTrainerCheckInsResponse
+{
+    /// <summary>Check-ins for the requested week, filtered to the caller's clients.</summary>
+    public List<TrainerCheckInDto> CheckIns { get; set; } = [];
+}
+
+/// <summary>One check-in row as seen by the trainer.</summary>
+public class TrainerCheckInDto
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Client's ApplicationUser.Id.</summary>
+    public Guid ClientUserId { get; set; }
+
+    /// <summary>Client's display name.</summary>
+    public string ClientName { get; set; } = string.Empty;
+
+    /// <summary>Profession context.</summary>
+    public string Profession { get; set; } = string.Empty;
+
+    /// <summary>ISO-week Monday.</summary>
+    public DateOnly WeekStartDate { get; set; }
+
+    /// <summary>Flags selected by the client. Empty until responded.</summary>
+    public List<CheckInFlag> Flags { get; set; } = [];
+
+    /// <summary>Client's note. Null until responded.</summary>
+    public string? Note { get; set; }
+
+    /// <summary>When the scheduler sent this check-in.</summary>
+    public DateTime SentAt { get; set; }
+
+    /// <summary>When the client responded. Null if not yet responded.</summary>
+    public DateTime? RespondedAt { get; set; }
+
+    /// <summary>When the client dismissed. Null if not dismissed.</summary>
+    public DateTime? DismissedByClientAt { get; set; }
+
+    /// <summary>When the trainer marked this reviewed. Null if not reviewed.</summary>
+    public DateTime? ReviewedByTrainerAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedEndpoint.cs
@@ -1,0 +1,84 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.MarkCheckInReviewed;
+
+/// <summary>
+/// Trainer marks a check-in as reviewed.
+/// Broadcasts <c>weeklycheckinupdated</c> to both the professional and the client
+/// so the client's read-only view can become locked immediately.
+/// </summary>
+public class MarkCheckInReviewedEndpoint(
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier)
+    : Endpoint<MarkCheckInReviewedRequest, MarkCheckInReviewedResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/trainer/weekly-check-ins/{id}/mark-reviewed");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Mark a check-in as reviewed (trainer)";
+            s.Description =
+                "Sets ReviewedByTrainerAt on the check-in. " +
+                "After this the client can no longer edit their response. " +
+                "Broadcasts weeklycheckinupdated to both sides.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(MarkCheckInReviewedRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var professionalUserId = Guid.Parse(userId);
+
+        var checkIn = await db.WeeklyCheckIns
+            .FirstOrDefaultAsync(c => c.Id == req.Id, ct);
+
+        if (checkIn is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (checkIn.ProfessionalUserId != professionalUserId)
+        {
+            await Send.ForbiddenAsync(ct);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        checkIn.ReviewedByTrainerAt = now;
+        checkIn.DateModified = now;
+
+        await db.SaveChangesAsync(ct);
+
+        // Broadcast to both sides so each open tab/screen can update immediately.
+        var broadcastPayload = new
+        {
+            id = checkIn.Id,
+            reviewedAt = checkIn.ReviewedByTrainerAt
+        };
+
+        await notifier.NotifyAsync(professionalUserId, "weeklycheckinupdated", broadcastPayload, ct);
+        await notifier.NotifyAsync(checkIn.ClientUserId, "weeklycheckinupdated", broadcastPayload, ct);
+
+        await Send.OkAsync(new MarkCheckInReviewedResponse
+        {
+            Id = checkIn.Id,
+            ReviewedAt = checkIn.ReviewedByTrainerAt.Value
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedRequest.cs
@@ -1,0 +1,10 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.MarkCheckInReviewed;
+
+/// <summary>
+/// Request for POST /trainer/weekly-check-ins/{id}/mark-reviewed.
+/// </summary>
+public class MarkCheckInReviewedRequest
+{
+    /// <summary>Check-in identifier (route parameter).</summary>
+    public Guid Id { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedResponse.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.MarkCheckInReviewed;
+
+/// <summary>
+/// Response for POST /trainer/weekly-check-ins/{id}/mark-reviewed.
+/// </summary>
+public class MarkCheckInReviewedResponse
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>When the trainer marked the check-in reviewed (UTC).</summary>
+    public DateTime ReviewedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInEndpoint.cs
@@ -1,0 +1,124 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.RespondToCheckIn;
+
+/// <summary>
+/// Client submits (or re-submits) a response to a weekly check-in reminder.
+/// Blocked when the trainer has already marked the check-in reviewed.
+/// </summary>
+public class RespondToCheckInEndpoint(
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier)
+    : Endpoint<RespondToCheckInRequest, RespondToCheckInResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/weekly-check-ins/{id}/respond");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Respond to a weekly check-in";
+            s.Description =
+                "Persists the client's flags and note for a weekly check-in. " +
+                "Returns 409 if the trainer already marked this check-in reviewed.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(RespondToCheckInRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientUserId = Guid.Parse(userId);
+
+        var checkIn = await db.WeeklyCheckIns
+            .FirstOrDefaultAsync(c => c.Id == req.Id, ct);
+
+        if (checkIn is null || checkIn.ClientUserId != clientUserId)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (checkIn.ReviewedByTrainerAt.HasValue)
+        {
+            await this.SendProblemAsync(
+                statusCode: 409,
+                errorCode: ErrorCodes.CheckInAlreadyReviewed,
+                detail: "This check-in has already been reviewed by your trainer and can no longer be edited.",
+                ct);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        checkIn.Flags = req.Flags;
+        checkIn.Note = req.Note;
+        checkIn.RespondedAt = now;
+        checkIn.DateModified = now;
+
+        // Create in-app notification for the professional (no push — in-app only).
+        var notificationData = JsonSerializer.Serialize(new
+        {
+            weeklyCheckInId = checkIn.Id,
+            profession = checkIn.Profession.ToString(),
+            clientUserId
+        });
+
+        var notification = new Notification
+        {
+            RecipientUserId = checkIn.ProfessionalUserId,
+            Type = NotificationType.WeeklyCheckInResponded,
+            Title = "Client responded to check-in",
+            Body = "A client has responded to their weekly check-in reminder.",
+            Data = notificationData
+        };
+
+        db.Notifications.Add(notification);
+        await db.SaveChangesAsync(ct);
+
+        // Broadcast to both the client and the professional so both open tabs refresh.
+        var broadcastPayload = new
+        {
+            id = checkIn.Id,
+            respondedAt = checkIn.RespondedAt
+        };
+
+        await notifier.NotifyAsync(clientUserId, "weeklycheckinupdated", broadcastPayload, ct);
+        await notifier.NotifyAsync(checkIn.ProfessionalUserId, "weeklycheckinupdated", broadcastPayload, ct);
+
+        // Notify the professional's notification bell in real time.
+        await notifier.NotifyAsync(
+            checkIn.ProfessionalUserId,
+            "newnotification",
+            new
+            {
+                id = notification.Id,
+                type = NotificationType.WeeklyCheckInResponded.ToString(),
+                data = notificationData
+            },
+            ct);
+
+        await Send.OkAsync(new RespondToCheckInResponse
+        {
+            Id = checkIn.Id,
+            Flags = checkIn.Flags,
+            Note = checkIn.Note,
+            RespondedAt = checkIn.RespondedAt.Value
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInRequest.cs
@@ -1,0 +1,22 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.RespondToCheckIn;
+
+/// <summary>
+/// Request body for POST /client/weekly-check-ins/{id}/respond.
+/// </summary>
+public class RespondToCheckInRequest
+{
+    /// <summary>Route parameter — check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Zero or more flags selected by the client.
+    /// </summary>
+    public List<CheckInFlag> Flags { get; set; } = [];
+
+    /// <summary>
+    /// Optional free-text note. ≤ 500 characters.
+    /// </summary>
+    public string? Note { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInResponse.cs
@@ -1,0 +1,21 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.RespondToCheckIn;
+
+/// <summary>
+/// Response for POST /client/weekly-check-ins/{id}/respond.
+/// </summary>
+public class RespondToCheckInResponse
+{
+    /// <summary>Check-in identifier.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Flags persisted.</summary>
+    public List<CheckInFlag> Flags { get; set; } = [];
+
+    /// <summary>Note persisted.</summary>
+    public string? Note { get; set; }
+
+    /// <summary>When the response was recorded (UTC).</summary>
+    public DateTime RespondedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInValidator.cs
@@ -1,0 +1,23 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.WeeklyCheckIns.RespondToCheckIn;
+
+/// <summary>
+/// Validates <see cref="RespondToCheckInRequest"/>.
+/// </summary>
+public class RespondToCheckInValidator : Validator<RespondToCheckInRequest>
+{
+    /// <summary>Initializes validation rules.</summary>
+    public RespondToCheckInValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty()
+            .WithMessage("Check-in id is required.");
+
+        RuleFor(x => x.Note)
+            .MaximumLength(500)
+            .When(x => x.Note is not null)
+            .WithMessage("Note must not exceed 500 characters.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,8 +1,11 @@
+using System.Text.Json;
 using FitnessPlatform.Application.Domain.Common;
 using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FitnessPlatform.Application.Infrastructure.Data;
 
@@ -116,6 +119,11 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     /// </summary>
     public virtual DbSet<WeeklyCheckInClientOverride> WeeklyCheckInClientOverrides { get; set; } = null!;
 
+    /// <summary>
+    /// Weekly check-in instances (scheduler → client response → trainer review lifecycle).
+    /// </summary>
+    public virtual DbSet<WeeklyCheckIn> WeeklyCheckIns { get; set; } = null!;
+
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -178,6 +186,42 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             e.HasOne(o => o.ProfessionalUser)
                 .WithMany()
                 .HasForeignKey(o => o.ProfessionalUserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        builder.Entity<WeeklyCheckIn>(e =>
+        {
+            e.HasKey(c => c.Id);
+            e.Property(c => c.Profession).HasConversion<string>();
+            e.Property(c => c.WeekStartDate).HasColumnType("date");
+
+            // Flags stored as a jsonb array of flag name strings
+            var flagsConverter = new ValueConverter<List<CheckInFlag>, string>(
+                flags => JsonSerializer.Serialize(flags.Select(f => f.ToString()).ToList(),
+                    (JsonSerializerOptions?)null),
+                json => JsonSerializer.Deserialize<List<string>>(json, (JsonSerializerOptions?)null)!
+                    .Select(s => Enum.Parse<CheckInFlag>(s)).ToList());
+
+            e.Property(c => c.Flags)
+                .HasConversion(flagsConverter)
+                .HasColumnType("jsonb");
+
+            e.HasIndex(c => new
+            {
+                c.ClientUserId,
+                c.ProfessionalUserId,
+                c.Profession,
+                c.WeekStartDate
+            }).IsUnique();
+
+            e.HasOne(c => c.ClientUser)
+                .WithMany()
+                .HasForeignKey(c => c.ClientUserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            e.HasOne(c => c.ProfessionalUser)
+                .WithMany()
+                .HasForeignKey(c => c.ProfessionalUserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });
 

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
@@ -124,6 +124,11 @@ public interface IApplicationDbContext
     DbSet<WeeklyCheckInClientOverride> WeeklyCheckInClientOverrides { get; set; }
 
     /// <summary>
+    /// Weekly check-in instances (scheduler → client response → trainer review lifecycle).
+    /// </summary>
+    DbSet<WeeklyCheckIn> WeeklyCheckIns { get; set; }
+
+    /// <summary>
     /// Saves all changes made in this context to the database.
     /// </summary>
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260419182855_AddWeeklyCheckIn.Designer.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260419182855_AddWeeklyCheckIn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419182855_AddWeeklyCheckIn")]
+    partial class AddWeeklyCheckIn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260419182855_AddWeeklyCheckIn.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260419182855_AddWeeklyCheckIn.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWeeklyCheckIn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "weekly_check_ins",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    client_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    professional_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    profession = table.Column<string>(type: "text", nullable: false),
+                    week_start_date = table.Column<DateOnly>(type: "date", nullable: false),
+                    flags = table.Column<string>(type: "jsonb", nullable: false),
+                    note = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    sent_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    responded_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    dismissed_by_client_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    reviewed_by_trainer_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    date_created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    date_modified = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_weekly_check_ins", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_weekly_check_ins_users_client_user_id",
+                        column: x => x.client_user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "fk_weekly_check_ins_users_professional_user_id",
+                        column: x => x.professional_user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_weekly_check_ins_client_user_id_professional_user_id_profes",
+                table: "weekly_check_ins",
+                columns: new[] { "client_user_id", "professional_user_id", "profession", "week_start_date" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_weekly_check_ins_professional_user_id",
+                table: "weekly_check_ins",
+                column: "professional_user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "weekly_check_ins");
+        }
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/WeeklyCheckInScheduler.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/WeeklyCheckInScheduler.cs
@@ -1,0 +1,382 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+[assembly: InternalsVisibleTo("FitnessPlatform.Tests")]
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Background service that fires weekly check-in reminders on an hourly tick.
+/// For each enabled <see cref="WeeklyCheckInSetting"/> (with optional per-client overrides),
+/// it checks whether the configured fire time fell within the last tick window and, if so,
+/// inserts a <see cref="WeeklyCheckIn"/> row, creates a push notification, and broadcasts
+/// via SignalR.
+/// </summary>
+public class WeeklyCheckInScheduler(
+    IServiceScopeFactory scopeFactory,
+    ILogger<WeeklyCheckInScheduler> logger) : BackgroundService
+{
+    // Exposed for unit/integration tests — drive the scheduler with a virtual clock.
+    internal DateTime? OverrideNow { get; set; }
+
+    private DateTime _lastTickAt;
+    private bool _cursorInitialized;
+
+    /// <summary>
+    /// Entry point used by tests: execute one scheduler cycle treating <paramref name="now"/>
+    /// as the current UTC time.  The internal cursor is seeded on first call.
+    /// </summary>
+    internal async Task TickAsync(DateTime now, CancellationToken ct = default)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+
+        if (!_cursorInitialized)
+        {
+            _lastTickAt = await SeedCursorAsync(db, now, ct);
+            _cursorInitialized = true;
+        }
+
+        await ProcessTickAsync(db, scope.ServiceProvider, now, ct);
+        _lastTickAt = now;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Align first tick to the next :00 boundary.
+        var now = UtcNow();
+        var delay = TimeSpan.FromMinutes(60 - now.Minute)
+                            .Subtract(TimeSpan.FromSeconds(now.Second))
+                            .Subtract(TimeSpan.FromMilliseconds(now.Millisecond));
+
+        if (delay.TotalMilliseconds > 0)
+        {
+            logger.LogInformation(
+                "WeeklyCheckInScheduler: first tick in {Delay:mm\\:ss} (aligning to :00).", delay);
+            await Task.Delay(delay, stoppingToken);
+        }
+
+        // Seed cursor from DB so a cold start doesn't re-fire the last hour.
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+            _lastTickAt = await SeedCursorAsync(db, UtcNow(), stoppingToken);
+        }
+
+        _cursorInitialized = true;
+
+        using var timer = new PeriodicTimer(TimeSpan.FromHours(1));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var tickNow = UtcNow();
+            logger.LogDebug("WeeklyCheckInScheduler: tick at {TickNow:u}.", tickNow);
+
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+                await ProcessTickAsync(db, scope.ServiceProvider, tickNow, stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogError(ex, "WeeklyCheckInScheduler: unhandled error on tick at {TickNow:u}.", tickNow);
+            }
+
+            _lastTickAt = tickNow;
+
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
+    private async Task<DateTime> SeedCursorAsync(
+        IApplicationDbContext db, DateTime now, CancellationToken ct)
+    {
+        // Seed the cursor so that settings whose fire time fell in the last hour
+        // before startup are not re-fired (they already ran, and we would duplicate).
+        // We back off by 1 minute to ensure a setting whose fire time was at :00
+        // is not skipped on the very first tick after startup.
+        var maxSentAt = await db.WeeklyCheckIns
+            .AsNoTracking()
+            .MaxAsync(c => (DateTime?)c.SentAt, ct);
+
+        var oneHourAgo = now.AddHours(-1);
+
+        if (maxSentAt.HasValue)
+        {
+            var seedFrom = maxSentAt.Value.AddMinutes(-1);
+            var cursor = seedFrom < oneHourAgo ? oneHourAgo : seedFrom;
+            logger.LogInformation(
+                "WeeklyCheckInScheduler: seeding cursor to {Cursor:u} (maxSentAt={MaxSentAt:u}).",
+                cursor, maxSentAt.Value);
+            return cursor;
+        }
+
+        logger.LogInformation(
+            "WeeklyCheckInScheduler: no previous check-ins; seeding cursor to {Cursor:u}.", oneHourAgo);
+        return oneHourAgo;
+    }
+
+    private async Task ProcessTickAsync(
+        IApplicationDbContext db,
+        IServiceProvider services,
+        DateTime now,
+        CancellationToken ct)
+    {
+        // Load all enabled settings with their associated professional users
+        // and optional per-client overrides.
+        var settings = await db.WeeklyCheckInSettings
+            .AsNoTracking()
+            .Where(s => s.Enabled)
+            .Include(s => s.User)
+            .ToListAsync(ct);
+
+        if (settings.Count == 0) return;
+
+        var professionalUserIds = settings.Select(s => s.UserId).Distinct().ToList();
+
+        // Load all active client links for these professionals.
+        // We need the client's UserId (Guid) — walk via ProfessionalProfile.
+        var professionalProfiles = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .Where(p => professionalUserIds.Contains(p.UserId))
+            .Include(p => p.ClientLinks.Where(l => l.IsActive))
+                .ThenInclude(l => l.ClientProfile)
+                    .ThenInclude(cp => cp.User)
+            .ToListAsync(ct);
+
+        var profProfileById = professionalProfiles.ToDictionary(p => p.UserId);
+
+        // Load all relevant overrides at once.
+        var overrides = await db.WeeklyCheckInClientOverrides
+            .AsNoTracking()
+            .Where(o => professionalUserIds.Contains(o.ProfessionalUserId))
+            .ToListAsync(ct);
+
+        // Index overrides for quick lookup.
+        var overrideIndex = overrides.ToDictionary(
+            o => (o.ProfessionalUserId, o.ClientUserId, o.Profession));
+
+        var notifier = services.GetRequiredService<IRealtimeNotifier>();
+        var push = services.GetRequiredService<IPushNotificationService>();
+
+        foreach (var setting in settings)
+        {
+            if (!profProfileById.TryGetValue(setting.UserId, out var profProfile))
+                continue;
+
+            foreach (var link in profProfile.ClientLinks.Where(l => l.IsActive))
+            {
+                var clientUserId = link.ClientProfile.UserId;
+
+                overrideIndex.TryGetValue(
+                    (setting.UserId, clientUserId, setting.Profession),
+                    out var clientOverride);
+
+                // Override wins if present and non-null; otherwise fall back to setting.
+                var effectiveEnabled = clientOverride?.Enabled ?? setting.Enabled;
+                if (!effectiveEnabled) continue;
+
+                var effectiveDayOfWeek = clientOverride?.DayOfWeek ?? setting.DayOfWeek;
+                var effectiveTimeOfDay = clientOverride?.TimeOfDay ?? setting.TimeOfDay;
+
+                // Compute nextFireAt in the professional's time zone.
+                var professionalTz = GetTimeZoneInfo(setting.User.TimeZone);
+                var nextFireAt = ComputeNextFireAt(
+                    effectiveDayOfWeek, effectiveTimeOfDay, professionalTz, now);
+
+                // Fire if nextFireAt falls within the half-open window (_lastTickAt, now].
+                if (nextFireAt <= _lastTickAt || nextFireAt > now)
+                    continue;
+
+                // WeekStartDate = Monday of the ISO week AFTER the fire moment.
+                var weekStartDate = NextIsoMonday(nextFireAt);
+
+                var checkIn = new WeeklyCheckIn
+                {
+                    ClientUserId = clientUserId,
+                    ProfessionalUserId = setting.UserId,
+                    Profession = setting.Profession,
+                    WeekStartDate = weekStartDate,
+                    SentAt = now,
+                    DateCreated = now,
+                    DateModified = now
+                };
+
+                db.WeeklyCheckIns.Add(checkIn);
+
+                try
+                {
+                    await db.SaveChangesAsync(ct);
+                }
+                catch (DbUpdateException ex)
+                    when (IsUniqueViolation(ex))
+                {
+                    logger.LogWarning(
+                        "WeeklyCheckInScheduler: duplicate check-in skipped for " +
+                        "client={ClientUserId} professional={ProfessionalUserId} " +
+                        "profession={Profession} week={WeekStartDate}.",
+                        clientUserId, setting.UserId, setting.Profession, weekStartDate);
+
+                    // Remove the tracked entity so the context remains usable.
+                    db.WeeklyCheckIns.Remove(checkIn);
+                    continue;
+                }
+
+                // Create in-app notification for the client.
+                var professionalName =
+                    $"{setting.User.FirstName} {setting.User.LastName}".Trim();
+
+                var notificationData = JsonSerializer.Serialize(new
+                {
+                    weeklyCheckInId = checkIn.Id,
+                    profession = setting.Profession.ToString(),
+                    professionalName
+                });
+
+                var notification = new Notification
+                {
+                    RecipientUserId = clientUserId,
+                    Type = NotificationType.WeeklyCheckInRequested,
+                    Title = "Planning next week",
+                    Body = $"{professionalName} is planning next week. Let them know if anything special is coming up.",
+                    Data = notificationData
+                };
+
+                db.Notifications.Add(notification);
+                await db.SaveChangesAsync(ct);
+
+                // Send push notification.
+                try
+                {
+                    await push.SendAsync(
+                        clientUserId,
+                        "Planning next week",
+                        $"{professionalName} is planning next week. Let them know if anything special is coming up.",
+                        new { type = "WeeklyCheckInRequested", weeklyCheckInId = checkIn.Id },
+                        ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "WeeklyCheckInScheduler: failed to send push to client {ClientUserId}.", clientUserId);
+                }
+
+                // Broadcast via SignalR to the client's connection group.
+                try
+                {
+                    await notifier.NotifyAsync(
+                        clientUserId,
+                        "newnotification",
+                        new
+                        {
+                            id = notification.Id,
+                            type = NotificationType.WeeklyCheckInRequested.ToString(),
+                            data = notificationData
+                        },
+                        ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "WeeklyCheckInScheduler: failed to broadcast newnotification to client {ClientUserId}.",
+                        clientUserId);
+                }
+
+                logger.LogInformation(
+                    "WeeklyCheckInScheduler: fired check-in {CheckInId} client={ClientUserId} professional={ProfessionalUserId} profession={Profession} week={WeekStartDate}.",
+                    checkIn.Id, clientUserId, setting.UserId, setting.Profession, weekStartDate);
+            }
+        }
+    }
+
+    // ── Pure helpers (testable in isolation) ─────────────────────────────────
+
+    /// <summary>
+    /// Computes the most recent past occurrence of <paramref name="dayOfWeek"/>
+    /// at <paramref name="timeOfDay"/> in the given <paramref name="timeZone"/>,
+    /// relative to <paramref name="utcNow"/>, then returns it as UTC.
+    /// "Most recent" means the latest moment ≤ utcNow that matches the day+time combination.
+    /// </summary>
+    internal static DateTime ComputeNextFireAt(
+        DayOfWeek dayOfWeek,
+        TimeSpan timeOfDay,
+        TimeZoneInfo timeZone,
+        DateTime utcNow)
+    {
+        // Convert now to local time so we can reason about day+time in the professional's zone.
+        var localNow = TimeZoneInfo.ConvertTimeFromUtc(utcNow, timeZone);
+
+        // Walk back from today to find the last occurrence of the desired day.
+        var localDate = localNow.Date;
+        var daysBack = ((int)localDate.DayOfWeek - (int)dayOfWeek + 7) % 7;
+        var localFireDate = localDate.AddDays(-daysBack);
+        var localFireAt = localFireDate + timeOfDay;
+
+        // If this occurrence is in the future relative to localNow, step back by a week.
+        if (localFireAt > localNow)
+            localFireAt = localFireAt.AddDays(-7);
+
+        // Convert back to UTC.
+        return TimeZoneInfo.ConvertTimeToUtc(
+            DateTime.SpecifyKind(localFireAt, DateTimeKind.Unspecified),
+            timeZone);
+    }
+
+    /// <summary>
+    /// Returns the Monday of the ISO week that follows the week containing
+    /// <paramref name="referenceDate"/>. Always returns a <see cref="DateOnly"/>.
+    /// ISO weeks start on Monday (DayOfWeek.Monday = 1, Sunday = 0).
+    /// </summary>
+    internal static DateOnly NextIsoMonday(DateTime referenceDate)
+    {
+        var date = DateOnly.FromDateTime(referenceDate);
+        // How many days back from date to reach the Monday of the current ISO week.
+        // DayOfWeek.Monday = 1, Sunday = 0 → treat Sunday as day 7 for ISO.
+        var dayIndex = date.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)date.DayOfWeek;
+        var daysFromMonday = dayIndex - 1; // 0 for Monday, 6 for Sunday
+        // Monday of current week + 7 = Monday of next ISO week.
+        return date.AddDays(-daysFromMonday + 7);
+    }
+
+    private DateTime UtcNow() => OverrideNow ?? DateTime.UtcNow;
+
+    private TimeZoneInfo GetTimeZoneInfo(string ianaId)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+        }
+        catch
+        {
+            logger.LogWarning(
+                "WeeklyCheckInScheduler: unknown time zone '{IanaId}'; falling back to UTC.", ianaId);
+            return TimeZoneInfo.Utc;
+        }
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        return ex.InnerException is PostgresException pgEx
+               && pgEx.SqlState == "23505"; // unique_violation
+    }
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -196,6 +196,10 @@ else
 // Realtime notifications (SignalR)
 builder.Services.AddScoped<IRealtimeNotifier, SignalRNotifier>();
 
+// Weekly check-in scheduler — registered as both singleton (for test access) and hosted service.
+builder.Services.AddSingleton<WeeklyCheckInScheduler>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<WeeklyCheckInScheduler>());
+
 // Compliance
 builder.Services.AddScoped<IComplianceService, ComplianceService>();
 

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/DismissCheckInEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/DismissCheckInEndpointTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WeeklyCheckIns;
+
+/// <summary>
+/// Integration tests for POST /client/weekly-check-ins/{id}/dismiss.
+/// Uses Testcontainers PostgreSQL (Docker required). Excluded from CI.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class DismissCheckInEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "dismiss") =>
+        $"{Guid.NewGuid():N}@{tag}-test.com";
+
+    private async Task<(HttpClient Http, Guid ClientUserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Dismiss", "Client", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<Guid> SetupTrainerUserIdAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "T", "T", "Trainer");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return user.Id;
+    }
+
+    private async Task<Guid> InsertCheckInAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var days = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var monday = today.AddDays(-days);
+
+        var checkIn = new WeeklyCheckIn
+        {
+            ClientUserId = clientUserId,
+            ProfessionalUserId = professionalUserId,
+            Profession = Profession.Nutrition,
+            WeekStartDate = monday,
+            SentAt = DateTime.UtcNow.AddHours(-2),
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        };
+
+        db.WeeklyCheckIns.Add(checkIn);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return checkIn.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{Guid.NewGuid()}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_ValidCheckIn_Returns200_SetsDismissedAt_NoTrainerNotification()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientUserId, trainerId);
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{checkInId}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify DismissedByClientAt is set.
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.WeeklyCheckIns, c => c.Id == checkInId, TestContext.Current.CancellationToken);
+
+        persisted.DismissedByClientAt.Should().NotBeNull();
+
+        // No WeeklyCheckInResponded notification should be created for the trainer.
+        var respondedNotifications = await db.Notifications
+            .Where(n => n.RecipientUserId == trainerId &&
+                        n.Type == FitnessPlatform.Application.Domain.Enums.NotificationType.WeeklyCheckInResponded)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        respondedNotifications.Should().BeEmpty();
+
+        // weeklycheckinupdated is broadcast (to remove banner on client side).
+        var updatedCalls = notifier.Calls.Where(c => c.EventType == "weeklycheckinupdated").ToList();
+        updatedCalls.Should().HaveCountGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public async Task Dismiss_OtherClientCheckIn_Returns404()
+    {
+        var (http, _) = await SetupClientAsync();
+        var trainerId = await SetupTrainerUserIdAsync();
+
+        // Create check-in for a different client.
+        var http2 = factory.CreateClient();
+        var email2 = UniqueEmail("other2");
+        await TestHelpers.RegisterAsync(http2, email2, "TestPass1!", "Other", "Client", "Client");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var otherUser = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email2, TestContext.Current.CancellationToken);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var days = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var monday = today.AddDays(-days).AddDays(14); // future week to avoid constraint
+
+        var otherCheckIn = new WeeklyCheckIn
+        {
+            ClientUserId = otherUser.Id,
+            ProfessionalUserId = trainerId,
+            Profession = Profession.Nutrition,
+            WeekStartDate = monday,
+            SentAt = DateTime.UtcNow,
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        };
+        db.WeeklyCheckIns.Add(otherCheckIn);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{otherCheckIn.Id}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/GetCurrentClientCheckInsEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/GetCurrentClientCheckInsEndpointTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WeeklyCheckIns;
+
+/// <summary>
+/// Integration tests for GET /client/weekly-check-ins/current.
+/// Uses Testcontainers PostgreSQL (Docker required). Excluded from CI.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class GetCurrentClientCheckInsEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "get-current") =>
+        $"{Guid.NewGuid():N}@{tag}.com";
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Test", "Client", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+
+        return (http, user.Id);
+    }
+
+    private async Task<Guid> SetupTrainerAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Trainer", "Trainer", "Trainer");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return user.Id;
+    }
+
+    private async Task InsertCheckInAsync(
+        Guid clientUserId,
+        Guid professionalUserId,
+        Profession profession,
+        DateOnly? weekStartDate = null,
+        DateTime? respondedAt = null,
+        DateTime? dismissedAt = null)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var monday = weekStartDate ?? CurrentWeekMonday();
+
+        db.WeeklyCheckIns.Add(new WeeklyCheckIn
+        {
+            ClientUserId = clientUserId,
+            ProfessionalUserId = professionalUserId,
+            Profession = profession,
+            WeekStartDate = monday,
+            SentAt = DateTime.UtcNow.AddHours(-1),
+            RespondedAt = respondedAt,
+            DismissedByClientAt = dismissedAt,
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateOnly CurrentWeekMonday()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var days = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        return today.AddDays(-days);
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCurrent_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.GetAsync(
+            "/client/weekly-check-ins/current", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetCurrent_TrainerRole_Returns403()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer-role");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "T", "T", "Trainer");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        var response = await http.GetAsync(
+            "/client/weekly-check-ins/current", TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Happy paths ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCurrent_NoCheckIns_ReturnsEmptyList()
+    {
+        var (http, _) = await SetupClientAsync();
+
+        var response = await http.GetAsync(
+            "/client/weekly-check-ins/current", TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CheckInsWrapper>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body!.CheckIns.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCurrent_ActiveCheckIn_ReturnsIt()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerAsync();
+
+        await InsertCheckInAsync(clientUserId, trainerId, Profession.Training);
+
+        var response = await http.GetAsync(
+            "/client/weekly-check-ins/current", TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CheckInsWrapper>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body!.CheckIns.Should().HaveCount(1);
+        body.CheckIns[0].Profession.Should().Be("Training");
+    }
+
+    [Fact]
+    public async Task GetCurrent_AlreadyResponded_DoesNotReturn()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerAsync();
+
+        await InsertCheckInAsync(clientUserId, trainerId, Profession.Training,
+            respondedAt: DateTime.UtcNow);
+
+        var response = await http.GetAsync(
+            "/client/weekly-check-ins/current", TestContext.Current.CancellationToken);
+
+        var body = await response.Content.ReadFromJsonAsync<CheckInsWrapper>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body!.CheckIns.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCurrent_Dismissed_DoesNotReturn()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerAsync();
+
+        await InsertCheckInAsync(clientUserId, trainerId, Profession.Training,
+            dismissedAt: DateTime.UtcNow);
+
+        var response = await http.GetAsync(
+            "/client/weekly-check-ins/current", TestContext.Current.CancellationToken);
+
+        var body = await response.Content.ReadFromJsonAsync<CheckInsWrapper>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        body!.CheckIns.Should().BeEmpty();
+    }
+
+    // ── Local DTOs ────────────────────────────────────────────────────────────
+    private record CheckInsWrapper(List<CheckInDto> CheckIns);
+    private record CheckInDto(Guid Id, Guid ProfessionalUserId, string ProfessionalName, string Profession, DateOnly WeekStartDate, DateTime SentAt);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/GetTrainerCheckInsEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/GetTrainerCheckInsEndpointTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WeeklyCheckIns;
+
+/// <summary>
+/// Integration tests for GET /trainer/weekly-check-ins?weekStartDate=...
+/// Uses Testcontainers PostgreSQL (Docker required). Excluded from CI.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class GetTrainerCheckInsEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "get-trainer-ci") =>
+        $"{Guid.NewGuid():N}@{tag}.com";
+
+    private async Task<(HttpClient Http, Guid TrainerId)> SetupTrainerAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Trainer", "Get", "Trainer");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<Guid> SetupClientUserIdAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "C", "Client", "Client");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return user.Id;
+    }
+
+    private async Task InsertCheckInAsync(
+        Guid clientUserId,
+        Guid professionalUserId,
+        DateOnly weekStartDate,
+        bool dismissed = false)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        db.WeeklyCheckIns.Add(new WeeklyCheckIn
+        {
+            ClientUserId = clientUserId,
+            ProfessionalUserId = professionalUserId,
+            Profession = Profession.Training,
+            WeekStartDate = weekStartDate,
+            SentAt = DateTime.UtcNow.AddHours(-1),
+            DismissedByClientAt = dismissed ? DateTime.UtcNow : null,
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateOnly NextMonday() =>
+        DateOnly.FromDateTime(DateTime.UtcNow).AddDays(
+            ((int)DayOfWeek.Monday - (int)DateTime.UtcNow.DayOfWeek + 7) % 7 + 7);
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetList_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.GetAsync(
+            "/trainer/weekly-check-ins?weekStartDate=2026-04-21",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Filtering ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetList_ReturnsOnlyOwnRows()
+    {
+        var (http, trainerId) = await SetupTrainerAsync();
+        var (_, trainerId2) = await SetupTrainerAsync();
+        var clientId = await SetupClientUserIdAsync();
+
+        var weekDate = NextMonday();
+
+        await InsertCheckInAsync(clientId, trainerId, weekDate);
+        await InsertCheckInAsync(clientId, trainerId2, weekDate.AddDays(7)); // different week to avoid constraint
+
+        var response = await http.GetAsync(
+            $"/trainer/weekly-check-ins?weekStartDate={weekDate:yyyy-MM-dd}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CheckInsWrapper>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body!.CheckIns.Should().HaveCount(1);
+        body.CheckIns[0].Profession.Should().Be("Training");
+    }
+
+    [Fact]
+    public async Task GetList_DismissedRows_NotReturned()
+    {
+        var (http, trainerId) = await SetupTrainerAsync();
+        var clientId = await SetupClientUserIdAsync();
+
+        var weekDate = NextMonday().AddDays(14); // use a unique future week
+        await InsertCheckInAsync(clientId, trainerId, weekDate, dismissed: true);
+
+        var response = await http.GetAsync(
+            $"/trainer/weekly-check-ins?weekStartDate={weekDate:yyyy-MM-dd}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<CheckInsWrapper>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body!.CheckIns.Should().BeEmpty();
+    }
+
+    // ── Local DTOs ────────────────────────────────────────────────────────────
+    private record CheckInsWrapper(List<CheckInDto> CheckIns);
+    private record CheckInDto(Guid Id, Guid ClientUserId, string ClientName, string Profession, DateOnly WeekStartDate);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/MarkCheckInReviewedEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/MarkCheckInReviewedEndpointTests.cs
@@ -1,0 +1,169 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WeeklyCheckIns;
+
+/// <summary>
+/// Integration tests for POST /trainer/weekly-check-ins/{id}/mark-reviewed.
+/// Uses Testcontainers PostgreSQL (Docker required). Excluded from CI.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class MarkCheckInReviewedEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "mark-reviewed") =>
+        $"{Guid.NewGuid():N}@{tag}-test.com";
+
+    private async Task<(HttpClient Http, Guid TrainerId)> SetupTrainerAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Trainer", "Mark", "Trainer");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<Guid> SetupClientUserIdAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "C", "C", "Client");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return user.Id;
+    }
+
+    private async Task<Guid> InsertCheckInAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var days = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var monday = today.AddDays(-days);
+
+        var checkIn = new WeeklyCheckIn
+        {
+            ClientUserId = clientUserId,
+            ProfessionalUserId = professionalUserId,
+            Profession = Profession.Training,
+            WeekStartDate = monday,
+            SentAt = DateTime.UtcNow.AddHours(-2),
+            RespondedAt = DateTime.UtcNow.AddHours(-1),
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        };
+
+        db.WeeklyCheckIns.Add(checkIn);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return checkIn.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MarkReviewed_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            $"/trainer/weekly-check-ins/{Guid.NewGuid()}/mark-reviewed",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task MarkReviewed_ClientRole_Returns403()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client-role");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "C", "C", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        var response = await http.PostAsJsonAsync(
+            $"/trainer/weekly-check-ins/{Guid.NewGuid()}/mark-reviewed",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MarkReviewed_OwnCheckIn_Returns200_SetsReviewedAt_Broadcasts()
+    {
+        var (http, trainerId) = await SetupTrainerAsync();
+        var clientId = await SetupClientUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientId, trainerId);
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var response = await http.PostAsJsonAsync(
+            $"/trainer/weekly-check-ins/{checkInId}/mark-reviewed",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify DB.
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.WeeklyCheckIns, c => c.Id == checkInId, TestContext.Current.CancellationToken);
+
+        persisted.ReviewedByTrainerAt.Should().NotBeNull();
+
+        // Both trainer and client should receive weeklycheckinupdated.
+        var updatedCalls = notifier.Calls.Where(c => c.EventType == "weeklycheckinupdated").ToList();
+        updatedCalls.Should().HaveCountGreaterThanOrEqualTo(2);
+        updatedCalls.Should().Contain(c => c.UserId == trainerId);
+        updatedCalls.Should().Contain(c => c.UserId == clientId);
+    }
+
+    [Fact]
+    public async Task MarkReviewed_CrossTrainerAccess_Returns403()
+    {
+        var (_, trainerId) = await SetupTrainerAsync();
+        var clientId = await SetupClientUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientId, trainerId);
+
+        // Set up a second trainer and try to mark the first trainer's check-in.
+        var (http2, _) = await SetupTrainerAsync();
+
+        var response = await http2.PostAsJsonAsync(
+            $"/trainer/weekly-check-ins/{checkInId}/mark-reviewed",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task MarkReviewed_NotFound_Returns404()
+    {
+        var (http, _) = await SetupTrainerAsync();
+
+        var response = await http.PostAsJsonAsync(
+            $"/trainer/weekly-check-ins/{Guid.NewGuid()}/mark-reviewed",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/RespondToCheckInEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/RespondToCheckInEndpointTests.cs
@@ -1,0 +1,244 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WeeklyCheckIns;
+
+/// <summary>
+/// Integration tests for POST /client/weekly-check-ins/{id}/respond.
+/// Uses Testcontainers PostgreSQL (Docker required). Excluded from CI.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class RespondToCheckInEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "respond") =>
+        $"{Guid.NewGuid():N}@{tag}-test.com";
+
+    private async Task<(HttpClient Http, Guid ClientUserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Test", "Client", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<Guid> SetupTrainerUserIdAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "T", "T", "Trainer");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == email, TestContext.Current.CancellationToken);
+        return user.Id;
+    }
+
+    private async Task<Guid> InsertCheckInAsync(
+        Guid clientUserId,
+        Guid professionalUserId,
+        DateTime? reviewedAt = null)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var days = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var monday = today.AddDays(-days);
+
+        var checkIn = new WeeklyCheckIn
+        {
+            ClientUserId = clientUserId,
+            ProfessionalUserId = professionalUserId,
+            Profession = Profession.Training,
+            WeekStartDate = monday,
+            SentAt = DateTime.UtcNow.AddHours(-1),
+            ReviewedByTrainerAt = reviewedAt,
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        };
+
+        db.WeeklyCheckIns.Add(checkIn);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return checkIn.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Respond_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{Guid.NewGuid()}/respond",
+            new { flags = Array.Empty<string>() },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Respond_TrainerRole_Returns403()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer-role");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "T", "T", "Trainer");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{Guid.NewGuid()}/respond",
+            new { flags = Array.Empty<string>() },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Respond_ValidRequest_Returns200_AndPersistsFlags()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientUserId, trainerId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{checkInId}/respond",
+            new
+            {
+                flags = new[] { "Traveling", "SickOrLowEnergy" },
+                note = "I'll be in Berlin for 3 days."
+            },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Verify persisted state in DB.
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.WeeklyCheckIns, c => c.Id == checkInId, TestContext.Current.CancellationToken);
+
+        persisted.RespondedAt.Should().NotBeNull();
+        persisted.Flags.Should().Contain(CheckInFlag.Traveling);
+        persisted.Flags.Should().Contain(CheckInFlag.SickOrLowEnergy);
+        persisted.Note.Should().Be("I'll be in Berlin for 3 days.");
+    }
+
+    [Fact]
+    public async Task Respond_AfterReviewed_Returns409WithCheckInAlreadyReviewed()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientUserId, trainerId,
+            reviewedAt: DateTime.UtcNow.AddMinutes(-5));
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{checkInId}/respond",
+            new { flags = Array.Empty<string>() },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        raw.Should().Contain("CHECK_IN_ALREADY_REVIEWED");
+    }
+
+    [Fact]
+    public async Task Respond_OtherClientCheckIn_Returns404()
+    {
+        var (http, _) = await SetupClientAsync();
+        var otherClientId = Guid.NewGuid(); // doesn't exist
+        var trainerId = await SetupTrainerUserIdAsync();
+
+        // Insert a check-in for a different (fake) client.
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        // We need to create a real client to satisfy FK constraints.
+        var otherEmail = UniqueEmail("other-client");
+        var http2 = factory.CreateClient();
+        await TestHelpers.RegisterAsync(http2, otherEmail, "TestPass1!", "Other", "Client", "Client");
+        var otherUser = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(db.Users, u => u.Email == otherEmail, TestContext.Current.CancellationToken);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var days = ((int)today.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var monday = today.AddDays(-days);
+
+        var otherCheckIn = new WeeklyCheckIn
+        {
+            ClientUserId = otherUser.Id,
+            ProfessionalUserId = trainerId,
+            Profession = Profession.Training,
+            WeekStartDate = monday.AddDays(7), // different week to avoid unique constraint
+            SentAt = DateTime.UtcNow,
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        };
+        db.WeeklyCheckIns.Add(otherCheckIn);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Authenticated as the first client, try to respond to the other client's check-in.
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{otherCheckIn.Id}/respond",
+            new { flags = Array.Empty<string>() },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Respond_NoteTooLong_Returns400()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientUserId, trainerId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{checkInId}/respond",
+            new
+            {
+                flags = Array.Empty<string>(),
+                note = new string('x', 501)
+            },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── SignalR broadcast ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Respond_HappyPath_BroadcastsWeeklyCheckInUpdated()
+    {
+        var (http, clientUserId) = await SetupClientAsync();
+        var trainerId = await SetupTrainerUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientUserId, trainerId);
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        await http.PostAsJsonAsync(
+            $"/client/weekly-check-ins/{checkInId}/respond",
+            new { flags = Array.Empty<string>() },
+            TestContext.Current.CancellationToken);
+
+        var wciUpdatedCalls = notifier.Calls
+            .Where(c => c.EventType == "weeklycheckinupdated")
+            .ToList();
+
+        wciUpdatedCalls.Should().HaveCountGreaterThanOrEqualTo(1);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/WeeklyCheckInSchedulerTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/WeeklyCheckInSchedulerTests.cs
@@ -1,0 +1,241 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.WeeklyCheckIns;
+
+/// <summary>
+/// Integration tests for <see cref="WeeklyCheckInScheduler"/> using a virtual clock.
+/// Uses Testcontainers PostgreSQL + MongoDB (Docker required). Excluded from CI.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class WeeklyCheckInSchedulerTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "scheduler") =>
+        $"{Guid.NewGuid():N}@{tag}-test.com";
+
+    /// <summary>
+    /// Sets up a trainer user and an enabled weekly check-in setting for Training profession.
+    /// Returns the trainer UserId and the setting.
+    /// </summary>
+    private async Task<(Guid TrainerUserId, Guid ClientUserId)>
+        SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek dayOfWeek = DayOfWeek.Monday,
+            TimeSpan? timeOfDay = null,
+            string timeZone = "Europe/Prague")
+    {
+        // Register trainer
+        var trainerEmail = UniqueEmail("trainer");
+        var trainerHttp = factory.CreateClient();
+        await TestHelpers.RegisterAsync(trainerHttp, trainerEmail, "TestPass1!", "Sched", "Trainer", "Trainer");
+
+        // Register client
+        var clientEmail = UniqueEmail("client");
+        var clientHttp = factory.CreateClient();
+        await TestHelpers.RegisterAsync(clientHttp, clientEmail, "TestPass1!", "Sched", "Client", "Client");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var trainerUser = await db.Users.FirstAsync(
+            u => u.Email == trainerEmail, TestContext.Current.CancellationToken);
+        var clientUser = await db.Users.FirstAsync(
+            u => u.Email == clientEmail, TestContext.Current.CancellationToken);
+
+        // Set timezone on trainer.
+        trainerUser.TimeZone = timeZone;
+
+        // Get professional profile (auto-created on registration).
+        var profProfile = await db.ProfessionalProfiles.FirstAsync(
+            p => p.UserId == trainerUser.Id, TestContext.Current.CancellationToken);
+
+        // Get client profile.
+        var clientProfile = await db.ClientProfiles.FirstAsync(
+            cp => cp.UserId == clientUser.Id, TestContext.Current.CancellationToken);
+
+        // Link client to trainer.
+        db.ClientProfessionalLinks.Add(new ClientProfessionalLink
+        {
+            PublicId = Guid.NewGuid(),
+            ProfessionalProfileId = profProfile.Id,
+            ClientProfileId = clientProfile.Id,
+            ProfessionalRole = UserRole.Trainer,
+            IsActive = true,
+            CanViewTrainingPlans = true,
+            CanViewNutritionPlans = false,
+            DateCreated = DateTime.UtcNow
+        });
+
+        // Create the setting.
+        db.WeeklyCheckInSettings.Add(new WeeklyCheckInSetting
+        {
+            UserId = trainerUser.Id,
+            Profession = Profession.Training,
+            DayOfWeek = dayOfWeek,
+            TimeOfDay = timeOfDay ?? TimeSpan.FromHours(18),
+            Enabled = true,
+            DateCreated = DateTime.UtcNow,
+            DateModified = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return (trainerUser.Id, clientUser.Id);
+    }
+
+    // ── Core scheduler behavior ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Tick_PastFireTime_CreatesExactlyOneCheckIn()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Monday,
+            TimeSpan.FromHours(18),
+            "Europe/Prague");
+
+        // Europe/Prague is UTC+2 in summer (CEST).
+        // Monday 18:00 Prague = Monday 16:00 UTC.
+        // So if "now" is just after Monday 16:00 UTC, the scheduler should fire.
+
+        // Find the last (past) Monday at 16:00 UTC.
+        var utcNow = DateTime.UtcNow;
+        var daysToLastMonday = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var lastMonday = utcNow.Date.AddDays(-daysToLastMonday);
+        // 18:00 Prague CEST = 16:00 UTC
+        var fireAt = lastMonday.AddHours(16);
+        // Ensure fireAt is in the past (back it up a week if today is exactly Monday 16:00 UTC).
+        if (fireAt >= utcNow) fireAt = fireAt.AddDays(-7);
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        // Set cursor to just before the fire time so it falls within the window.
+        scheduler.OverrideNow = fireAt.AddMinutes(-60);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Now tick PAST the fire time.
+        scheduler.OverrideNow = fireAt.AddMinutes(1);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var checkIns = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientUserId && c.ProfessionalUserId == trainerUserId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        checkIns.Should().HaveCount(1);
+        checkIns[0].SentAt.Should().BeCloseTo(scheduler.OverrideNow!.Value, precision: TimeSpan.FromSeconds(5));
+
+        // WeekStartDate should be the Monday of the NEXT ISO week after the fire moment.
+        var expectedWeekStart = WeeklyCheckInScheduler.NextIsoMonday(fireAt);
+        checkIns[0].WeekStartDate.Should().Be(expectedWeekStart);
+    }
+
+    [Fact]
+    public async Task Tick_SameFireTime_Twice_DoesNotDuplicate()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Tuesday,
+            TimeSpan.FromHours(10),
+            "UTC");
+
+        // Tuesday 10:00 UTC. Find last Tuesday.
+        var utcNow = DateTime.UtcNow;
+        var daysToLastTuesday = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Tuesday + 7) % 7;
+        var lastTuesday = utcNow.Date.AddDays(-daysToLastTuesday).AddHours(10);
+        if (lastTuesday >= utcNow) lastTuesday = lastTuesday.AddDays(-7);
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        // First tick: before fire.
+        scheduler.OverrideNow = lastTuesday.AddMinutes(-5);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Second tick: past fire time → should create 1 check-in.
+        scheduler.OverrideNow = lastTuesday.AddMinutes(30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Third tick: same window → unique-index prevents duplication.
+        scheduler.OverrideNow = lastTuesday.AddMinutes(45);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var checkIns = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientUserId && c.ProfessionalUserId == trainerUserId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        checkIns.Should().HaveCount(1, "unique-index must prevent duplicates even across multiple ticks");
+    }
+
+    [Fact]
+    public async Task Tick_CreatesNotificationRow()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Wednesday,
+            TimeSpan.FromHours(9),
+            "UTC");
+
+        var utcNow = DateTime.UtcNow;
+        var daysToLastWed = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Wednesday + 7) % 7;
+        var lastWed = utcNow.Date.AddDays(-daysToLastWed).AddHours(9);
+        if (lastWed >= utcNow) lastWed = lastWed.AddDays(-7);
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        scheduler.OverrideNow = lastWed.AddMinutes(-30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        scheduler.OverrideNow = lastWed.AddMinutes(5);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var notification = await db.Notifications
+            .Where(n =>
+                n.RecipientUserId == clientUserId &&
+                n.Type == NotificationType.WeeklyCheckInRequested)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        notification.Should().NotBeNull("the scheduler must create a WeeklyCheckInRequested notification");
+    }
+
+    [Fact]
+    public async Task Tick_BroadcastsViaSignalR()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Thursday,
+            TimeSpan.FromHours(20),
+            "UTC");
+
+        var utcNow = DateTime.UtcNow;
+        var daysToLastThu = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Thursday + 7) % 7;
+        var lastThu = utcNow.Date.AddDays(-daysToLastThu).AddHours(20);
+        if (lastThu >= utcNow) lastThu = lastThu.AddDays(-7);
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        scheduler.OverrideNow = lastThu.AddMinutes(-60);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        scheduler.OverrideNow = lastThu.AddMinutes(1);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        var newNotificationCalls = notifier.Calls
+            .Where(c => c.UserId == clientUserId && c.EventType == "newnotification")
+            .ToList();
+
+        newNotificationCalls.Should().HaveCount(1,
+            "scheduler must broadcast exactly one newnotification to the client");
+    }
+}

--- a/backend/FitnessPlatform.Tests/Services/WeeklyCheckInSchedulerUnitTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/WeeklyCheckInSchedulerUnitTests.cs
@@ -1,0 +1,132 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Infrastructure.Services;
+
+namespace FitnessPlatform.Tests.Services;
+
+/// <summary>
+/// Pure unit tests for the scheduler's TZ math helpers — no Docker required.
+/// </summary>
+public class WeeklyCheckInSchedulerUnitTests
+{
+    private static readonly TimeZoneInfo Prague =
+        TimeZoneInfo.FindSystemTimeZoneById("Europe/Prague");
+
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+
+    // ── ComputeNextFireAt ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeNextFireAt_FireDayIsToday_TimeAlreadyPassed_ReturnsToday()
+    {
+        // Today (UTC) is a Wednesday, 19:00.
+        // Setting: Wednesday 18:00 UTC.
+        var utcNow = new DateTime(2026, 4, 22, 19, 0, 0, DateTimeKind.Utc); // Wednesday
+        utcNow.DayOfWeek.Should().Be(DayOfWeek.Wednesday);
+
+        var result = WeeklyCheckInScheduler.ComputeNextFireAt(
+            DayOfWeek.Wednesday, TimeSpan.FromHours(18), Utc, utcNow);
+
+        result.Should().Be(new DateTime(2026, 4, 22, 18, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ComputeNextFireAt_FireDayIsToday_TimeFuture_ReturnsOneWeekAgo()
+    {
+        // Today (UTC) is a Wednesday, 17:00.
+        // Setting: Wednesday 18:00 UTC — hasn't fired yet today → step back to last Wednesday.
+        var utcNow = new DateTime(2026, 4, 22, 17, 0, 0, DateTimeKind.Utc); // Wednesday
+        var result = WeeklyCheckInScheduler.ComputeNextFireAt(
+            DayOfWeek.Wednesday, TimeSpan.FromHours(18), Utc, utcNow);
+
+        result.Should().Be(new DateTime(2026, 4, 15, 18, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ComputeNextFireAt_FireDayInPast_ReturnsCorrectPastDay()
+    {
+        // Today (UTC) is Friday. Setting is Monday 18:00 UTC.
+        // Friday = day 5, Monday = day 1. 5-1 = 4 days back → Monday.
+        var utcNow = new DateTime(2026, 4, 24, 20, 0, 0, DateTimeKind.Utc); // Friday
+        utcNow.DayOfWeek.Should().Be(DayOfWeek.Friday);
+
+        var result = WeeklyCheckInScheduler.ComputeNextFireAt(
+            DayOfWeek.Monday, TimeSpan.FromHours(18), Utc, utcNow);
+
+        result.Should().Be(new DateTime(2026, 4, 20, 18, 0, 0, DateTimeKind.Utc)); // previous Monday
+    }
+
+    [Fact]
+    public void ComputeNextFireAt_PragueTimezone_SummerTime_ConvertsCorrectly()
+    {
+        // April 2026 is CEST (UTC+2). Monday 18:00 Prague = 16:00 UTC.
+        // "now" is Monday 2026-04-20 17:00 UTC (= 19:00 Prague) — past the fire time.
+        var utcNow = new DateTime(2026, 4, 20, 17, 0, 0, DateTimeKind.Utc); // Monday
+        utcNow.DayOfWeek.Should().Be(DayOfWeek.Monday);
+
+        var result = WeeklyCheckInScheduler.ComputeNextFireAt(
+            DayOfWeek.Monday, TimeSpan.FromHours(18), Prague, utcNow);
+
+        // Expected: Monday 2026-04-20 18:00 Prague = 16:00 UTC.
+        result.Should().Be(new DateTime(2026, 4, 20, 16, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ComputeNextFireAt_PragueTimezone_SummerTime_NotYetFired_ReturnsOneWeekPrior()
+    {
+        // "now" is Monday 2026-04-20 15:00 UTC = 17:00 Prague — before the 18:00 fire time.
+        var utcNow = new DateTime(2026, 4, 20, 15, 0, 0, DateTimeKind.Utc);
+
+        var result = WeeklyCheckInScheduler.ComputeNextFireAt(
+            DayOfWeek.Monday, TimeSpan.FromHours(18), Prague, utcNow);
+
+        // Should return the previous Monday (2026-04-13 18:00 Prague = 16:00 UTC).
+        result.Should().Be(new DateTime(2026, 4, 13, 16, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void ComputeNextFireAt_SundayFire_TodayIsMonday_ReturnsSundayYesterday()
+    {
+        // Today is Monday 2026-04-20 12:00 UTC. Setting: Sunday 18:00 UTC.
+        var utcNow = new DateTime(2026, 4, 20, 12, 0, 0, DateTimeKind.Utc); // Monday
+        var result = WeeklyCheckInScheduler.ComputeNextFireAt(
+            DayOfWeek.Sunday, TimeSpan.FromHours(18), Utc, utcNow);
+
+        result.Should().Be(new DateTime(2026, 4, 19, 18, 0, 0, DateTimeKind.Utc)); // Sunday
+    }
+
+    // ── NextIsoMonday ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NextIsoMonday_FromMonday_ReturnsMondayNextWeek()
+    {
+        var monday = new DateTime(2026, 4, 20); // Monday
+        var result = WeeklyCheckInScheduler.NextIsoMonday(monday);
+        result.Should().Be(new DateOnly(2026, 4, 27));
+    }
+
+    [Fact]
+    public void NextIsoMonday_FromFriday_ReturnsMondayOfNextWeek()
+    {
+        var friday = new DateTime(2026, 4, 24); // Friday
+        var result = WeeklyCheckInScheduler.NextIsoMonday(friday);
+        result.Should().Be(new DateOnly(2026, 4, 27));
+    }
+
+    [Fact]
+    public void NextIsoMonday_FromSunday_ReturnsMondayTomorrow()
+    {
+        var sunday = new DateTime(2026, 4, 26); // Sunday
+        var result = WeeklyCheckInScheduler.NextIsoMonday(sunday);
+        result.Should().Be(new DateOnly(2026, 4, 27));
+    }
+
+    [Fact]
+    public void NextIsoMonday_FromSaturday_ReturnsMondayOfNextIsoWeek()
+    {
+        // Saturday April 25 is in ISO week April 20-26.
+        // Next ISO week starts April 27.
+        var saturday = new DateTime(2026, 4, 25); // Saturday
+        var result = WeeklyCheckInScheduler.NextIsoMonday(saturday);
+        result.Should().Be(new DateOnly(2026, 4, 27));
+    }
+}


### PR DESCRIPTION
Fixes #34

## Summary

Backend runtime engine of the weekly check-in reminder:

- **Entity & migration** — `WeeklyCheckIn` with `(ClientUserId, ProfessionalUserId, Profession, WeekStartDate)` unique index; `Flags` stored as JSON-string → jsonb column via `ValueConverter<List<CheckInFlag>, string>` (EF Core 10 + snake_case convention constraint made the native-array path non-trivial; string-to-jsonb keeps the column queryable and the conversion explicit).
- **Scheduler** — `WeeklyCheckInScheduler` registered **both as a Singleton and a HostedService**: the HostedService runs the hourly tick in production, and tests resolve the same singleton instance to call internal `TickAsync(now)` with a virtual clock. `InternalsVisibleTo("FitnessPlatform.Tests")` was added in `WeeklyCheckInScheduler.cs` to make the internal tick accessible to the test project. Idempotency is guaranteed by the unique index — duplicate insert attempts on the same `(client, professional, profession, week)` are swallowed with a logged warning.
- **7 endpoints**:
  - Client: `GET /client/weekly-check-ins/current`, `POST /client/weekly-check-ins/{id}/respond`, `POST /client/weekly-check-ins/{id}/dismiss`.
  - Trainer: `GET /trainer/weekly-check-ins?weekStartDate=...`, `GET /trainer/weekly-check-ins/{id}`, `POST /trainer/weekly-check-ins/{id}/mark-reviewed`, `GET /trainer/clients/{clientUserId}/weekly-check-ins/current?profession=...`.
  - The 409 on `respond` when `ReviewedByTrainerAt != null` uses `SendProblemAsync` with a fresh `ProblemDetails` — FastEndpoints' `ThrowErrorWithCode` helper is 400-only, and this needed an arbitrary 409 with the `CHECK_IN_ALREADY_REVIEWED` code.
- **SignalR** — `weeklycheckinupdated` event with payload `{ id, respondedAt?, reviewedAt?, dismissedAt? }` is broadcast to **both** the client's and the professional's connection groups on every state change (respond / dismiss / mark-reviewed), so both sides of the pair stay in sync without polling. `newnotification` is reused for `WeeklyCheckInRequested` (client) and `WeeklyCheckInResponded` (trainer).
- **Notifications pipeline** — scheduler creates `Notification(WeeklyCheckInRequested)`, invokes `ExpoPushNotificationService`, and broadcasts SignalR. Trainer-side `WeeklyCheckInResponded` is in-app only (no push) per the spec.
- **Tests** — 5 endpoint tests + 2 scheduler tests (Testcontainers + virtual-clock unit tests). CI workflow exclusion updated in `.github/workflows/backend.yml` for the existing Testcontainers carve-out.

## Design decisions (called out for review)

- **`List<CheckInFlag>` as jsonb via string converter.** EF Core 10's default value-conversion pipeline collided with the repo's snake_case naming convention on native array columns. A `ValueConverter<List<CheckInFlag>, string>` producing JSON and mapped to `jsonb` keeps the schema clean and avoids fragile array-column workarounds. Queries on `Flags` go through the serialized payload — acceptable since the only lookup path is by-id.
- **Scheduler as Singleton + HostedService.** The same instance is registered twice so production uses the timer loop and tests can call `TickAsync(now)` directly with a `TimeProvider` stub. The HostedService wrapper just delegates to the singleton.
- **`InternalsVisibleTo`.** Added inside `WeeklyCheckInScheduler.cs` so the test project can reach the internal tick method without widening the public API.
- **409 via `SendProblemAsync`.** Chosen because `ThrowErrorWithCode` is locked to 400; this preserves the `CHECK_IN_ALREADY_REVIEWED` error code on the correct status code.
- **`weeklycheckinupdated` broadcast to both groups.** Client dismisses → trainer's Today card should update. Trainer marks-reviewed → client's banner should update. Broadcasting to both pairs avoids a second round-trip.

## Test plan

- [ ] `dotnet test` passes locally (Docker required — Testcontainers).
- [ ] Scheduler: single-tick creates one row + notification + push + SignalR broadcast; double-tick across the same fire time creates exactly one row.
- [ ] `POST /client/.../respond` → 200, persists flags+note, creates trainer `Notification(WeeklyCheckInResponded)`, broadcasts `weeklycheckinupdated`.
- [ ] `POST /client/.../respond` on reviewed check-in → 409 with `CHECK_IN_ALREADY_REVIEWED`.
- [ ] `POST /client/.../dismiss` → 200, no trainer notification.
- [ ] `POST /trainer/.../mark-reviewed` → 200, broadcasts update.
- [ ] `GET /trainer/weekly-check-ins?weekStartDate=...` scoped to authed trainer; cross-trainer → 403.
- [ ] Migration `20260419182855_AddWeeklyCheckIn` applies cleanly on a fresh database.

> Note: touches `backend/**/Migrations/**` — per the repo's merge-exclusion list, this PR is **human-merge-only**. The automated merge gate will refuse; the maintainer merges manually after approval.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)