### PR TITLE
feat(mobile): client weekly check-in — banner + response sheet + notification type (#37)

### DIFF
--- a/mobile/app/(client)/(tabs)/index.tsx
+++ b/mobile/app/(client)/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   View,
   StyleSheet,
@@ -21,9 +21,12 @@ import { HasTrainerState } from '@/components/today/HasTrainerState'
 import { NotificationSheet } from '@/components/notifications/NotificationSheet'
 import { InviteCard } from '@/components/notifications/InviteCard'
 import { QuestionnaireBanner } from '@/components/notifications/QuestionnaireBanner'
+import { WeeklyCheckInBanner } from '@/components/today/WeeklyCheckInBanner'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useClientInvite } from '@/hooks/useClientInvite'
 import { getPendingQuestionnaires, type PendingQuestionnairesResponse } from '@/api/questionnaire'
+import { getCurrentCheckIns, type CheckInSummary } from '@/api/weeklyCheckIns'
+import { onEvent } from '@/api/signalr'
 import { Toast } from '@/lib/toast'
 
 // ─── Main Screen ──────────────────────────────────────────────────────
@@ -50,8 +53,27 @@ export default function TodayScreen() {
   // Pending invite — always fetch, client can receive invites in any state
   const { invite, accept, decline } = useClientInvite(true)
 
-  // Pending questionnaires — visible in all states with an active link
+  // ── Weekly check-ins (pending banner) ──
   const hasActiveLink = useAuthStore((s) => s.user?.hasActiveLink ?? false)
+  const checkInsQuery = useQuery({
+    queryKey: ['current-weekly-check-ins'],
+    queryFn: getCurrentCheckIns,
+    enabled: hasActiveLink,
+    staleTime: 30_000,
+  })
+  const pendingCheckIns: CheckInSummary[] = checkInsQuery.data?.checkIns ?? []
+
+  // Subscribe to weeklycheckinupdated so the banner disappears when client responds
+  // or when the trainer marks reviewed (both paths fire the event).
+  useEffect(() => {
+    const unsub = onEvent('weeklycheckinupdated', () => {
+      queryClient.invalidateQueries({ queryKey: ['current-weekly-check-ins'] })
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    })
+    return unsub
+  }, [queryClient])
+
+  // Pending questionnaires — visible in all states with an active link
   const pendingQQuery = useQuery<PendingQuestionnairesResponse>({
     queryKey: ['pending-questionnaires'],
     queryFn: getPendingQuestionnaires,
@@ -85,6 +107,11 @@ export default function TodayScreen() {
             router.push(href(`/(client)/messages/${n.actionPayload.threadId}`))
           }
           break
+        case 'weekly_checkin':
+          if (n.actionPayload?.weeklyCheckInId) {
+            router.push(href(`/(client)/weekly-checkin/${n.actionPayload.weeklyCheckInId}`))
+          }
+          break
       }
     },
     [markRead, router],
@@ -111,6 +138,7 @@ export default function TodayScreen() {
       queryClient.invalidateQueries({ queryKey: ['notifications'] }),
       queryClient.invalidateQueries({ queryKey: ['client-invite'] }),
       queryClient.invalidateQueries({ queryKey: ['pending-questionnaires'] }),
+      queryClient.invalidateQueries({ queryKey: ['current-weekly-check-ins'] }),
     ])
     setRefreshing(false)
   }, [queryClient])
@@ -167,6 +195,17 @@ export default function TodayScreen() {
             }}
           />
         )}
+
+        {/* Weekly check-in banners — one per pending check-in, stacks vertically */}
+        {pendingCheckIns.map((checkIn) => (
+          <WeeklyCheckInBanner
+            key={checkIn.id}
+            checkIn={checkIn}
+            onOpen={(ci) =>
+              router.push(href(`/(client)/weekly-checkin/${ci.id}`))
+            }
+          />
+        ))}
 
         {/* ── State: no-trainer ── */}
         {todayState === 'no-trainer' && <NoTrainerState />}

--- a/mobile/app/(client)/weekly-checkin/[id].tsx
+++ b/mobile/app/(client)/weekly-checkin/[id].tsx
@@ -267,10 +267,11 @@ export default function WeeklyCheckInScreen() {
     )
   }
 
-  const professionLabel =
+  const professionLabel = `${effectiveCheckIn.profession === 'Training' ? '🏋️' : '🥗'} ${t(
     effectiveCheckIn.profession === 'Training'
-      ? '🏋️ Training'
-      : '🥗 Nutrition'
+      ? 'weeklyCheckIn.profession.training'
+      : 'weeklyCheckIn.profession.nutrition',
+  )}`
 
   const promptKey =
     effectiveCheckIn.profession === 'Training'

--- a/mobile/app/(client)/weekly-checkin/[id].tsx
+++ b/mobile/app/(client)/weekly-checkin/[id].tsx
@@ -1,0 +1,616 @@
+import React, { useState, useCallback } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { goldAlpha } from '@/constants/colors'
+import { Radius } from '@/constants/radius'
+import { Avatar } from '@/components/ui/Avatar'
+import { Toast } from '@/lib/toast'
+import {
+  getCurrentCheckIns,
+  respondToCheckIn,
+  dismissCheckIn,
+  CHECK_IN_FLAGS,
+} from '@/api/weeklyCheckIns'
+import type { CheckInFlag, CheckInDetail } from '@/api/weeklyCheckIns'
+
+// ─── Flag metadata ─────────────────────────────────────────────────────────────
+
+const FLAG_EMOJI: Record<CheckInFlag, string> = {
+  Traveling: '✈️',
+  EventOrCelebration: '🎉',
+  SickOrLowEnergy: '🤒',
+  InjuryOrPain: '🩹',
+  MoreTimeAvailable: '⏱️',
+  LessTimeAvailable: '⏳',
+}
+
+const FLAG_I18N_KEY: Record<CheckInFlag, string> = {
+  Traveling: 'weeklyCheckIn.flag.traveling',
+  EventOrCelebration: 'weeklyCheckIn.flag.eventOrCelebration',
+  SickOrLowEnergy: 'weeklyCheckIn.flag.sickOrLowEnergy',
+  InjuryOrPain: 'weeklyCheckIn.flag.injuryOrPain',
+  MoreTimeAvailable: 'weeklyCheckIn.flag.moreTimeAvailable',
+  LessTimeAvailable: 'weeklyCheckIn.flag.lessTimeAvailable',
+}
+
+const NOTE_MAX_LENGTH = 500
+
+// ─── Helper: format week range ────────────────────────────────────────────────
+
+/**
+ * Given an ISO date string "YYYY-MM-DD" for the week's Monday,
+ * returns a localized range string "Mon Apr 20 – Sun Apr 26".
+ */
+function formatWeekRange(weekStartDate: string, locale: string): string {
+  const monday = new Date(`${weekStartDate}T00:00:00`)
+  const sunday = new Date(monday)
+  sunday.setDate(monday.getDate() + 6)
+
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' }
+  const monStr = monday.toLocaleDateString(locale, opts)
+  const sunStr = sunday.toLocaleDateString(locale, { ...opts, year: 'numeric' })
+  return `${monStr} – ${sunStr}`
+}
+
+// ─── Chip component ────────────────────────────────────────────────────────────
+
+interface ChipProps {
+  flag: CheckInFlag
+  selected: boolean
+  disabled: boolean
+  onToggle: (flag: CheckInFlag) => void
+}
+
+function FlagChip({ flag, selected, disabled, onToggle }: ChipProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  const bgColor = selected ? goldAlpha['20'] : colors.fill2
+  const borderColor = selected ? colors.gold : colors.sep
+  const textColor = selected ? colors.gold : colors.label2
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.chip,
+        {
+          backgroundColor: bgColor,
+          borderColor,
+          opacity: pressed && !disabled ? 0.75 : 1,
+        },
+      ]}
+      onPress={() => !disabled && onToggle(flag)}
+      disabled={disabled}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: selected, disabled }}
+      accessibilityLabel={`${FLAG_EMOJI[flag]} ${t(FLAG_I18N_KEY[flag])}`}
+    >
+      <Text style={styles.chipEmoji}>{FLAG_EMOJI[flag]}</Text>
+      <Text style={[styles.chipLabel, { color: textColor }]} numberOfLines={2}>
+        {t(FLAG_I18N_KEY[flag])}
+      </Text>
+    </Pressable>
+  )
+}
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export default function WeeklyCheckInScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const colors = useTheme()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { t, i18n } = useTranslation()
+
+  // Fetch the full list to find this specific check-in (including responded ones).
+  // The current endpoint returns only active (pending) check-ins.
+  // For responded check-ins, the data comes via route params from the banner/notification.
+  // We use a TanStack query so SignalR invalidations auto-refresh.
+  const { data, isLoading } = useQuery({
+    queryKey: ['current-weekly-check-ins'],
+    queryFn: getCurrentCheckIns,
+    // Stale time: 30s — SignalR drives the real invalidation
+    staleTime: 30_000,
+  })
+
+  // Find this check-in in the result. If not found (already responded / dismissed),
+  // we rely on the detail passed via navigation params (see note below).
+  const activeCheckIn = data?.checkIns.find((c) => c.id === id)
+
+  // When the check-in was previously responded to, it won't appear in the
+  // /current list (which only returns pending). The parent (Today screen)
+  // passes the full detail via expo-router params for the read-only case.
+  // We read those extra params here.
+  const params = useLocalSearchParams<{
+    id: string
+    professionalName?: string
+    profession?: string
+    weekStartDate?: string
+    flags?: string
+    note?: string
+    respondedAt?: string
+    reviewedByTrainerAt?: string
+  }>()
+
+  // Build the effective check-in object, preferring live query data.
+  const effectiveCheckIn: CheckInDetail | null = activeCheckIn
+    ? {
+        ...activeCheckIn,
+        flags: [],
+        note: null,
+        respondedAt: null,
+        dismissedByClientAt: null,
+        reviewedByTrainerAt: null,
+      }
+    : params.professionalName
+      ? {
+          id: params.id ?? id,
+          professionalUserId: '',
+          professionalName: params.professionalName,
+          profession: (params.profession as CheckInDetail['profession']) ?? 'Training',
+          weekStartDate: params.weekStartDate ?? '',
+          sentAt: '',
+          flags: params.flags ? (JSON.parse(params.flags) as CheckInFlag[]) : [],
+          note: params.note ?? null,
+          respondedAt: params.respondedAt ?? null,
+          dismissedByClientAt: null,
+          reviewedByTrainerAt: params.reviewedByTrainerAt ?? null,
+        }
+      : null
+
+  // ── Edit mode state ──
+  const alreadyReviewed = Boolean(effectiveCheckIn?.reviewedByTrainerAt)
+  const isResponded = Boolean(effectiveCheckIn?.respondedAt)
+
+  // Start in read-only mode when already responded; editing allowed until reviewed.
+  const [editing, setEditing] = useState(!isResponded)
+  const [selectedFlags, setSelectedFlags] = useState<CheckInFlag[]>(
+    effectiveCheckIn?.flags ?? [],
+  )
+  const [note, setNote] = useState(effectiveCheckIn?.note ?? '')
+
+  const isReadOnly = isResponded && !editing
+
+  // ── Mutations ──
+  const respondMutation = useMutation({
+    mutationFn: (body: { flags: CheckInFlag[]; note?: string }) =>
+      respondToCheckIn(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['current-weekly-check-ins'] })
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+      router.back()
+    },
+    onError: (err: unknown) => {
+      // Check for 409 CHECK_IN_ALREADY_REVIEWED
+      const status = (err as { response?: { status?: number; data?: { errorCode?: string } } })
+        ?.response?.status
+      if (status === 409) {
+        Toast.show(t('weeklyCheckIn.sheet.editLocked'))
+        queryClient.invalidateQueries({ queryKey: ['current-weekly-check-ins'] })
+        return
+      }
+      Toast.show(t('common.error'))
+    },
+  })
+
+  const dismissMutation = useMutation({
+    mutationFn: () => dismissCheckIn(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['current-weekly-check-ins'] })
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+      router.back()
+    },
+    onError: () => {
+      Toast.show(t('common.error'))
+    },
+  })
+
+  // ── Handlers ──
+  const handleToggleFlag = useCallback((flag: CheckInFlag) => {
+    setSelectedFlags((prev) =>
+      prev.includes(flag) ? prev.filter((f) => f !== flag) : [...prev, flag],
+    )
+  }, [])
+
+  const handleSubmit = useCallback(() => {
+    respondMutation.mutate({
+      flags: selectedFlags,
+      note: note.trim() || undefined,
+    })
+  }, [respondMutation, selectedFlags, note])
+
+  const handleSkip = useCallback(() => {
+    dismissMutation.mutate()
+  }, [dismissMutation])
+
+  const handleClose = useCallback(() => {
+    router.back()
+  }, [router])
+
+  // ── Loading / not found ──
+  if (isLoading && !effectiveCheckIn) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.gold} />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  if (!effectiveCheckIn) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+        <View style={styles.centered}>
+          <Text style={[Type.body, { color: colors.label2 }]}>{t('common.error')}</Text>
+          <Pressable onPress={handleClose} style={styles.closeBtn}>
+            <Text style={[Type.body, { color: colors.blue }]}>{t('common.back')}</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  const professionLabel =
+    effectiveCheckIn.profession === 'Training'
+      ? '🏋️ Training'
+      : '🥗 Nutrition'
+
+  const promptKey =
+    effectiveCheckIn.profession === 'Training'
+      ? 'weeklyCheckIn.defaultPrompt.training'
+      : 'weeklyCheckIn.defaultPrompt.nutrition'
+
+  const notePlaceholderKey =
+    effectiveCheckIn.profession === 'Training'
+      ? 'weeklyCheckIn.sheet.notePlaceholder.training'
+      : 'weeklyCheckIn.sheet.notePlaceholder.nutrition'
+
+  const weekRange = effectiveCheckIn.weekStartDate
+    ? formatWeekRange(effectiveCheckIn.weekStartDate, i18n.language)
+    : ''
+
+  const isMutating = respondMutation.isPending || dismissMutation.isPending
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 24}
+      >
+        {/* ── Drag indicator + close ── */}
+        <View style={styles.dragRow}>
+          <View style={[styles.dragHandle, { backgroundColor: colors.sep }]} />
+          <Pressable
+            onPress={handleClose}
+            style={styles.closeTouchable}
+            accessibilityRole="button"
+            accessibilityLabel={t('weeklyCheckIn.sheet.close')}
+          >
+            <Ionicons name="close" size={22} color={colors.label2} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Header: avatar + name + profession pill ── */}
+          <View style={styles.header}>
+            <Avatar name={effectiveCheckIn.professionalName} size="md" />
+            <View style={styles.headerText}>
+              <Text style={[Type.title3, { color: colors.label }]}>
+                {effectiveCheckIn.professionalName}
+              </Text>
+              <View style={[styles.profPill, { backgroundColor: goldAlpha['12'] }]}>
+                <Text style={[styles.profPillText, { color: colors.gold }]}>
+                  {professionLabel}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {/* ── Prompt ── */}
+          <Text style={[Type.subheadline, { color: colors.label2, marginTop: 16 }]}>
+            {t(promptKey)}
+          </Text>
+
+          {/* ── Week anchor ── */}
+          {weekRange !== '' && (
+            <View style={[styles.weekAnchor, { backgroundColor: colors.fill2, borderColor: colors.sep2 }]}>
+              <Ionicons name="calendar-outline" size={14} color={colors.label3} />
+              <Text style={[Type.footnote, { color: colors.label2 }]}>
+                {t('weeklyCheckIn.sheet.weekOf', { range: weekRange })}
+              </Text>
+            </View>
+          )}
+
+          {/* ── Chips grid (2 columns) ── */}
+          <View style={styles.chipsGrid}>
+            {CHECK_IN_FLAGS.map((flag) => (
+              <FlagChip
+                key={flag}
+                flag={flag}
+                selected={selectedFlags.includes(flag)}
+                disabled={isReadOnly}
+                onToggle={handleToggleFlag}
+              />
+            ))}
+          </View>
+
+          {/* ── Note textarea ── */}
+          <View style={[styles.noteWrapper, { borderColor: colors.sep, backgroundColor: colors.bg2 }]}>
+            <TextInput
+              style={[styles.noteInput, { color: colors.label }]}
+              placeholder={t(notePlaceholderKey)}
+              placeholderTextColor={colors.label3}
+              multiline
+              maxLength={NOTE_MAX_LENGTH}
+              value={note}
+              onChangeText={setNote}
+              editable={!isReadOnly}
+              textAlignVertical="top"
+              accessibilityLabel={t(notePlaceholderKey)}
+            />
+            <Text style={[styles.charCounter, { color: colors.label3 }]}>
+              {note.length}/{NOTE_MAX_LENGTH}
+            </Text>
+          </View>
+
+          {/* ── Reviewed lock notice ── */}
+          {isResponded && alreadyReviewed && (
+            <View style={[styles.lockedBanner, { backgroundColor: colors.fill2 }]}>
+              <Ionicons name="lock-closed-outline" size={14} color={colors.label3} />
+              <Text style={[Type.caption1, { color: colors.label2, flex: 1 }]}>
+                {t('weeklyCheckIn.sheet.editLocked')}
+              </Text>
+            </View>
+          )}
+
+          {/* ── Edit button (read-only, not yet reviewed) ── */}
+          {isResponded && !alreadyReviewed && !editing && (
+            <Pressable
+              style={[styles.editBtn, { borderColor: colors.sep, backgroundColor: colors.fill2 }]}
+              onPress={() => setEditing(true)}
+              accessibilityRole="button"
+            >
+              <Ionicons name="pencil-outline" size={16} color={colors.label2} />
+              <Text style={[Type.subheadline, { color: colors.label2 }]}>Edit</Text>
+            </Pressable>
+          )}
+
+          {/* Spacer so pinned actions don't occlude content on short screens */}
+          <View style={styles.bottomSpacer} />
+        </ScrollView>
+
+        {/* ── Pinned action bar ── */}
+        {(!isResponded || editing) && (
+          <View style={[styles.actions, { borderTopColor: colors.sep2, backgroundColor: colors.bg }]}>
+            {/* Submit */}
+            <Pressable
+              style={({ pressed }) => [
+                styles.actionBtn,
+                styles.actionBtnPrimary,
+                { backgroundColor: colors.gold, opacity: pressed || isMutating ? 0.75 : 1 },
+              ]}
+              onPress={handleSubmit}
+              disabled={isMutating}
+              accessibilityRole="button"
+            >
+              {respondMutation.isPending ? (
+                <ActivityIndicator size="small" color={colors.onAccent} />
+              ) : (
+                <Text style={[styles.actionBtnText, { color: colors.onAccent }]}>
+                  {t('weeklyCheckIn.sheet.submit')}
+                </Text>
+              )}
+            </Pressable>
+
+            {/* Skip (only in initial, non-edit mode) */}
+            {!isResponded && (
+              <Pressable
+                style={({ pressed }) => [
+                  styles.actionBtn,
+                  styles.actionBtnSecondary,
+                  { borderColor: colors.sep, opacity: pressed || isMutating ? 0.65 : 1 },
+                ]}
+                onPress={handleSkip}
+                disabled={isMutating}
+                accessibilityRole="button"
+              >
+                {dismissMutation.isPending ? (
+                  <ActivityIndicator size="small" color={colors.label2} />
+                ) : (
+                  <Text style={[styles.actionBtnText, { color: colors.label2 }]}>
+                    {t('weeklyCheckIn.sheet.skip')}
+                  </Text>
+                )}
+              </Pressable>
+            )}
+          </View>
+        )}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  flex: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  closeBtn: {
+    padding: 8,
+  },
+  dragRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 12,
+    paddingHorizontal: 16,
+    paddingBottom: 4,
+    position: 'relative',
+  },
+  dragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+  },
+  closeTouchable: {
+    position: 'absolute',
+    right: 16,
+    top: 8,
+    padding: 6,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    marginTop: 16,
+  },
+  headerText: {
+    flex: 1,
+    gap: 6,
+  },
+  profPill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: Radius.full,
+  },
+  profPillText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  weekAnchor: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
+  chipsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    marginTop: 20,
+  },
+  chip: {
+    width: '47%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    borderRadius: Radius.md,
+    borderWidth: 1.5,
+  },
+  chipEmoji: {
+    fontSize: 18,
+  },
+  chipLabel: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  noteWrapper: {
+    marginTop: 20,
+    borderWidth: 1,
+    borderRadius: Radius.md,
+    padding: 12,
+    minHeight: 100,
+  },
+  noteInput: {
+    fontSize: 15,
+    lineHeight: 22,
+    minHeight: 72,
+  },
+  charCounter: {
+    fontSize: 11,
+    textAlign: 'right',
+    marginTop: 6,
+  },
+  lockedBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    borderRadius: Radius.md,
+  },
+  editBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: 16,
+    paddingVertical: 11,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+  },
+  bottomSpacer: {
+    height: 16,
+  },
+  actions: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 16,
+    gap: 10,
+    borderTopWidth: 1,
+  },
+  actionBtn: {
+    paddingVertical: 14,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actionBtnPrimary: {
+    // background set inline
+  },
+  actionBtnSecondary: {
+    borderWidth: 1,
+  },
+  actionBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+})

--- a/mobile/app/(client)/weekly-checkin/[id].tsx
+++ b/mobile/app/(client)/weekly-checkin/[id].tsx
@@ -394,7 +394,7 @@ export default function WeeklyCheckInScreen() {
               accessibilityRole="button"
             >
               <Ionicons name="pencil-outline" size={16} color={colors.label2} />
-              <Text style={[Type.subheadline, { color: colors.label2 }]}>Edit</Text>
+              <Text style={[Type.subheadline, { color: colors.label2 }]}>{t('weeklyCheckIn.sheet.edit')}</Text>
             </Pressable>
           )}
 

--- a/mobile/app/(client)/weekly-checkin/_layout.tsx
+++ b/mobile/app/(client)/weekly-checkin/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router'
+
+/**
+ * Modal stack for the weekly check-in response sheet.
+ * `presentation: 'modal'` makes the [id] screen slide up as a full-height modal.
+ */
+export default function WeeklyCheckInLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        presentation: 'modal',
+        animation: 'slide_from_bottom',
+      }}
+    />
+  )
+}

--- a/mobile/src/api/signalr.ts
+++ b/mobile/src/api/signalr.ts
@@ -23,6 +23,9 @@ const KNOWN_EVENTS = [
   'typing',
   'userpresence',
   'conversationunarchived',
+  // Weekly check-in: fires when client responds or trainer marks reviewed.
+  // Payload: { id: string, respondedAt?: string, reviewedAt?: string, dismissedAt?: string }
+  'weeklycheckinupdated',
 ]
 
 function createConnection(): HubConnection {

--- a/mobile/src/api/weeklyCheckIns.ts
+++ b/mobile/src/api/weeklyCheckIns.ts
@@ -1,0 +1,124 @@
+/**
+ * API module for client-facing weekly check-in endpoints.
+ *
+ * DTOs are hand-mirrored from the C# backend because regen-api cannot run
+ * without a local backend instance (MongoDB auth unavailable in CI).
+ *
+ * Sources:
+ *   - GetCurrentClientCheckInsResponse.cs
+ *   - RespondToCheckInRequest.cs / RespondToCheckInResponse.cs
+ *   - DismissCheckInResponse.cs
+ *   - CheckInFlag.cs (enum)
+ */
+import api from './client'
+
+// ─── Enum ────────────────────────────────────────────────────────────────────
+
+export type CheckInFlag =
+  | 'Traveling'
+  | 'EventOrCelebration'
+  | 'SickOrLowEnergy'
+  | 'InjuryOrPain'
+  | 'MoreTimeAvailable'
+  | 'LessTimeAvailable'
+
+/** All flag values in display order (matches spec §5.2 chip grid). */
+export const CHECK_IN_FLAGS: CheckInFlag[] = [
+  'Traveling',
+  'EventOrCelebration',
+  'SickOrLowEnergy',
+  'InjuryOrPain',
+  'MoreTimeAvailable',
+  'LessTimeAvailable',
+]
+
+/** Profession type string as returned by the backend. */
+export type ProfessionType = 'Training' | 'Nutrition'
+
+// ─── Response DTOs ────────────────────────────────────────────────────────────
+
+/** A single active check-in returned by GET /client/weekly-check-ins/current. */
+export interface CheckInSummary {
+  id: string
+  professionalUserId: string
+  professionalName: string
+  /** "Training" | "Nutrition" */
+  profession: ProfessionType
+  /** ISO date string "YYYY-MM-DD" */
+  weekStartDate: string
+  sentAt: string
+}
+
+export interface GetCurrentClientCheckInsResponse {
+  checkIns: CheckInSummary[]
+}
+
+/** Full check-in detail used by the response sheet for read-only variant. */
+export interface CheckInDetail extends CheckInSummary {
+  flags: CheckInFlag[]
+  note: string | null
+  respondedAt: string | null
+  dismissedByClientAt: string | null
+  reviewedByTrainerAt: string | null
+}
+
+// ─── Request / response for respond ──────────────────────────────────────────
+
+export interface RespondToCheckInRequest {
+  flags: CheckInFlag[]
+  note?: string
+}
+
+export interface RespondToCheckInResponse {
+  id: string
+  flags: CheckInFlag[]
+  note: string | null
+  respondedAt: string
+}
+
+// ─── Response for dismiss ─────────────────────────────────────────────────────
+
+export interface DismissCheckInResponse {
+  id: string
+  dismissedAt: string
+}
+
+// ─── API functions ────────────────────────────────────────────────────────────
+
+/**
+ * GET /client/weekly-check-ins/current
+ * Returns 0–2 active (not responded, not dismissed) check-ins for this ISO week.
+ */
+export async function getCurrentCheckIns(): Promise<GetCurrentClientCheckInsResponse> {
+  const { data } = await api.get<GetCurrentClientCheckInsResponse>(
+    '/client/weekly-check-ins/current',
+  )
+  return data
+}
+
+/**
+ * POST /client/weekly-check-ins/{id}/respond
+ * Persists the client's flags and optional note.
+ * Returns 409 with errorCode "CHECK_IN_ALREADY_REVIEWED" if trainer already marked reviewed.
+ */
+export async function respondToCheckIn(
+  id: string,
+  body: RespondToCheckInRequest,
+): Promise<RespondToCheckInResponse> {
+  const { data } = await api.post<RespondToCheckInResponse>(
+    `/client/weekly-check-ins/${id}/respond`,
+    body,
+  )
+  return data
+}
+
+/**
+ * POST /client/weekly-check-ins/{id}/dismiss
+ * Skips the check-in for this week; does not create a trainer notification.
+ */
+export async function dismissCheckIn(id: string): Promise<DismissCheckInResponse> {
+  const { data } = await api.post<DismissCheckInResponse>(
+    `/client/weekly-check-ins/${id}/dismiss`,
+  )
+  return data
+}

--- a/mobile/src/components/notifications/NotificationRow.tsx
+++ b/mobile/src/components/notifications/NotificationRow.tsx
@@ -11,12 +11,13 @@ const NOTIF_CONFIG: Record<Notification['type'], {
   icon: keyof typeof Ionicons.glyphMap;
   color: string;
 }> = {
-  invitation:    { bg: goldAlpha['12'], icon: 'person-add',       color: '#c9a84c' },
-  questionnaire: { bg: goldAlpha['12'], icon: 'clipboard',        color: '#c9a84c' },
-  new_plan:      { bg: 'rgba(11,110,153,0.10)', icon: 'calendar',        color: '#0b6e99' },
-  message:       { bg: 'rgba(0,122,255,0.10)',  icon: 'chatbubble',      color: '#007aff' },
-  training_done: { bg: 'rgba(52,199,89,0.10)',  icon: 'checkmark-circle', color: '#34c759' },
-  alarm:         { bg: 'rgba(255,59,48,0.10)',  icon: 'alert-circle',     color: '#ff3b30' },
+  invitation:     { bg: goldAlpha['12'],                 icon: 'person-add',         color: '#c9a84c' },
+  questionnaire:  { bg: goldAlpha['12'],                 icon: 'clipboard',          color: '#c9a84c' },
+  new_plan:       { bg: 'rgba(11,110,153,0.10)',         icon: 'calendar',           color: '#0b6e99' },
+  message:        { bg: 'rgba(0,122,255,0.10)',          icon: 'chatbubble',         color: '#007aff' },
+  training_done:  { bg: 'rgba(52,199,89,0.10)',          icon: 'checkmark-circle',   color: '#34c759' },
+  alarm:          { bg: 'rgba(255,59,48,0.10)',          icon: 'alert-circle',       color: '#ff3b30' },
+  weekly_checkin: { bg: goldAlpha['12'],                 icon: 'calendar-number',    color: '#c9a84c' },
 }
 
 function timeAgo(timestamp: string): string {

--- a/mobile/src/components/today/WeeklyCheckInBanner.tsx
+++ b/mobile/src/components/today/WeeklyCheckInBanner.tsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useRef } from 'react'
+import { View, Text, StyleSheet, Pressable, Animated } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { goldAlpha } from '@/constants/colors'
+import { Radius } from '@/constants/radius'
+import type { CheckInSummary } from '@/api/weeklyCheckIns'
+
+interface WeeklyCheckInBannerProps {
+  /** A single pending check-in (one banner per item). */
+  checkIn: CheckInSummary
+  /** Called when the user taps "Let them know". */
+  onOpen: (checkIn: CheckInSummary) => void
+}
+
+function ProfessionPill({ profession }: { profession: CheckInSummary['profession'] }) {
+  const colors = useTheme()
+  const emoji = profession === 'Training' ? '🏋️' : '🥗'
+  return (
+    <View style={[styles.pill, { backgroundColor: goldAlpha['12'] }]}>
+      <Text style={[styles.pillText, { color: colors.gold }]}>
+        {emoji}
+      </Text>
+    </View>
+  )
+}
+
+export function WeeklyCheckInBanner({ checkIn, onOpen }: WeeklyCheckInBannerProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  const opacity = useRef(new Animated.Value(0)).current
+  const translateY = useRef(new Animated.Value(-32)).current
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.spring(translateY, {
+        toValue: 0,
+        damping: 16,
+        stiffness: 100,
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 450,
+        useNativeDriver: true,
+      }),
+    ]).start()
+  }, [opacity, translateY])
+
+  const promptKey =
+    checkIn.profession === 'Training'
+      ? 'weeklyCheckIn.defaultPrompt.training'
+      : 'weeklyCheckIn.defaultPrompt.nutrition'
+
+  return (
+    <Animated.View style={[styles.wrapper, { opacity, transform: [{ translateY }] }]}>
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: colors.goldBg,
+            borderColor: goldAlpha['25'],
+          },
+        ]}
+      >
+        {/* Icon + text row */}
+        <View style={styles.iconRow}>
+          <View style={[styles.iconCircle, { backgroundColor: goldAlpha['20'] }]}>
+            <Text style={styles.iconEmoji}>📅</Text>
+          </View>
+          <View style={styles.textBlock}>
+            <View style={styles.nameRow}>
+              <Text
+                style={[Type.headline, { color: colors.label, flexShrink: 1 }]}
+                numberOfLines={1}
+              >
+                {checkIn.professionalName}
+              </Text>
+              <ProfessionPill profession={checkIn.profession} />
+            </View>
+            <Text
+              style={[Type.caption1, { color: colors.label2, marginTop: 2 }]}
+              numberOfLines={2}
+            >
+              {t(promptKey)}
+            </Text>
+          </View>
+        </View>
+
+        {/* CTA button */}
+        <Pressable
+          style={({ pressed }) => [
+            styles.btn,
+            { backgroundColor: colors.gold, opacity: pressed ? 0.8 : 1 },
+          ]}
+          onPress={() => onOpen(checkIn)}
+          accessibilityRole="button"
+          accessibilityLabel={t('weeklyCheckIn.banner.cta')}
+        >
+          <Text style={[styles.btnText, { color: colors.onAccent }]}>
+            {t('weeklyCheckIn.banner.cta')}
+          </Text>
+        </Pressable>
+      </View>
+    </Animated.View>
+  )
+}
+
+export default WeeklyCheckInBanner
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginHorizontal: 16,
+    marginTop: 16,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: Radius.lg,
+    padding: 16,
+  },
+  iconRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconCircle: {
+    width: 44,
+    height: 44,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconEmoji: {
+    fontSize: 22,
+  },
+  textBlock: {
+    flex: 1,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  pill: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: Radius.full,
+  },
+  pillText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  btn: {
+    marginTop: 14,
+    paddingVertical: 12,
+    borderRadius: Radius.sm,
+    alignItems: 'center',
+  },
+  btnText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+})

--- a/mobile/src/hooks/useNotifications.ts
+++ b/mobile/src/hooks/useNotifications.ts
@@ -3,13 +3,34 @@ import api from '../api/client'
 
 export interface Notification {
   id: string
-  type: 'invitation' | 'questionnaire' | 'new_plan' | 'message' | 'training_done' | 'alarm'
+  type: 'invitation' | 'questionnaire' | 'new_plan' | 'message' | 'training_done' | 'alarm' | 'weekly_checkin'
   title: string
   body: string
   timestamp: string
   read: boolean
   actionLabel?: string
   actionPayload?: Record<string, string>
+}
+
+/**
+ * Maps backend NotificationType strings to the mobile Notification.type union.
+ * Extend here when the backend adds new NotificationType enum values.
+ */
+export const BACKEND_TYPE_MAP: Record<string, Notification['type']> = {
+  InvitationReceived: 'invitation',
+  InvitationAccepted: 'invitation',
+  InvitationDeclined: 'invitation',
+  InvitationCancelled: 'invitation',
+  QuestionnaireAssigned: 'questionnaire',
+  QuestionnaireSubmitted: 'questionnaire',
+  PlanPublished: 'new_plan',
+  ClientRequestReceived: 'invitation',
+  ClientRequestAccepted: 'invitation',
+  ClientRequestRejected: 'invitation',
+  PersonalRecord: 'training_done',
+  General: 'alarm',
+  WeeklyCheckInRequested: 'weekly_checkin',
+  // WeeklyCheckInResponded goes to trainers only — not mapped on client side
 }
 
 interface NotificationsResponse {

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -585,6 +585,10 @@
   },
   "weeklyCheckIn": {
     "title": "Týdenní check-iny",
+    "profession": {
+      "training": "Trénink",
+      "nutrition": "Výživa"
+    },
     "defaultPrompt": {
       "training": "Tvůj trenér brzy plánuje příští týden. Čeká tě něco zvláštního?",
       "nutrition": "Tvůj nutricionista brzy plánuje příští týden. Čeká tě něco zvláštního?"

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -583,6 +583,38 @@
     "revokeMessage": "Chcete zrušit žádost odeslanou {{name}}?",
     "revokeConfirm": "Zrušit"
   },
+  "weeklyCheckIn": {
+    "title": "Týdenní check-iny",
+    "defaultPrompt": {
+      "training": "Tvůj trenér brzy plánuje příští týden. Čeká tě něco zvláštního?",
+      "nutrition": "Tvůj nutricionista brzy plánuje příští týden. Čeká tě něco zvláštního?"
+    },
+    "push": {
+      "title": "Plánování příštího týdne"
+    },
+    "banner": {
+      "cta": "Dej jim vědět"
+    },
+    "sheet": {
+      "submit": "Odeslat",
+      "skip": "Přeskočit tento týden",
+      "close": "Zavřít",
+      "notePlaceholder": {
+        "training": "Cokoli dalšího, co by měl tvůj trenér vědět?",
+        "nutrition": "Cokoli dalšího, co by měl tvůj nutricionista vědět?"
+      },
+      "weekOf": "Týden {{range}}",
+      "editLocked": "Tvůj trenér to už viděl."
+    },
+    "flag": {
+      "traveling": "Cestování",
+      "eventOrCelebration": "Akce / oslava",
+      "sickOrLowEnergy": "Nemoc / nízká energie",
+      "injuryOrPain": "Zranění nebo bolest",
+      "moreTimeAvailable": "Více času než obvykle",
+      "lessTimeAvailable": "Méně času než obvykle"
+    }
+  },
   "nutrition": {
     "title": "Výživa",
     "noPlanMessage": "Váš nutricionista vyhodnocuje vaše data a připravuje personalizovaný plán. Mohou vás kontaktovat pro další informace.",

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -604,7 +604,8 @@
         "nutrition": "Cokoli dalšího, co by měl tvůj nutricionista vědět?"
       },
       "weekOf": "Týden {{range}}",
-      "editLocked": "Tvůj trenér to už viděl."
+      "editLocked": "Tvůj trenér to už viděl.",
+      "edit": "Upravit"
     },
     "flag": {
       "traveling": "Cestování",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -625,7 +625,8 @@
         "nutrition": "Gibt es noch etwas, das dein Ernährungsberater wissen sollte?"
       },
       "weekOf": "Woche {{range}}",
-      "editLocked": "Dein Trainer hat das bereits gesehen."
+      "editLocked": "Dein Trainer hat das bereits gesehen.",
+      "edit": "Bearbeiten"
     },
     "flag": {
       "traveling": "Reisen",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -604,6 +604,38 @@
     "loading": "Rezept wird geladen...",
     "error": "Rezeptdetails konnten nicht geladen werden"
   },
+  "weeklyCheckIn": {
+    "title": "Wöchentliche Check-ins",
+    "defaultPrompt": {
+      "training": "Dein Trainer plant bald die nächste Woche. Steht etwas Besonderes an?",
+      "nutrition": "Dein Ernährungsberater plant bald die nächste Woche. Steht etwas Besonderes an?"
+    },
+    "push": {
+      "title": "Planung der nächsten Woche"
+    },
+    "banner": {
+      "cta": "Informier sie"
+    },
+    "sheet": {
+      "submit": "Absenden",
+      "skip": "Diese Woche überspringen",
+      "close": "Schließen",
+      "notePlaceholder": {
+        "training": "Gibt es noch etwas, das dein Trainer wissen sollte?",
+        "nutrition": "Gibt es noch etwas, das dein Ernährungsberater wissen sollte?"
+      },
+      "weekOf": "Woche {{range}}",
+      "editLocked": "Dein Trainer hat das bereits gesehen."
+    },
+    "flag": {
+      "traveling": "Reisen",
+      "eventOrCelebration": "Veranstaltung / Feier",
+      "sickOrLowEnergy": "Krank / wenig Energie",
+      "injuryOrPain": "Verletzung oder Schmerzen",
+      "moreTimeAvailable": "Mehr Zeit als gewöhnlich",
+      "lessTimeAvailable": "Weniger Zeit als gewöhnlich"
+    }
+  },
   "nutrition": {
     "title": "Ernährung",
     "noPlanMessage": "Dein Ernährungsberater wertet deine Daten aus und erstellt einen personalisierten Plan. Du wirst ggf. für weitere Informationen kontaktiert.",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -606,6 +606,10 @@
   },
   "weeklyCheckIn": {
     "title": "Wöchentliche Check-ins",
+    "profession": {
+      "training": "Training",
+      "nutrition": "Ernährung"
+    },
     "defaultPrompt": {
       "training": "Dein Trainer plant bald die nächste Woche. Steht etwas Besonderes an?",
       "nutrition": "Dein Ernährungsberater plant bald die nächste Woche. Steht etwas Besonderes an?"

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -740,7 +740,8 @@
         "nutrition": "Anything else your nutritionist should know?"
       },
       "weekOf": "Week of {{range}}",
-      "editLocked": "Your trainer already saw this."
+      "editLocked": "Your trainer already saw this.",
+      "edit": "Edit"
     },
     "flag": {
       "traveling": "Traveling",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -693,6 +693,12 @@
     "revokeMessage": "Revoke the request sent to {{name}}?",
     "revokeConfirm": "Revoke"
   },
+  "weeklyCheckIn": {
+    "profession": {
+      "training": "Training",
+      "nutrition": "Nutrition"
+    }
+  },
   "foodDetail": {
     "nutritionValues": "Nutrition Values",
     "protein": "Protein",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -719,6 +719,38 @@
     "loading": "Loading recipe...",
     "error": "Could not load recipe detail"
   },
+  "weeklyCheckIn": {
+    "title": "Weekly check-ins",
+    "defaultPrompt": {
+      "training": "Your trainer is planning next week soon. Anything special coming up?",
+      "nutrition": "Your nutritionist is planning next week soon. Anything special coming up?"
+    },
+    "push": {
+      "title": "Planning next week"
+    },
+    "banner": {
+      "cta": "Let them know"
+    },
+    "sheet": {
+      "submit": "Submit",
+      "skip": "Skip this week",
+      "close": "Close",
+      "notePlaceholder": {
+        "training": "Anything else your trainer should know?",
+        "nutrition": "Anything else your nutritionist should know?"
+      },
+      "weekOf": "Week of {{range}}",
+      "editLocked": "Your trainer already saw this."
+    },
+    "flag": {
+      "traveling": "Traveling",
+      "eventOrCelebration": "Event / celebration",
+      "sickOrLowEnergy": "Sick / low energy",
+      "injuryOrPain": "Injury or pain",
+      "moreTimeAvailable": "More time than usual",
+      "lessTimeAvailable": "Less time than usual"
+    }
+  },
   "nutrition": {
     "title": "Nutrition",
     "noPlanMessage": "Your nutritionist is reviewing your data and preparing a personalized plan. They may reach out for additional information.",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -693,12 +693,6 @@
     "revokeMessage": "Revoke the request sent to {{name}}?",
     "revokeConfirm": "Revoke"
   },
-  "weeklyCheckIn": {
-    "profession": {
-      "training": "Training",
-      "nutrition": "Nutrition"
-    }
-  },
   "foodDetail": {
     "nutritionValues": "Nutrition Values",
     "protein": "Protein",
@@ -756,6 +750,10 @@
       "injuryOrPain": "Injury or pain",
       "moreTimeAvailable": "More time than usual",
       "lessTimeAvailable": "Less time than usual"
+    },
+    "profession": {
+      "training": "Training",
+      "nutrition": "Nutrition"
     }
   },
   "nutrition": {

--- a/web/src/api/weekly-checkins.ts
+++ b/web/src/api/weekly-checkins.ts
@@ -160,6 +160,139 @@ export async function deleteCheckInOverride(
   await api.delete(`/trainer/weekly-check-ins/overrides/${clientUserId}/${profession}`);
 }
 
+/* ─────────────────────── CheckInFlag ───────────────────────────────────────────── */
+
+/**
+ * Mirrors the C# CheckInFlag enum.
+ * Values are serialized as strings by the backend (JsonStringEnumConverter).
+ */
+export type CheckInFlag =
+  | 'Traveling'
+  | 'EventOrCelebration'
+  | 'SickOrLowEnergy'
+  | 'InjuryOrPain'
+  | 'MoreTimeAvailable'
+  | 'LessTimeAvailable';
+
+/* ─────────────────────── GET /trainer/weekly-check-ins?weekStartDate=... ────────── */
+
+/**
+ * One check-in row as returned for the trainer's Today card.
+ * Mirrors TrainerCheckInDto in GetTrainerCheckInsResponse.cs.
+ */
+export interface TrainerCheckInDto {
+  id: string; // Guid
+  clientUserId: string; // Guid
+  clientName: string;
+  /** "Training" | "Nutrition" */
+  profession: Profession;
+  /** ISO date string — the Monday of the planned week */
+  weekStartDate: string;
+  flags: CheckInFlag[];
+  note: string | null;
+  sentAt: string; // ISO datetime
+  respondedAt: string | null;
+  dismissedByClientAt: string | null;
+  reviewedByTrainerAt: string | null;
+}
+
+/** Response wrapper for GET /trainer/weekly-check-ins. */
+export interface GetTrainerCheckInsResponse {
+  checkIns: TrainerCheckInDto[];
+}
+
+/** GET /trainer/weekly-check-ins?weekStartDate=YYYY-MM-DD */
+export async function getTrainerCheckIns(
+  weekStartDate: string,
+): Promise<GetTrainerCheckInsResponse> {
+  const { data } = await api.get<GetTrainerCheckInsResponse>('/trainer/weekly-check-ins', {
+    params: { weekStartDate },
+  });
+  return data;
+}
+
+/* ─────────────────────── GET /trainer/weekly-check-ins/{id} ─────────────────────── */
+
+/**
+ * Detail check-in DTO.
+ * Mirrors GetCheckInDetailResponse.cs.
+ */
+export interface CheckInDetailDto {
+  id: string;
+  clientUserId: string;
+  clientName: string;
+  professionalUserId: string;
+  profession: Profession;
+  weekStartDate: string;
+  flags: CheckInFlag[];
+  note: string | null;
+  sentAt: string;
+  respondedAt: string | null;
+  dismissedByClientAt: string | null;
+  reviewedByTrainerAt: string | null;
+}
+
+/** GET /trainer/weekly-check-ins/{id} */
+export async function getCheckInDetail(id: string): Promise<CheckInDetailDto> {
+  const { data } = await api.get<CheckInDetailDto>(`/trainer/weekly-check-ins/${id}`);
+  return data;
+}
+
+/* ─────────────────────── POST /trainer/weekly-check-ins/{id}/mark-reviewed ─────── */
+
+/** Response for POST /trainer/weekly-check-ins/{id}/mark-reviewed. */
+export interface MarkCheckInReviewedResponse {
+  id: string;
+  reviewedAt: string; // ISO datetime (UTC)
+}
+
+/** POST /trainer/weekly-check-ins/{id}/mark-reviewed */
+export async function markCheckInReviewed(id: string): Promise<MarkCheckInReviewedResponse> {
+  const { data } = await api.post<MarkCheckInReviewedResponse>(
+    `/trainer/weekly-check-ins/${id}/mark-reviewed`,
+  );
+  return data;
+}
+
+/* ─────────────────────── GET /trainer/clients/{clientUserId}/weekly-check-ins/current ─ */
+
+/**
+ * A single check-in as seen from the plan-editor banner.
+ * Mirrors ClientCheckInDto in GetClientCurrentCheckInResponse.cs.
+ */
+export interface ClientCheckInDto {
+  id: string;
+  profession: Profession;
+  weekStartDate: string;
+  flags: CheckInFlag[];
+  note: string | null;
+  sentAt: string;
+  respondedAt: string | null;
+  dismissedByClientAt: string | null;
+  reviewedByTrainerAt: string | null;
+}
+
+/** Response wrapper for GET /trainer/clients/{clientUserId}/weekly-check-ins/current. */
+export interface GetClientCurrentCheckInResponse {
+  checkIns: ClientCheckInDto[];
+}
+
+/**
+ * GET /trainer/clients/{clientUserId}/weekly-check-ins/current
+ * @param clientUserId - Client's ApplicationUser Id (Guid string)
+ * @param profession   - Optional: "Training" | "Nutrition". Omit to get all professions.
+ */
+export async function getClientCurrentCheckIn(
+  clientUserId: string,
+  profession?: Profession,
+): Promise<GetClientCurrentCheckInResponse> {
+  const { data } = await api.get<GetClientCurrentCheckInResponse>(
+    `/trainer/clients/${clientUserId}/weekly-check-ins/current`,
+    { params: profession ? { profession } : {} },
+  );
+  return data;
+}
+
 /* ─────────────────────── UI helpers ────────────────────────────────────────────── */
 
 /**

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ import { useSignalR } from '@/hooks/useSignalR';
 import { useToastStore } from '@/stores/toast';
 import { isTrainingProgressUpdatedEvent } from '@/api/trainingProgressEvent';
 import { isPersonalRecordAchievedEvent } from '@/api/personalRecordEvent';
+import { weeklyCheckInKeys } from '@/hooks/useWeeklyCheckIns';
 
 const DARK_MODE_KEY = 'gf-dark-mode';
 
@@ -191,6 +192,17 @@ export function AppShell() {
       // workout that may update streak / training count cells in the client table.
       // Key shape verified: DashboardPage.tsx line 88 uses ['dashboard-summary'].
       queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
+    },
+    weeklycheckinupdated: (payload: unknown) => {
+      if (import.meta.env.DEV) {
+        console.debug('weeklycheckinupdated', payload);
+      }
+      // Invalidate all weekly check-in queries (trainer list + all client-current variants).
+      // The payload carries { id, respondedAt?, reviewedAt?, dismissedAt? } but we do a
+      // broad invalidation so every open banner and card refreshes consistently.
+      const data = payload as { id?: string } | undefined;
+      void data; // payload available for future fine-grained invalidation
+      queryClient.invalidateQueries({ queryKey: weeklyCheckInKeys.all });
     },
     typing: (payload: unknown) => {
       const data = payload as { conversationId?: string; senderId?: string } | undefined;

--- a/web/src/components/profile/OverrideDialog.tsx
+++ b/web/src/components/profile/OverrideDialog.tsx
@@ -1,0 +1,360 @@
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Button, Toggle, Select, Dialog } from '@/components/ui';
+import { useToastStore } from '@/stores/toast';
+import {
+  upsertCheckInOverride,
+  deleteCheckInOverride,
+  DAY_OF_WEEK_KEYS,
+  ORDERED_DAYS,
+  formatTimeDisplay,
+  toTimeSpanString,
+} from '@/api/weekly-checkins';
+import type {
+  DayOfWeekInt,
+  CheckInSettingDto,
+  CheckInOverrideDto,
+} from '@/api/weekly-checkins';
+
+/* ─────────────────────── Constants ─────────────────────── */
+
+/** Hour options from 06:00 to 22:00, rendered as "HH:mm". */
+const HOUR_OPTIONS: string[] = Array.from({ length: 17 }, (_, i) => {
+  const h = i + 6;
+  return `${String(h).padStart(2, '0')}:00`;
+});
+
+const DEFAULT_DAY: DayOfWeekInt = 1;
+const DEFAULT_HOUR = '09:00';
+
+/* ─────────────────────── Zod schema ─────────────────────── */
+
+const dayOfWeekSchema = z.union([
+  z.literal(0), z.literal(1), z.literal(2), z.literal(3),
+  z.literal(4), z.literal(5), z.literal(6),
+]);
+
+const overrideSchema = z.object({
+  useDefaultDay: z.boolean(),
+  dayOfWeek: dayOfWeekSchema.nullable(),
+  useDefaultTime: z.boolean(),
+  timeOfDay: z.string().nullable(),
+  useDefaultEnabled: z.boolean(),
+  enabled: z.boolean().nullable(),
+  useDefaultAddendum: z.boolean(),
+  addendum: z.string().max(200, 'Max 200 characters').nullable(),
+});
+type OverrideForm = z.infer<typeof overrideSchema>;
+
+/* ─────────────────────── Helper ─────────────────────── */
+
+/**
+ * Derives effective values for an override by merging it with the trainer's
+ * default setting for the same profession. Null fields inherit from setting.
+ */
+function resolveEffective(
+  override: CheckInOverrideDto,
+  settings: CheckInSettingDto[],
+): {
+  effectiveDayOfWeek: DayOfWeekInt;
+  effectiveTimeDisplay: string;
+} {
+  const setting = settings.find((s) => s.profession === override.profession);
+  const effectiveDayOfWeek: DayOfWeekInt =
+    override.dayOfWeek !== null ? override.dayOfWeek : (setting?.dayOfWeek ?? DEFAULT_DAY);
+  const effectiveTimeDisplay =
+    override.timeOfDay !== null
+      ? formatTimeDisplay(override.timeOfDay)
+      : setting
+        ? formatTimeDisplay(setting.timeOfDay)
+        : DEFAULT_HOUR;
+  return { effectiveDayOfWeek, effectiveTimeDisplay };
+}
+
+/* ─────────────────────── Component ─────────────────────── */
+
+export interface OverrideDialogProps {
+  override: CheckInOverrideDto;
+  settings: CheckInSettingDto[];
+  onClose: () => void;
+}
+
+/**
+ * Dialog for editing (or reverting) a per-client weekly check-in override.
+ * Extracted from WeeklyCheckInTab so it can be reused from the client detail page.
+ */
+export function OverrideDialog({ override, settings, onClose }: OverrideDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const { effectiveDayOfWeek, effectiveTimeDisplay } = resolveEffective(override, settings);
+
+  const defaultValues: OverrideForm = {
+    useDefaultDay: override.dayOfWeek === null,
+    dayOfWeek: override.dayOfWeek !== null ? override.dayOfWeek : effectiveDayOfWeek,
+    useDefaultTime: override.timeOfDay === null,
+    timeOfDay:
+      override.timeOfDay !== null
+        ? formatTimeDisplay(override.timeOfDay)
+        : effectiveTimeDisplay,
+    useDefaultEnabled: override.enabled === null,
+    enabled: override.enabled,
+    useDefaultAddendum: override.addendum === null,
+    addendum: override.addendum ?? null,
+  };
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<OverrideForm>({
+    resolver: zodResolver(overrideSchema),
+    defaultValues,
+  });
+
+  const useDefaultDay = watch('useDefaultDay');
+  const useDefaultTime = watch('useDefaultTime');
+  const useDefaultEnabled = watch('useDefaultEnabled');
+  const useDefaultAddendum = watch('useDefaultAddendum');
+  const addendum = watch('addendum') ?? '';
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteCheckInOverride(override.clientUserId, override.profession),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['weekly-checkin-overrides'] });
+      addToast(t('weeklyCheckIn.config.overrideDeleted'), 'success');
+      onClose();
+    },
+    onError: () => {
+      addToast(t('weeklyCheckIn.config.saveError'), 'error');
+    },
+  });
+
+  const onSubmit = async (data: OverrideForm) => {
+    const allDefault =
+      data.useDefaultDay && data.useDefaultTime && data.useDefaultEnabled && data.useDefaultAddendum;
+
+    if (allDefault) {
+      deleteMutation.mutate();
+      return;
+    }
+
+    try {
+      await upsertCheckInOverride(override.clientUserId, override.profession, {
+        dayOfWeek: data.useDefaultDay ? null : (data.dayOfWeek ?? null),
+        timeOfDay: data.useDefaultTime
+          ? null
+          : (data.timeOfDay ? toTimeSpanString(data.timeOfDay) : null),
+        enabled: data.useDefaultEnabled ? null : (data.enabled ?? null),
+        addendum: data.useDefaultAddendum ? null : (data.addendum || null),
+      });
+      void queryClient.invalidateQueries({ queryKey: ['weekly-checkin-overrides'] });
+      addToast(t('weeklyCheckIn.config.overrideSaved'), 'success');
+      onClose();
+    } catch {
+      addToast(t('weeklyCheckIn.config.saveError'), 'error');
+    }
+  };
+
+  const clientName = override.clientFirstName || override.clientLastName
+    ? `${override.clientFirstName} ${override.clientLastName}`.trim()
+    : override.clientUserId;
+  const professionLabel =
+    override.profession === 'Training'
+      ? t('weeklyCheckIn.professionTraining')
+      : t('weeklyCheckIn.professionNutrition');
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={`${clientName} — ${professionLabel}`}
+      maxWidth={500}
+      footer={
+        <>
+          <Button onClick={onClose}>{t('common.cancel')}</Button>
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={isSubmitting || deleteMutation.isPending}
+            onClick={handleSubmit(onSubmit)}
+          >
+            {isSubmitting || deleteMutation.isPending
+              ? t('common.saving')
+              : t('common.save')}
+          </Button>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {/* Enabled */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-[13px] text-text">{t('weeklyCheckIn.config.enabled')}</span>
+            <Controller
+              name="useDefaultEnabled"
+              control={control}
+              render={({ field }) => (
+                <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={(e) => field.onChange(e.target.checked)}
+                    className="cursor-pointer"
+                  />
+                  {t('weeklyCheckIn.config.useDefault')}
+                </label>
+              )}
+            />
+          </div>
+          {!useDefaultEnabled && (
+            <Controller
+              name="enabled"
+              control={control}
+              render={({ field }) => (
+                <Toggle
+                  checked={field.value ?? false}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          )}
+        </div>
+
+        {/* Day of week */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-xs font-medium text-text2">
+              {t('weeklyCheckIn.config.dayOfWeek')}
+            </label>
+            <Controller
+              name="useDefaultDay"
+              control={control}
+              render={({ field }) => (
+                <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={(e) => field.onChange(e.target.checked)}
+                    className="cursor-pointer"
+                  />
+                  {t('weeklyCheckIn.config.useDefault')}
+                </label>
+              )}
+            />
+          </div>
+          {!useDefaultDay && (
+            <Controller
+              name="dayOfWeek"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value !== null ? String(field.value) : ''}
+                  onChange={(e) => field.onChange(Number(e.target.value) as DayOfWeekInt)}
+                >
+                  {ORDERED_DAYS.map((day) => (
+                    <option key={day} value={String(day)}>
+                      {t(`weeklyCheckIn.day.${DAY_OF_WEEK_KEYS[day]}`)}
+                    </option>
+                  ))}
+                </Select>
+              )}
+            />
+          )}
+          {!useDefaultDay && errors.dayOfWeek && (
+            <p className="text-[11px] text-red mt-1">{errors.dayOfWeek.message}</p>
+          )}
+        </div>
+
+        {/* Time */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-xs font-medium text-text2">
+              {t('weeklyCheckIn.config.time')}
+            </label>
+            <Controller
+              name="useDefaultTime"
+              control={control}
+              render={({ field }) => (
+                <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={(e) => field.onChange(e.target.checked)}
+                    className="cursor-pointer"
+                  />
+                  {t('weeklyCheckIn.config.useDefault')}
+                </label>
+              )}
+            />
+          </div>
+          {!useDefaultTime && (
+            <Controller
+              name="timeOfDay"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? ''}
+                  onChange={(e) => field.onChange(e.target.value)}
+                >
+                  {HOUR_OPTIONS.map((h) => (
+                    <option key={h} value={h}>
+                      {h}
+                    </option>
+                  ))}
+                </Select>
+              )}
+            />
+          )}
+        </div>
+
+        {/* Addendum */}
+        <div className="mb-2">
+          <div className="flex items-center justify-between mb-1.5">
+            <label className="text-xs font-medium text-text2">
+              {t('weeklyCheckIn.config.addendum')}
+            </label>
+            <div className="flex items-center gap-3">
+              {!useDefaultAddendum && (
+                <span className="text-[11px] text-text3">{addendum.length}/200</span>
+              )}
+              <Controller
+                name="useDefaultAddendum"
+                control={control}
+                render={({ field }) => (
+                  <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={field.value}
+                      onChange={(e) => field.onChange(e.target.checked)}
+                      className="cursor-pointer"
+                    />
+                    {t('weeklyCheckIn.config.useDefault')}
+                  </label>
+                )}
+              />
+            </div>
+          </div>
+          {!useDefaultAddendum && (
+            <textarea
+              {...register('addendum')}
+              rows={3}
+              maxLength={200}
+              className="w-full py-[7px] px-2.5 border border-border-md rounded-md text-[13px] text-text bg-bg font-[inherit] resize-vertical focus:outline-none focus:border-border-hv transition-colors"
+              placeholder={t('weeklyCheckIn.config.addendumPlaceholder')}
+            />
+          )}
+          {!useDefaultAddendum && errors.addendum && (
+            <p className="text-[11px] text-red mt-1">{errors.addendum.message}</p>
+          )}
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/web/src/components/profile/WeeklyCheckInTab.tsx
+++ b/web/src/components/profile/WeeklyCheckInTab.tsx
@@ -2,16 +2,14 @@ import { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Button, Toggle, Select, Dialog } from '@/components/ui';
+import { Button, Toggle, Select } from '@/components/ui';
 import { useToastStore } from '@/stores/toast';
 import {
   getCheckInSettings,
   getCheckInOverrides,
   upsertCheckInSetting,
-  upsertCheckInOverride,
-  deleteCheckInOverride,
   DAY_OF_WEEK_KEYS,
   ORDERED_DAYS,
   formatTimeDisplay,
@@ -23,6 +21,7 @@ import type {
   CheckInSettingDto,
   CheckInOverrideDto,
 } from '@/api/weekly-checkins';
+import { OverrideDialog } from './OverrideDialog';
 
 /* ─────────────────────── Constants ─────────────────────── */
 
@@ -54,19 +53,6 @@ const settingSchema = z.object({
   defaultAddendum: z.string().max(200, 'Max 200 characters').nullable(),
 });
 type SettingForm = z.infer<typeof settingSchema>;
-
-const overrideSchema = z.object({
-  useDefaultDay: z.boolean(),
-  dayOfWeek: dayOfWeekSchema.nullable(),
-  useDefaultTime: z.boolean(),
-  /** "HH:mm" display value */
-  timeOfDay: z.string().nullable(),
-  useDefaultEnabled: z.boolean(),
-  enabled: z.boolean().nullable(),
-  useDefaultAddendum: z.boolean(),
-  addendum: z.string().max(200, 'Max 200 characters').nullable(),
-});
-type OverrideForm = z.infer<typeof overrideSchema>;
 
 /* ─────────────────────── Helpers ────────────────────────── */
 
@@ -255,283 +241,7 @@ function ProfessionBlock({ profession, setting }: ProfessionBlockProps) {
   );
 }
 
-/* ─────────────────────── Override dialog ─────────────────────── */
-
-interface OverrideDialogProps {
-  override: CheckInOverrideDto;
-  settings: CheckInSettingDto[];
-  onClose: () => void;
-}
-
-function OverrideDialog({ override, settings, onClose }: OverrideDialogProps) {
-  const { t } = useTranslation();
-  const queryClient = useQueryClient();
-  const addToast = useToastStore((s) => s.addToast);
-
-  const { effectiveDayOfWeek, effectiveTimeDisplay } = resolveEffective(override, settings);
-
-  const defaultValues: OverrideForm = {
-    useDefaultDay: override.dayOfWeek === null,
-    dayOfWeek: override.dayOfWeek !== null ? override.dayOfWeek : effectiveDayOfWeek,
-    useDefaultTime: override.timeOfDay === null,
-    timeOfDay:
-      override.timeOfDay !== null
-        ? formatTimeDisplay(override.timeOfDay)
-        : effectiveTimeDisplay,
-    useDefaultEnabled: override.enabled === null,
-    enabled: override.enabled,
-    useDefaultAddendum: override.addendum === null,
-    addendum: override.addendum ?? null,
-  };
-
-  const {
-    register,
-    handleSubmit,
-    control,
-    watch,
-    formState: { errors, isSubmitting },
-  } = useForm<OverrideForm>({
-    resolver: zodResolver(overrideSchema),
-    defaultValues,
-  });
-
-  const useDefaultDay = watch('useDefaultDay');
-  const useDefaultTime = watch('useDefaultTime');
-  const useDefaultEnabled = watch('useDefaultEnabled');
-  const useDefaultAddendum = watch('useDefaultAddendum');
-  const addendum = watch('addendum') ?? '';
-
-  const deleteMutation = useMutation({
-    mutationFn: () =>
-      deleteCheckInOverride(override.clientUserId, override.profession),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['weekly-checkin-overrides'] });
-      addToast(t('weeklyCheckIn.config.overrideDeleted'), 'success');
-      onClose();
-    },
-    onError: () => {
-      addToast(t('weeklyCheckIn.config.saveError'), 'error');
-    },
-  });
-
-  const onSubmit = async (data: OverrideForm) => {
-    const allDefault =
-      data.useDefaultDay && data.useDefaultTime && data.useDefaultEnabled && data.useDefaultAddendum;
-
-    if (allDefault) {
-      deleteMutation.mutate();
-      return;
-    }
-
-    try {
-      await upsertCheckInOverride(override.clientUserId, override.profession, {
-        dayOfWeek: data.useDefaultDay ? null : (data.dayOfWeek ?? null),
-        timeOfDay: data.useDefaultTime ? null : (data.timeOfDay ? toTimeSpanString(data.timeOfDay) : null),
-        enabled: data.useDefaultEnabled ? null : (data.enabled ?? null),
-        addendum: data.useDefaultAddendum ? null : (data.addendum || null),
-      });
-      void queryClient.invalidateQueries({ queryKey: ['weekly-checkin-overrides'] });
-      addToast(t('weeklyCheckIn.config.overrideSaved'), 'success');
-      onClose();
-    } catch {
-      addToast(t('weeklyCheckIn.config.saveError'), 'error');
-    }
-  };
-
-  const clientName = `${override.clientFirstName} ${override.clientLastName}`;
-  const professionLabel =
-    override.profession === 'Training'
-      ? t('weeklyCheckIn.professionTraining')
-      : t('weeklyCheckIn.professionNutrition');
-
-  return (
-    <Dialog
-      open
-      onClose={onClose}
-      title={`${clientName} — ${professionLabel}`}
-      maxWidth={500}
-      footer={
-        <>
-          <Button onClick={onClose}>{t('common.cancel')}</Button>
-          <Button
-            type="submit"
-            variant="primary"
-            disabled={isSubmitting || deleteMutation.isPending}
-            onClick={handleSubmit(onSubmit)}
-          >
-            {isSubmitting || deleteMutation.isPending
-              ? t('common.saving')
-              : t('common.save')}
-          </Button>
-        </>
-      }
-    >
-      <form onSubmit={handleSubmit(onSubmit)}>
-        {/* Enabled */}
-        <div className="mb-4">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-[13px] text-text">{t('weeklyCheckIn.config.enabled')}</span>
-            <Controller
-              name="useDefaultEnabled"
-              control={control}
-              render={({ field }) => (
-                <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={field.value}
-                    onChange={(e) => field.onChange(e.target.checked)}
-                    className="cursor-pointer"
-                  />
-                  {t('weeklyCheckIn.config.useDefault')}
-                </label>
-              )}
-            />
-          </div>
-          {!useDefaultEnabled && (
-            <Controller
-              name="enabled"
-              control={control}
-              render={({ field }) => (
-                <Toggle
-                  checked={field.value ?? false}
-                  onChange={field.onChange}
-                />
-              )}
-            />
-          )}
-        </div>
-
-        {/* Day of week */}
-        <div className="mb-4">
-          <div className="flex items-center justify-between mb-1.5">
-            <label className="text-xs font-medium text-text2">
-              {t('weeklyCheckIn.config.dayOfWeek')}
-            </label>
-            <Controller
-              name="useDefaultDay"
-              control={control}
-              render={({ field }) => (
-                <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={field.value}
-                    onChange={(e) => field.onChange(e.target.checked)}
-                    className="cursor-pointer"
-                  />
-                  {t('weeklyCheckIn.config.useDefault')}
-                </label>
-              )}
-            />
-          </div>
-          {!useDefaultDay && (
-            <Controller
-              name="dayOfWeek"
-              control={control}
-              render={({ field }) => (
-                <Select
-                  value={field.value !== null ? String(field.value) : ''}
-                  onChange={(e) => field.onChange(Number(e.target.value) as DayOfWeekInt)}
-                >
-                  {ORDERED_DAYS.map((day) => (
-                    <option key={day} value={String(day)}>
-                      {t(`weeklyCheckIn.day.${DAY_OF_WEEK_KEYS[day]}`)}
-                    </option>
-                  ))}
-                </Select>
-              )}
-            />
-          )}
-          {!useDefaultDay && errors.dayOfWeek && (
-            <p className="text-[11px] text-red mt-1">{errors.dayOfWeek.message}</p>
-          )}
-        </div>
-
-        {/* Time */}
-        <div className="mb-4">
-          <div className="flex items-center justify-between mb-1.5">
-            <label className="text-xs font-medium text-text2">
-              {t('weeklyCheckIn.config.time')}
-            </label>
-            <Controller
-              name="useDefaultTime"
-              control={control}
-              render={({ field }) => (
-                <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={field.value}
-                    onChange={(e) => field.onChange(e.target.checked)}
-                    className="cursor-pointer"
-                  />
-                  {t('weeklyCheckIn.config.useDefault')}
-                </label>
-              )}
-            />
-          </div>
-          {!useDefaultTime && (
-            <Controller
-              name="timeOfDay"
-              control={control}
-              render={({ field }) => (
-                <Select
-                  value={field.value ?? ''}
-                  onChange={(e) => field.onChange(e.target.value)}
-                >
-                  {HOUR_OPTIONS.map((h) => (
-                    <option key={h} value={h}>
-                      {h}
-                    </option>
-                  ))}
-                </Select>
-              )}
-            />
-          )}
-        </div>
-
-        {/* Addendum */}
-        <div className="mb-2">
-          <div className="flex items-center justify-between mb-1.5">
-            <label className="text-xs font-medium text-text2">
-              {t('weeklyCheckIn.config.addendum')}
-            </label>
-            <div className="flex items-center gap-3">
-              {!useDefaultAddendum && (
-                <span className="text-[11px] text-text3">{addendum.length}/200</span>
-              )}
-              <Controller
-                name="useDefaultAddendum"
-                control={control}
-                render={({ field }) => (
-                  <label className="flex items-center gap-1.5 text-[12px] text-text2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={field.value}
-                      onChange={(e) => field.onChange(e.target.checked)}
-                      className="cursor-pointer"
-                    />
-                    {t('weeklyCheckIn.config.useDefault')}
-                  </label>
-                )}
-              />
-            </div>
-          </div>
-          {!useDefaultAddendum && (
-            <textarea
-              {...register('addendum')}
-              rows={3}
-              maxLength={200}
-              className="w-full py-[7px] px-2.5 border border-border-md rounded-md text-[13px] text-text bg-bg font-[inherit] resize-vertical focus:outline-none focus:border-border-hv transition-colors"
-              placeholder={t('weeklyCheckIn.config.addendumPlaceholder')}
-            />
-          )}
-          {!useDefaultAddendum && errors.addendum && (
-            <p className="text-[11px] text-red mt-1">{errors.addendum.message}</p>
-          )}
-        </div>
-      </form>
-    </Dialog>
-  );
-}
+/* OverrideDialog is imported from ./OverrideDialog — see that file for the implementation. */
 
 /* ─────────────────────── Override row ─────────────────────── */
 

--- a/web/src/components/weekly-checkin/CheckInBanner.tsx
+++ b/web/src/components/weekly-checkin/CheckInBanner.tsx
@@ -1,0 +1,134 @@
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui';
+import { CheckInFlagChips } from './CheckInFlagChips';
+import { useClientCurrentCheckIn, useMarkCheckInReviewed } from '@/hooks/useWeeklyCheckIns';
+import type { Profession, ClientCheckInDto } from '@/api/weekly-checkins';
+
+interface CheckInBannerProps {
+  clientUserId: string;
+  profession: Profession;
+}
+
+/** Formats an ISO datetime string for localized display. */
+function formatDate(isoString: string, language: string): string {
+  try {
+    return new Date(isoString).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+/** Inner banner for a single check-in record. */
+function CheckInBannerInner({
+  checkIn,
+  language,
+}: {
+  checkIn: ClientCheckInDto;
+  language: string;
+}) {
+  const { t } = useTranslation();
+  const { mutate: markReviewed, isPending } = useMarkCheckInReviewed();
+
+  const hasResponded = checkIn.respondedAt !== null;
+  const isReviewed = checkIn.reviewedByTrainerAt !== null;
+
+  // Collapsed "Reviewed" pill — shown after trainer marks reviewed
+  if (isReviewed) {
+    return (
+      <div
+        className="flex items-center gap-2 px-3 py-1.5 rounded-md border border-border-md bg-bg2 text-[12px] text-text2"
+        role="status"
+      >
+        <span className="text-green font-medium">✓</span>
+        <span>{t('weeklyCheckIn.plan.reviewedPill')}</span>
+      </div>
+    );
+  }
+
+  if (!hasResponded) {
+    // Pending state: reminder sent but client hasn't responded
+    return (
+      <div
+        className="flex items-center gap-3 px-4 py-2.5 rounded-md border border-border-md bg-bg2 text-[13px] text-text2"
+        role="status"
+      >
+        <span className="text-lg shrink-0">📋</span>
+        <span>
+          {t('weeklyCheckIn.plan.bannerPending', {
+            sentAt: formatDate(checkIn.sentAt, language),
+          })}
+        </span>
+      </div>
+    );
+  }
+
+  // Responded state: show flags + note + mark-reviewed button
+  return (
+    <div
+      className="flex flex-col gap-2 px-4 py-3 rounded-md border border-accent-br bg-accent-bg"
+      role="region"
+      aria-label={t('weeklyCheckIn.plan.bannerResponded', {
+        submittedAt: formatDate(checkIn.respondedAt!, language),
+      })}
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-lg shrink-0">📋</span>
+          <span className="text-[13px] font-semibold text-text">
+            {t('weeklyCheckIn.plan.bannerResponded', {
+              submittedAt: formatDate(checkIn.respondedAt!, language),
+            })}
+          </span>
+        </div>
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={isPending}
+          onClick={() => markReviewed(checkIn.id)}
+        >
+          {isPending ? t('common.saving') : t('weeklyCheckIn.plan.markReviewed')}
+        </Button>
+      </div>
+
+      {/* Flags */}
+      {checkIn.flags.length > 0 && <CheckInFlagChips flags={checkIn.flags} />}
+
+      {/* Note */}
+      {checkIn.note && (
+        <p className="text-[12px] text-text2 leading-relaxed border-l-2 border-accent pl-2.5 ml-0.5">
+          {checkIn.note}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Banner shown at the top of plan editor pages (nutrition + training).
+ *
+ * Fetches the current check-in for the given client + profession.
+ * Hidden entirely when no check-in exists for this week.
+ */
+export function CheckInBanner({ clientUserId, profession }: CheckInBannerProps) {
+  const { i18n } = useTranslation();
+  const { data: checkIns, isLoading } = useClientCurrentCheckIn(clientUserId, profession);
+
+  // Hide while loading to avoid layout shift
+  if (isLoading) return null;
+
+  const checkIn = checkIns[0] ?? null;
+
+  // No check-in for this week — banner hidden
+  if (!checkIn) return null;
+
+  return (
+    <div className="px-4 pt-3 pb-1 shrink-0">
+      <CheckInBannerInner checkIn={checkIn} language={i18n.language} />
+    </div>
+  );
+}

--- a/web/src/components/weekly-checkin/CheckInFlagChips.tsx
+++ b/web/src/components/weekly-checkin/CheckInFlagChips.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import type { CheckInFlag } from '@/api/weekly-checkins';
+
+/** Emoji icon per flag — defined here to avoid magic strings scattered across the codebase. */
+const FLAG_ICONS: Record<CheckInFlag, string> = {
+  Traveling: '✈️',
+  EventOrCelebration: '🎉',
+  SickOrLowEnergy: '🤒',
+  InjuryOrPain: '🩹',
+  MoreTimeAvailable: '⏱️',
+  LessTimeAvailable: '⏳',
+};
+
+interface CheckInFlagChipsProps {
+  flags: CheckInFlag[];
+  /** When true renders a muted, compact chip row (for pending / no-response states). */
+  muted?: boolean;
+}
+
+/**
+ * Renders a horizontal row of flag chips for a weekly check-in response.
+ * Returns null when the flag list is empty.
+ */
+export function CheckInFlagChips({ flags, muted = false }: CheckInFlagChipsProps) {
+  const { t } = useTranslation();
+
+  if (flags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {flags.map((flag) => (
+        <span
+          key={flag}
+          className={
+            muted
+              ? 'inline-flex items-center gap-1 px-2 py-[2px] rounded-full text-[11px] font-medium bg-bg3 text-text3'
+              : 'inline-flex items-center gap-1 px-2 py-[2px] rounded-full text-[11px] font-medium bg-accent-bg text-accent border border-accent-br'
+          }
+        >
+          <span>{FLAG_ICONS[flag]}</span>
+          {t(`weeklyCheckIn.flag.${flag.charAt(0).toLowerCase() + flag.slice(1)}`)}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/weekly-checkin/WeeklyCheckInCard.tsx
+++ b/web/src/components/weekly-checkin/WeeklyCheckInCard.tsx
@@ -1,0 +1,164 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui';
+import { CheckInFlagChips } from './CheckInFlagChips';
+import { useTrainerWeeklyCheckIns } from '@/hooks/useWeeklyCheckIns';
+import type { TrainerCheckInDto } from '@/api/weekly-checkins';
+
+/** Returns the ISO-week Monday (YYYY-MM-DD) for today's date. */
+function currentISOWeekMonday(): string {
+  const today = new Date();
+  const dow = today.getDay(); // 0=Sunday, 1=Monday, …
+  // Shift so Monday=0, Sunday=6
+  const daysSinceMonday = (dow + 6) % 7;
+  const monday = new Date(today);
+  monday.setDate(today.getDate() - daysSinceMonday);
+  const y = monday.getFullYear();
+  const m = String(monday.getMonth() + 1).padStart(2, '0');
+  const d = String(monday.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Derives the initials (up to 2 chars) from a full name string. */
+function nameInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return (parts[0]?.[0] ?? '').toUpperCase();
+  return `${parts[0]?.[0] ?? ''}${parts[parts.length - 1]?.[0] ?? ''}`.toUpperCase();
+}
+
+/**
+ * Maps a profession value to a route segment for the plan editors.
+ * "Training" → "/training-plans/{clientId}"
+ * "Nutrition" → "/clients/{clientId}/nutrition" (navigate to the client page which has plan links)
+ *
+ * Judgment call: since the spec says "Open plan →" button should route to the matching
+ * plan editor, and we don't have a direct clientId-to-planId resolver here, we navigate
+ * to the client detail page which has links to both editors.  A future iteration could
+ * store a planId on the TrainerCheckInDto and navigate directly.
+ */
+function buildPlanRoute(checkIn: TrainerCheckInDto): string {
+  return `/clients/${checkIn.clientUserId}`;
+}
+
+/* ─────────────────────── Individual row ─────────────────────── */
+
+interface CheckInRowProps {
+  checkIn: TrainerCheckInDto;
+  language: string;
+}
+
+function CheckInRow({ checkIn, language }: CheckInRowProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const initials = nameInitials(checkIn.clientName);
+  const professionLabel =
+    checkIn.profession === 'Training'
+      ? t('weeklyCheckIn.professionTraining')
+      : t('weeklyCheckIn.professionNutrition');
+
+  const submittedLabel = checkIn.respondedAt
+    ? new Date(checkIn.respondedAt).toLocaleDateString(language, {
+        day: 'numeric',
+        month: 'short',
+      })
+    : null;
+
+  return (
+    <div className="flex items-start gap-3 py-3 border-b border-border last:border-b-0">
+      {/* Avatar */}
+      <div className="w-8 h-8 rounded-full bg-bg3 text-text2 text-[11px] font-semibold flex items-center justify-center shrink-0 mt-0.5">
+        {initials}
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        {/* Name + profession pill */}
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-[13px] font-medium text-text truncate">{checkIn.clientName}</span>
+          <span className="inline-flex items-center px-1.5 py-[1px] rounded-full text-[10px] font-medium bg-accent-bg text-accent border border-accent-br shrink-0">
+            {professionLabel}
+          </span>
+          {submittedLabel && (
+            <span className="text-[11px] text-text3 shrink-0">{submittedLabel}</span>
+          )}
+        </div>
+
+        {/* Flag chips — compact summary */}
+        {checkIn.flags.length > 0 && <CheckInFlagChips flags={checkIn.flags} />}
+
+        {/* Note preview */}
+        {checkIn.note && (
+          <p className="mt-1 text-[11px] text-text2 truncate">{checkIn.note}</p>
+        )}
+      </div>
+
+      {/* Open plan action */}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => navigate(buildPlanRoute(checkIn))}
+        className="shrink-0"
+      >
+        {t('weeklyCheckIn.today.openPlan')} →
+      </Button>
+    </div>
+  );
+}
+
+/* ─────────────────────── Card ─────────────────────── */
+
+/**
+ * "Weekly check-ins · this week" card for the trainer dashboard.
+ * Hidden when there are no check-ins for the current ISO week.
+ */
+export function WeeklyCheckInCard() {
+  const { t, i18n } = useTranslation();
+  const weekStartDate = currentISOWeekMonday();
+  const { data: checkIns, isLoading } = useTrainerWeeklyCheckIns(weekStartDate);
+
+  // Only show responded check-ins in the card (pending/dismissed are counted in footer)
+  const responded = checkIns.filter((c) => c.respondedAt !== null);
+  const noResponseCount = checkIns.filter(
+    (c) => c.respondedAt === null && c.dismissedByClientAt === null,
+  ).length;
+
+  if (isLoading) return null;
+  // Hide card entirely when there are no check-ins this week at all
+  if (checkIns.length === 0) return null;
+
+  return (
+    <div
+      className="border border-border-md rounded-md overflow-hidden mb-4"
+      role="region"
+      aria-label={t('weeklyCheckIn.today.cardTitle')}
+    >
+      {/* Card header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-bg2">
+        <span className="text-[12px] font-semibold text-text uppercase tracking-wide">
+          {t('weeklyCheckIn.today.cardTitle')}
+        </span>
+        <span className="text-[11px] text-text3">{weekStartDate}</span>
+      </div>
+
+      {/* Responded rows */}
+      {responded.length > 0 ? (
+        <div className="px-4">
+          {responded.map((checkIn) => (
+            <CheckInRow key={checkIn.id} checkIn={checkIn} language={i18n.language} />
+          ))}
+        </div>
+      ) : (
+        <div className="px-4 py-4 text-[13px] text-text3 text-center">
+          {t('weeklyCheckIn.today.noRespondedYet')}
+        </div>
+      )}
+
+      {/* Footer: count of clients who haven't responded */}
+      {noResponseCount > 0 && (
+        <div className="px-4 py-2.5 border-t border-border bg-bg2 text-[12px] text-text2">
+          {t('weeklyCheckIn.today.noResponseCount', { count: noResponseCount })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/weekly-checkin/WeeklyCheckInSection.tsx
+++ b/web/src/components/weekly-checkin/WeeklyCheckInSection.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui';
+import { CheckInFlagChips } from './CheckInFlagChips';
+import { useClientCurrentCheckIn, useMarkCheckInReviewed } from '@/hooks/useWeeklyCheckIns';
+import {
+  getCheckInOverrides,
+  getCheckInSettings,
+  type CheckInOverrideDto,
+  type CheckInSettingDto,
+} from '@/api/weekly-checkins';
+import { useQuery } from '@tanstack/react-query';
+import { OverrideDialog } from '@/components/profile/OverrideDialog';
+
+interface WeeklyCheckInSectionProps {
+  /** The client's ApplicationUser Id (Guid string) — used as route param. */
+  clientUserId: string;
+}
+
+/** Formats an ISO datetime for display. */
+function formatDateTime(isoString: string, language: string): string {
+  try {
+    return new Date(isoString).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+/**
+ * "Weekly check-in · this week" section shown on the client detail page.
+ *
+ * Displays the latest check-in for either profession (or both if present).
+ * Includes a "Mark reviewed" button and an "Override settings" button.
+ */
+export function WeeklyCheckInSection({ clientUserId }: WeeklyCheckInSectionProps) {
+  const { t, i18n } = useTranslation();
+  const [overrideTarget, setOverrideTarget] = useState<CheckInOverrideDto | null>(null);
+
+  const { data: checkIns, isLoading } = useClientCurrentCheckIn(clientUserId);
+  const { mutate: markReviewed, isPending: isMarkingReviewed } = useMarkCheckInReviewed();
+
+  // Load settings + overrides for the OverrideDialog
+  const { data: settingsResponse } = useQuery({
+    queryKey: ['weekly-checkin-settings'],
+    queryFn: getCheckInSettings,
+  });
+  const { data: overridesResponse } = useQuery({
+    queryKey: ['weekly-checkin-overrides'],
+    queryFn: getCheckInOverrides,
+  });
+
+  if (isLoading) return null;
+  if (!checkIns || checkIns.length === 0) return null;
+
+  const settings: CheckInSettingDto[] = settingsResponse?.settings ?? [];
+  const overrides: CheckInOverrideDto[] = overridesResponse?.overrides ?? [];
+
+  /** Finds the override DTO for this client + profession, or constructs a minimal one. */
+  function getOverrideForProfession(profession: 'Training' | 'Nutrition'): CheckInOverrideDto {
+    const existing = overrides.find(
+      (o) => o.clientUserId === clientUserId && o.profession === profession,
+    );
+    if (existing) return existing;
+
+    // Construct a "use-defaults" override DTO so the dialog can still open
+    const parts = clientUserId.split('-');
+    return {
+      id: '',
+      clientUserId,
+      clientFirstName: parts[0] ?? '',
+      clientLastName: '',
+      profession,
+      dayOfWeek: null,
+      timeOfDay: null,
+      enabled: null,
+      addendum: null,
+    };
+  }
+
+  return (
+    <div className="mt-5">
+      {/* Section heading */}
+      <h2 className="text-[13px] font-semibold text-text uppercase tracking-wide mb-3">
+        {t('weeklyCheckIn.clientDetail.title')}
+      </h2>
+
+      <div className="flex flex-col gap-3">
+        {checkIns.map((checkIn) => {
+          const professionLabel =
+            checkIn.profession === 'Training'
+              ? t('weeklyCheckIn.professionTraining')
+              : t('weeklyCheckIn.professionNutrition');
+          const hasResponded = checkIn.respondedAt !== null;
+          const isReviewed = checkIn.reviewedByTrainerAt !== null;
+
+          return (
+            <div
+              key={checkIn.id}
+              className="border border-border-md rounded-md p-4"
+            >
+              {/* Row header: profession + reviewed badge */}
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-accent-bg text-accent border border-accent-br">
+                    {professionLabel}
+                  </span>
+                  {isReviewed && (
+                    <span className="inline-flex items-center gap-1 px-2 py-[2px] rounded-full text-[11px] font-medium bg-green-bg text-green border border-[var(--green-br)]">
+                      ✓ {t('weeklyCheckIn.plan.reviewedPill')}
+                    </span>
+                  )}
+                </div>
+                {/* Override settings button */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setOverrideTarget(getOverrideForProfession(checkIn.profession))}
+                >
+                  {t('weeklyCheckIn.clientDetail.overrideSettings')}
+                </Button>
+              </div>
+
+              {!hasResponded ? (
+                /* Pending state */
+                <p className="text-[13px] text-text2">
+                  {t('weeklyCheckIn.plan.bannerPending', {
+                    sentAt: formatDateTime(checkIn.sentAt, i18n.language),
+                  })}
+                </p>
+              ) : (
+                /* Responded state */
+                <div className="flex flex-col gap-2">
+                  {/* Submitted at */}
+                  <p className="text-[12px] text-text3">
+                    {t('weeklyCheckIn.plan.bannerResponded', {
+                      submittedAt: formatDateTime(checkIn.respondedAt!, i18n.language),
+                    })}
+                  </p>
+
+                  {/* Flags */}
+                  {checkIn.flags.length > 0 && <CheckInFlagChips flags={checkIn.flags} />}
+
+                  {/* Note */}
+                  {checkIn.note && (
+                    <p className="text-[12px] text-text2 leading-relaxed border-l-2 border-accent pl-2.5">
+                      {checkIn.note}
+                    </p>
+                  )}
+
+                  {/* Mark reviewed button */}
+                  {!isReviewed && (
+                    <div className="mt-1">
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        disabled={isMarkingReviewed}
+                        onClick={() => markReviewed(checkIn.id)}
+                      >
+                        {isMarkingReviewed ? t('common.saving') : t('weeklyCheckIn.plan.markReviewed')}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Override dialog */}
+      {overrideTarget && (
+        <OverrideDialog
+          override={overrideTarget}
+          settings={settings}
+          onClose={() => setOverrideTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useWeeklyCheckIns.ts
+++ b/web/src/hooks/useWeeklyCheckIns.ts
@@ -1,0 +1,98 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getTrainerCheckIns,
+  getClientCurrentCheckIn,
+  markCheckInReviewed,
+  type Profession,
+  type TrainerCheckInDto,
+  type ClientCheckInDto,
+  type MarkCheckInReviewedResponse,
+} from '@/api/weekly-checkins';
+
+// ── Query key factories ──────────────────────────────────────────────────────
+
+export const weeklyCheckInKeys = {
+  /** All trainer weekly-check-in queries */
+  all: ['weekly-check-ins'] as const,
+  /** List for Today card: keyed by ISO week Monday date */
+  trainerList: (weekStartDate: string) =>
+    ['weekly-check-ins', 'trainer-list', weekStartDate] as const,
+  /** Current check-in for a specific client (+ optional profession filter) */
+  clientCurrent: (clientUserId: string, profession?: Profession) =>
+    ['weekly-check-ins', 'client-current', clientUserId, profession ?? 'all'] as const,
+} as const;
+
+// ── Hooks ────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns all responded weekly check-ins for the trainer's clients for a given
+ * ISO week. Used by the "Weekly check-ins · this week" Today card.
+ *
+ * @param weekStartDate - ISO date string for the Monday of the week (YYYY-MM-DD).
+ */
+export function useTrainerWeeklyCheckIns(weekStartDate: string): {
+  data: TrainerCheckInDto[];
+  isLoading: boolean;
+} {
+  const { data, isLoading } = useQuery({
+    queryKey: weeklyCheckInKeys.trainerList(weekStartDate),
+    queryFn: () => getTrainerCheckIns(weekStartDate),
+    staleTime: 60_000,
+    enabled: Boolean(weekStartDate),
+  });
+
+  return {
+    data: data?.checkIns ?? [],
+    isLoading,
+  };
+}
+
+/**
+ * Returns the current week's check-in for a specific client, optionally
+ * filtered to one profession. Used by plan-editor banners and client detail.
+ *
+ * @param clientUserId - Client's ApplicationUser Id (Guid string).
+ * @param profession   - Optional profession filter ("Training" | "Nutrition").
+ */
+export function useClientCurrentCheckIn(
+  clientUserId: string,
+  profession?: Profession,
+): {
+  data: ClientCheckInDto[];
+  isLoading: boolean;
+} {
+  const { data, isLoading } = useQuery({
+    queryKey: weeklyCheckInKeys.clientCurrent(clientUserId, profession),
+    queryFn: () => getClientCurrentCheckIn(clientUserId, profession),
+    staleTime: 60_000,
+    enabled: Boolean(clientUserId),
+  });
+
+  return {
+    data: data?.checkIns ?? [],
+    isLoading,
+  };
+}
+
+/**
+ * Mutation for POST /trainer/weekly-check-ins/{id}/mark-reviewed.
+ * On success, invalidates both the trainer list and client-current queries
+ * so banners update without a page reload.
+ */
+export function useMarkCheckInReviewed(): {
+  mutate: (id: string) => void;
+  isPending: boolean;
+  data: MarkCheckInReviewedResponse | undefined;
+} {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, data } = useMutation({
+    mutationFn: (id: string) => markCheckInReviewed(id),
+    onSuccess: () => {
+      // Invalidate all weekly check-in queries (trainer list + all client-currents)
+      void queryClient.invalidateQueries({ queryKey: weeklyCheckInKeys.all });
+    },
+  });
+
+  return { mutate, isPending, data };
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1240,12 +1240,19 @@
     "today": {
       "cardTitle": "Týdenní check-iny · tento týden",
       "noResponseCount_one": "{{count}} klient ještě neodpověděl",
-      "noResponseCount_other": "{{count}} klientů ještě neodpovědělo"
+      "noResponseCount_other": "{{count}} klientů ještě neodpovědělo",
+      "openPlan": "Otevřít plán",
+      "noRespondedYet": "Žádné odpovědi za tento týden"
     },
     "plan": {
       "bannerResponded": "Check-in klienta · {{submittedAt}}",
       "bannerPending": "Připomínka odeslána {{sentAt}}. Zatím bez odpovědi.",
-      "markReviewed": "Označit jako zkontrolované"
+      "markReviewed": "Označit jako zkontrolované",
+      "reviewedPill": "Zkontrolováno"
+    },
+    "clientDetail": {
+      "title": "Týdenní check-in · tento týden",
+      "overrideSettings": "Upravit nastavení"
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1240,12 +1240,19 @@
     "today": {
       "cardTitle": "Wöchentliche Check-ins · diese Woche",
       "noResponseCount_one": "{{count}} Klient hat noch nicht geantwortet",
-      "noResponseCount_other": "{{count}} Klienten haben noch nicht geantwortet"
+      "noResponseCount_other": "{{count}} Klienten haben noch nicht geantwortet",
+      "openPlan": "Plan öffnen",
+      "noRespondedYet": "Noch keine Antworten diese Woche"
     },
     "plan": {
       "bannerResponded": "Kunden-Check-in · {{submittedAt}}",
       "bannerPending": "Erinnerung gesendet {{sentAt}}. Noch keine Antwort.",
-      "markReviewed": "Als überprüft markieren"
+      "markReviewed": "Als überprüft markieren",
+      "reviewedPill": "Überprüft"
+    },
+    "clientDetail": {
+      "title": "Wöchentlicher Check-in · diese Woche",
+      "overrideSettings": "Einstellungen anpassen"
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1241,12 +1241,19 @@
     "today": {
       "cardTitle": "Weekly check-ins · this week",
       "noResponseCount_one": "{{count}} client hasn't responded",
-      "noResponseCount_other": "{{count}} clients haven't responded"
+      "noResponseCount_other": "{{count}} clients haven't responded",
+      "openPlan": "Open plan",
+      "noRespondedYet": "No responses yet this week"
     },
     "plan": {
       "bannerResponded": "Client check-in · {{submittedAt}}",
       "bannerPending": "Reminder sent {{sentAt}}. No response yet.",
-      "markReviewed": "Mark reviewed"
+      "markReviewed": "Mark reviewed",
+      "reviewedPill": "Reviewed"
+    },
+    "clientDetail": {
+      "title": "Weekly check-in · this week",
+      "overrideSettings": "Override settings"
     }
   }
 }

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -11,6 +11,7 @@ import { Button, Tag, Dialog, Input } from '@/components/ui';
 import { PropertyList, StatsGrid } from '@/components/data';
 import { ActivityTimeline } from '@/components/domain';
 import { QuestionnaireAnswersSection } from '@/components/questionnaire';
+import { WeeklyCheckInSection } from '@/components/weekly-checkin/WeeklyCheckInSection';
 
 export default function ClientDetailPage() {
   const { t, i18n } = useTranslation();
@@ -365,6 +366,17 @@ export default function ClientDetailPage() {
           <div className="my-3.5">
             <QuestionnaireAnswersSection clientId={id!} />
           </div>
+
+          {/* Weekly check-in section */}
+          {/* NOTE: id here is the client's publicId (route param). The backend
+              GET /trainer/clients/{clientUserId}/weekly-check-ins/current
+              expects the ApplicationUser.Id (Guid). Until the backend exposes
+              clientUserId in the client dashboard response, this will return
+              empty results and the section stays hidden. A follow-up task
+              should add clientUserId to GetClientDashboardResponse. */}
+          {id && (
+            <WeeklyCheckInSection clientUserId={id} />
+          )}
 
           {/* Divider */}
           <div className="h-px bg-border my-3.5" />

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -24,6 +24,7 @@ import {
   Callout,
   Mention,
 } from '@/components/data';
+import { WeeklyCheckInCard } from '@/components/weekly-checkin/WeeklyCheckInCard';
 
 type ViewType = 'table' | 'list' | 'cards';
 
@@ -365,6 +366,11 @@ export default function DashboardPage() {
 
           {/* Stats */}
           <StatsGrid stats={stats} />
+
+          {/* Weekly check-ins card */}
+          <div className="mt-4">
+            <WeeklyCheckInCard />
+          </div>
 
           {/* Callouts for low-compliance clients */}
           {alertClients.map((client) => {

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -19,6 +19,7 @@ import { showSuccess, showApiError } from '@/lib/api-errors';
 import { cn } from '@/lib/cn';
 import { type MealKind } from '@/components/nutrition/meal-kind';
 import { DayNoteInput } from '@/components/common/DayNoteInput';
+import { CheckInBanner } from '@/components/weekly-checkin/CheckInBanner';
 
 export default function NutritionPlanPage() {
   const { t, i18n } = useTranslation();
@@ -361,6 +362,11 @@ export default function NutritionPlanPage() {
         }
       />
       </div>
+
+      {/* ── Weekly check-in banner ── */}
+      {plan.clientId && (
+        <CheckInBanner clientUserId={plan.clientId} profession="Nutrition" />
+      )}
 
       {/* ── Week tabs ── */}
       <WeekDayTabs

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -18,6 +18,7 @@ import type { WeekTabData } from '@/components/nutrition/WeekDayTabs';
 import { TrainingSidebar } from '@/components/training/TrainingSidebar';
 import { cn } from '@/lib/cn';
 import { DayNoteInput } from '@/components/common/DayNoteInput';
+import { CheckInBanner } from '@/components/weekly-checkin/CheckInBanner';
 import { DAY_KEYS, MUSCLE_ICONS, MUSCLE_COLORS } from '@/constants/training';
 import { SessionDragWrapper } from '@/components/training/SessionDragWrapper';
 import { ExerciseDropZone } from '@/components/training/ExerciseDropZone';
@@ -358,6 +359,11 @@ export default function TrainingPlanPage() {
         }
       />
       </div>
+
+      {/* ── Weekly check-in banner ── */}
+      {plan.clientId && (
+        <CheckInBanner clientUserId={plan.clientId} profession="Training" />
+      )}
 
       {/* ── Week tabs ── */}
       <WeekDayTabs


### PR DESCRIPTION
Fixes #37

## Summary

Wires the client-facing weekly check-in flow end-to-end in the mobile app:

- **Today banner (`WeeklyCheckInBanner`)** — surfaces pending and in-progress check-ins on the Today screen with stacking support for multiple open check-ins.
- **Response sheet** — Expo Router modal route at `(client)/weekly-checkin/[id].tsx` with a `_layout.tsx` wrapper, covering the full question flow (compliance, energy/stress scales, PRs, free-text notes) and a read-only variant for already-submitted responses.
- **Notification type union** — extends the client notification type with `weekly-check-in-opened` / `weekly-check-in-reminder`, adds corresponding `NOTIF_CONFIG` entries, and wires tap-routing from `NotificationRow` into the response sheet.
- **SignalR wiring** — listens for `weeklycheckinupdated` events on the hub and invalidates the relevant queries (today state + notifications) so the banner updates without a reload.
- **Hand-authored API types (`mobile/src/api/weeklyCheckIns.ts`)** — mirrors the backend DTOs shipped in #34, pending a full NSwag regen pass once the client-facing endpoints stabilize.
- **i18n** — new `weeklyCheckIn.*` key family in all three locales (cs / en / de), including the `sheet.edit` key added in the QA-follow-up commit.

## Known limitations

1. **No `GET /client/weekly-check-ins/{id}` endpoint yet.** The read-only variant of the response sheet relies on route params passed from the opening context (Today banner row, in-app notification row). Push-tap opening will need the same passthrough contract once that endpoint lands — tracked as a small follow-up.
2. **Push-tap handler not established in this codebase.** Opening from a cold push notification requires a root-level `expo-notifications` `addNotificationResponseReceivedListener`, which isn't wired anywhere yet. Tap routing via the in-app notification row and the Today banner is fully functional. Push-tap tracked as a small follow-up.

## Dependency

This branch is based on top of `feature/36-weekly-checkin-visibility-ui` (PR #51). Once #51 merges to `develop`, this branch should be rebased onto the freshly-squashed `develop` HEAD — GitHub will then show the clean mobile-only diff (11 files, ~1094 insertions).

## Test plan

- [ ] Open Today screen as a client with a pending check-in — banner renders with correct copy (cs/en/de).
- [ ] Tap banner → response sheet opens, fill out all questions, submit → banner clears, notification updates.
- [ ] Trigger `weeklycheckinupdated` via SignalR → today query invalidates, banner reflects new state without reload.
- [ ] Tap an in-app `weekly-check-in-opened` notification row → routes into the response sheet.
- [ ] Tap a `weekly-check-in-reminder` notification row → routes into the response sheet.
- [ ] Submitted check-in → sheet renders in read-only mode, "Edit" CTA is localized (all three locales).
- [ ] Stacked state: two open check-ins → banner stacking renders both.
- [ ] `npx tsc --noEmit` in `/mobile` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)