### PR TITLE
docs: update prototypes with weekly check-in scenes (#39)

### DIFF
--- a/docs/mobile_prototype.html
+++ b/docs/mobile_prototype.html
@@ -722,6 +722,8 @@ body.dark-proto .tab.active .tab-lbl{color:#c9a84c}
       <button class="pb" onclick="showPhone('ph-recipe-detail')">Detail receptu</button>
       <button class="pb" onclick="showPhone('ph-onb-intro')">Dotazník — intro</button>
       <button class="pb" onclick="showPhone('ph-onb-s1')">Dotazník — krok</button>
+      <button class="pb" onclick="showPhone('ph-weekly-checkin')">Check-in — vyplnit</button>
+      <button class="pb" onclick="showPhone('ph-weekly-checkin-sent')">Check-in — odesláno</button>
     </div>
   </div>
   <div class="ps"></div>
@@ -839,6 +841,26 @@ body.dark-proto .tab.active .tab-lbl{color:#c9a84c}
           <div style="font-size:13px;color:var(--ios-label2);margin-top:1px">Od trenéra Marka a výživové poradkyně Jany</div>
         </div>
         <div style="color:var(--ios-label3);font-size:16px;font-weight:600;flex-shrink:0">›</div>
+      </div>
+
+      <!-- Weekly check-in banners (trainer + nutritionist stacked) -->
+      <div id="today-weekly-checkin-banners" style="margin:10px 20px 0;display:flex;flex-direction:column;gap:8px">
+        <div onclick="showPhone('ph-weekly-checkin')" style="display:flex;align-items:center;gap:10px;background:rgba(201,168,76,.1);border:1px solid rgba(201,168,76,.25);border-radius:var(--ios-r);padding:12px 14px;cursor:pointer;transition:background .15s" onmouseover="this.style.background='rgba(201,168,76,.18)'" onmouseout="this.style.background='rgba(201,168,76,.1)'">
+          <div style="font-size:22px;flex-shrink:0">📅</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:15px;font-weight:600;color:var(--ios-label);letter-spacing:-.2px">Plánování příštího týdne</div>
+            <div style="font-size:13px;color:var(--ios-label2);margin-top:1px">Marek Trenér · chce vědět, co tě čeká</div>
+          </div>
+          <div style="color:var(--ios-label3);font-size:16px;font-weight:600;flex-shrink:0">›</div>
+        </div>
+        <div onclick="showPhone('ph-weekly-checkin')" style="display:flex;align-items:center;gap:10px;background:rgba(52,199,89,.08);border:1px solid rgba(52,199,89,.22);border-radius:var(--ios-r);padding:12px 14px;cursor:pointer;transition:background .15s" onmouseover="this.style.background='rgba(52,199,89,.15)'" onmouseout="this.style.background='rgba(52,199,89,.08)'">
+          <div style="font-size:22px;flex-shrink:0">🥗</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:15px;font-weight:600;color:var(--ios-label);letter-spacing:-.2px">Plánování příštího jídelníčku</div>
+            <div style="font-size:13px;color:var(--ios-label2);margin-top:1px">Lucie Poradce · chce vědět, co tě čeká</div>
+          </div>
+          <div style="color:var(--ios-label3);font-size:16px;font-weight:600;flex-shrink:0">›</div>
+        </div>
       </div>
 
       <!-- Today summary strip -->
@@ -1303,6 +1325,19 @@ body.dark-proto .tab.active .tab-lbl{color:#c9a84c}
             <div class="notif-time">před 5 minutami</div>
             <div class="notif-actions">
               <div class="notif-action-btn notif-action-primary" onclick="event.stopPropagation();showToastOn('ph-today','Dotazník otevřen')">Vyplnit</div>
+              <div class="notif-action-btn notif-action-secondary" onclick="event.stopPropagation()">Později</div>
+            </div>
+          </div>
+        </div>
+        <div class="notif-row unread" onclick="closeNotifSheet('ph-today');showPhone('ph-weekly-checkin')">
+          <div class="notif-unread-dot"></div>
+          <div class="notif-icon-wrap" style="background:rgba(201,168,76,.12)">📅</div>
+          <div class="notif-body">
+            <div class="notif-title">Plánování příštího týdne</div>
+            <div class="notif-text">Marek Trenér bude brzy připravovat tvůj plán — dej vědět, jestli tě nečeká něco mimořádného.</div>
+            <div class="notif-time">před 20 minutami</div>
+            <div class="notif-actions">
+              <div class="notif-action-btn notif-action-primary" onclick="event.stopPropagation();showPhone('ph-weekly-checkin')">Vyplnit</div>
               <div class="notif-action-btn notif-action-secondary" onclick="event.stopPropagation()">Později</div>
             </div>
           </div>
@@ -2083,6 +2118,214 @@ body.dark-proto .tab.active .tab-lbl{color:#c9a84c}
 </div>
 </div>
 
+<!-- ═══════════════════════════════════════════
+     TÝDENNÍ CHECK-IN — odpověď na plánování
+═══════════════════════════════════════════ -->
+<div class="phone-wrap">
+<div class="phone-label">Check-in příštího týdne</div>
+<div class="phone" id="ph-weekly-checkin" style="display:none">
+  <div class="di"></div>
+  <div class="status-bar">
+    <span class="sb-time">9:41</span>
+    <div class="sb-icons">
+      <svg width="17" height="12" viewBox="0 0 17 12"><rect x="0" y="3" width="3" height="9" rx="1"/><rect x="4.5" y="2" width="3" height="10" rx="1"/><rect x="9" y="0" width="3" height="12" rx="1"/><rect x="13.5" y="1" width="3" height="11" rx="1"/></svg>
+      <svg width="25" height="12" viewBox="0 0 25 12"><rect x="0" y="1" width="21" height="10" rx="3.5" stroke="#000" stroke-width="1" fill="none"/><rect x="22" y="4" width="2.5" height="4" rx="1" fill="#000" opacity=".4"/><rect x="1.5" y="2.5" width="15" height="7" rx="2" fill="#000"/></svg>
+    </div>
+  </div>
+
+  <!-- Modal-style top bar -->
+  <div style="display:flex;align-items:center;justify-content:space-between;padding:14px 20px 4px">
+    <div onclick="showPhone('ph-today')" style="font-size:15px;font-weight:600;color:var(--ios-label2);cursor:pointer">Zavřít</div>
+    <div style="font-size:15px;font-weight:600;color:var(--ios-label)">Příští týden</div>
+    <div style="width:48px"></div>
+  </div>
+
+  <div class="scroll-area" style="padding-bottom:110px">
+
+    <!-- Trainer header -->
+    <div style="padding:14px 20px 4px;display:flex;align-items:center;gap:12px">
+      <div style="width:48px;height:48px;border-radius:15px;background:linear-gradient(135deg,#c9a84c,#b8942f);display:flex;align-items:center;justify-content:center;font-size:17px;font-weight:700;color:#fff;flex-shrink:0">MT</div>
+      <div style="flex:1;min-width:0">
+        <div style="font-size:17px;font-weight:600;color:var(--ios-label)">Marek Trenér</div>
+        <div style="display:inline-flex;align-items:center;gap:6px;margin-top:3px;padding:3px 10px;border-radius:99px;background:rgba(201,168,76,.12)">
+          <span style="width:6px;height:6px;border-radius:50%;background:var(--ios-gold)"></span>
+          <span style="font-size:11px;font-weight:600;color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Prompt block (default copy + trainer addendum) -->
+    <div style="margin:16px 20px 0;padding:16px;background:var(--ios-bg2);border-radius:var(--ios-r-lg);box-shadow:0 1px 3px rgba(0,0,0,.06)">
+      <div style="font-size:15px;color:var(--ios-label);line-height:1.5">
+        Tvůj trenér brzy připraví plán na příští týden. Dej vědět, jestli tě nečeká něco mimořádného, co by plán mohlo ovlivnit.
+      </div>
+      <div style="margin-top:12px;padding:10px 12px;background:rgba(201,168,76,.06);border-left:3px solid var(--ios-gold);border-radius:6px">
+        <div style="font-size:11px;font-weight:600;color:var(--ios-gold);text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px">Od Marka</div>
+        <div style="font-size:13px;color:var(--ios-label2);line-height:1.45;font-style:italic">„Pokud plánuješ dlouhou cestu, dej vědět — přizpůsobím týdenní rozložení."</div>
+      </div>
+      <div style="margin-top:10px;font-size:12px;color:var(--ios-label3)">Týden 20.–26. 10. 2026</div>
+    </div>
+
+    <!-- Chips grid -->
+    <div style="margin:20px 20px 0">
+      <div style="font-size:13px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Co tě čeká?</div>
+      <div style="display:flex;flex-wrap:wrap;gap:8px">
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:rgba(201,168,76,.14);border:1.5px solid var(--ios-gold);cursor:pointer">
+          <span style="font-size:15px">✈️</span>
+          <span style="font-size:13px;font-weight:600;color:var(--ios-gold)">Cestování</span>
+        </div>
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:var(--ios-bg2);border:1px solid var(--ios-sep2);cursor:pointer">
+          <span style="font-size:15px">🎉</span>
+          <span style="font-size:13px;font-weight:500;color:var(--ios-label)">Oslava / akce</span>
+        </div>
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:var(--ios-bg2);border:1px solid var(--ios-sep2);cursor:pointer">
+          <span style="font-size:15px">🤒</span>
+          <span style="font-size:13px;font-weight:500;color:var(--ios-label)">Nemoc / únava</span>
+        </div>
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:var(--ios-bg2);border:1px solid var(--ios-sep2);cursor:pointer">
+          <span style="font-size:15px">🩹</span>
+          <span style="font-size:13px;font-weight:500;color:var(--ios-label)">Zranění / bolest</span>
+        </div>
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:rgba(201,168,76,.14);border:1.5px solid var(--ios-gold);cursor:pointer">
+          <span style="font-size:15px">⏱️</span>
+          <span style="font-size:13px;font-weight:600;color:var(--ios-gold)">Více času než obvykle</span>
+        </div>
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:var(--ios-bg2);border:1px solid var(--ios-sep2);cursor:pointer">
+          <span style="font-size:15px">⏳</span>
+          <span style="font-size:13px;font-weight:500;color:var(--ios-label)">Méně času než obvykle</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Note textarea -->
+    <div style="margin:24px 20px 0">
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
+        <div style="font-size:13px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.05em">Poznámka (volitelné)</div>
+        <div style="font-size:12px;color:var(--ios-label3)">84 / 500</div>
+      </div>
+      <div style="background:var(--ios-bg2);border:1px solid var(--ios-sep2);border-radius:var(--ios-r);padding:14px 16px;min-height:110px">
+        <div style="font-size:15px;color:var(--ios-label);line-height:1.5">Od pátku jsem pryč, vrátím se v neděli večer. Klidně přidej víc objemu první čtyři dny — pak dej lehčí týden.</div>
+      </div>
+    </div>
+
+    <div style="height:20px"></div>
+  </div>
+
+  <!-- Action bar pinned at bottom (above tab bar) -->
+  <div style="position:absolute;left:0;right:0;bottom:83px;padding:12px 20px;background:var(--ios-bg);border-top:.5px solid var(--ios-sep2);display:flex;gap:10px">
+    <div onclick="showPhone('ph-weekly-checkin-sent')" style="flex:1;display:flex;align-items:center;justify-content:center;padding:14px;border-radius:14px;background:var(--ios-gold);color:#fff;font-size:15px;font-weight:600;cursor:pointer">Odeslat</div>
+    <div onclick="showPhone('ph-today')" style="padding:14px 18px;border-radius:14px;background:var(--ios-bg2);border:1px solid var(--ios-sep2);color:var(--ios-label);font-size:14px;font-weight:600;cursor:pointer">Přeskočit týden</div>
+  </div>
+
+  <!-- Tab bar -->
+  <div class="tab-bar">
+    <div class="tab active" onclick="showPhone('ph-today')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" fill="#8e8e93"/><path d="M9 22V12h6v10" fill="#8e8e93"/></svg></div><div class="tab-lbl">Dnes</div></div>
+    <div class="tab" onclick="showPhone('ph-discover')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="8" stroke="#8e8e93" stroke-width="2"/><path d="m21 21-4.35-4.35" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Trenéři</div></div>
+    <div class="tab" onclick="showPhone('ph-plans')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><rect x="3" y="4" width="18" height="18" rx="2" stroke="#8e8e93" stroke-width="2"/><path d="M16 2v4M8 2v4M3 10h18" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Plány</div></div>
+    <div class="tab" onclick="showPhone('ph-messages')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="#8e8e93" stroke-width="2" stroke-linejoin="round"/></svg></div><div class="tab-lbl">Zprávy</div></div>
+    <div class="tab" onclick="showPhone('ph-profile')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="8" r="4" stroke="#8e8e93" stroke-width="2"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Profil</div></div>
+  </div>
+</div>
+</div>
+<!-- ═══════════════════════════════════════════
+     TÝDENNÍ CHECK-IN — odesláno (read-only)
+═══════════════════════════════════════════ -->
+<div class="phone-wrap">
+<div class="phone-label">Check-in — odesláno</div>
+<div class="phone" id="ph-weekly-checkin-sent" style="display:none">
+  <div class="di"></div>
+  <div class="status-bar">
+    <span class="sb-time">9:41</span>
+    <div class="sb-icons">
+      <svg width="17" height="12" viewBox="0 0 17 12"><rect x="0" y="3" width="3" height="9" rx="1"/><rect x="4.5" y="2" width="3" height="10" rx="1"/><rect x="9" y="0" width="3" height="12" rx="1"/><rect x="13.5" y="1" width="3" height="11" rx="1"/></svg>
+      <svg width="25" height="12" viewBox="0 0 25 12"><rect x="0" y="1" width="21" height="10" rx="3.5" stroke="#000" stroke-width="1" fill="none"/><rect x="22" y="4" width="2.5" height="4" rx="1" fill="#000" opacity=".4"/><rect x="1.5" y="2.5" width="15" height="7" rx="2" fill="#000"/></svg>
+    </div>
+  </div>
+
+  <!-- Modal-style top bar -->
+  <div style="display:flex;align-items:center;justify-content:space-between;padding:14px 20px 4px">
+    <div onclick="showPhone('ph-today')" style="font-size:15px;font-weight:600;color:var(--ios-label2);cursor:pointer">Zavřít</div>
+    <div style="font-size:15px;font-weight:600;color:var(--ios-label)">Příští týden</div>
+    <div style="width:48px"></div>
+  </div>
+
+  <div class="scroll-area" style="padding-bottom:110px">
+
+    <!-- Status pill -->
+    <div style="margin:12px 20px 0;display:flex;justify-content:center">
+      <div style="display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:99px;background:rgba(52,199,89,.12)">
+        <span style="font-size:13px">✓</span>
+        <span style="font-size:12px;font-weight:600;color:var(--ios-green)">Odesláno · čtvrtek 18:04</span>
+      </div>
+    </div>
+
+    <!-- Trainer header -->
+    <div style="padding:14px 20px 4px;display:flex;align-items:center;gap:12px">
+      <div style="width:48px;height:48px;border-radius:15px;background:linear-gradient(135deg,#c9a84c,#b8942f);display:flex;align-items:center;justify-content:center;font-size:17px;font-weight:700;color:#fff;flex-shrink:0">MT</div>
+      <div style="flex:1;min-width:0">
+        <div style="font-size:17px;font-weight:600;color:var(--ios-label)">Marek Trenér</div>
+        <div style="display:inline-flex;align-items:center;gap:6px;margin-top:3px;padding:3px 10px;border-radius:99px;background:rgba(201,168,76,.12)">
+          <span style="width:6px;height:6px;border-radius:50%;background:var(--ios-gold)"></span>
+          <span style="font-size:11px;font-weight:600;color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Prompt block (same copy, now secondary) -->
+    <div style="margin:16px 20px 0;padding:16px;background:var(--ios-bg2);border-radius:var(--ios-r-lg);box-shadow:0 1px 3px rgba(0,0,0,.06);opacity:.85">
+      <div style="font-size:14px;color:var(--ios-label2);line-height:1.5">
+        Tvůj trenér brzy připraví plán na příští týden. Dej vědět, jestli tě nečeká něco mimořádného, co by plán mohlo ovlivnit.
+      </div>
+      <div style="margin-top:10px;font-size:12px;color:var(--ios-label3)">Týden 20.–26. 10. 2026</div>
+    </div>
+
+    <!-- Selected chips (read-only) -->
+    <div style="margin:20px 20px 0">
+      <div style="font-size:13px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Tvoje odpověď</div>
+      <div style="display:flex;flex-wrap:wrap;gap:8px">
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:rgba(201,168,76,.14);border:1.5px solid var(--ios-gold)">
+          <span style="font-size:15px">✈️</span>
+          <span style="font-size:13px;font-weight:600;color:var(--ios-gold)">Cestování</span>
+        </div>
+        <div style="display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:99px;background:rgba(201,168,76,.14);border:1.5px solid var(--ios-gold)">
+          <span style="font-size:15px">⏱️</span>
+          <span style="font-size:13px;font-weight:600;color:var(--ios-gold)">Více času než obvykle</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Note read-only -->
+    <div style="margin:24px 20px 0">
+      <div style="font-size:13px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.05em;margin-bottom:10px">Poznámka</div>
+      <div style="background:var(--ios-bg2);border:1px solid var(--ios-sep2);border-radius:var(--ios-r);padding:14px 16px">
+        <div style="font-size:15px;color:var(--ios-label);line-height:1.5">Od pátku jsem pryč, vrátím se v neděli večer. Klidně přidej víc objemu první čtyři dny — pak dej lehčí týden.</div>
+      </div>
+    </div>
+
+    <!-- Review-locked notice (Marek already planned) -->
+    <div style="margin:20px 20px 0;padding:12px 14px;background:rgba(120,120,128,.08);border:1px solid var(--ios-sep2);border-radius:var(--ios-r);display:flex;align-items:center;gap:10px">
+      <span style="font-size:18px;flex-shrink:0">🔒</span>
+      <div style="flex:1;font-size:13px;color:var(--ios-label2);line-height:1.45">Tvůj trenér si tvou odpověď už přečetl — upravit ji teď nejde.</div>
+    </div>
+
+    <div style="height:20px"></div>
+  </div>
+
+  <!-- Action bar pinned at bottom — Edit disabled -->
+  <div style="position:absolute;left:0;right:0;bottom:83px;padding:12px 20px;background:var(--ios-bg);border-top:.5px solid var(--ios-sep2);display:flex;gap:10px">
+    <div style="flex:1;display:flex;align-items:center;justify-content:center;padding:14px;border-radius:14px;background:var(--ios-fill);color:var(--ios-label3);font-size:15px;font-weight:600;cursor:not-allowed">Upravit (uzamčeno)</div>
+  </div>
+
+  <!-- Tab bar -->
+  <div class="tab-bar">
+    <div class="tab active" onclick="showPhone('ph-today')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" fill="#8e8e93"/><path d="M9 22V12h6v10" fill="#8e8e93"/></svg></div><div class="tab-lbl">Dnes</div></div>
+    <div class="tab" onclick="showPhone('ph-discover')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="8" stroke="#8e8e93" stroke-width="2"/><path d="m21 21-4.35-4.35" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Trenéři</div></div>
+    <div class="tab" onclick="showPhone('ph-plans')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><rect x="3" y="4" width="18" height="18" rx="2" stroke="#8e8e93" stroke-width="2"/><path d="M16 2v4M8 2v4M3 10h18" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Plány</div></div>
+    <div class="tab" onclick="showPhone('ph-messages')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="#8e8e93" stroke-width="2" stroke-linejoin="round"/></svg></div><div class="tab-lbl">Zprávy</div></div>
+    <div class="tab" onclick="showPhone('ph-profile')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="8" r="4" stroke="#8e8e93" stroke-width="2"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Profil</div></div>
+  </div>
+</div>
+</div>
 <!-- ═══════════════════════════════════════════
      PROFIL & POKROK
 ═══════════════════════════════════════════ -->
@@ -4723,7 +4966,7 @@ function showPhone(id){
   document.querySelectorAll('.phone').forEach(function(p){ p.style.display='none'; });
   var el = document.getElementById(id); if(el) el.style.display='block';
   document.querySelectorAll('.pb').forEach(function(b){ b.classList.remove('active'); });
-  var map = {'ph-today':'Dnes','ph-invite-detail':'Detail pozvánky','ph-discover':'Spolupráce','ph-trainer-profile':'Profil trenéra','ph-plans':'Plány','ph-plan-history':'Archiv plánů','ph-plan-detail-complete':'Dokončený plán','ph-nutrition-plan-detail':'Detail výživového plánu','ph-training-plan-detail':'Detail tréninku','ph-food-detail':'Detail potraviny','ph-recipe-detail':'Detail receptu','ph-pending-questionnaires':'Čekající dotazníky','ph-profile':'Profil','ph-messages':'Zprávy','ph-archive':'Archiv','ph-chat':'Chat detail','ph-chat-former':'Chat — bývalý trenér','ph-live-training':'Živý trénink'};
+  var map = {'ph-today':'Dnes','ph-invite-detail':'Detail pozvánky','ph-discover':'Spolupráce','ph-trainer-profile':'Profil trenéra','ph-plans':'Plány','ph-plan-history':'Archiv plánů','ph-plan-detail-complete':'Dokončený plán','ph-nutrition-plan-detail':'Detail výživového plánu','ph-training-plan-detail':'Detail tréninku','ph-food-detail':'Detail potraviny','ph-recipe-detail':'Detail receptu','ph-pending-questionnaires':'Čekající dotazníky','ph-weekly-checkin':'Check-in — vyplnit','ph-weekly-checkin-sent':'Check-in — odesláno','ph-profile':'Profil','ph-messages':'Zprávy','ph-archive':'Archiv','ph-chat':'Chat detail','ph-chat-former':'Chat — bývalý trenér','ph-live-training':'Živý trénink'};
   document.querySelectorAll('.pb').forEach(function(b){
     if(b.textContent.trim() === map[id]) b.classList.add('active');
   });

--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -570,6 +570,9 @@ body.dark .btn-auth-primary { color: #0d0900; }
   <button class="tn-btn" onclick="showScreen('s-nutrition')">Jídelníček</button>
   <button class="tn-btn" onclick="showScreen('s-foods')">Databáze potravin</button>
   <button class="tn-btn" onclick="showScreen('s-goals')">Cíle klienta</button>
+  <div class="tn-sep"></div>
+  <div class="tn-lbl">Nastavení</div>
+  <button class="tn-btn" onclick="showScreen('s-settings-checkins')">Týdenní check-iny</button>
   <div class="tn-right">
     <button class="tn-icon" onclick="toggleDark()" id="dark-btn" title="Tmavý režim">☾</button>
   </div>
@@ -621,6 +624,54 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <div class="callout-body">
         <div class="callout-title">Jakub Malý — nízká compliance</div>
         <div class="callout-text">Plní 2/5 tréninků. <span class="mention" onclick="showScreen('s-messages')">✉ Napsat zprávu</span></div>
+      </div>
+    </div>
+
+    <!-- Weekly check-ins card -->
+    <div style="background:var(--bg2);border:1px solid var(--bd);border-radius:8px;margin-bottom:16px">
+      <div style="padding:12px 16px;border-bottom:1px solid var(--bd);display:flex;align-items:center;justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:8px">
+          <span style="font-size:16px">📅</span>
+          <div>
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Týdenní check-iny · tento týden</div>
+            <div style="font-size:12px;color:var(--t2)">Před plánováním příštího týdne</div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;gap:10px">
+          <div style="font-size:12px;color:var(--t2)">2 odpověděli · 3 ne</div>
+          <button class="btn" style="font-size:12px;padding:4px 10px" onclick="showScreen('s-settings-checkins')">Nastavení</button>
+        </div>
+      </div>
+      <div style="padding:0">
+        <div style="display:grid;grid-template-columns:36px 1fr auto auto;gap:12px;padding:12px 16px;align-items:center;border-bottom:1px solid var(--bd);cursor:pointer" onclick="showScreen('s-training')">
+          <div style="width:32px;height:32px;border-radius:6px;background:rgba(0,122,255,.12);color:#007aff;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600">PH</div>
+          <div style="min-width:0">
+            <div style="font-size:14px;font-weight:600;color:var(--t);margin-bottom:3px">Petra Horáková <span style="font-size:10px;font-weight:600;padding:1px 6px;border-radius:99px;background:rgba(201,168,76,.15);color:var(--acc);text-transform:uppercase;letter-spacing:.04em;margin-left:4px">Trénink</span></div>
+            <div style="display:flex;flex-wrap:wrap;gap:4px">
+              <span style="font-size:11px;padding:1px 7px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc)">✈️ Cestování</span>
+              <span style="font-size:11px;padding:1px 7px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc)">⏱️ Více času</span>
+            </div>
+            <div style="font-size:12px;color:var(--t2);margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">„Od pátku jsem pryč, vrátím se v neděli večer…"</div>
+          </div>
+          <div style="font-size:11px;color:var(--t3);white-space:nowrap">čt 18:04</div>
+          <button class="btn primary" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showScreen('s-training')">Otevřít plán →</button>
+        </div>
+        <div style="display:grid;grid-template-columns:36px 1fr auto auto;gap:12px;padding:12px 16px;align-items:center;border-bottom:1px solid var(--bd);cursor:pointer" onclick="showScreen('s-nutrition')">
+          <div style="width:32px;height:32px;border-radius:6px;background:rgba(52,199,89,.12);color:#34c759;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600">LP</div>
+          <div style="min-width:0">
+            <div style="font-size:14px;font-weight:600;color:var(--t);margin-bottom:3px">Lucie Procházková <span style="font-size:10px;font-weight:600;padding:1px 6px;border-radius:99px;background:rgba(52,199,89,.15);color:#34c759;text-transform:uppercase;letter-spacing:.04em;margin-left:4px">Výživa</span></div>
+            <div style="display:flex;flex-wrap:wrap;gap:4px">
+              <span style="font-size:11px;padding:1px 7px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc)">🎉 Oslava / akce</span>
+            </div>
+            <div style="font-size:12px;color:var(--t2);margin-top:4px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">„V sobotu rodinná oslava — dá se to naplánovat jako cheat day?"</div>
+          </div>
+          <div style="font-size:11px;color:var(--t3);white-space:nowrap">pá 10:12</div>
+          <button class="btn primary" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showScreen('s-nutrition')">Otevřít plán →</button>
+        </div>
+        <div style="padding:10px 16px;font-size:12px;color:var(--t2);display:flex;justify-content:space-between;align-items:center;background:rgba(120,120,128,.03)">
+          <span><strong style="color:var(--t)">3 klienti</strong> zatím neodpověděli</span>
+          <span style="color:var(--t3)">Plánujete ve čtvrtek 18:00</span>
+        </div>
       </div>
     </div>
     <!-- views -->
@@ -721,6 +772,46 @@ body.dark .btn-auth-primary { color: #0d0900; }
     </div>
   </div>
   <div class="pc">
+    <!-- Weekly check-in response banner — state 1: RESPONDED (client answered before planning) -->
+    <div style="background:var(--bg2);border:1px solid var(--acc-br);border-left:3px solid var(--acc);border-radius:8px;margin-bottom:10px">
+      <div style="padding:12px 16px;display:flex;align-items:flex-start;gap:12px">
+        <div style="font-size:18px;margin-top:1px">📅</div>
+        <div style="flex:1;min-width:0">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+            <div style="font-size:13px;font-weight:600;color:var(--t)">Check-in od Petry · tento týden</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(52,199,89,.12);color:#34c759;text-transform:uppercase;letter-spacing:.04em">Odpověděla</span>
+            <span style="font-size:11px;color:var(--t2)">odesláno čt 18:04</span>
+          </div>
+          <div style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:8px">
+            <span style="font-size:11px;font-weight:500;padding:2px 8px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc)">✈️ Cestování</span>
+            <span style="font-size:11px;font-weight:500;padding:2px 8px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc)">⏱️ Více času než obvykle</span>
+          </div>
+          <div style="font-size:13px;color:var(--t2);line-height:1.45">„Od pátku jsem pryč, vrátím se v neděli večer. Klidně přidej víc objemu první čtyři dny — pak dej lehčí týden."</div>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:6px;flex-shrink:0">
+          <button class="btn primary" style="font-size:12px;padding:5px 10px;white-space:nowrap">✓ Zkontrolováno</button>
+          <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-settings-checkins')">Nastavení</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Weekly check-in response banner — state 2: SENT BUT NOT YET RESPONDED (scene variant for QA) -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-left:3px solid var(--t4);border-radius:8px;margin-bottom:12px;opacity:.85">
+      <div style="padding:10px 16px;display:flex;align-items:center;gap:12px">
+        <div style="font-size:16px">⏳</div>
+        <div style="flex:1;min-width:0">
+          <div style="display:flex;align-items:center;gap:8px">
+            <div style="font-size:13px;font-weight:600;color:var(--t2)">Check-in čeká na odpověď</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(120,120,128,.1);color:var(--t3);text-transform:uppercase;letter-spacing:.04em">Variant · nezodpovězeno</span>
+          </div>
+          <div style="font-size:12px;color:var(--t3);margin-top:2px">Odesláno čt 18:00 · Klient zatím nereagoval · Můžeš plánovat i bez odpovědi.</div>
+        </div>
+        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-messages')">💬 Napsat klientovi</button>
+      </div>
+    </div>
+    <!-- Banner state 3 (hidden) is omitted here by design — when the client has no scheduled check-in, the banner does not render at all. -->
+
+
     <div class="week-grid">
       <div class="day-col"><div class="day-hdr today">Po</div><div class="day-body"><div class="day-session" onclick="openDialog('dlg-session-detail')"><div class="day-sname">Push A</div><div class="day-smeta">5 cviků · 60 min</div></div><div class="day-add" onclick="openDialog('dlg-add-session')">+ Přidat</div></div></div>
       <div class="day-col"><div class="day-hdr">Út</div><div class="day-body"><div class="day-session"><div class="day-sname">Pull A</div><div class="day-smeta">4 cviky · 50 min</div></div><div class="day-add" onclick="openDialog('dlg-add-session')">+ Přidat</div></div></div>
@@ -789,6 +880,43 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <button class="btn primary" onclick="publishPlan()">Publikovat</button>
     </div>
   </div>
+  <!-- Weekly check-in response banner — state 1: RESPONDED -->
+  <div style="margin:10px 16px 0;background:var(--bg2);border:1px solid var(--acc-br);border-left:3px solid var(--acc);border-radius:8px">
+    <div style="padding:10px 14px;display:flex;align-items:flex-start;gap:10px">
+      <div style="font-size:16px;margin-top:1px">📅</div>
+      <div style="flex:1;min-width:0">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
+          <div style="font-size:13px;font-weight:600;color:var(--t)">Check-in od Petry · tento týden</div>
+          <span style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(52,199,89,.12);color:#34c759;text-transform:uppercase;letter-spacing:.04em">Odpověděla</span>
+          <span style="font-size:11px;color:var(--t2)">odesláno pá 10:12</span>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:6px">
+          <span style="font-size:11px;font-weight:500;padding:2px 8px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc)">🎉 Oslava / akce</span>
+        </div>
+        <div style="font-size:12px;color:var(--t2);line-height:1.45">„V sobotu rodinná oslava — dá se to naplánovat jako cheat day?"</div>
+      </div>
+      <div style="display:flex;gap:6px;flex-shrink:0">
+        <button class="btn primary" style="font-size:12px;padding:5px 10px;white-space:nowrap">✓ Zkontrolováno</button>
+        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-settings-checkins')">Nastavení</button>
+      </div>
+    </div>
+  </div>
+  <!-- Weekly check-in response banner — state 2: SENT BUT NOT YET RESPONDED (scene variant for QA) -->
+  <div style="margin:6px 16px 0;background:var(--bg2);border:1px solid var(--br);border-left:3px solid var(--t4);border-radius:8px;opacity:.85">
+    <div style="padding:8px 14px;display:flex;align-items:center;gap:10px">
+      <div style="font-size:15px">⏳</div>
+      <div style="flex:1;min-width:0">
+        <div style="display:flex;align-items:center;gap:8px">
+          <div style="font-size:13px;font-weight:600;color:var(--t2)">Check-in čeká na odpověď</div>
+          <span style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(120,120,128,.1);color:var(--t3);text-transform:uppercase;letter-spacing:.04em">Variant · nezodpovězeno</span>
+        </div>
+        <div style="font-size:12px;color:var(--t3);margin-top:2px">Odesláno pá 10:00 · Klient zatím nereagoval</div>
+      </div>
+      <button class="btn" style="font-size:12px;padding:4px 9px;white-space:nowrap" onclick="showScreen('s-messages')">💬 Napsat</button>
+    </div>
+  </div>
+  <!-- Banner state 3 (hidden) is omitted here by design — when the client has no scheduled check-in, the banner does not render at all. -->
+
   <!-- week tabs -->
   <div class="week-tabs" id="nutr-week-tabs"></div>
   <!-- day tabs -->
@@ -933,6 +1061,226 @@ body.dark .btn-auth-primary { color: #0d0900; }
 <!-- ═══════════════════════════════════════════════════════════
      PŘIHLÁŠENÍ
 ═══════════════════════════════════════════════════════════ -->
+<div id="s-settings-checkins" class="screen">
+<div class="shell">
+<div class="sb" id="sb-settings-checkins"></div>
+<div class="main">
+  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><span>Nastavení</span><span class="bc-sep">/</span><span>Týdenní check-iny</span></div>
+
+  <div class="ph">
+    <div class="ph-icon">⚙</div>
+    <h1>Nastavení</h1>
+    <div class="ph-sub">Profil · Týdenní check-iny · Notifikace · Jazyk</div>
+  </div>
+
+  <!-- Inline tabs -->
+  <div class="toolbar" style="border-bottom:1px solid var(--br);margin-bottom:0">
+    <div class="tb-view" onclick="showToast('Profil')">Profil</div>
+    <div class="tb-view active">Týdenní check-iny</div>
+    <div class="tb-view" onclick="showToast('Notifikace')">Notifikace</div>
+    <div class="tb-view" onclick="showToast('Jazyk')">Jazyk</div>
+  </div>
+
+  <div class="pc">
+    <!-- Intro callout -->
+    <div class="callout" style="margin-bottom:20px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
+      <div class="callout-icon">📅</div>
+      <div class="callout-body">
+        <div class="callout-title">Týdenní check-iny před plánováním</div>
+        <div class="callout-text">V nastavený den a čas se klientovi ozve notifikace, aby dal vědět, jestli ho v příštím týdnu nečeká něco mimořádného (cestování, zranění, zvláštní rozvrh). Odpověď uvidíš v kartě klienta i přímo v editoru plánu.</div>
+      </div>
+    </div>
+
+    <!-- Default — Training -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;margin-bottom:14px">
+      <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:32px;height:32px;border-radius:8px;background:rgba(201,168,76,.15);color:var(--acc);display:flex;align-items:center;justify-content:center;font-size:16px">🏋️</span>
+          <div>
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Výchozí pro Trénink</div>
+            <div style="font-size:12px;color:var(--t2)">Platí pro všechny klienty, u kterých nemáš individuální nastavení</div>
+          </div>
+        </div>
+        <div class="toggle-wrap" style="margin:0;padding:0">
+          <span class="toggle-lbl" style="font-size:12px">Aktivní</span>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+      <div style="padding:16px 18px">
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Den v týdnu</label>
+            <select class="form-select">
+              <option>Pondělí</option>
+              <option>Úterý</option>
+              <option>Středa</option>
+              <option selected>Čtvrtek</option>
+              <option>Pátek</option>
+              <option>Sobota</option>
+              <option>Neděle</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Čas (hodina)</label>
+            <select class="form-select">
+              <option>06:00</option><option>07:00</option><option>08:00</option>
+              <option>09:00</option><option>10:00</option><option>11:00</option>
+              <option>12:00</option><option>13:00</option><option>14:00</option>
+              <option>15:00</option><option>16:00</option><option>17:00</option>
+              <option selected>18:00</option><option>19:00</option><option>20:00</option>
+              <option>21:00</option><option>22:00</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Časová zóna</label>
+            <input class="form-input" value="Europe/Prague" readonly style="background:var(--bg3);color:var(--t2)">
+          </div>
+        </div>
+        <div class="form-group" style="margin-top:4px">
+          <label class="form-label">Výchozí zpráva (volitelné)</label>
+          <textarea class="form-input" rows="2" maxlength="200" placeholder="Krátká osobní zpráva, která se připojí k notifikaci pro všechny klienty…">Pokud plánuješ dlouhou cestu, dej vědět — přizpůsobím týdenní rozložení.</textarea>
+          <div style="font-size:11px;color:var(--t3);margin-top:4px">86 / 200 znaků</div>
+        </div>
+      </div>
+      <div style="padding:10px 18px;border-top:1px solid var(--br);display:flex;justify-content:space-between;align-items:center;background:rgba(120,120,128,.03)">
+        <span style="font-size:12px;color:var(--t2)">Posledních 4 týdny: <strong style="color:var(--t)">22 odpovědí</strong> · 8 nezodpovězeno</span>
+        <button class="btn primary" onclick="showToast('Uloženo')">Uložit</button>
+      </div>
+    </div>
+
+    <!-- Default — Nutrition -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;margin-bottom:24px">
+      <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:32px;height:32px;border-radius:8px;background:rgba(52,199,89,.15);color:#34c759;display:flex;align-items:center;justify-content:center;font-size:16px">🥗</span>
+          <div>
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Výchozí pro Výživu</div>
+            <div style="font-size:12px;color:var(--t2)">Platí pro všechny klienty s výživovým plánem</div>
+          </div>
+        </div>
+        <div class="toggle-wrap" style="margin:0;padding:0">
+          <span class="toggle-lbl" style="font-size:12px">Aktivní</span>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+      <div style="padding:16px 18px">
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Den v týdnu</label>
+            <select class="form-select">
+              <option>Pondělí</option>
+              <option>Úterý</option>
+              <option>Středa</option>
+              <option>Čtvrtek</option>
+              <option>Pátek</option>
+              <option>Sobota</option>
+              <option selected>Neděle</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Čas (hodina)</label>
+            <select class="form-select">
+              <option>06:00</option><option>07:00</option><option>08:00</option>
+              <option>09:00</option><option>10:00</option><option>11:00</option>
+              <option>12:00</option><option>13:00</option><option>14:00</option>
+              <option>15:00</option><option>16:00</option><option>17:00</option>
+              <option>18:00</option><option selected>19:00</option><option>20:00</option>
+              <option>21:00</option><option>22:00</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Časová zóna</label>
+            <input class="form-input" value="Europe/Prague" readonly style="background:var(--bg3);color:var(--t2)">
+          </div>
+        </div>
+        <div class="form-group" style="margin-top:4px">
+          <label class="form-label">Výchozí zpráva (volitelné)</label>
+          <textarea class="form-input" rows="2" maxlength="200" placeholder="Zpráva pro klienty s výživovým plánem…"></textarea>
+          <div style="font-size:11px;color:var(--t3);margin-top:4px">0 / 200 znaků</div>
+        </div>
+      </div>
+      <div style="padding:10px 18px;border-top:1px solid var(--br);display:flex;justify-content:space-between;align-items:center;background:rgba(120,120,128,.03)">
+        <span style="font-size:12px;color:var(--t2)">Posledních 4 týdny: <strong style="color:var(--t)">14 odpovědí</strong> · 4 nezodpovězeno</span>
+        <button class="btn primary" onclick="showToast('Uloženo')">Uložit</button>
+      </div>
+    </div>
+
+    <!-- Per-client overrides -->
+    <div style="display:flex;align-items:baseline;justify-content:space-between;margin-bottom:10px">
+      <div>
+        <div style="font-size:15px;font-weight:600;color:var(--t)">Výjimky u klientů</div>
+        <div style="font-size:12px;color:var(--t2);margin-top:2px">5 z 8 klientů používá výchozí nastavení · 3 mají individuální rozvrh</div>
+      </div>
+      <div style="font-size:12px;color:var(--t3)">Klikni na klienta pro úpravu</div>
+    </div>
+
+    <div class="db-wrap">
+      <table class="db-table">
+        <thead>
+          <tr>
+            <th>Klient</th>
+            <th>Profese</th>
+            <th>Nastavení</th>
+            <th>Den</th>
+            <th>Čas</th>
+            <th>Aktivní</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer">
+            <td><strong>Petra Horáková</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag tag-gray">Výchozí</span></td>
+            <td>Čt</td>
+            <td>18:00</td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer;background:rgba(201,168,76,.03)">
+            <td><strong>Tomáš Navrátil</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.12);color:var(--acc)">Individuální</span></td>
+            <td><strong style="color:var(--acc)">Út</strong></td>
+            <td><strong style="color:var(--acc)">20:00</strong></td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer">
+            <td><strong>Lucie Procházková</strong></td>
+            <td><span class="tag" style="background:rgba(52,199,89,.1);color:#34c759;border:1px solid rgba(52,199,89,.3)">Výživa</span></td>
+            <td><span class="tag tag-gray">Výchozí</span></td>
+            <td>Ne</td>
+            <td>19:00</td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer;background:rgba(201,168,76,.03)">
+            <td><strong>Martin Krejčí</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.12);color:var(--acc)">Individuální</span></td>
+            <td>Čt</td>
+            <td>18:00</td>
+            <td><span class="tag tag-gray">✕</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer;background:rgba(201,168,76,.03)">
+            <td><strong>Jakub Malý</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.12);color:var(--acc)">Individuální</span></td>
+            <td><strong style="color:var(--acc)">Pá</strong></td>
+            <td><strong style="color:var(--acc)">16:00</strong></td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+</div>
+</div>
+</div>
 <div id="s-login" class="screen">
 <div class="auth-wrap">
 <div class="auth-card">
@@ -1315,6 +1663,86 @@ body.dark .btn-auth-primary { color: #0d0900; }
   </div>
 </div>
 
+<!-- Individuální rozvrh check-inu pro klienta -->
+<div class="overlay" id="dlg-checkin-override" onclick="closeOnOverlay(event,'dlg-checkin-override')">
+  <div class="dialog" style="max-width:480px">
+    <div class="dlg-hdr"><div class="dlg-title">Individuální rozvrh — Tomáš Navrátil</div><button class="dlg-close" onclick="closeDialog('dlg-checkin-override')">✕</button></div>
+    <div class="dlg-body">
+      <div class="callout" style="margin-bottom:14px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
+        <div class="callout-icon">ℹ</div>
+        <div class="callout-body">
+          <div class="callout-text" style="font-size:12px">Odškrtni <strong>Výchozí</strong> u pole, které chceš u tohoto klienta upravit. Zaškrtnutá políčka přebírají nastavení z výchozího rozvrhu pro Trénink.</div>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+          <label class="form-label" style="margin:0">Aktivní</label>
+          <label style="display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--t2);cursor:pointer">
+            <input type="checkbox"> Výchozí
+          </label>
+        </div>
+        <div class="toggle-wrap" style="margin:0;padding:8px 10px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+          <span class="toggle-lbl">Posílat check-in tomuto klientovi</span>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+            <label class="form-label" style="margin:0">Den v týdnu</label>
+            <label style="display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--t2);cursor:pointer">
+              <input type="checkbox"> Výchozí
+            </label>
+          </div>
+          <select class="form-select">
+            <option>Pondělí</option>
+            <option selected>Úterý</option>
+            <option>Středa</option>
+            <option>Čtvrtek</option>
+            <option>Pátek</option>
+            <option>Sobota</option>
+            <option>Neděle</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+            <label class="form-label" style="margin:0">Čas (hodina)</label>
+            <label style="display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--t2);cursor:pointer">
+              <input type="checkbox"> Výchozí
+            </label>
+          </div>
+          <select class="form-select">
+            <option>06:00</option><option>07:00</option><option>08:00</option>
+            <option>09:00</option><option>10:00</option><option>11:00</option>
+            <option>12:00</option><option>13:00</option><option>14:00</option>
+            <option>15:00</option><option>16:00</option><option>17:00</option>
+            <option>18:00</option><option>19:00</option><option selected>20:00</option>
+            <option>21:00</option><option>22:00</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+          <label class="form-label" style="margin:0">Zpráva pro klienta</label>
+          <label style="display:inline-flex;align-items:center;gap:6px;font-size:12px;color:var(--t2);cursor:pointer">
+            <input type="checkbox" checked> Výchozí
+          </label>
+        </div>
+        <textarea class="form-input" rows="2" maxlength="200" placeholder="Individuální zpráva pro tohoto klienta…" disabled style="background:var(--bg3);color:var(--t2)">Pokud plánuješ dlouhou cestu, dej vědět — přizpůsobím týdenní rozložení.</textarea>
+        <div style="font-size:11px;color:var(--t3);margin-top:4px">Používá výchozí zprávu</div>
+      </div>
+    </div>
+    <div class="dlg-footer">
+      <button class="btn danger" onclick="closeDialog('dlg-checkin-override');showToast('Rozvrh vrácen na výchozí')">Vrátit vše na výchozí</button>
+      <button class="btn" onclick="closeDialog('dlg-checkin-override')">Zrušit</button>
+      <button class="btn primary" onclick="closeDialog('dlg-checkin-override');showToast('Rozvrh uložen')">Uložit</button>
+    </div>
+  </div>
+</div>
+
 <!-- Filtr klientů -->
 <div class="overlay" id="dlg-filter" onclick="closeOnOverlay(event,'dlg-filter')">
   <div class="dialog" style="max-width:360px">
@@ -1663,7 +2091,7 @@ function showScreen(id){
   document.querySelectorAll('.tn-btn').forEach(function(b){if(b.getAttribute('onclick')==="showScreen('"+id+"')") b.classList.add('active');});
   window.scrollTo(0,0);
   // Build sidebars
-  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals'};
+  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins'};
   if(sbMap[id]) buildSidebar(sbMap[id],id);
   // Init nutrition editor
   if(id==='s-nutrition'&&!_nutrInit){_nutrInit=true;initNutrition();}

--- a/docs/trainer_prototype.html
+++ b/docs/trainer_prototype.html
@@ -315,6 +315,7 @@ body.dark-proto .phone{background:#000}
   <button class="pb" onclick="nav('chat')">Chat detail</button>
   <button class="pb" onclick="nav('ziadosti')">Hledat klienty</button>
   <button class="pb" onclick="nav('profil')">Profil</button>
+  <button class="pb" onclick="showProfilWithOverride()">Profil · override modal</button>
   <div class="ps"></div>
   <div class="pg">Sekce detailu</div>
   <button class="pb" id="dtab-progress" onclick="switchDetailTab('progress')">Pokrok</button>
@@ -398,6 +399,45 @@ body.dark-proto .phone{background:#000}
         </div>
       </div>
     </div>
+    <div class="ios-section-hdr"><div class="ios-section-title">Týdenní check-iny · tento týden</div><span class="ios-section-action" onclick="nav('profil')">Nastavení</span></div>
+    <div class="ios-card">
+      <div class="ios-row" style="min-height:auto;padding:12px 14px;align-items:flex-start" onclick="nav('detail')">
+        <div style="width:36px;height:36px;border-radius:11px;background:rgba(0,122,255,.12);color:var(--ios-blue);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;flex-shrink:0">PH</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;font-weight:500;color:var(--ios-label)">Petra Horáková</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+          </div>
+          <div style="display:flex;flex-wrap:wrap;gap:4px;margin-top:5px">
+            <span style="font-size:11px;font-weight:500;padding:2px 8px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--ios-gold)">✈️ Cestování</span>
+            <span style="font-size:11px;font-weight:500;padding:2px 8px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--ios-gold)">⏱️ Více času</span>
+          </div>
+          <div style="font-size:11px;color:var(--ios-label3);margin-top:5px">„Od pátku jsem pryč, vrátím se v neděli…"</div>
+        </div>
+        <div style="padding:6px 10px;border-radius:99px;background:var(--ios-gold);font-size:12px;font-weight:600;color:#fff;cursor:pointer;flex-shrink:0">Plán</div>
+      </div>
+      <div class="ios-row" style="min-height:auto;padding:12px 14px;align-items:flex-start" onclick="nav('detail')">
+        <div style="width:36px;height:36px;border-radius:11px;background:rgba(52,199,89,.12);color:var(--ios-green);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;flex-shrink:0">TN</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;font-weight:500;color:var(--ios-label)">Tomáš Navrátil</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+          </div>
+          <div style="display:flex;flex-wrap:wrap;gap:4px;margin-top:5px">
+            <span style="font-size:11px;font-weight:500;padding:2px 8px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--ios-gold)">🤒 Nemoc / únava</span>
+          </div>
+          <div style="font-size:11px;color:var(--ios-label3);margin-top:5px">„Od pondělí mi bylo špatně, vezmi to prosím pomaleji…"</div>
+        </div>
+        <div style="padding:6px 10px;border-radius:99px;background:var(--ios-gold);font-size:12px;font-weight:600;color:#fff;cursor:pointer;flex-shrink:0">Plán</div>
+      </div>
+      <div style="padding:10px 14px;border-top:.5px solid var(--ios-sep2);background:rgba(120,120,128,.04);display:flex;align-items:center;justify-content:space-between">
+        <div style="font-size:12px;color:var(--ios-label2)">
+          <span style="font-weight:600;color:var(--ios-label)">3 klienti</span> zatím neodpověděli
+        </div>
+        <div style="font-size:11px;color:var(--ios-label3)">Plánujete ve čtvrtek 18:00</div>
+      </div>
+    </div>
+
     <div class="ios-section-hdr"><div class="ios-section-title">Nové zprávy</div><span class="ios-section-action" onclick="nav('zpravy')">Vše</span></div>
     <div class="ios-list">
       <div class="ios-row" onclick="nav('chat')">
@@ -457,6 +497,18 @@ body.dark-proto .phone{background:#000}
             <div class="notif-time">před 30 minutami</div>
             <div class="notif-actions">
               <div class="notif-action-btn notif-action-primary" onclick="event.stopPropagation();showToastOn('ph-dnes','Zpráva odeslána')">Napsat zprávu</div>
+            </div>
+          </div>
+        </div>
+        <div class="notif-row unread">
+          <div class="notif-unread-dot"></div>
+          <div class="notif-icon-wrap" style="background:rgba(201,168,76,.12)">📅</div>
+          <div class="notif-body">
+            <div class="notif-title">Petra odpověděla na týdenní check-in</div>
+            <div class="notif-text">Cestování + Více času než obvykle · „Od pátku jsem pryč…"</div>
+            <div class="notif-time">před 18 minutami</div>
+            <div class="notif-actions">
+              <div class="notif-action-btn notif-action-primary" onclick="event.stopPropagation();nav('detail')">Otevřít plán</div>
             </div>
           </div>
         </div>
@@ -785,6 +837,32 @@ body.dark-proto .phone{background:#000}
         <div style="font-size:12px;font-weight:600;color:var(--ios-gold);margin-bottom:2px">Pouze náhled</div>
         <div style="font-size:12px;color:var(--ios-label2)">Editace plánů probíhá ve webovém portálu.</div>
       </div>
+
+      <!-- Weekly check-in panel -->
+      <div style="margin:0 20px 14px;background:var(--ios-bg2);border:1px solid rgba(201,168,76,.25);border-radius:var(--ios-r-lg);overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.06)">
+        <div style="padding:12px 14px;display:flex;align-items:center;justify-content:space-between;background:rgba(201,168,76,.08);border-bottom:.5px solid var(--ios-sep2)">
+          <div style="display:flex;align-items:center;gap:8px">
+            <div style="font-size:16px">📅</div>
+            <div>
+              <div style="font-size:13px;font-weight:600;color:var(--ios-label)">Týdenní check-in · tento týden</div>
+              <div style="font-size:11px;color:var(--ios-label3);margin-top:1px">Odesláno čt 18:04 · týden 20.–26. 10.</div>
+            </div>
+          </div>
+          <div style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(255,149,0,.1);color:var(--ios-orange);text-transform:uppercase;letter-spacing:.04em">Ke zkontrolování</div>
+        </div>
+        <div style="padding:12px 14px">
+          <div style="display:flex;flex-wrap:wrap;gap:5px;margin-bottom:10px">
+            <span style="font-size:11px;font-weight:500;padding:3px 9px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--ios-gold)">✈️ Cestování</span>
+            <span style="font-size:11px;font-weight:500;padding:3px 9px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--ios-gold)">⏱️ Více času než obvykle</span>
+          </div>
+          <div style="font-size:13px;color:var(--ios-label2);line-height:1.45;margin-bottom:12px">„Od pátku jsem pryč, vrátím se v neděli večer. Klidně přidej víc objemu první čtyři dny — pak dej lehčí týden."</div>
+          <div style="display:flex;gap:8px">
+            <div style="flex:1;padding:8px;border-radius:9px;background:var(--ios-gold);text-align:center;font-size:13px;font-weight:600;color:#fff;cursor:pointer">Označit jako zkontrolováno</div>
+            <div onclick="showProfilWithOverride()" style="padding:8px 14px;border-radius:9px;background:var(--ios-fill);text-align:center;font-size:13px;font-weight:500;color:var(--ios-label2);cursor:pointer">Override nastavení</div>
+          </div>
+        </div>
+      </div>
+
       <div class="seg-ctrl" style="margin-bottom:12px">
         <div class="seg-opt active" id="plan-seg-trenink" onclick="switchPlanTab('trenink')">Trénink</div>
         <div class="seg-opt" id="plan-seg-nutr" onclick="switchPlanTab('nutr')">Výživa</div>
@@ -858,6 +936,7 @@ body.dark-proto .phone{background:#000}
     <div class="tab" onclick="nav('zpravy')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="#8e8e93" stroke-width="2" stroke-linejoin="round"/></svg></div><div class="tab-lbl">Zprávy</div></div>
     <div class="tab" onclick="nav('profil')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="8" r="4" stroke="#8e8e93" stroke-width="2"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" stroke="#8e8e93" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl">Profil</div></div>
   </div>
+</div>
 </div>
 
 <!-- ═══════════════════════════════
@@ -1039,6 +1118,157 @@ body.dark-proto .phone{background:#000}
       </div>
     </div>
 
+    <div class="ios-section-hdr" style="margin-top:4px"><div class="ios-section-title">Týdenní check-iny</div></div>
+    <div style="margin:0 20px 12px;padding:10px 14px;background:rgba(201,168,76,.07);border:1px solid rgba(201,168,76,.2);border-radius:var(--ios-r)">
+      <div style="font-size:12px;color:var(--ios-label2);line-height:1.45">Klientům se ozve notifikace ve stanovený den a čas, než jim budeš plánovat další týden. Níže nastavíš výchozí rozvrh pro každou profesi a případné výjimky u jednotlivých klientů.</div>
+    </div>
+
+    <!-- Default — Training -->
+    <div class="ios-card" style="margin-bottom:10px">
+      <div style="padding:12px 14px;display:flex;align-items:center;justify-content:space-between;border-bottom:.5px solid var(--ios-sep2)">
+        <div style="display:flex;align-items:center;gap:10px;min-width:0">
+          <div style="width:32px;height:32px;border-radius:10px;background:rgba(201,168,76,.15);color:var(--ios-gold);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🏋️</div>
+          <div style="min-width:0">
+            <div style="font-size:15px;font-weight:600;color:var(--ios-label)">Výchozí · Trénink</div>
+            <div style="font-size:12px;color:var(--ios-label2);margin-top:1px">8 klientů s tréninkovým plánem</div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;flex-shrink:0">
+          <span style="font-size:12px;color:var(--ios-label2)">Aktivní</span>
+          <div style="width:44px;height:26px;border-radius:13px;background:var(--ios-green);position:relative;cursor:pointer"><div style="position:absolute;right:3px;top:3px;width:20px;height:20px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.2)"></div></div>
+        </div>
+      </div>
+      <div style="padding:12px 14px">
+        <div style="display:flex;gap:10px;margin-bottom:10px">
+          <div style="flex:1">
+            <div style="font-size:11px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Den</div>
+            <div style="background:var(--ios-fill);border-radius:9px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;cursor:pointer">
+              <span style="font-size:14px;color:var(--ios-label)">Čtvrtek</span>
+              <span style="color:var(--ios-label3);font-size:11px">▾</span>
+            </div>
+          </div>
+          <div style="flex:1">
+            <div style="font-size:11px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Hodina</div>
+            <div style="background:var(--ios-fill);border-radius:9px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;cursor:pointer">
+              <span style="font-size:14px;color:var(--ios-label)">18:00</span>
+              <span style="color:var(--ios-label3);font-size:11px">▾</span>
+            </div>
+          </div>
+        </div>
+        <div style="font-size:11px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Zpráva (volitelné)</div>
+        <div style="background:var(--ios-fill);border:1px solid var(--ios-sep2);border-radius:9px;padding:10px 12px;min-height:66px">
+          <div style="font-size:13px;color:var(--ios-label);line-height:1.4">Pokud plánuješ dlouhou cestu, dej vědět — přizpůsobím týdenní rozložení.</div>
+        </div>
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-top:6px">
+          <div style="font-size:11px;color:var(--ios-label3)">86 / 200 znaků</div>
+          <div style="padding:7px 14px;border-radius:9px;background:var(--ios-gold);color:#fff;font-size:13px;font-weight:600;cursor:pointer">Uložit</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Default — Nutrition -->
+    <div class="ios-card" style="margin-bottom:14px">
+      <div style="padding:12px 14px;display:flex;align-items:center;justify-content:space-between;border-bottom:.5px solid var(--ios-sep2)">
+        <div style="display:flex;align-items:center;gap:10px;min-width:0">
+          <div style="width:32px;height:32px;border-radius:10px;background:rgba(52,199,89,.15);color:var(--ios-green);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🥗</div>
+          <div style="min-width:0">
+            <div style="font-size:15px;font-weight:600;color:var(--ios-label)">Výchozí · Výživa</div>
+            <div style="font-size:12px;color:var(--ios-label2);margin-top:1px">5 klientů s výživovým plánem</div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;flex-shrink:0">
+          <span style="font-size:12px;color:var(--ios-label2)">Aktivní</span>
+          <div style="width:44px;height:26px;border-radius:13px;background:var(--ios-green);position:relative;cursor:pointer"><div style="position:absolute;right:3px;top:3px;width:20px;height:20px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.2)"></div></div>
+        </div>
+      </div>
+      <div style="padding:12px 14px">
+        <div style="display:flex;gap:10px;margin-bottom:10px">
+          <div style="flex:1">
+            <div style="font-size:11px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Den</div>
+            <div style="background:var(--ios-fill);border-radius:9px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;cursor:pointer">
+              <span style="font-size:14px;color:var(--ios-label)">Neděle</span>
+              <span style="color:var(--ios-label3);font-size:11px">▾</span>
+            </div>
+          </div>
+          <div style="flex:1">
+            <div style="font-size:11px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Hodina</div>
+            <div style="background:var(--ios-fill);border-radius:9px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;cursor:pointer">
+              <span style="font-size:14px;color:var(--ios-label)">19:00</span>
+              <span style="color:var(--ios-label3);font-size:11px">▾</span>
+            </div>
+          </div>
+        </div>
+        <div style="font-size:11px;font-weight:600;color:var(--ios-label2);text-transform:uppercase;letter-spacing:.04em;margin-bottom:4px">Zpráva (volitelné)</div>
+        <div style="background:var(--ios-fill);border:1px solid var(--ios-sep2);border-radius:9px;padding:10px 12px;min-height:66px">
+          <div style="font-size:13px;color:var(--ios-label3);line-height:1.4;font-style:italic">Krátká zpráva pro klienty s výživovým plánem…</div>
+        </div>
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-top:6px">
+          <div style="font-size:11px;color:var(--ios-label3)">0 / 200 znaků</div>
+          <div style="padding:7px 14px;border-radius:9px;background:var(--ios-gold);color:#fff;font-size:13px;font-weight:600;cursor:pointer">Uložit</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Per-client overrides -->
+    <div class="ios-section-hdr" style="margin-top:0"><div class="ios-section-title" style="font-size:17px">Výjimky u klientů</div><span class="ios-section-action" style="font-size:13px">3 z 8</span></div>
+    <div class="ios-list">
+      <div class="ios-row" onclick="openCheckinOverride()">
+        <div style="width:32px;height:32px;border-radius:10px;background:rgba(0,122,255,.12);color:var(--ios-blue);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;flex-shrink:0">PH</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;color:var(--ios-label)">Petra Horáková</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+          </div>
+          <div style="font-size:12px;color:var(--ios-label2);margin-top:3px"><span style="padding:1px 7px;border-radius:99px;background:var(--ios-fill);font-size:11px">Výchozí</span> · Čt 18:00 · aktivní</div>
+        </div>
+        <div class="ios-row-chev">›</div>
+      </div>
+      <div class="ios-row" onclick="openCheckinOverride()" style="background:rgba(201,168,76,.04)">
+        <div style="width:32px;height:32px;border-radius:10px;background:rgba(52,199,89,.12);color:var(--ios-green);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;flex-shrink:0">TN</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;color:var(--ios-label)">Tomáš Navrátil</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+          </div>
+          <div style="font-size:12px;color:var(--ios-label2);margin-top:3px"><span style="padding:1px 7px;border-radius:99px;background:rgba(201,168,76,.14);color:var(--ios-gold);font-size:11px;font-weight:600">Individuální</span> · <span style="color:var(--ios-gold);font-weight:600">Út 20:00</span> · aktivní</div>
+        </div>
+        <div class="ios-row-chev">›</div>
+      </div>
+      <div class="ios-row" onclick="openCheckinOverride()">
+        <div style="width:32px;height:32px;border-radius:10px;background:rgba(175,82,222,.12);color:var(--ios-purple);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;flex-shrink:0">LP</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;color:var(--ios-label)">Lucie Procházková</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--ios-green);text-transform:uppercase;letter-spacing:.04em">Výživa</span>
+          </div>
+          <div style="font-size:12px;color:var(--ios-label2);margin-top:3px"><span style="padding:1px 7px;border-radius:99px;background:var(--ios-fill);font-size:11px">Výchozí</span> · Ne 19:00 · aktivní</div>
+        </div>
+        <div class="ios-row-chev">›</div>
+      </div>
+      <div class="ios-row" onclick="openCheckinOverride()" style="background:rgba(201,168,76,.04)">
+        <div style="width:32px;height:32px;border-radius:10px;background:rgba(255,149,0,.12);color:var(--ios-orange);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;flex-shrink:0">MK</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;color:var(--ios-label)">Martin Krejčí</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+          </div>
+          <div style="font-size:12px;color:var(--ios-label2);margin-top:3px"><span style="padding:1px 7px;border-radius:99px;background:rgba(201,168,76,.14);color:var(--ios-gold);font-size:11px;font-weight:600">Individuální</span> · Čt 18:00 · <span style="color:var(--ios-red)">neaktivní</span></div>
+        </div>
+        <div class="ios-row-chev">›</div>
+      </div>
+      <div class="ios-row" onclick="openCheckinOverride()" style="background:rgba(201,168,76,.04)">
+        <div style="width:32px;height:32px;border-radius:10px;background:rgba(255,59,48,.12);color:var(--ios-red);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;flex-shrink:0">JM</div>
+        <div class="ios-row-body">
+          <div style="display:flex;align-items:center;gap:6px">
+            <div style="font-size:15px;color:var(--ios-label)">Jakub Malý</div>
+            <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span>
+          </div>
+          <div style="font-size:12px;color:var(--ios-label2);margin-top:3px"><span style="padding:1px 7px;border-radius:99px;background:rgba(201,168,76,.14);color:var(--ios-gold);font-size:11px;font-weight:600">Individuální</span> · <span style="color:var(--ios-gold);font-weight:600">Pá 16:00</span> · aktivní</div>
+        </div>
+        <div class="ios-row-chev">›</div>
+      </div>
+    </div>
+
     <div class="ios-section-hdr" style="margin-top:4px"><div class="ios-section-title">Nastavení</div></div>
     <div class="ios-list">
       <div class="ios-row"><div class="ios-row-icon" style="background:var(--ios-fill)">🔔</div><div class="ios-row-body"><div class="ios-row-title">Notifikace</div></div><div class="ios-row-right"><div style="width:44px;height:26px;border-radius:13px;background:var(--ios-green);position:relative;cursor:pointer"><div style="position:absolute;right:3px;top:3px;width:20px;height:20px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.2)"></div></div></div></div>
@@ -1055,6 +1285,102 @@ body.dark-proto .phone{background:#000}
     <div class="tab" onclick="nav('ziadosti')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="#8e8e93" stroke-width="2"/></svg></div><div class="tab-lbl">Žádosti</div></div>
     <div class="tab" onclick="nav('zpravy')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="#8e8e93" stroke-width="2" stroke-linejoin="round"/></svg></div><div class="tab-lbl">Zprávy</div></div>
     <div class="tab" onclick="nav('profil')"><div class="tab-icon"><svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="8" r="4" stroke="#c9a84c" stroke-width="2"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" stroke="#c9a84c" stroke-width="2" stroke-linecap="round"/></svg></div><div class="tab-lbl" style="color:#c9a84c">Profil</div></div>
+  </div>
+
+  <!-- Override dialog — visible modal state (scene variant for QA) -->
+  <div id="profil-checkin-override" style="position:absolute;inset:0;background:rgba(0,0,0,.45);display:none;align-items:flex-end;z-index:20" onclick="if(event.target===this)closeCheckinOverride()">
+    <div style="width:100%;background:var(--ios-bg);border-radius:14px 14px 0 0;max-height:78%;display:flex;flex-direction:column;overflow:hidden">
+      <!-- Sheet handle -->
+      <div style="display:flex;justify-content:center;padding:8px 0 4px">
+        <div style="width:36px;height:5px;border-radius:99px;background:var(--ios-sep)"></div>
+      </div>
+      <!-- Sheet header -->
+      <div style="padding:6px 16px 10px;display:flex;align-items:center;justify-content:space-between;border-bottom:.5px solid var(--ios-sep2)">
+        <div onclick="closeCheckinOverride()" style="font-size:15px;font-weight:600;color:var(--ios-blue);cursor:pointer">Zrušit</div>
+        <div style="font-size:15px;font-weight:600;color:var(--ios-label)">Individuální rozvrh</div>
+        <div onclick="closeCheckinOverride()" style="font-size:15px;font-weight:600;color:var(--ios-gold);cursor:pointer">Uložit</div>
+      </div>
+      <!-- Sheet body -->
+      <div style="flex:1;overflow-y:auto;padding:14px 16px 20px">
+        <!-- Client header -->
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
+          <div style="width:38px;height:38px;border-radius:12px;background:rgba(52,199,89,.12);color:var(--ios-green);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;flex-shrink:0">TN</div>
+          <div>
+            <div style="font-size:15px;font-weight:600;color:var(--ios-label)">Tomáš Navrátil</div>
+            <div style="display:inline-flex;align-items:center;gap:4px;margin-top:2px"><span style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(201,168,76,.12);color:var(--ios-gold);text-transform:uppercase;letter-spacing:.04em">Trénink</span></div>
+          </div>
+        </div>
+
+        <div style="padding:10px 12px;background:rgba(201,168,76,.07);border:1px solid rgba(201,168,76,.2);border-radius:var(--ios-r);font-size:12px;color:var(--ios-label2);line-height:1.45;margin-bottom:14px">
+          Odškrtni <strong style="color:var(--ios-label)">Výchozí</strong> u pole, které chceš u tohoto klienta upravit. Zaškrtnutá políčka přebírají nastavení z výchozího rozvrhu pro Trénink.
+        </div>
+
+        <!-- Active row -->
+        <div style="margin-bottom:12px">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+            <div style="font-size:13px;font-weight:600;color:var(--ios-label)">Aktivní</div>
+            <label style="display:inline-flex;align-items:center;gap:5px;font-size:12px;color:var(--ios-label2);cursor:pointer">
+              <span style="width:16px;height:16px;border-radius:4px;border:1.5px solid var(--ios-sep);display:inline-flex;align-items:center;justify-content:center"></span>
+              Výchozí
+            </label>
+          </div>
+          <div style="background:var(--ios-bg2);border:1px solid var(--ios-sep2);border-radius:9px;padding:10px 12px;display:flex;align-items:center;justify-content:space-between">
+            <span style="font-size:13px;color:var(--ios-label)">Posílat check-in tomuto klientovi</span>
+            <div style="width:44px;height:26px;border-radius:13px;background:var(--ios-green);position:relative;cursor:pointer"><div style="position:absolute;right:3px;top:3px;width:20px;height:20px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.2)"></div></div>
+          </div>
+        </div>
+
+        <!-- Day / Hour row -->
+        <div style="display:flex;gap:10px;margin-bottom:12px">
+          <div style="flex:1">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+              <div style="font-size:13px;font-weight:600;color:var(--ios-label)">Den</div>
+              <label style="display:inline-flex;align-items:center;gap:5px;font-size:12px;color:var(--ios-label2);cursor:pointer">
+                <span style="width:16px;height:16px;border-radius:4px;border:1.5px solid var(--ios-sep);display:inline-flex;align-items:center;justify-content:center"></span>
+                Výchozí
+              </label>
+            </div>
+            <div style="background:var(--ios-bg2);border:1px solid var(--ios-sep2);border-radius:9px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;cursor:pointer">
+              <span style="font-size:14px;color:var(--ios-label)">Úterý</span>
+              <span style="color:var(--ios-label3);font-size:11px">▾</span>
+            </div>
+          </div>
+          <div style="flex:1">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+              <div style="font-size:13px;font-weight:600;color:var(--ios-label)">Hodina</div>
+              <label style="display:inline-flex;align-items:center;gap:5px;font-size:12px;color:var(--ios-label2);cursor:pointer">
+                <span style="width:16px;height:16px;border-radius:4px;border:1.5px solid var(--ios-sep);display:inline-flex;align-items:center;justify-content:center"></span>
+                Výchozí
+              </label>
+            </div>
+            <div style="background:var(--ios-bg2);border:1px solid var(--ios-sep2);border-radius:9px;padding:9px 11px;display:flex;align-items:center;justify-content:space-between;cursor:pointer">
+              <span style="font-size:14px;color:var(--ios-label)">20:00</span>
+              <span style="color:var(--ios-label3);font-size:11px">▾</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Message row -->
+        <div>
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+            <div style="font-size:13px;font-weight:600;color:var(--ios-label)">Zpráva pro klienta</div>
+            <label style="display:inline-flex;align-items:center;gap:5px;font-size:12px;color:var(--ios-label2);cursor:pointer">
+              <span style="width:16px;height:16px;border-radius:4px;background:var(--ios-gold);border:1.5px solid var(--ios-gold);display:inline-flex;align-items:center;justify-content:center;color:#fff;font-size:11px;font-weight:700">✓</span>
+              Výchozí
+            </label>
+          </div>
+          <div style="background:var(--ios-fill);border:1px solid var(--ios-sep2);border-radius:9px;padding:10px 12px;min-height:56px">
+            <div style="font-size:13px;color:var(--ios-label3);line-height:1.4;font-style:italic">Pokud plánuješ dlouhou cestu, dej vědět — přizpůsobím týdenní rozložení.</div>
+          </div>
+          <div style="font-size:11px;color:var(--ios-label3);margin-top:4px">Používá výchozí zprávu</div>
+        </div>
+
+        <!-- Reset-to-default footer link -->
+        <div style="margin-top:18px;display:flex;justify-content:center">
+          <div style="font-size:13px;font-weight:500;color:var(--ios-red);cursor:pointer">Vrátit vše na výchozí</div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 </div>
@@ -1398,6 +1724,20 @@ function toggleDark(){
 }
 
 nav('klienti');
+
+function openCheckinOverride(){
+  var ov = document.getElementById('profil-checkin-override');
+  if(ov) ov.style.display = 'flex';
+}
+function closeCheckinOverride(){
+  var ov = document.getElementById('profil-checkin-override');
+  if(ov) ov.style.display = 'none';
+}
+
+function showProfilWithOverride(){
+  nav('profil');
+  openCheckinOverride();
+}
 
 function switchPlanTab(tab){
   var tView = document.getElementById('plan-trenink-view');


### PR DESCRIPTION
Fixes #39

## Summary

- **Mobile (2 scenes)**: updated Today scene with stacked banner variant (weekly check-in banner shown alongside existing banners); new `weekly-checkin` sheet scene with a responded-variant that shows the previously submitted answers.
- **Trainer (3 scenes)**: updated Dnes card to surface the weekly check-in state; extended Profil tab with a weekly check-in configuration panel and override modal reachable via a dedicated nav button; updated client detail panel with the check-in history and latest-response summary.
- **Notion (3 scenes)**: dashboard card showing check-in status, training banner variant, and nutrition banner variant — all three drive off the same check-in state.
- Rebuilt artifacts (`docs/mobile_prototype.html`, `docs/trainer_prototype.html`, `docs/notion_portal.html`) via `node docs/prototypes/build.mjs`; rebuild is byte-identical.
- Drive-by fix for an unclosed `</div>` in `docs/prototypes/trainer/scenes/detail.html` source.

## Test plan

- [x] `node docs/prototypes/build.mjs` rebuild is byte-identical to committed artifacts.
- [x] HTMLParser smoke test passes on all three built prototypes.
- [x] No duplicate element IDs across scenes in any prototype.
- [x] Override modal reachable via the dedicated nav button in the trainer prototype.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>