### PR TITLE
docs(prototypes): notion portal — diary-request toolbar entry points (#61)

### DIFF
--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -774,6 +774,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
   </div>
   <div class="toolbar">
     <div style="margin-left:auto;display:flex;gap:6px">
+      <button class="btn" onclick="showScreen('s-diary-request')">📸 Foto-deník</button>
       <button class="btn" onclick="openDialog('dlg-edit-client')">✏ Upravit profil</button>
       <button class="btn primary" onclick="showScreen('s-messages')">✉ Napsat zprávu</button>
     </div>
@@ -934,6 +935,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <span id="nutr-save-ind" style="font-size:11px;color:var(--green)">Uloženo</span>
       <button class="btn" onclick="openDialog('dlg-shopping-list')">🛒 Nákupní seznam</button>
       <button class="btn" onclick="openDialog('dlg-add-meal')">+ Jídlo</button>
+      <button class="btn" onclick="showScreen('s-diary-request')">📸 Foto-deník</button>
       <button class="btn" style="color:var(--acc);border-color:var(--acc-br)" onclick="openDialog('dlg-complete-plan')">✓ Dokončit plán</button>
       <button class="btn primary" onclick="publishPlan()">Publikovat</button>
     </div>


### PR DESCRIPTION
## Summary

After #60 merged, `s-diary-request` was only reachable from the top-nav "Fotky" section and from the active-diary status banner on the nutrition plan. Neither is obvious when a nutritionist first needs to send a request. This PR adds a "📸 Foto-deník" button to the two natural contexts:

- **Client detail** (`scenes/client.html`) toolbar — placed before "✏ Upravit profil".
- **Nutrition plan** (`scenes/nutrition.html`) toolbar — placed between "+ Jídlo" and "✓ Dokončit plán".

Both use the existing `.btn` primitive and existing tokens — no new styles.

Fixes #61.

## Test plan

- [ ] Open `docs/notion_portal.html`; navigate to `s-client` — "📸 Foto-deník" button visible in toolbar and opens `s-diary-request`.
- [ ] Navigate to `s-nutrition` — same button in the topbar actions, also opens `s-diary-request`.
- [ ] No hardcoded colors or styles outside token conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)