### PR TITLE
docs(prototypes): notion portal — restore coach Profile scene (#63)

### DIFF
--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -572,8 +572,8 @@ body.dark .btn-auth-primary { color: #0d0900; }
   <button class="tn-btn" onclick="showScreen('s-goals')">Cíle klienta</button>
   <div class="tn-sep"></div>
   <div class="tn-lbl">Fotky</div>
-  <button class="tn-btn" onclick="showScreen('s-diary-request')">Žádost o deník</button>
   <button class="tn-btn" onclick="showScreen('s-client-photos')">Fotky klienta</button>
+  <button class="tn-btn" onclick="openDialog('dlg-diary-request')">Nová žádost o deník</button>
   <div class="tn-sep"></div>
   <div class="tn-lbl">Nastavení</div>
   <button class="tn-btn" onclick="showScreen('s-profile')">Profil</button>
@@ -692,7 +692,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
         </div>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="font-size:12px;color:var(--t2)">2 aktivní · 1 čeká</div>
-          <button class="btn" style="font-size:12px;padding:4px 10px" onclick="showScreen('s-diary-request')">Nová žádost</button>
+          <button class="btn" style="font-size:12px;padding:4px 10px" onclick="openDialog('dlg-diary-request')">Nová žádost</button>
         </div>
       </div>
       <div style="padding:0">
@@ -775,7 +775,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
   </div>
   <div class="toolbar">
     <div style="margin-left:auto;display:flex;gap:6px">
-      <button class="btn" onclick="showScreen('s-diary-request')">📸 Foto-deník</button>
+      <button class="btn" onclick="openDialog('dlg-diary-request')">📸 Foto-deník</button>
       <button class="btn" onclick="openDialog('dlg-edit-client')">✏ Upravit profil</button>
       <button class="btn primary" onclick="showScreen('s-messages')">✉ Napsat zprávu</button>
     </div>
@@ -936,7 +936,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <span id="nutr-save-ind" style="font-size:11px;color:var(--green)">Uloženo</span>
       <button class="btn" onclick="openDialog('dlg-shopping-list')">🛒 Nákupní seznam</button>
       <button class="btn" onclick="openDialog('dlg-add-meal')">+ Jídlo</button>
-      <button class="btn" onclick="showScreen('s-diary-request')">📸 Foto-deník</button>
+      <button class="btn" onclick="openDialog('dlg-diary-request')">📸 Foto-deník</button>
       <button class="btn" style="color:var(--acc);border-color:var(--acc-br)" onclick="openDialog('dlg-complete-plan')">✓ Dokončit plán</button>
       <button class="btn primary" onclick="publishPlan()">Publikovat</button>
     </div>
@@ -954,7 +954,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
       </div>
       <div style="display:flex;gap:6px;flex-shrink:0">
         <button class="btn primary" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-client-photos')">Zobrazit fotky</button>
-        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-diary-request')">Nová žádost</button>
+        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="openDialog('dlg-diary-request')">Nová žádost</button>
       </div>
     </div>
   </div>
@@ -2069,80 +2069,6 @@ body.dark .btn-auth-primary { color: #0d0900; }
 <!-- ═══════════════════════════════════════════════════════════
      PROFIL — konec
 ═══════════════════════════════════════════════════════════ -->
-<div id="s-diary-request" class="screen">
-<div class="shell">
-<div class="sb" id="sb-diary-request"></div>
-<div class="main">
-  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><a onclick="showScreen('s-client')">Petra Horáková</a><span class="bc-sep">/</span><span>Foto-deník · žádost</span></div>
-
-  <div class="ph">
-    <div class="ph-icon">📸</div>
-    <h1>Požádat o foto-deník</h1>
-    <div class="ph-sub">Odešli klientovi žádost o sérii fotek jídel</div>
-  </div>
-
-  <div class="toolbar">
-    <div style="margin-left:auto;display:flex;gap:6px">
-      <button class="btn" onclick="showScreen('s-client')">Zrušit</button>
-      <button class="btn primary" onclick="showToast('Žádost odeslána')">Odeslat žádost</button>
-    </div>
-  </div>
-
-  <div class="pc">
-    <!-- Client strip -->
-    <div style="display:flex;align-items:center;gap:12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:12px 16px;margin-bottom:16px">
-      <div style="width:36px;height:36px;border-radius:8px;background:rgba(0,122,255,.12);color:var(--blue);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:600">PH</div>
-      <div style="min-width:0">
-        <div style="font-size:14px;font-weight:600;color:var(--t)">Petra Horáková</div>
-        <div style="font-size:12px;color:var(--t2)">Výživa · Týden 4 / 12</div>
-      </div>
-    </div>
-
-    <!-- How it works callout -->
-    <div class="callout" style="margin-bottom:20px">
-      <div class="callout-icon">ℹ</div>
-      <div class="callout-body">
-        <div class="callout-title">Jak to bude fungovat</div>
-        <div class="callout-text">Klient uvidí žádost jako banner na úvodní obrazovce v mobilu. Může ji přijmout nebo odmítnout (s volitelným důvodem). Po akceptaci si vybere mezi jednorázovým nahráním nebo sedmidenním workflow — fotky uvidíš v reálném čase, jak je klient nahrává.</div>
-      </div>
-    </div>
-
-    <!-- Message -->
-    <div style="font-size:13px;font-weight:600;margin-bottom:8px;color:var(--t)">Zpráva pro klienta</div>
-    <div class="form-group" style="margin-bottom:20px">
-      <textarea class="form-input" rows="4" maxlength="500">Abych si udělala co nejlepší obrázek o tvých stravovacích návycích, než ti sestavím plán, ráda bych od tebe dostala fotky všech jídel, které běžně jíš.</textarea>
-      <div style="font-size:11px;color:var(--t3);margin-top:4px">187 / 500 znaků</div>
-    </div>
-
-    <!-- Duration -->
-    <div style="font-size:13px;font-weight:600;margin-bottom:8px;color:var(--t)">Délka deníku</div>
-    <div class="filter-bar" style="margin-bottom:20px">
-      <div class="chip">3 dny</div>
-      <div class="chip active">7 dní</div>
-      <div class="chip">14 dní</div>
-    </div>
-
-    <!-- Upload mode -->
-    <div style="font-size:13px;font-weight:600;margin-bottom:8px;color:var(--t)">Způsob nahrání — výběr udělá klient</div>
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:20px">
-      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:14px">
-        <div style="font-size:13px;font-weight:600;color:var(--t);margin-bottom:4px">📤 Nahrát vše najednou</div>
-        <div style="font-size:12px;color:var(--t2);line-height:1.5">Klient nafotí, co obvykle jí, a pošle všechny fotky jedním odesláním.</div>
-      </div>
-      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:14px">
-        <div style="font-size:13px;font-weight:600;color:var(--t);margin-bottom:4px">📅 Sedmidenní workflow</div>
-        <div style="font-size:12px;color:var(--t2);line-height:1.5">Každý den připomenutí; fotky se zobrazují živě, jak klient nahrává.</div>
-      </div>
-    </div>
-
-    <!-- Green info callout -->
-    <div style="background:rgba(52,199,89,.08);border:1px solid rgba(52,199,89,.22);border-radius:var(--rm);padding:12px 14px;font-size:12px;color:var(--t2);line-height:1.5">
-      💚 Budeš dostávat notifikace při každé nahrané fotce. Odpovědět můžeš v chatu.
-    </div>
-  </div>
-</div>
-</div>
-</div>
 <div id="s-client-photos" class="screen">
 <div class="shell">
 <div class="sb" id="sb-client-photos"></div>
@@ -2583,36 +2509,153 @@ body.dark .btn-auth-primary { color: #0d0900; }
      DIALOGY
 ══════════════════════════════════════════════════════════════ -->
 
-<!-- Nový klient -->
+<!-- Nový klient — pozvánka (matches web NewClientDialog.tsx) -->
 <div class="overlay" id="dlg-new-client" onclick="closeOnOverlay(event,'dlg-new-client')">
-  <div class="dialog" style="max-width:520px">
-    <div class="dlg-hdr"><div class="dlg-title">Nový klient</div><button class="dlg-close" onclick="closeDialog('dlg-new-client')">✕</button></div>
+  <div class="dialog" style="max-width:520px;padding:0;overflow:hidden">
+    <!-- Hero -->
+    <div style="height:90px;background:var(--acc-bg);display:flex;align-items:center;justify-content:center">
+      <span style="font-size:36px;opacity:.6">✉️</span>
+    </div>
+    <div class="dlg-hdr">
+      <div>
+        <div class="dlg-title">Pozvat klienta</div>
+        <div style="font-size:12px;color:var(--t3);margin-top:2px">Klient dostane email s odkazem pro nastavení hesla a přijetí pozvánky.</div>
+      </div>
+      <button class="dlg-close" onclick="closeDialog('dlg-new-client')">✕</button>
+    </div>
     <div class="dlg-body">
+      <!-- Name + email -->
       <div class="form-row">
         <div class="form-group"><label class="form-label">Jméno</label><input class="form-input" placeholder="Jan"></div>
         <div class="form-group"><label class="form-label">Příjmení</label><input class="form-input" placeholder="Novák"></div>
       </div>
       <div class="form-group"><label class="form-label">Email</label><input class="form-input" type="email" placeholder="jan@example.cz"></div>
-      <div class="form-row">
-        <div class="form-group"><label class="form-label">Pohlaví</label><select class="form-select"><option>Muž</option><option>Žena</option></select></div>
-        <div class="form-group"><label class="form-label">Věk</label><input class="form-input" type="number" placeholder="30"></div>
+
+      <!-- Intro message -->
+      <div class="form-group">
+        <label class="form-label">Úvodní zpráva <span style="color:var(--t4);font-weight:400">(volitelné)</span></label>
+        <textarea class="form-input" rows="3" maxlength="500" placeholder="Představ se, popiš další kroky, přidej odkaz na video…"></textarea>
+        <div style="font-size:10px;color:var(--t4);text-align:right;margin-top:2px">0 / 500</div>
       </div>
-      <div class="form-row">
-        <div class="form-group"><label class="form-label">Výška (cm)</label><input class="form-input" type="number" placeholder="175"></div>
-        <div class="form-group"><label class="form-label">Váha (kg)</label><input class="form-input" type="number" placeholder="80"></div>
-      </div>
-      <div class="form-group"><label class="form-label">Primární cíl</label><select class="form-select"><option>Zhubnout</option><option>Nabrat svalovou hmotu</option><option>Rekomposice</option><option>Kondice a zdraví</option></select></div>
+
       <div class="form-divider"></div>
-      <div class="form-section-title">Pozvánka</div>
-      <div class="toggle-wrap">
-        <span class="toggle-lbl">Odeslat pozvánku emailem ihned</span>
-        <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+
+      <!-- Questionnaire attachment -->
+      <div class="form-section-title">📋 Přiložit dotazník</div>
+      <div class="form-group">
+        <label class="form-label">Šablona dotazníku</label>
+        <select class="form-select">
+          <option value="">Bez dotazníku</option>
+          <option selected>Vstupní dotazník — trénink (Výchozí)</option>
+          <option>Výživový vstupní dotazník</option>
+          <option>Kontrolní dotazník po 8 týdnech</option>
+        </select>
+        <div style="font-size:11px;color:var(--t3);margin-top:4px">Klient vyplní dotazník po přijetí pozvánky. Odpovědi uvidíš v jeho profilu.</div>
       </div>
-      <div class="form-hint">Klient dostane email s odkazem pro nastavení hesla a přijetí pozvánky.</div>
+
+      <div class="form-divider"></div>
+
+      <!-- Photo-diary attachment -->
+      <div class="form-section-title" style="display:flex;align-items:center;justify-content:space-between">
+        <span>📸 Přiložit foto-deník</span>
+        <div class="toggle on" id="dlg-new-client-diary-toggle" onclick="this.classList.toggle('on');document.getElementById('dlg-new-client-diary-body').style.display = this.classList.contains('on') ? '' : 'none'"><div class="toggle-thumb"></div></div>
+      </div>
+      <div id="dlg-new-client-diary-body">
+        <div style="font-size:12px;color:var(--t2);margin-bottom:10px">Po akceptaci pozvánky bude klient vyzván k nasdílení fotografií jídel.</div>
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Délka deníku</label>
+            <select class="form-select">
+              <option>3 dny</option>
+              <option selected>7 dní</option>
+              <option>14 dní</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Režim odesílání</label>
+            <select class="form-select">
+              <option>Vybere klient při akceptaci</option>
+              <option>Vše najednou</option>
+              <option>Denní workflow</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-group" style="margin-bottom:0">
+          <label class="form-label">Zpráva ke žádosti</label>
+          <textarea class="form-input" rows="3" maxlength="500" placeholder="Osobní zpráva pro klienta…">Abych si udělala co nejlepší obrázek o tvých stravovacích návycích, než ti sestavím plán, ráda bych od tebe dostala fotky všech jídel, které běžně jíš.</textarea>
+          <div style="font-size:10px;color:var(--t4);text-align:right;margin-top:2px">187 / 500</div>
+        </div>
+      </div>
     </div>
     <div class="dlg-footer">
       <button class="btn" onclick="closeDialog('dlg-new-client')">Zrušit</button>
-      <button class="btn primary" onclick="addClient()">Vytvořit klienta</button>
+      <button class="btn primary" onclick="closeDialog('dlg-new-client');showToast('Pozvánka odeslána')">Odeslat pozvánku</button>
+    </div>
+  </div>
+</div>
+
+<!-- Foto-deník — samostatná žádost pro existujícího klienta (z detailu plánu) -->
+<div class="overlay" id="dlg-diary-request" onclick="closeOnOverlay(event,'dlg-diary-request')">
+  <div class="dialog" style="max-width:520px;padding:0;overflow:hidden">
+    <!-- Hero -->
+    <div style="height:90px;background:rgba(52,199,89,.1);display:flex;align-items:center;justify-content:center">
+      <span style="font-size:36px;opacity:.8">📸</span>
+    </div>
+    <div class="dlg-hdr">
+      <div>
+        <div class="dlg-title">Požádat o foto-deník</div>
+        <div style="font-size:12px;color:var(--t3);margin-top:2px">Klient uvidí žádost jako banner na úvodní obrazovce v mobilu.</div>
+      </div>
+      <button class="dlg-close" onclick="closeDialog('dlg-diary-request')">✕</button>
+    </div>
+    <div class="dlg-body">
+      <!-- Client strip -->
+      <div style="display:flex;align-items:center;gap:12px;padding:10px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);margin-bottom:16px">
+        <div style="width:32px;height:32px;border-radius:8px;background:rgba(0,122,255,.12);color:var(--blue);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600;flex-shrink:0">PH</div>
+        <div style="flex:1;min-width:0">
+          <div style="font-size:13px;font-weight:600;color:var(--t)">Petra Horáková</div>
+          <div style="font-size:11px;color:var(--t2)">Výživa · Týden 4 / 12</div>
+        </div>
+      </div>
+
+      <!-- Info callout -->
+      <div class="callout" style="margin-bottom:16px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
+        <div class="callout-icon">ℹ</div>
+        <div class="callout-body">
+          <div class="callout-text" style="font-size:12px">Klient může žádost přijmout nebo odmítnout (s volitelným důvodem). Po akceptaci si vybere mezi jednorázovým nahráním nebo denním workflow — fotky uvidíš v reálném čase.</div>
+        </div>
+      </div>
+
+      <!-- Duration -->
+      <div class="form-row">
+        <div class="form-group">
+          <label class="form-label">Délka deníku</label>
+          <select class="form-select">
+            <option>3 dny</option>
+            <option selected>7 dní</option>
+            <option>14 dní</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label class="form-label">Režim odesílání</label>
+          <select class="form-select">
+            <option>Vybere klient při akceptaci</option>
+            <option>Vše najednou</option>
+            <option>Denní workflow</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Message -->
+      <div class="form-group" style="margin-bottom:0">
+        <label class="form-label">Zpráva pro klienta</label>
+        <textarea class="form-input" rows="4" maxlength="500" placeholder="Osobní zpráva pro klienta…">Abych si udělala co nejlepší obrázek o tvých stravovacích návycích, než ti sestavím plán, ráda bych od tebe dostala fotky všech jídel, které běžně jíš.</textarea>
+        <div style="font-size:10px;color:var(--t4);text-align:right;margin-top:2px">187 / 500</div>
+      </div>
+    </div>
+    <div class="dlg-footer">
+      <button class="btn" onclick="closeDialog('dlg-diary-request')">Zrušit</button>
+      <button class="btn primary" onclick="closeDialog('dlg-diary-request');showToast('Žádost odeslána')">Odeslat žádost</button>
     </div>
   </div>
 </div>
@@ -3042,6 +3085,7 @@ function buildSidebar(containerId, activeScreen){
   var html='<div class="sb-ws"><div class="sb-ws-icon">GF</div><div class="sb-ws-name">GoodFellas</div><div class="sb-ws-chev">⌄</div></div>';
   html+='<div class="sb-div"></div>';
   html+='<div class="sb-sec"><div class="sb-item'+(activeScreen==='s-dashboard'?' active':'')+'" onclick="showScreen(\'s-dashboard\')"><span class="sbi-icon">⊞</span><span class="sbi-lbl">Dashboard</span></div>';
+  html+='<div class="sb-item'+(activeScreen==='s-profile'?' active':'')+'" onclick="showScreen(\'s-profile\')"><span class="sbi-icon">👤</span><span class="sbi-lbl">Profil</span></div>';
   html+='<div class="sb-item'+(activeScreen==='s-messages'?' active':'')+'" onclick="showScreen(\'s-messages\')"><span class="sbi-icon">✉</span><span class="sbi-lbl">Zprávy</span><span class="sbi-badge">1</span></div></div>';
   html+='<div class="sb-div"></div><div class="sb-sec"><div class="sb-sec-lbl">Klienti</div>';
   CLIENTS.forEach(function(cl){
@@ -3069,7 +3113,7 @@ function showScreen(id){
   document.querySelectorAll('.tn-btn').forEach(function(b){if(b.getAttribute('onclick')==="showScreen('"+id+"')") b.classList.add('active');});
   window.scrollTo(0,0);
   // Build sidebars
-  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins','s-diary-request':'sb-diary-request','s-client-photos':'sb-client-photos','s-profile':'sb-profile'};
+  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins','s-client-photos':'sb-client-photos','s-profile':'sb-profile'};
   if(sbMap[id]) buildSidebar(sbMap[id],id);
   // Init nutrition editor
   if(id==='s-nutrition'&&!_nutrInit){_nutrInit=true;initNutrition();}

--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -576,6 +576,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
   <button class="tn-btn" onclick="showScreen('s-client-photos')">Fotky klienta</button>
   <div class="tn-sep"></div>
   <div class="tn-lbl">Nastavení</div>
+  <button class="tn-btn" onclick="showScreen('s-profile')">Profil</button>
   <button class="tn-btn" onclick="showScreen('s-settings-checkins')">Týdenní check-iny</button>
   <div class="tn-right">
     <button class="tn-icon" onclick="toggleDark()" id="dark-btn" title="Tmavý režim">☾</button>
@@ -774,6 +775,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
   </div>
   <div class="toolbar">
     <div style="margin-left:auto;display:flex;gap:6px">
+      <button class="btn" onclick="showScreen('s-diary-request')">📸 Foto-deník</button>
       <button class="btn" onclick="openDialog('dlg-edit-client')">✏ Upravit profil</button>
       <button class="btn primary" onclick="showScreen('s-messages')">✉ Napsat zprávu</button>
     </div>
@@ -934,6 +936,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <span id="nutr-save-ind" style="font-size:11px;color:var(--green)">Uloženo</span>
       <button class="btn" onclick="openDialog('dlg-shopping-list')">🛒 Nákupní seznam</button>
       <button class="btn" onclick="openDialog('dlg-add-meal')">+ Jídlo</button>
+      <button class="btn" onclick="showScreen('s-diary-request')">📸 Foto-deník</button>
       <button class="btn" style="color:var(--acc);border-color:var(--acc-br)" onclick="openDialog('dlg-complete-plan')">✓ Dokončit plán</button>
       <button class="btn primary" onclick="publishPlan()">Publikovat</button>
     </div>
@@ -1157,8 +1160,9 @@ body.dark .btn-auth-primary { color: #0d0900; }
 
   <!-- Inline tabs -->
   <div class="toolbar" style="border-bottom:1px solid var(--br);margin-bottom:0">
-    <div class="tb-view" onclick="showToast('Profil')">Profil</div>
-    <div class="tb-view active">Týdenní check-iny</div>
+    <div class="tb-view" onclick="showScreen('s-profile')">👤 Osobní údaje</div>
+    <div class="tb-view" onclick="showScreen('s-profile')">📋 Dotazníky</div>
+    <div class="tb-view active">🔔 Týdenní check-iny</div>
     <div class="tb-view" onclick="showToast('Notifikace')">Notifikace</div>
     <div class="tb-view" onclick="showToast('Jazyk')">Jazyk</div>
   </div>
@@ -1363,6 +1367,349 @@ body.dark .btn-auth-primary { color: #0d0900; }
 </div>
 </div>
 </div>
+<div id="s-profile" class="screen">
+<div class="shell">
+<div class="sb" id="sb-profile"></div>
+<div class="main">
+  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><span>Nastavení</span><span class="bc-sep">/</span><span>Profil</span></div>
+
+  <div class="ph">
+    <div class="ph-icon">👤</div>
+    <h1>Profil</h1>
+    <div class="ph-sub">Osobní údaje · Dotazníky · Týdenní check-iny</div>
+  </div>
+
+  <!-- Inline tabs -->
+  <div class="toolbar" style="border-bottom:1px solid var(--br);margin-bottom:0">
+    <div class="tb-view active" id="prof-tab-personal" onclick="switchProfileTab('personal')">👤 Osobní údaje</div>
+    <div class="tb-view" id="prof-tab-questionnaires" onclick="switchProfileTab('questionnaires')">📋 Dotazníky</div>
+    <div class="tb-view" onclick="showScreen('s-settings-checkins')">🔔 Týdenní check-iny</div>
+    <div style="margin-left:auto;display:flex;gap:8px;align-items:center">
+      <span style="font-size:11px;color:var(--orange);display:flex;align-items:center;gap:4px"><span style="width:6px;height:6px;border-radius:50%;background:var(--orange)"></span>Neuložené změny</span>
+      <button class="btn primary" onclick="showToast('Profil uložen')">Uložit</button>
+    </div>
+  </div>
+
+  <!-- ══ TAB: OSOBNÍ ÚDAJE ══ -->
+  <div class="pc" id="prof-content-personal">
+
+    <!-- Profile card -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:20px;margin-bottom:20px;display:flex;gap:20px;align-items:flex-start">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:6px;flex-shrink:0">
+        <div style="position:relative">
+          <div style="width:84px;height:84px;border-radius:50%;background:rgba(201,168,76,.15);color:var(--acc);display:flex;align-items:center;justify-content:center;font-size:30px;font-weight:600">MT</div>
+          <div style="position:absolute;right:-2px;bottom:-2px;width:28px;height:28px;border-radius:50%;background:var(--acc);border:3px solid var(--bg2);display:flex;align-items:center;justify-content:center;color:#fff;font-size:13px;cursor:pointer">📷</div>
+        </div>
+        <div style="font-size:11px;color:var(--t3);text-align:center;line-height:1.4;max-width:108px">Klikni pro<br>změnu fotky</div>
+      </div>
+      <div style="flex:1;min-width:0">
+        <div class="form-row" style="margin-bottom:14px">
+          <div class="form-group"><label class="form-label">Jméno</label><input class="form-input" value="Marek"></div>
+          <div class="form-group"><label class="form-label">Příjmení</label><input class="form-input" value="Trenér"></div>
+        </div>
+        <div class="form-row" style="margin-bottom:0">
+          <div class="form-group"><label class="form-label">Email</label><input class="form-input" value="marek@goodfellas.cz" readonly style="opacity:.6"></div>
+          <div class="form-group" style="margin-bottom:0"><label class="form-label">Telefon</label><input class="form-input" value="+420 777 123 456" placeholder="+420 777 123 456"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Roles section -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px;margin-bottom:20px">
+      <div style="font-size:13px;font-weight:600;color:var(--t);margin-bottom:4px">Role</div>
+      <div style="font-size:12px;color:var(--t2);margin-bottom:14px">Vyber, jaké služby poskytuješ klientům. Role lze kombinovat.</div>
+      <div style="display:flex;flex-direction:column;gap:10px">
+        <div style="display:flex;align-items:center;gap:12px;padding:10px 12px;background:var(--bg);border:1px solid var(--br);border-radius:var(--rm)">
+          <div style="width:34px;height:34px;border-radius:10px;background:rgba(201,168,76,.15);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🏋️</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;font-weight:600;color:var(--t)">Trenér</div>
+            <div style="font-size:11px;color:var(--t2)">Silový trénink, kardio, rehabilitace, kondice</div>
+          </div>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:12px;padding:10px 12px;background:var(--bg);border:1px solid var(--br);border-radius:var(--rm)">
+          <div style="width:34px;height:34px;border-radius:10px;background:rgba(52,199,89,.15);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🥗</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;font-weight:600;color:var(--t)">Výživový poradce</div>
+            <div style="font-size:11px;color:var(--t2)">Jídelníčky, makra, stravovací strategie</div>
+          </div>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Trainer public profile -->
+    <div class="form-section-title" style="margin-bottom:12px">Veřejný profil trenéra</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:14px">
+      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px">
+        <div class="form-group" style="margin-bottom:0">
+          <label class="form-label">Bio</label>
+          <textarea class="form-input" rows="4" placeholder="Představ se klientům...">Certifikovaný trenér s 8letou praxí. Specializuji se na silový trénink a redukci tuku u kancelářských profesí.</textarea>
+          <div style="font-size:11px;color:var(--t3);margin-top:4px">146 / 500 znaků</div>
+        </div>
+      </div>
+      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px">
+        <div class="form-row">
+          <div class="form-group"><label class="form-label">Město</label><input class="form-input" value="Praha"></div>
+          <div class="form-group"><label class="form-label">Cena (Kč / měsíc)</label><input class="form-input" type="number" value="2500"></div>
+        </div>
+        <div class="form-group"><label class="form-label">Typ spolupráce</label>
+          <select class="form-select">
+            <option>Osobní (prezenčně)</option>
+            <option selected>Osobní + online</option>
+            <option>Pouze online</option>
+          </select>
+        </div>
+        <div class="form-group" style="margin-bottom:0"><label class="form-label">Maximálně klientů</label><input class="form-input" type="number" value="15"></div>
+      </div>
+    </div>
+
+    <!-- Specializations / certs / languages -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px;margin-bottom:14px">
+      <div class="form-group">
+        <label class="form-label">Specializace</label>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc);font-size:12px;font-weight:500">Silový trénink <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc);font-size:12px;font-weight:500">Redukce tuku <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:rgba(201,168,76,.1);color:var(--acc);font-size:12px;font-weight:500">Výživa <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <input class="form-input" placeholder="+ Přidat" style="flex:1;min-width:120px;padding:4px 10px;font-size:12px;margin:0">
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Certifikáty</label>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-size:12px;font-weight:500">EREPS L3 <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-size:12px;font-weight:500">FitCoach <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-size:12px;font-weight:500">Precision Nutrition <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <input class="form-input" placeholder="+ Přidat" style="flex:1;min-width:120px;padding:4px 10px;font-size:12px;margin:0">
+        </div>
+      </div>
+      <div class="form-group" style="margin-bottom:0">
+        <label class="form-label">Jazyky</label>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:var(--bg3);color:var(--t2);font-size:12px;font-weight:500">Čeština <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <span style="display:inline-flex;align-items:center;gap:6px;padding:5px 10px;border-radius:99px;background:var(--bg3);color:var(--t2);font-size:12px;font-weight:500">Angličtina <span style="cursor:pointer;opacity:.6">✕</span></span>
+          <input class="form-input" placeholder="+ Přidat" style="flex:1;min-width:120px;padding:4px 10px;font-size:12px;margin:0">
+        </div>
+      </div>
+    </div>
+
+    <!-- Social links + visibility toggles -->
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:14px">
+      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px">
+        <div class="form-section-title" style="font-size:12px;margin-bottom:10px">Sociální sítě</div>
+        <div class="form-group"><label class="form-label">LinkedIn</label><input class="form-input" placeholder="https://linkedin.com/in/..." value="https://linkedin.com/in/marektrener"></div>
+        <div class="form-group"><label class="form-label">Instagram</label><input class="form-input" placeholder="@handle" value="@marek.trener"></div>
+        <div class="form-group" style="margin-bottom:0"><label class="form-label">Web</label><input class="form-input" placeholder="https://..." value="https://marektrener.cz"></div>
+      </div>
+      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px">
+        <div class="form-section-title" style="font-size:12px;margin-bottom:10px">Viditelnost v Marketplace</div>
+        <div class="toggle-wrap" style="margin:0 0 10px;padding:10px 12px;background:var(--bg);border:1px solid var(--br);border-radius:var(--rm)">
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;font-weight:600;color:var(--t)">Zobrazovat ve vyhledávání</div>
+            <div style="font-size:11px;color:var(--t2);margin-top:2px">Tvůj profil najdou potenciální klienti v Marketplace.</div>
+          </div>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+        <div class="toggle-wrap" style="margin:0;padding:10px 12px;background:var(--bg);border:1px solid var(--br);border-radius:var(--rm)">
+          <div style="flex:1;min-width:0">
+            <div style="font-size:13px;font-weight:600;color:var(--t)">Přijímám nové klienty</div>
+            <div style="font-size:11px;color:var(--t2);margin-top:2px">Pokud vypnuto, klienti tě mohou najít, ale nemohou odeslat žádost.</div>
+          </div>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /content-personal -->
+
+  <!-- ══ TAB: DOTAZNÍKY ══ -->
+  <div class="pc" id="prof-content-questionnaires" style="display:none">
+
+    <!-- List view (default) -->
+    <div id="prof-q-list">
+      <div class="callout" style="margin-bottom:16px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
+        <div class="callout-icon">📋</div>
+        <div class="callout-body">
+          <div class="callout-title">Šablony dotazníků</div>
+          <div class="callout-text" style="font-size:12px">Vytvoř si vlastní dotazníky pro nové klienty. Dotazník se přiloží k pozvánce nebo k individuálnímu plánu. Klient odpovědi uvidíš v detailu klienta v sekci Dotazník.</div>
+        </div>
+      </div>
+
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
+        <div style="font-size:13px;color:var(--t2)">3 šablony celkem</div>
+        <button class="btn primary" onclick="showToast('Nová šablona vytvořena')">+ Nová šablona</button>
+      </div>
+
+      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;overflow:hidden">
+        <!-- Questionnaire 1 -->
+        <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;gap:14px;cursor:pointer" onclick="profQShowEditor('Vstupní dotazník — trénink')">
+          <div style="width:36px;height:36px;border-radius:8px;background:rgba(201,168,76,.12);color:var(--acc);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">📝</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Vstupní dotazník — trénink</div>
+            <div style="font-size:12px;color:var(--t2);margin-top:2px">8 otázek · <span style="color:var(--acc)">Výchozí</span> · upraveno 12. 3. 2026</div>
+          </div>
+          <div style="font-size:11px;padding:3px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-weight:500">Aktivní</div>
+          <button class="btn" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();profQShowEditor('Vstupní dotazník — trénink')">Upravit</button>
+          <button class="btn danger" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showToast('Šablona smazána')">Smazat</button>
+        </div>
+        <!-- Questionnaire 2 -->
+        <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;gap:14px;cursor:pointer" onclick="profQShowEditor('Výživový vstupní dotazník')">
+          <div style="width:36px;height:36px;border-radius:8px;background:rgba(52,199,89,.12);color:var(--green);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🥗</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Výživový vstupní dotazník</div>
+            <div style="font-size:12px;color:var(--t2);margin-top:2px">12 otázek · upraveno 4. 3. 2026</div>
+          </div>
+          <div style="font-size:11px;padding:3px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-weight:500">Aktivní</div>
+          <button class="btn" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();profQShowEditor('Výživový vstupní dotazník')">Upravit</button>
+          <button class="btn danger" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showToast('Šablona smazána')">Smazat</button>
+        </div>
+        <!-- Questionnaire 3 -->
+        <div style="padding:14px 18px;display:flex;align-items:center;gap:14px;cursor:pointer" onclick="profQShowEditor('Kontrolní dotazník po 8 týdnech')">
+          <div style="width:36px;height:36px;border-radius:8px;background:rgba(0,122,255,.12);color:var(--blue);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🔍</div>
+          <div style="flex:1;min-width:0">
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Kontrolní dotazník po 8 týdnech</div>
+            <div style="font-size:12px;color:var(--t2);margin-top:2px">6 otázek · upraveno 18. 1. 2026</div>
+          </div>
+          <div style="font-size:11px;padding:3px 8px;border-radius:99px;background:var(--bg3);color:var(--t3);font-weight:500">Draft</div>
+          <button class="btn" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();profQShowEditor('Kontrolní dotazník po 8 týdnech')">Upravit</button>
+          <button class="btn danger" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showToast('Šablona smazána')">Smazat</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Editor view -->
+    <div id="prof-q-editor" style="display:none">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
+        <button class="btn" onclick="profQHideEditor()">‹ Zpět na seznam</button>
+        <span style="font-size:11px;color:var(--orange);display:flex;align-items:center;gap:4px;margin-left:auto"><span style="width:6px;height:6px;border-radius:50%;background:var(--orange)"></span>Neuložené změny</span>
+      </div>
+
+      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px;margin-bottom:14px">
+        <div class="form-group" style="margin-bottom:0">
+          <label class="form-label">Název šablony</label>
+          <input class="form-input" id="prof-q-name" value="Vstupní dotazník — trénink">
+        </div>
+      </div>
+
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+        <div style="font-size:13px;font-weight:600;color:var(--t)">Otázky (8)</div>
+        <button class="btn" onclick="showToast('Otázka přidána')">+ Přidat otázku</button>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:8px">
+        <!-- Question 1 -->
+        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
+          <div style="display:flex;align-items:center;gap:10px">
+            <span style="color:var(--t3);cursor:grab">⠿</span>
+            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(0,122,255,.12);color:var(--blue)">Jednotlivý výběr</span>
+            <div style="flex:1;font-size:13px;color:var(--t)">Jak dlouho pravidelně cvičíš?</div>
+            <span style="font-size:11px;color:var(--t3)">4 možnosti</span>
+            <span style="color:var(--t4);cursor:pointer">✏</span>
+            <span style="color:var(--t4);cursor:pointer">✕</span>
+          </div>
+        </div>
+        <!-- Question 2 -->
+        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
+          <div style="display:flex;align-items:center;gap:10px">
+            <span style="color:var(--t3);cursor:grab">⠿</span>
+            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green)">Číslo</span>
+            <div style="flex:1;font-size:13px;color:var(--t)">Aktuální váha (kg)</div>
+            <span style="font-size:11px;color:var(--t3)">→ synchronizace s profilem</span>
+            <span style="color:var(--t4);cursor:pointer">✏</span>
+            <span style="color:var(--t4);cursor:pointer">✕</span>
+          </div>
+        </div>
+        <!-- Question 3 -->
+        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
+          <div style="display:flex;align-items:center;gap:10px">
+            <span style="color:var(--t3);cursor:grab">⠿</span>
+            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green)">Číslo</span>
+            <div style="flex:1;font-size:13px;color:var(--t)">Výška (cm)</div>
+            <span style="font-size:11px;color:var(--t3)">→ synchronizace s profilem</span>
+            <span style="color:var(--t4);cursor:pointer">✏</span>
+            <span style="color:var(--t4);cursor:pointer">✕</span>
+          </div>
+        </div>
+        <!-- Question 4 -->
+        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
+          <div style="display:flex;align-items:center;gap:10px">
+            <span style="color:var(--t3);cursor:grab">⠿</span>
+            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(0,122,255,.12);color:var(--blue)">Jednotlivý výběr</span>
+            <div style="flex:1;font-size:13px;color:var(--t)">Primární cíl</div>
+            <span style="font-size:11px;color:var(--t3)">5 možností · → profil</span>
+            <span style="color:var(--t4);cursor:pointer">✏</span>
+            <span style="color:var(--t4);cursor:pointer">✕</span>
+          </div>
+        </div>
+        <!-- Question 5 -->
+        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
+          <div style="display:flex;align-items:center;gap:10px">
+            <span style="color:var(--t3);cursor:grab">⠿</span>
+            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(175,82,222,.12);color:var(--purple)">Text</span>
+            <div style="flex:1;font-size:13px;color:var(--t)">Zdravotní omezení nebo zranění</div>
+            <span style="font-size:11px;color:var(--t3)">→ profil</span>
+            <span style="color:var(--t4);cursor:pointer">✏</span>
+            <span style="color:var(--t4);cursor:pointer">✕</span>
+          </div>
+        </div>
+        <!-- Question 6 -->
+        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
+          <div style="display:flex;align-items:center;gap:10px">
+            <span style="color:var(--t3);cursor:grab">⠿</span>
+            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(255,149,0,.12);color:var(--orange)">Škála 1–10</span>
+            <div style="flex:1;font-size:13px;color:var(--t)">Motivace ke změně</div>
+            <span style="color:var(--t4);cursor:pointer">✏</span>
+            <span style="color:var(--t4);cursor:pointer">✕</span>
+          </div>
+        </div>
+      </div>
+
+      <div style="margin-top:14px;padding:14px 18px;background:var(--bg2);border:1px solid var(--br);border-radius:8px">
+        <div style="font-size:13px;font-weight:600;color:var(--t);margin-bottom:6px">Náhled pro klienta</div>
+        <div style="font-size:12px;color:var(--t2);margin-bottom:12px">Takto uvidí dotazník klient při vyplňování.</div>
+        <button class="btn" onclick="showToast('Náhled otevřen v novém okně')">👁 Zobrazit náhled</button>
+      </div>
+    </div>
+
+  </div><!-- /content-questionnaires -->
+
+  <script>
+    function switchProfileTab(tab){
+      var tabs = {
+        personal: ['prof-tab-personal','prof-content-personal'],
+        questionnaires: ['prof-tab-questionnaires','prof-content-questionnaires']
+      };
+      Object.keys(tabs).forEach(function(k){
+        var btn = document.getElementById(tabs[k][0]);
+        var content = document.getElementById(tabs[k][1]);
+        if(btn) btn.classList.toggle('active', k === tab);
+        if(content) content.style.display = (k === tab) ? '' : 'none';
+      });
+    }
+    function profQShowEditor(name){
+      var list = document.getElementById('prof-q-list');
+      var ed = document.getElementById('prof-q-editor');
+      var nm = document.getElementById('prof-q-name');
+      if(list) list.style.display = 'none';
+      if(ed) ed.style.display = '';
+      if(nm && name) nm.value = name;
+    }
+    function profQHideEditor(){
+      var list = document.getElementById('prof-q-list');
+      var ed = document.getElementById('prof-q-editor');
+      if(list) list.style.display = '';
+      if(ed) ed.style.display = 'none';
+    }
+  </script>
+
+</div>
+</div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════
+     PROFIL — konec
+═══════════════════════════════════════════════════════════ -->
 <div id="s-diary-request" class="screen">
 <div class="shell">
 <div class="sb" id="sb-diary-request"></div>
@@ -2363,7 +2710,7 @@ function showScreen(id){
   document.querySelectorAll('.tn-btn').forEach(function(b){if(b.getAttribute('onclick')==="showScreen('"+id+"')") b.classList.add('active');});
   window.scrollTo(0,0);
   // Build sidebars
-  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins','s-diary-request':'sb-diary-request','s-client-photos':'sb-client-photos'};
+  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins','s-diary-request':'sb-diary-request','s-client-photos':'sb-client-photos','s-profile':'sb-profile'};
   if(sbMap[id]) buildSidebar(sbMap[id],id);
   // Init nutrition editor
   if(id==='s-nutrition'&&!_nutrInit){_nutrInit=true;initNutrition();}

--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -1371,7 +1371,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
 <div class="shell">
 <div class="sb" id="sb-profile"></div>
 <div class="main">
-  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><span>Nastavení</span><span class="bc-sep">/</span><span>Profil</span></div>
+  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><span>Profil</span></div>
 
   <div class="ph">
     <div class="ph-icon">👤</div>
@@ -1383,14 +1383,16 @@ body.dark .btn-auth-primary { color: #0d0900; }
   <div class="toolbar" style="border-bottom:1px solid var(--br);margin-bottom:0">
     <div class="tb-view active" id="prof-tab-personal" onclick="switchProfileTab('personal')">👤 Osobní údaje</div>
     <div class="tb-view" id="prof-tab-questionnaires" onclick="switchProfileTab('questionnaires')">📋 Dotazníky</div>
-    <div class="tb-view" onclick="showScreen('s-settings-checkins')">🔔 Týdenní check-iny</div>
+    <div class="tb-view" id="prof-tab-checkins" onclick="switchProfileTab('checkins')">🔔 Týdenní check-iny</div>
     <div style="margin-left:auto;display:flex;gap:8px;align-items:center">
-      <span style="font-size:11px;color:var(--orange);display:flex;align-items:center;gap:4px"><span style="width:6px;height:6px;border-radius:50%;background:var(--orange)"></span>Neuložené změny</span>
-      <button class="btn primary" onclick="showToast('Profil uložen')">Uložit</button>
+      <span id="prof-dirty-ind" style="font-size:11px;color:var(--orange);display:flex;align-items:center;gap:4px"><span style="width:6px;height:6px;border-radius:50%;background:var(--orange)"></span>Neuložené změny</span>
+      <button id="prof-save-btn" class="btn primary" onclick="showToast('Profil uložen')">Uložit</button>
     </div>
   </div>
 
-  <!-- ══ TAB: OSOBNÍ ÚDAJE ══ -->
+  <!-- ════════════════════════════════════════════════════════
+       TAB: OSOBNÍ ÚDAJE
+  ════════════════════════════════════════════════════════ -->
   <div class="pc" id="prof-content-personal">
 
     <!-- Profile card -->
@@ -1523,162 +1525,505 @@ body.dark .btn-auth-primary { color: #0d0900; }
 
   </div><!-- /content-personal -->
 
-  <!-- ══ TAB: DOTAZNÍKY ══ -->
+  <!-- ════════════════════════════════════════════════════════
+       TAB: DOTAZNÍKY — matches QuestionnaireList + QuestionnaireEditor
+  ════════════════════════════════════════════════════════ -->
   <div class="pc" id="prof-content-questionnaires" style="display:none">
 
-    <!-- List view (default) -->
+    <!-- LIST VIEW (default) -->
     <div id="prof-q-list">
-      <div class="callout" style="margin-bottom:16px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
-        <div class="callout-icon">📋</div>
-        <div class="callout-body">
-          <div class="callout-title">Šablony dotazníků</div>
-          <div class="callout-text" style="font-size:12px">Vytvoř si vlastní dotazníky pro nové klienty. Dotazník se přiloží k pozvánce nebo k individuálnímu plánu. Klient odpovědi uvidíš v detailu klienta v sekci Dotazník.</div>
+      <div style="display:flex;flex-direction:column;gap:8px">
+
+        <!-- Card 1 -->
+        <div onclick="profQShowEditor('q1')" style="display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer;transition:background .1s">
+          <span style="font-size:20px;flex-shrink:0">📋</span>
+          <div style="flex:1;min-width:0">
+            <div style="display:flex;align-items:center;gap:6px">
+              <span style="font-size:14px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Vstupní dotazník — trénink</span>
+              <span style="padding:1px 6px;border-radius:10px;font-size:10px;font-weight:500;color:var(--acc);background:rgba(201,168,76,.1);border:1px solid var(--acc-br);flex-shrink:0">Výchozí</span>
+            </div>
+            <div style="font-size:12px;color:var(--t3);margin-top:2px">8 otázek · Vstupní dotazník pro nové klienty</div>
+          </div>
+          <span onclick="event.stopPropagation();showToast('Smazat šablonu?')" style="width:24px;height:24px;flex-shrink:0;display:flex;align-items:center;justify-content:center;border-radius:var(--r);cursor:pointer;color:var(--t4);font-size:12px">✕</span>
         </div>
+
+        <!-- Card 2 -->
+        <div onclick="profQShowEditor('q2')" style="display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer;transition:background .1s">
+          <span style="font-size:20px;flex-shrink:0">📋</span>
+          <div style="flex:1;min-width:0">
+            <div style="display:flex;align-items:center;gap:6px">
+              <span style="font-size:14px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Výživový vstupní dotazník</span>
+            </div>
+            <div style="font-size:12px;color:var(--t3);margin-top:2px">12 otázek · Strava, preferovaná jídla, alergie</div>
+          </div>
+          <span onclick="event.stopPropagation();showToast('Smazat šablonu?')" style="width:24px;height:24px;flex-shrink:0;display:flex;align-items:center;justify-content:center;border-radius:var(--r);cursor:pointer;color:var(--t4);font-size:12px">✕</span>
+        </div>
+
+        <!-- Card 3 -->
+        <div onclick="profQShowEditor('q3')" style="display:flex;align-items:center;gap:12px;padding:12px 16px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer;transition:background .1s">
+          <span style="font-size:20px;flex-shrink:0">📋</span>
+          <div style="flex:1;min-width:0">
+            <div style="display:flex;align-items:center;gap:6px">
+              <span style="font-size:14px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Kontrolní dotazník po 8 týdnech</span>
+              <span style="padding:1px 6px;border-radius:10px;font-size:10px;font-weight:500;color:var(--t3);background:var(--bg3);flex-shrink:0">Neaktivní</span>
+            </div>
+            <div style="font-size:12px;color:var(--t3);margin-top:2px">6 otázek · Mid-plan check-up</div>
+          </div>
+          <span onclick="event.stopPropagation();showToast('Smazat šablonu?')" style="width:24px;height:24px;flex-shrink:0;display:flex;align-items:center;justify-content:center;border-radius:var(--r);cursor:pointer;color:var(--t4);font-size:12px">✕</span>
+        </div>
+
       </div>
 
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
-        <div style="font-size:13px;color:var(--t2)">3 šablony celkem</div>
-        <button class="btn primary" onclick="showToast('Nová šablona vytvořena')">+ Nová šablona</button>
-      </div>
-
-      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;overflow:hidden">
-        <!-- Questionnaire 1 -->
-        <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;gap:14px;cursor:pointer" onclick="profQShowEditor('Vstupní dotazník — trénink')">
-          <div style="width:36px;height:36px;border-radius:8px;background:rgba(201,168,76,.12);color:var(--acc);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">📝</div>
-          <div style="flex:1;min-width:0">
-            <div style="font-size:14px;font-weight:600;color:var(--t)">Vstupní dotazník — trénink</div>
-            <div style="font-size:12px;color:var(--t2);margin-top:2px">8 otázek · <span style="color:var(--acc)">Výchozí</span> · upraveno 12. 3. 2026</div>
-          </div>
-          <div style="font-size:11px;padding:3px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-weight:500">Aktivní</div>
-          <button class="btn" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();profQShowEditor('Vstupní dotazník — trénink')">Upravit</button>
-          <button class="btn danger" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showToast('Šablona smazána')">Smazat</button>
-        </div>
-        <!-- Questionnaire 2 -->
-        <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;gap:14px;cursor:pointer" onclick="profQShowEditor('Výživový vstupní dotazník')">
-          <div style="width:36px;height:36px;border-radius:8px;background:rgba(52,199,89,.12);color:var(--green);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🥗</div>
-          <div style="flex:1;min-width:0">
-            <div style="font-size:14px;font-weight:600;color:var(--t)">Výživový vstupní dotazník</div>
-            <div style="font-size:12px;color:var(--t2);margin-top:2px">12 otázek · upraveno 4. 3. 2026</div>
-          </div>
-          <div style="font-size:11px;padding:3px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green);font-weight:500">Aktivní</div>
-          <button class="btn" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();profQShowEditor('Výživový vstupní dotazník')">Upravit</button>
-          <button class="btn danger" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showToast('Šablona smazána')">Smazat</button>
-        </div>
-        <!-- Questionnaire 3 -->
-        <div style="padding:14px 18px;display:flex;align-items:center;gap:14px;cursor:pointer" onclick="profQShowEditor('Kontrolní dotazník po 8 týdnech')">
-          <div style="width:36px;height:36px;border-radius:8px;background:rgba(0,122,255,.12);color:var(--blue);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0">🔍</div>
-          <div style="flex:1;min-width:0">
-            <div style="font-size:14px;font-weight:600;color:var(--t)">Kontrolní dotazník po 8 týdnech</div>
-            <div style="font-size:12px;color:var(--t2);margin-top:2px">6 otázek · upraveno 18. 1. 2026</div>
-          </div>
-          <div style="font-size:11px;padding:3px 8px;border-radius:99px;background:var(--bg3);color:var(--t3);font-weight:500">Draft</div>
-          <button class="btn" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();profQShowEditor('Kontrolní dotazník po 8 týdnech')">Upravit</button>
-          <button class="btn danger" style="font-size:12px;padding:5px 10px" onclick="event.stopPropagation();showToast('Šablona smazána')">Smazat</button>
-        </div>
-      </div>
+      <!-- Dashed add button -->
+      <button type="button" onclick="showToast('Nová šablona vytvořena');profQShowEditor('new')" style="display:inline-flex;align-items:center;gap:4px;padding:7px 14px;border:1px dashed var(--br);border-radius:var(--rm);background:none;cursor:pointer;color:var(--t3);font-size:13px;font-family:inherit;margin-top:12px">+ Přidat šablonu</button>
     </div>
 
-    <!-- Editor view -->
+    <!-- EDITOR VIEW -->
     <div id="prof-q-editor" style="display:none">
-      <div style="display:flex;align-items:center;gap:10px;margin-bottom:14px">
-        <button class="btn" onclick="profQHideEditor()">‹ Zpět na seznam</button>
-        <span style="font-size:11px;color:var(--orange);display:flex;align-items:center;gap:4px;margin-left:auto"><span style="width:6px;height:6px;border-radius:50%;background:var(--orange)"></span>Neuložené změny</span>
-      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:32px;align-items:start">
 
-      <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:16px 18px;margin-bottom:14px">
-        <div class="form-group" style="margin-bottom:0">
-          <label class="form-label">Název šablony</label>
-          <input class="form-input" id="prof-q-name" value="Vstupní dotazník — trénink">
-        </div>
-      </div>
+        <!-- LEFT: editor -->
+        <div>
+          <button onclick="profQHideEditor()" style="display:inline-flex;align-items:center;gap:4px;padding:4px 8px;margin-bottom:12px;border:none;background:none;cursor:pointer;color:var(--t3);font-size:12px;font-family:inherit">← Zpět na seznam</button>
 
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-        <div style="font-size:13px;font-weight:600;color:var(--t)">Otázky (8)</div>
-        <button class="btn" onclick="showToast('Otázka přidána')">+ Přidat otázku</button>
-      </div>
+          <!-- Title -->
+          <div class="form-group" style="margin-bottom:12px">
+            <label class="form-label">Název šablony</label>
+            <input id="prof-q-title" class="form-input" value="Vstupní dotazník — trénink" style="font-size:16px;font-weight:600;padding:8px 10px">
+          </div>
 
-      <div style="display:flex;flex-direction:column;gap:8px">
-        <!-- Question 1 -->
-        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
-          <div style="display:flex;align-items:center;gap:10px">
-            <span style="color:var(--t3);cursor:grab">⠿</span>
-            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(0,122,255,.12);color:var(--blue)">Jednotlivý výběr</span>
-            <div style="flex:1;font-size:13px;color:var(--t)">Jak dlouho pravidelně cvičíš?</div>
-            <span style="font-size:11px;color:var(--t3)">4 možnosti</span>
-            <span style="color:var(--t4);cursor:pointer">✏</span>
-            <span style="color:var(--t4);cursor:pointer">✕</span>
+          <!-- Description -->
+          <div class="form-group" style="margin-bottom:12px">
+            <label class="form-label">Popis (volitelné)</label>
+            <textarea class="form-input" rows="2" style="font-size:13px">Vstupní dotazník pro nové klienty před sestavením tréninkového plánu.</textarea>
           </div>
-        </div>
-        <!-- Question 2 -->
-        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
-          <div style="display:flex;align-items:center;gap:10px">
-            <span style="color:var(--t3);cursor:grab">⠿</span>
-            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green)">Číslo</span>
-            <div style="flex:1;font-size:13px;color:var(--t)">Aktuální váha (kg)</div>
-            <span style="font-size:11px;color:var(--t3)">→ synchronizace s profilem</span>
-            <span style="color:var(--t4);cursor:pointer">✏</span>
-            <span style="color:var(--t4);cursor:pointer">✕</span>
-          </div>
-        </div>
-        <!-- Question 3 -->
-        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
-          <div style="display:flex;align-items:center;gap:10px">
-            <span style="color:var(--t3);cursor:grab">⠿</span>
-            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(52,199,89,.12);color:var(--green)">Číslo</span>
-            <div style="flex:1;font-size:13px;color:var(--t)">Výška (cm)</div>
-            <span style="font-size:11px;color:var(--t3)">→ synchronizace s profilem</span>
-            <span style="color:var(--t4);cursor:pointer">✏</span>
-            <span style="color:var(--t4);cursor:pointer">✕</span>
-          </div>
-        </div>
-        <!-- Question 4 -->
-        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
-          <div style="display:flex;align-items:center;gap:10px">
-            <span style="color:var(--t3);cursor:grab">⠿</span>
-            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(0,122,255,.12);color:var(--blue)">Jednotlivý výběr</span>
-            <div style="flex:1;font-size:13px;color:var(--t)">Primární cíl</div>
-            <span style="font-size:11px;color:var(--t3)">5 možností · → profil</span>
-            <span style="color:var(--t4);cursor:pointer">✏</span>
-            <span style="color:var(--t4);cursor:pointer">✕</span>
-          </div>
-        </div>
-        <!-- Question 5 -->
-        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
-          <div style="display:flex;align-items:center;gap:10px">
-            <span style="color:var(--t3);cursor:grab">⠿</span>
-            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(175,82,222,.12);color:var(--purple)">Text</span>
-            <div style="flex:1;font-size:13px;color:var(--t)">Zdravotní omezení nebo zranění</div>
-            <span style="font-size:11px;color:var(--t3)">→ profil</span>
-            <span style="color:var(--t4);cursor:pointer">✏</span>
-            <span style="color:var(--t4);cursor:pointer">✕</span>
-          </div>
-        </div>
-        <!-- Question 6 -->
-        <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:12px 14px">
-          <div style="display:flex;align-items:center;gap:10px">
-            <span style="color:var(--t3);cursor:grab">⠿</span>
-            <span style="font-size:11px;font-weight:600;padding:2px 8px;border-radius:99px;background:rgba(255,149,0,.12);color:var(--orange)">Škála 1–10</span>
-            <div style="flex:1;font-size:13px;color:var(--t)">Motivace ke změně</div>
-            <span style="color:var(--t4);cursor:pointer">✏</span>
-            <span style="color:var(--t4);cursor:pointer">✕</span>
-          </div>
-        </div>
-      </div>
 
-      <div style="margin-top:14px;padding:14px 18px;background:var(--bg2);border:1px solid var(--br);border-radius:8px">
-        <div style="font-size:13px;font-weight:600;color:var(--t);margin-bottom:6px">Náhled pro klienta</div>
-        <div style="font-size:12px;color:var(--t2);margin-bottom:12px">Takto uvidí dotazník klient při vyplňování.</div>
-        <button class="btn" onclick="showToast('Náhled otevřen v novém okně')">👁 Zobrazit náhled</button>
+          <!-- Active toggle -->
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 0">
+            <span style="font-size:13px;color:var(--t2)">Aktivní</span>
+            <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+          </div>
+
+          <!-- Default toggle -->
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;padding:8px 0">
+            <div>
+              <span style="font-size:13px;color:var(--t2)">Výchozí</span>
+              <div style="font-size:11px;color:var(--t3);margin-top:1px">Automaticky se přiloží k novým pozvánkám</div>
+            </div>
+            <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+          </div>
+
+          <div class="divider" style="margin-bottom:16px"></div>
+
+          <!-- Questions list -->
+          <div style="display:flex;flex-direction:column;gap:8px">
+
+            <!-- Section header -->
+            <div style="background:var(--bg);border:1px solid var(--br);border-left:3px solid var(--acc);border-radius:var(--rm);margin-top:8px">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">§</span>
+                <span style="flex:1;font-size:14px;font-weight:600;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Základní údaje</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Sekce</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+            <!-- Question — single_choice (expanded) -->
+            <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">◉</span>
+                <span style="flex:1;font-size:13px;font-weight:400;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Jak dlouho pravidelně cvičíš?</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Jednotlivý výběr</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s;transform:rotate(90deg)">▶</span>
+              </div>
+              <div style="padding:0 12px 12px">
+                <div class="form-group" style="margin-bottom:10px">
+                  <label class="form-label" style="font-size:11px">Typ</label>
+                  <select class="form-select" style="font-size:13px">
+                    <option>Krátký text</option>
+                    <option selected>Jednotlivý výběr</option>
+                    <option>Vícenásobný výběr</option>
+                    <option>Číslo</option>
+                    <option>Škála</option>
+                    <option>Soubor</option>
+                  </select>
+                </div>
+                <div class="form-group" style="margin-bottom:10px">
+                  <label class="form-label" style="font-size:11px">Otázka</label>
+                  <input class="form-input" value="Jak dlouho pravidelně cvičíš?" style="font-size:13px">
+                </div>
+                <div class="form-group" style="margin-bottom:10px">
+                  <label class="form-label" style="font-size:11px">Nápověda (volitelné)</label>
+                  <input class="form-input" value="" placeholder="Zobrazí se pod otázkou" style="font-size:13px">
+                </div>
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
+                  <span style="font-size:12px;color:var(--t2)">Povinná</span>
+                  <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+                </div>
+                <!-- Options -->
+                <div class="form-group" style="margin-bottom:6px">
+                  <label class="form-label" style="font-size:11px">Možnosti</label>
+                  <div style="display:flex;flex-direction:column;gap:4px">
+                    <div style="display:flex;align-items:center;gap:4px"><input class="form-input" value="Méně než 6 měsíců" style="flex:1;font-size:13px"><span style="width:24px;height:24px;display:flex;align-items:center;justify-content:center;color:var(--t4);font-size:12px;cursor:pointer">✕</span></div>
+                    <div style="display:flex;align-items:center;gap:4px"><input class="form-input" value="6 – 12 měsíců" style="flex:1;font-size:13px"><span style="width:24px;height:24px;display:flex;align-items:center;justify-content:center;color:var(--t4);font-size:12px;cursor:pointer">✕</span></div>
+                    <div style="display:flex;align-items:center;gap:4px"><input class="form-input" value="1 – 3 roky" style="flex:1;font-size:13px"><span style="width:24px;height:24px;display:flex;align-items:center;justify-content:center;color:var(--t4);font-size:12px;cursor:pointer">✕</span></div>
+                    <div style="display:flex;align-items:center;gap:4px"><input class="form-input" value="Více než 3 roky" style="flex:1;font-size:13px"><span style="width:24px;height:24px;display:flex;align-items:center;justify-content:center;color:var(--t4);font-size:12px;cursor:pointer">✕</span></div>
+                  </div>
+                  <button type="button" style="display:inline-flex;align-items:center;gap:4px;padding:5px 10px;border:1px dashed var(--br);border-radius:var(--rm);background:none;cursor:pointer;color:var(--t3);font-size:12px;font-family:inherit;margin-top:6px">+ Možnost</button>
+                </div>
+                <!-- Mapped field -->
+                <div class="form-group" style="margin-bottom:0">
+                  <label class="form-label" style="font-size:11px">Mapované pole profilu</label>
+                  <select class="form-select" style="font-size:13px">
+                    <option selected>Žádné</option>
+                    <option>Výška</option>
+                    <option>Váha</option>
+                    <option>Cíl</option>
+                    <option>Zdravotní omezení</option>
+                    <option>Aktuální frekvence tréninků</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <!-- Question — number (collapsed) -->
+            <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">#</span>
+                <span style="flex:1;font-size:13px;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Aktuální váha</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Číslo</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+            <!-- Question — number (collapsed) -->
+            <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">#</span>
+                <span style="flex:1;font-size:13px;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Výška</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Číslo</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+            <!-- Question — single_choice (collapsed) -->
+            <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">◉</span>
+                <span style="flex:1;font-size:13px;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Primární cíl</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Jednotlivý výběr</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+            <!-- Section header 2 -->
+            <div style="background:var(--bg);border:1px solid var(--br);border-left:3px solid var(--acc);border-radius:var(--rm);margin-top:8px">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">§</span>
+                <span style="flex:1;font-size:14px;font-weight:600;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Zdraví &amp; motivace</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Sekce</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+            <!-- Question — short text -->
+            <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">Aa</span>
+                <span style="flex:1;font-size:13px;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Zdravotní omezení nebo zranění</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Krátký text</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+            <!-- Question — scale -->
+            <div style="background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm)">
+              <div onclick="profQToggleCard(this)" style="padding:10px 12px;display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none">
+                <span style="cursor:grab;color:var(--t4);font-size:14px;line-height:1;flex-shrink:0" onclick="event.stopPropagation()">⠿</span>
+                <span style="font-size:13px;color:var(--t3);flex-shrink:0;width:24px;text-align:center">⟷</span>
+                <span style="flex:1;font-size:13px;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Motivace ke změně</span>
+                <span style="font-size:11px;color:var(--t4);flex-shrink:0">Škála</span>
+                <span style="font-size:11px;color:var(--t4);transition:transform .15s">▶</span>
+              </div>
+            </div>
+
+          </div>
+
+          <!-- Add buttons -->
+          <div style="display:flex;gap:8px;margin-top:12px;flex-wrap:wrap">
+            <button type="button" onclick="showToast('Otázka přidána')" style="display:inline-flex;align-items:center;gap:4px;padding:7px 14px;border:1px dashed var(--br);border-radius:var(--rm);background:none;cursor:pointer;color:var(--t3);font-size:13px;font-family:inherit">+ Otázka</button>
+            <button type="button" onclick="showToast('Sekce přidána')" style="display:inline-flex;align-items:center;gap:4px;padding:7px 14px;border:1px dashed var(--br);border-radius:var(--rm);background:none;cursor:pointer;color:var(--t3);font-size:13px;font-family:inherit">+ Sekce</button>
+          </div>
+
+        </div>
+
+        <!-- RIGHT: live preview -->
+        <div style="position:sticky;top:20px">
+          <div style="font-size:11px;color:var(--t3);text-transform:uppercase;letter-spacing:.06em;margin-bottom:8px">Náhled pro klienta</div>
+          <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;padding:20px">
+            <div style="font-size:18px;font-weight:600;color:var(--t);margin-bottom:6px">Vstupní dotazník — trénink</div>
+            <div style="font-size:13px;color:var(--t2);margin-bottom:18px">Vstupní dotazník pro nové klienty před sestavením tréninkového plánu.</div>
+
+            <div style="font-size:13px;font-weight:600;color:var(--acc);margin-bottom:10px;padding-bottom:6px;border-bottom:1px solid var(--acc-br)">Základní údaje</div>
+
+            <div style="margin-bottom:16px">
+              <div style="font-size:13px;font-weight:500;color:var(--t);margin-bottom:6px">Jak dlouho pravidelně cvičíš? <span style="color:var(--red)">*</span></div>
+              <div style="display:flex;flex-direction:column;gap:6px">
+                <label style="display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--br);border-radius:var(--rm);cursor:pointer;font-size:13px;color:var(--t)"><input type="radio" name="q1-preview" disabled> Méně než 6 měsíců</label>
+                <label style="display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--br);border-radius:var(--rm);cursor:pointer;font-size:13px;color:var(--t)"><input type="radio" name="q1-preview" disabled> 6 – 12 měsíců</label>
+                <label style="display:flex;align-items:center;gap:8px;padding:8px 10px;border:1.5px solid var(--acc);background:rgba(201,168,76,.06);border-radius:var(--rm);cursor:pointer;font-size:13px;color:var(--t)"><input type="radio" name="q1-preview" checked disabled> 1 – 3 roky</label>
+                <label style="display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--br);border-radius:var(--rm);cursor:pointer;font-size:13px;color:var(--t)"><input type="radio" name="q1-preview" disabled> Více než 3 roky</label>
+              </div>
+            </div>
+
+            <div style="margin-bottom:16px">
+              <div style="font-size:13px;font-weight:500;color:var(--t);margin-bottom:6px">Aktuální váha <span style="color:var(--red)">*</span></div>
+              <input class="form-input" value="63,1" readonly style="font-size:13px;background:var(--bg);max-width:160px"> <span style="font-size:12px;color:var(--t2);margin-left:6px">kg</span>
+            </div>
+
+            <div style="margin-bottom:16px">
+              <div style="font-size:13px;font-weight:500;color:var(--t);margin-bottom:6px">Výška <span style="color:var(--red)">*</span></div>
+              <input class="form-input" value="168" readonly style="font-size:13px;background:var(--bg);max-width:160px"> <span style="font-size:12px;color:var(--t2);margin-left:6px">cm</span>
+            </div>
+
+            <div style="margin-bottom:16px">
+              <div style="font-size:13px;font-weight:500;color:var(--t);margin-bottom:6px">Primární cíl <span style="color:var(--red)">*</span></div>
+              <select class="form-select" disabled style="font-size:13px;background:var(--bg)"><option>Zhubnout</option></select>
+            </div>
+
+            <div style="font-size:13px;font-weight:600;color:var(--acc);margin:20px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--acc-br)">Zdraví &amp; motivace</div>
+
+            <div style="margin-bottom:16px">
+              <div style="font-size:13px;font-weight:500;color:var(--t);margin-bottom:6px">Zdravotní omezení nebo zranění</div>
+              <input class="form-input" readonly placeholder="Tvoje odpověď…" style="font-size:13px;background:var(--bg)">
+            </div>
+
+            <div style="margin-bottom:16px">
+              <div style="font-size:13px;font-weight:500;color:var(--t);margin-bottom:6px">Motivace ke změně <span style="color:var(--red)">*</span></div>
+              <div style="display:flex;gap:4px">
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">1</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">2</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">3</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">4</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">5</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">6</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">7</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1.5px solid var(--acc);background:rgba(201,168,76,.06);border-radius:6px;font-size:12px;color:var(--t);font-weight:600">8</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">9</div>
+                <div style="flex:1;padding:6px;text-align:center;border:1px solid var(--br);border-radius:6px;font-size:12px;color:var(--t3)">10</div>
+              </div>
+            </div>
+
+            <div style="display:flex;justify-content:flex-end;margin-top:20px">
+              <button class="btn primary" disabled style="opacity:.6">Odeslat odpovědi</button>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
 
   </div><!-- /content-questionnaires -->
 
+  <!-- ════════════════════════════════════════════════════════
+       TAB: TÝDENNÍ CHECK-INY
+  ════════════════════════════════════════════════════════ -->
+  <div class="pc" id="prof-content-checkins" style="display:none">
+
+    <!-- Intro callout -->
+    <div class="callout" style="margin-bottom:20px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
+      <div class="callout-icon">📅</div>
+      <div class="callout-body">
+        <div class="callout-title">Týdenní check-iny před plánováním</div>
+        <div class="callout-text">V nastavený den a čas se klientovi ozve notifikace, aby dal vědět, jestli ho v příštím týdnu nečeká něco mimořádného (cestování, zranění, zvláštní rozvrh). Odpověď uvidíš v kartě klienta i přímo v editoru plánu.</div>
+      </div>
+    </div>
+
+    <!-- Default — Training -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;margin-bottom:14px">
+      <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:32px;height:32px;border-radius:8px;background:rgba(201,168,76,.15);color:var(--acc);display:flex;align-items:center;justify-content:center;font-size:16px">🏋️</span>
+          <div>
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Výchozí pro Trénink</div>
+            <div style="font-size:12px;color:var(--t2)">Platí pro všechny klienty, u kterých nemáš individuální nastavení</div>
+          </div>
+        </div>
+        <div class="toggle-wrap" style="margin:0;padding:0">
+          <span class="toggle-lbl" style="font-size:12px">Aktivní</span>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+      <div style="padding:16px 18px">
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Den v týdnu</label>
+            <select class="form-select">
+              <option>Pondělí</option><option>Úterý</option><option>Středa</option>
+              <option selected>Čtvrtek</option><option>Pátek</option><option>Sobota</option><option>Neděle</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Čas (hodina)</label>
+            <select class="form-select">
+              <option>06:00</option><option>07:00</option><option>08:00</option>
+              <option>09:00</option><option>10:00</option><option>11:00</option>
+              <option>12:00</option><option>13:00</option><option>14:00</option>
+              <option>15:00</option><option>16:00</option><option>17:00</option>
+              <option selected>18:00</option><option>19:00</option><option>20:00</option>
+              <option>21:00</option><option>22:00</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Časová zóna</label>
+            <input class="form-input" value="Europe/Prague" readonly style="background:var(--bg3);color:var(--t2)">
+          </div>
+        </div>
+        <div class="form-group" style="margin-top:4px">
+          <label class="form-label">Výchozí zpráva (volitelné)</label>
+          <textarea class="form-input" rows="2" maxlength="200" placeholder="Krátká osobní zpráva, která se připojí k notifikaci pro všechny klienty…">Pokud plánuješ dlouhou cestu, dej vědět — přizpůsobím týdenní rozložení.</textarea>
+          <div style="font-size:11px;color:var(--t3);margin-top:4px">86 / 200 znaků</div>
+        </div>
+      </div>
+      <div style="padding:10px 18px;border-top:1px solid var(--br);display:flex;justify-content:space-between;align-items:center;background:rgba(120,120,128,.03)">
+        <span style="font-size:12px;color:var(--t2)">Posledních 4 týdny: <strong style="color:var(--t)">22 odpovědí</strong> · 8 nezodpovězeno</span>
+        <button class="btn primary" onclick="showToast('Uloženo')">Uložit</button>
+      </div>
+    </div>
+
+    <!-- Default — Nutrition -->
+    <div style="background:var(--bg2);border:1px solid var(--br);border-radius:8px;margin-bottom:24px">
+      <div style="padding:14px 18px;border-bottom:1px solid var(--br);display:flex;align-items:center;justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span style="width:32px;height:32px;border-radius:8px;background:rgba(52,199,89,.15);color:#34c759;display:flex;align-items:center;justify-content:center;font-size:16px">🥗</span>
+          <div>
+            <div style="font-size:14px;font-weight:600;color:var(--t)">Výchozí pro Výživu</div>
+            <div style="font-size:12px;color:var(--t2)">Platí pro všechny klienty s výživovým plánem</div>
+          </div>
+        </div>
+        <div class="toggle-wrap" style="margin:0;padding:0">
+          <span class="toggle-lbl" style="font-size:12px">Aktivní</span>
+          <div class="toggle on" onclick="this.classList.toggle('on')"><div class="toggle-thumb"></div></div>
+        </div>
+      </div>
+      <div style="padding:16px 18px">
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Den v týdnu</label>
+            <select class="form-select">
+              <option>Pondělí</option><option>Úterý</option><option>Středa</option>
+              <option>Čtvrtek</option><option>Pátek</option><option>Sobota</option><option selected>Neděle</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Čas (hodina)</label>
+            <select class="form-select">
+              <option>06:00</option><option>07:00</option><option>08:00</option>
+              <option>09:00</option><option>10:00</option><option>11:00</option>
+              <option>12:00</option><option>13:00</option><option>14:00</option>
+              <option>15:00</option><option>16:00</option><option>17:00</option>
+              <option>18:00</option><option selected>19:00</option><option>20:00</option>
+              <option>21:00</option><option>22:00</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Časová zóna</label>
+            <input class="form-input" value="Europe/Prague" readonly style="background:var(--bg3);color:var(--t2)">
+          </div>
+        </div>
+        <div class="form-group" style="margin-top:4px">
+          <label class="form-label">Výchozí zpráva (volitelné)</label>
+          <textarea class="form-input" rows="2" maxlength="200" placeholder="Zpráva pro klienty s výživovým plánem…"></textarea>
+          <div style="font-size:11px;color:var(--t3);margin-top:4px">0 / 200 znaků</div>
+        </div>
+      </div>
+      <div style="padding:10px 18px;border-top:1px solid var(--br);display:flex;justify-content:space-between;align-items:center;background:rgba(120,120,128,.03)">
+        <span style="font-size:12px;color:var(--t2)">Posledních 4 týdny: <strong style="color:var(--t)">14 odpovědí</strong> · 4 nezodpovězeno</span>
+        <button class="btn primary" onclick="showToast('Uloženo')">Uložit</button>
+      </div>
+    </div>
+
+    <!-- Per-client overrides -->
+    <div style="display:flex;align-items:baseline;justify-content:space-between;margin-bottom:10px">
+      <div>
+        <div style="font-size:15px;font-weight:600;color:var(--t)">Výjimky u klientů</div>
+        <div style="font-size:12px;color:var(--t2);margin-top:2px">5 z 8 klientů používá výchozí nastavení · 3 mají individuální rozvrh</div>
+      </div>
+      <div style="font-size:12px;color:var(--t3)">Klikni na klienta pro úpravu</div>
+    </div>
+
+    <div class="db-wrap">
+      <table class="db-table">
+        <thead>
+          <tr>
+            <th>Klient</th><th>Profese</th><th>Nastavení</th><th>Den</th><th>Čas</th><th>Aktivní</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer">
+            <td><strong>Petra Horáková</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag tag-gray">Výchozí</span></td>
+            <td>Čt</td>
+            <td>18:00</td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer;background:rgba(201,168,76,.03)">
+            <td><strong>Tomáš Navrátil</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.12);color:var(--acc)">Individuální</span></td>
+            <td><strong style="color:var(--acc)">Út</strong></td>
+            <td><strong style="color:var(--acc)">20:00</strong></td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer">
+            <td><strong>Lucie Procházková</strong></td>
+            <td><span class="tag" style="background:rgba(52,199,89,.1);color:#34c759;border:1px solid rgba(52,199,89,.3)">Výživa</span></td>
+            <td><span class="tag tag-gray">Výchozí</span></td>
+            <td>Ne</td>
+            <td>19:00</td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer;background:rgba(201,168,76,.03)">
+            <td><strong>Martin Krejčí</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.12);color:var(--acc)">Individuální</span></td>
+            <td>Čt</td>
+            <td>18:00</td>
+            <td><span class="tag tag-gray">✕</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+          <tr onclick="openDialog('dlg-checkin-override')" style="cursor:pointer;background:rgba(201,168,76,.03)">
+            <td><strong>Jakub Malý</strong></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.1);color:var(--acc);border:1px solid var(--acc-br)">Trénink</span></td>
+            <td><span class="tag" style="background:rgba(201,168,76,.12);color:var(--acc)">Individuální</span></td>
+            <td><strong style="color:var(--acc)">Pá</strong></td>
+            <td><strong style="color:var(--acc)">16:00</strong></td>
+            <td><span class="tag tag-green">✓</span></td>
+            <td style="color:var(--t3)">›</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div><!-- /content-checkins -->
+
   <script>
     function switchProfileTab(tab){
       var tabs = {
-        personal: ['prof-tab-personal','prof-content-personal'],
-        questionnaires: ['prof-tab-questionnaires','prof-content-questionnaires']
+        personal:       ['prof-tab-personal',       'prof-content-personal'],
+        questionnaires: ['prof-tab-questionnaires', 'prof-content-questionnaires'],
+        checkins:       ['prof-tab-checkins',       'prof-content-checkins']
       };
       Object.keys(tabs).forEach(function(k){
         var btn = document.getElementById(tabs[k][0]);
@@ -1686,20 +2031,34 @@ body.dark .btn-auth-primary { color: #0d0900; }
         if(btn) btn.classList.toggle('active', k === tab);
         if(content) content.style.display = (k === tab) ? '' : 'none';
       });
+      // The Save button only applies to Personal + Questionnaires; hide on Check-ins
+      var saveBtn  = document.getElementById('prof-save-btn');
+      var dirtyInd = document.getElementById('prof-dirty-ind');
+      if(saveBtn)  saveBtn.style.display  = (tab === 'checkins') ? 'none' : '';
+      if(dirtyInd) dirtyInd.style.display = (tab === 'checkins') ? 'none' : 'flex';
     }
-    function profQShowEditor(name){
-      var list = document.getElementById('prof-q-list');
-      var ed = document.getElementById('prof-q-editor');
-      var nm = document.getElementById('prof-q-name');
-      if(list) list.style.display = 'none';
-      if(ed) ed.style.display = '';
-      if(nm && name) nm.value = name;
+    function profQShowEditor(id){
+      document.getElementById('prof-q-list').style.display = 'none';
+      document.getElementById('prof-q-editor').style.display = '';
     }
     function profQHideEditor(){
-      var list = document.getElementById('prof-q-list');
-      var ed = document.getElementById('prof-q-editor');
-      if(list) list.style.display = '';
-      if(ed) ed.style.display = 'none';
+      document.getElementById('prof-q-list').style.display = '';
+      document.getElementById('prof-q-editor').style.display = 'none';
+    }
+    function profQToggleCard(header){
+      var body = header.nextElementSibling;
+      var chev = header.lastElementChild;
+      if(!body) return;
+      var open = body.style.display !== 'none' && getComputedStyle(body).display !== 'none';
+      // Only cards with a sibling body are expandable (sections and collapsed questions have no body)
+      if(body.tagName !== 'DIV' || !body.style) return;
+      if(open){
+        body.style.display = 'none';
+        if(chev) chev.style.transform = 'rotate(0deg)';
+      } else {
+        body.style.display = '';
+        if(chev) chev.style.transform = 'rotate(90deg)';
+      }
     }
   </script>
 

--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -923,42 +923,32 @@ body.dark .btn-auth-primary { color: #0d0900; }
 <div class="shell">
 <div class="sb" id="sb-nutrition"></div>
 <div style="flex:1;display:flex;flex-direction:column;overflow:hidden">
-  <!-- topbar -->
+
+  <!-- ── Topbar (matches NutritionPlanPage.tsx PageHeader actions) ── -->
   <div style="height:44px;border-bottom:1px solid var(--br);display:flex;align-items:center;gap:8px;padding:0 16px;background:var(--bg);flex-shrink:0">
-    <div style="font-size:12px;color:var(--t3);display:flex;align-items:center;gap:4px">
-      <a style="cursor:pointer;color:var(--t3)" onclick="showScreen('s-dashboard')">Dashboard</a>
-      <span style="color:var(--t4)">/</span>
-      <a style="cursor:pointer;color:var(--t3)" onclick="showScreen('s-client')">Petra Horáková</a>
-      <span style="color:var(--t4)">/</span>
-      <span style="color:var(--t)">Jídelníček – únor/březen</span>
+    <div style="display:flex;align-items:center;gap:8px;min-width:0">
+      <span style="font-size:15px">🥗</span>
+      <div style="min-width:0">
+        <div style="font-size:13px;font-weight:600;color:var(--t);line-height:1.2;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Jídelníček</div>
+        <div style="font-size:11px;color:var(--t3);display:flex;align-items:center;gap:4px">
+          <a style="cursor:pointer;color:var(--t3)" onclick="showScreen('s-dashboard')">Dashboard</a>
+          <span style="color:var(--t4)">/</span>
+          <a style="cursor:pointer;color:var(--t3)" onclick="showScreen('s-client')">Petra Horáková</a>
+          <span style="color:var(--t4)">/</span>
+          <span style="color:var(--t2)">Jídelníček – únor/březen</span>
+        </div>
+      </div>
     </div>
     <div style="margin-left:auto;display:flex;align-items:center;gap:6px">
       <span id="nutr-save-ind" style="font-size:11px;color:var(--green)">Uloženo</span>
-      <button class="btn" onclick="openDialog('dlg-shopping-list')">🛒 Nákupní seznam</button>
-      <button class="btn" onclick="openDialog('dlg-add-meal')">+ Jídlo</button>
-      <button class="btn" onclick="openDialog('dlg-diary-request')">📸 Foto-deník</button>
-      <button class="btn" style="color:var(--acc);border-color:var(--acc-br)" onclick="openDialog('dlg-complete-plan')">✓ Dokončit plán</button>
-      <button class="btn primary" onclick="publishPlan()">Publikovat</button>
+      <button class="btn" onclick="showToast('Změny zahozeny')" title="Vrátit plán do stavu před poslední úpravou">Zahodit změny</button>
+      <button class="btn" onclick="showToast('Uloženo')">Uložit</button>
+      <button class="btn" style="color:var(--acc);border-color:var(--acc-br)" onclick="openDialog('dlg-complete-plan')">Dokončit plán</button>
+      <button class="btn primary" onclick="publishPlan()">Publikovat týden</button>
     </div>
   </div>
-  <!-- Photo-diary status banner -->
-  <div style="margin:10px 16px 0;background:rgba(52,199,89,.08);border:1px solid rgba(52,199,89,.25);border-radius:8px">
-    <div style="padding:10px 14px;display:flex;align-items:center;gap:10px">
-      <div style="font-size:16px">📸</div>
-      <div style="flex:1;min-width:0">
-        <div style="display:flex;align-items:center;gap:8px;margin-bottom:2px">
-          <div style="font-size:13px;font-weight:600;color:var(--t)">Foto-deník Petry · Den 3 z 7</div>
-          <span style="font-size:10px;font-weight:600;padding:2px 7px;border-radius:99px;background:rgba(52,199,89,.15);color:#34c759;text-transform:uppercase;letter-spacing:.04em">Aktivní</span>
-        </div>
-        <div style="font-size:12px;color:var(--t2)">Klient nahrává fotky v reálném čase · poslední fotka před 2 h</div>
-      </div>
-      <div style="display:flex;gap:6px;flex-shrink:0">
-        <button class="btn primary" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-client-photos')">Zobrazit fotky</button>
-        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="openDialog('dlg-diary-request')">Nová žádost</button>
-      </div>
-    </div>
-  </div>
-  <!-- Weekly check-in response banner — state 1: RESPONDED -->
+
+  <!-- ── Weekly check-in banner — state 1: RESPONDED ── -->
   <div style="margin:10px 16px 0;background:var(--bg2);border:1px solid var(--acc-br);border-left:3px solid var(--acc);border-radius:8px">
     <div style="padding:10px 14px;display:flex;align-items:flex-start;gap:10px">
       <div style="font-size:16px;margin-top:1px">📅</div>
@@ -975,11 +965,11 @@ body.dark .btn-auth-primary { color: #0d0900; }
       </div>
       <div style="display:flex;gap:6px;flex-shrink:0">
         <button class="btn primary" style="font-size:12px;padding:5px 10px;white-space:nowrap">✓ Zkontrolováno</button>
-        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-settings-checkins')">Nastavení</button>
+        <button class="btn" style="font-size:12px;padding:5px 10px;white-space:nowrap" onclick="showScreen('s-profile')">Nastavení</button>
       </div>
     </div>
   </div>
-  <!-- Weekly check-in response banner — state 2: SENT BUT NOT YET RESPONDED (scene variant for QA) -->
+  <!-- Weekly check-in banner — state 2: SENT BUT NOT YET RESPONDED (variant) -->
   <div style="margin:6px 16px 0;background:var(--bg2);border:1px solid var(--br);border-left:3px solid var(--t4);border-radius:8px;opacity:.85">
     <div style="padding:8px 14px;display:flex;align-items:center;gap:10px">
       <div style="font-size:15px">⏳</div>
@@ -993,22 +983,51 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <button class="btn" style="font-size:12px;padding:4px 9px;white-space:nowrap" onclick="showScreen('s-messages')">💬 Napsat</button>
     </div>
   </div>
-  <!-- Banner state 3 (hidden) is omitted here by design — when the client has no scheduled check-in, the banner does not render at all. -->
 
-  <!-- week tabs -->
+  <!-- ── Week tabs (JS-rendered) + inline "+ Add week" ── -->
   <div class="week-tabs" id="nutr-week-tabs"></div>
-  <!-- day tabs -->
-  <div class="day-tabs" id="nutr-day-tabs"></div>
-  <!-- body -->
+
+  <!-- ── Body: day tabs + meals column | sidebar ── -->
   <div style="display:grid;grid-template-columns:1fr 256px;flex:1;overflow:hidden">
     <div style="display:flex;flex-direction:column;overflow:hidden;border-right:1px solid var(--br)">
-      <div style="flex:1;overflow-y:auto;padding:12px 16px" id="nutr-meals"></div>
-      <div class="meal-add-btn" style="margin:6px 16px 10px" onclick="openDialog('dlg-add-meal')"><span>+</span><span>Přidat jídlo</span></div>
+
+      <!-- Day tabs row with expand-week toggle on the right -->
+      <div style="display:flex;align-items:center;border-bottom:1px solid var(--br);flex-shrink:0">
+        <div class="day-tabs" id="nutr-day-tabs" style="flex:1;min-width:0"></div>
+        <button type="button" onclick="showToast('Přehled týdne')" title="Přehled celého týdne" style="flex-shrink:0;padding:0 10px;border:none;background:none;cursor:pointer;color:var(--t3);font-family:inherit;font-size:14px;align-self:stretch">⊞</button>
+      </div>
+
+      <!-- Meals column -->
+      <div style="flex:1;overflow-y:auto;padding:12px 20px">
+
+        <!-- Day note input (like DayNoteInput in code) -->
+        <div style="margin-bottom:10px">
+          <textarea class="form-input" rows="1" maxlength="300" placeholder="+ Přidat poznámku k tomuto dni…" style="font-size:12px;color:var(--t2);font-style:italic;resize:vertical;min-height:32px;padding:6px 10px"></textarea>
+        </div>
+
+        <div id="nutr-meals"></div>
+
+        <!-- Add meal button (dashed pill at bottom) -->
+        <div onclick="openDialog('dlg-add-meal')" style="display:inline-flex;align-items:center;gap:6px;padding:6px 14px;margin-top:6px;border:1px dashed var(--br);border-radius:var(--rm);background:none;cursor:pointer;color:var(--t3);font-size:13px;transition:background .1s,color .1s" onmouseover="this.style.background='rgba(120,120,128,.05)';this.style.color='var(--t)'" onmouseout="this.style.background='none';this.style.color='var(--t3)'">
+          <span>+</span><span>Přidat jídlo</span>
+        </div>
+      </div>
+
     </div>
-    <!-- sidebar macros -->
+
+    <!-- ═══════════════ Sidebar (matches NutritionPlanPage.tsx right column) ═══════════════ -->
     <div style="background:var(--bg2);display:flex;flex-direction:column;overflow-y:auto">
+
+      <!-- Start date picker -->
+      <div style="padding:12px;border-bottom:1px solid var(--br)">
+        <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em;margin-bottom:6px">Datum začátku plánu</div>
+        <input type="date" class="form-input" value="2026-02-03" style="font-size:13px;padding:7px 10px;width:100%">
+        <div style="font-size:11px;color:var(--t3);margin-top:4px">Plán začíná v pondělí 3. 2. 2026</div>
+      </div>
+
+      <!-- Macro sidebar (existing JS-driven panel) -->
       <div class="macro-panel">
-        <div class="mp-lbl">Denní přehled</div>
+        <div class="mp-lbl">Kalorie</div>
         <div class="mp-kcal-big" id="nutr-kcal-big">0</div>
         <div class="mp-rem" id="nutr-kcal-rem"></div>
         <div style="height:4px;border-radius:99px;background:var(--bg3);margin-top:6px;overflow:hidden"><div id="nutr-pb-kcal" style="height:100%;border-radius:99px;background:var(--acc);transition:width .3s;width:0%"></div></div>
@@ -1023,17 +1042,60 @@ body.dark .btn-auth-primary { color: #0d0900; }
         <div class="mp-macro-row"><div class="mp-macro-lbl"><div class="mp-macro-dot" style="background:var(--orange)"></div>Sacharidy</div><div class="mp-macro-val"><span class="mp-macro-cur" id="nutr-carbs">0g</span><span class="mp-macro-max"> / 180g</span></div></div>
         <div style="height:3px;border-radius:99px;background:var(--bg3);margin-bottom:8px;overflow:hidden"><div id="nutr-pb-c" style="height:100%;border-radius:99px;background:var(--orange);transition:width .3s;width:0%"></div></div>
         <div class="mp-macro-row"><div class="mp-macro-lbl"><div class="mp-macro-dot" style="background:var(--purple)"></div>Tuky</div><div class="mp-macro-val"><span class="mp-macro-cur" id="nutr-fat">0g</span><span class="mp-macro-max"> / 55g</span></div></div>
-        <div style="height:3px;border-radius:99px;background:var(--bg3);margin-bottom:0;overflow:hidden"><div id="nutr-pb-f" style="height:100%;border-radius:99px;background:var(--purple);transition:width .3s;width:0%"></div></div>
+        <div style="height:3px;border-radius:99px;background:var(--bg3);margin-bottom:8px;overflow:hidden"><div id="nutr-pb-f" style="height:100%;border-radius:99px;background:var(--purple);transition:width .3s;width:0%"></div></div>
+        <div class="mp-macro-row"><div class="mp-macro-lbl"><div class="mp-macro-dot" style="background:var(--green)"></div>Vláknina</div><div class="mp-macro-val"><span class="mp-macro-cur">22g</span><span class="mp-macro-max"> / 30g</span></div></div>
+        <div style="height:3px;border-radius:99px;background:var(--bg3);margin-bottom:0;overflow:hidden"><div style="width:73%;height:100%;border-radius:99px;background:var(--green)"></div></div>
       </div>
-      <div class="macro-panel" style="border-bottom:0">
-        <div class="mp-lbl">Klient</div>
+
+      <!-- Plan / client info -->
+      <div style="padding:12px;border-top:1px solid var(--br)">
+        <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em;margin-bottom:8px">Klient &amp; plán</div>
         <div style="font-size:12px;display:flex;flex-direction:column;gap:4px;margin-bottom:10px">
-          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Jméno</span><span>Petra Horáková</span></div>
-          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Cíl</span><span class="tag tag-blue" style="font-size:11px">Hubnutí</span></div>
-          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Deficit</span><span>−20 %</span></div>
+          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Klient</span><span style="color:var(--t)">Petra Horáková</span></div>
+          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Název plánu</span><span style="color:var(--t)">Duben / Květen</span></div>
+          <div style="display:flex;justify-content:space-between;align-items:center"><span style="color:var(--t3)">Status týdne</span><span style="font-size:11px;font-weight:500;padding:1px 6px;border-radius:99px;background:rgba(52,199,89,.12);color:#34c759">Publikováno</span></div>
+          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Cíl (kcal)</span><span style="color:var(--t)">1 700 kcal</span></div>
+          <div style="display:flex;justify-content:space-between"><span style="color:var(--t3)">Strategie</span><span class="tag tag-blue" style="font-size:11px">Hubnutí · −20 %</span></div>
         </div>
-        <button class="btn" style="width:100%;justify-content:center;font-size:12px" onclick="showScreen('s-goals')">🎯 Upravit cíle</button>
+        <button class="btn" style="display:flex;align-items:center;justify-content:center;gap:6px;width:100%;padding:7px 0;font-size:12px;margin-bottom:6px" onclick="openDialog('dlg-shopping-list')">🛒 Nákupní seznam</button>
+        <button class="btn" style="display:flex;align-items:center;justify-content:center;gap:6px;width:100%;padding:7px 0;font-size:12px" onclick="showScreen('s-goals')">🎯 Upravit cíle &amp; makra</button>
       </div>
+
+      <!-- Plan questionnaire panel (matches PlanQuestionnairePanel) -->
+      <div style="padding:12px;border-top:1px solid var(--br)">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+          <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em">Dotazník</div>
+          <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(52,199,89,.12);color:#34c759">Vyplněn</span>
+        </div>
+        <div style="background:var(--bg);border:1px solid var(--br);border-radius:var(--rm);padding:10px 12px">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+            <span style="font-size:16px">📋</span>
+            <div style="flex:1;min-width:0">
+              <div style="font-size:12px;font-weight:600;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Výživový vstupní dotazník</div>
+              <div style="font-size:11px;color:var(--t3)">12 otázek · 12. 3. 2026</div>
+            </div>
+          </div>
+          <button class="btn" style="width:100%;justify-content:center;font-size:11px;padding:5px 0" onclick="showScreen('s-client')">Zobrazit odpovědi</button>
+        </div>
+      </div>
+
+      <!-- Photo-diary panel -->
+      <div style="padding:12px;border-top:1px solid var(--br)">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+          <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em">📸 Foto-deník</div>
+          <span style="font-size:10px;font-weight:600;padding:2px 6px;border-radius:99px;background:rgba(52,199,89,.15);color:#34c759">Aktivní</span>
+        </div>
+        <div style="background:var(--bg);border:1px solid var(--br);border-radius:var(--rm);padding:10px 12px">
+          <div style="font-size:12px;font-weight:600;color:var(--t);margin-bottom:4px">Den 3 ze 7</div>
+          <div style="height:4px;background:var(--bg3);border-radius:99px;margin-bottom:8px;overflow:hidden"><div style="width:43%;height:100%;background:#34c759;border-radius:99px"></div></div>
+          <div style="font-size:11px;color:var(--t2);margin-bottom:8px">9 fotek · poslední před 2 h</div>
+          <div style="display:flex;gap:6px">
+            <button class="btn primary" style="flex:1;font-size:11px;padding:5px 8px;justify-content:center" onclick="showScreen('s-client-photos')">Zobrazit</button>
+            <button class="btn" style="flex:1;font-size:11px;padding:5px 8px;justify-content:center" onclick="openDialog('dlg-diary-request')">Nová</button>
+          </div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -569,6 +569,7 @@ body.dark .btn-auth-primary { color: #0d0900; }
   <div class="tn-lbl">Výživa</div>
   <button class="tn-btn" onclick="showScreen('s-nutrition')">Jídelníček</button>
   <button class="tn-btn" onclick="showScreen('s-foods')">Databáze potravin</button>
+  <button class="tn-btn" onclick="showScreen('s-recipes')">Recepty</button>
   <button class="tn-btn" onclick="showScreen('s-goals')">Cíle klienta</button>
   <div class="tn-sep"></div>
   <div class="tn-lbl">Fotky</div>
@@ -1109,23 +1110,53 @@ body.dark .btn-auth-primary { color: #0d0900; }
 <div class="shell">
 <div class="sb" id="sb-foods"></div>
 <div class="main">
-  <div class="ph"><div class="ph-icon">📦</div><h1>Databáze potravin</h1><div class="ph-sub">Vlastní + Open Food Facts</div></div>
+  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><span>Databáze potravin</span></div>
+
+  <div class="ph">
+    <div class="ph-icon">📦</div>
+    <h1>Databáze potravin</h1>
+    <div class="ph-sub">Vlastní potraviny a veřejná databáze (Open Food Facts)</div>
+  </div>
+
+  <!-- Toolbar: view switcher + search + filter + sort + add -->
   <div class="toolbar">
     <div class="tb-view active" id="fv-table" onclick="switchFoodsView('table')">⊞ Tabulka</div>
+    <div class="tb-view" id="fv-list" onclick="switchFoodsView('list')">☰ Seznam</div>
     <div class="tb-view" id="fv-cards" onclick="switchFoodsView('cards')">⬜ Karty</div>
     <div class="tb-sep"></div>
-    <div class="tb-action">⊞ Filtr</div>
-    <div style="margin-left:auto"><button class="btn primary" onclick="openDialog('dlg-add-food')">+ Přidat potravinu</button></div>
-  </div>
-  <div class="pc">
-    <div class="callout" style="margin-bottom:10px;background:rgba(201,168,76,.06);border:1px solid var(--acc-br)">
-      <div class="callout-icon">📸</div>
-      <div class="callout-body">
-        <div class="callout-title">Nové — fotky potravin</div>
-        <div class="callout-text" style="font-size:12px">Potraviny mohou nyní mít vlastní fotku, která se zobrazí klientovi v detailu jídla. Upload se provede z dialogu potraviny.</div>
+    <div class="search-wrap" style="width:240px">
+      <span style="color:var(--t3)">🔍</span>
+      <input type="text" id="foods-search" placeholder="Hledat potravinu..." oninput="renderFoods()">
+    </div>
+    <select class="form-select" id="foods-category-select" onchange="selectFoodCategory(this.value)" style="padding:6px 10px;font-size:13px;min-width:160px">
+      <option value="all" selected>Všechny kategorie</option>
+      <option value="protein">Proteiny</option>
+      <option value="carbs">Sacharidy</option>
+      <option value="veg">Zelenina</option>
+      <option value="fruit">Ovoce</option>
+      <option value="fat">Tuky</option>
+      <option value="dairy">Mléčné</option>
+      <option value="beverages">Nápoje</option>
+      <option value="other">Ostatní</option>
+    </select>
+    <div style="position:relative">
+      <button class="btn" onclick="toggleFoodsSortMenu(this)" style="font-size:12px">↕ Seřadit</button>
+      <div id="foods-sort-menu" style="display:none;position:absolute;right:0;top:100%;margin-top:4px;z-index:20;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);box-shadow:0 4px 12px rgba(0,0,0,.12);padding:4px;min-width:180px">
+        <button class="sort-opt active" onclick="setFoodsSort('name', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--acc);border-radius:4px">Název <span style="float:right;font-size:10px">↑</span></button>
+        <button class="sort-opt" onclick="setFoodsSort('kcal', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">kcal</button>
+        <button class="sort-opt" onclick="setFoodsSort('protein', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Bílkoviny</button>
+        <button class="sort-opt" onclick="setFoodsSort('carbs', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Sacharidy</button>
+        <button class="sort-opt" onclick="setFoodsSort('fat', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Tuky</button>
+        <button class="sort-opt" onclick="setFoodsSort('fiber', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Vláknina</button>
+        <button class="sort-opt" onclick="setFoodsSort('category', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Kategorie</button>
       </div>
     </div>
-    <div class="filter-bar">
+    <div style="margin-left:auto"><button class="btn primary" onclick="openDialog('dlg-add-food')">+ Přidat potravinu</button></div>
+  </div>
+
+  <div class="pc" style="padding:12px 80px">
+    <!-- Chip filter row (kept for the existing filterFoods() JS path) -->
+    <div class="filter-bar" style="display:none">
       <div class="chip active" onclick="filterFoods('all',this)">Vše</div>
       <div class="chip" onclick="filterFoods('protein',this)">Proteiny</div>
       <div class="chip" onclick="filterFoods('carbs',this)">Sacharidy</div>
@@ -1133,21 +1164,140 @@ body.dark .btn-auth-primary { color: #0d0900; }
       <div class="chip" onclick="filterFoods('fat',this)">Tuky</div>
       <div class="chip" onclick="filterFoods('custom',this)" style="margin-left:auto">Vlastní</div>
     </div>
-    <div class="search-wrap" style="margin-bottom:12px">
-      <span style="color:var(--t3)">🔍</span>
-      <input type="text" id="foods-search" placeholder="Hledat potravinu..." oninput="renderFoods()">
-    </div>
+
+    <!-- Table view -->
     <div id="foods-table-view">
       <div class="db-wrap">
         <table class="db-table">
-          <thead><tr><th style="width:44px"></th><th style="width:220px">Název ↑</th><th>Kategorie</th><th>kcal/100g</th><th>Bílk.</th><th>Sach.</th><th>Tuky</th><th>Zdroj</th><th></th></tr></thead>
+          <thead>
+            <tr>
+              <th style="width:220px">Název</th>
+              <th>Poznámka</th>
+              <th style="width:90px">kcal/100g</th>
+              <th style="width:70px">B</th>
+              <th style="width:70px">S</th>
+              <th style="width:70px">T</th>
+              <th style="width:70px">Vl</th>
+              <th style="width:140px">Kategorie</th>
+              <th style="width:44px"></th>
+            </tr>
+          </thead>
           <tbody id="foods-tbody"></tbody>
         </table>
-        <div class="db-add" onclick="openDialog('dlg-add-food')"><span>+</span><span>Přidat vlastní potravinu</span></div>
       </div>
     </div>
+
+    <!-- List view -->
+    <div id="foods-list-view" style="display:none">
+      <div id="foods-list" style="display:flex;flex-direction:column;gap:6px"></div>
+    </div>
+
+    <!-- Cards view -->
     <div id="foods-cards-view" style="display:none">
       <div class="card-grid" id="foods-cards-grid"></div>
+    </div>
+
+    <!-- Pagination -->
+    <div style="margin-top:14px;display:flex;align-items:center;justify-content:space-between;padding:0 4px">
+      <div style="font-size:12px;color:var(--t3)">Zobrazeno <strong style="color:var(--t)">1–50</strong> z 2&nbsp;431</div>
+      <div style="display:flex;gap:4px">
+        <button class="btn" style="font-size:12px;padding:4px 10px" disabled>‹</button>
+        <button class="btn primary" style="font-size:12px;padding:4px 10px">1</button>
+        <button class="btn" style="font-size:12px;padding:4px 10px">2</button>
+        <button class="btn" style="font-size:12px;padding:4px 10px">3</button>
+        <span style="padding:4px 6px;font-size:12px;color:var(--t3)">…</span>
+        <button class="btn" style="font-size:12px;padding:4px 10px">49</button>
+        <button class="btn" style="font-size:12px;padding:4px 10px">›</button>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════
+     DATABÁZE RECEPTŮ
+═══════════════════════════════════════════════════════════ -->
+<div id="s-recipes" class="screen">
+<div class="shell">
+<div class="sb" id="sb-recipes"></div>
+<div class="main">
+  <div class="bc"><a onclick="showScreen('s-dashboard')">Dashboard</a><span class="bc-sep">/</span><span>Recepty</span></div>
+
+  <div class="ph">
+    <div class="ph-icon">📖</div>
+    <h1>Recepty</h1>
+    <div class="ph-sub">Vlastní recepty, které můžeš přiřadit do jídelníčků</div>
+  </div>
+
+  <!-- Toolbar: view switcher + search + sort + add -->
+  <div class="toolbar">
+    <div class="tb-view active" id="rv-table" onclick="switchRecipesView('table')">⊞ Tabulka</div>
+    <div class="tb-view" id="rv-list" onclick="switchRecipesView('list')">☰ Seznam</div>
+    <div class="tb-view" id="rv-cards" onclick="switchRecipesView('cards')">⬜ Karty</div>
+    <div class="tb-sep"></div>
+    <div class="search-wrap" style="width:240px">
+      <span style="color:var(--t3)">🔍</span>
+      <input type="text" id="recipes-search" placeholder="Hledat recept..." oninput="renderRecipesGrid()">
+    </div>
+    <div style="position:relative">
+      <button class="btn" onclick="toggleRecipesSortMenu(this)" style="font-size:12px">↕ Seřadit</button>
+      <div id="recipes-sort-menu" style="display:none;position:absolute;right:0;top:100%;margin-top:4px;z-index:20;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);box-shadow:0 4px 12px rgba(0,0,0,.12);padding:4px;min-width:180px">
+        <button class="sort-opt active" onclick="setRecipesSort('name', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--acc);border-radius:4px">Název <span style="float:right;font-size:10px">↑</span></button>
+        <button class="sort-opt" onclick="setRecipesSort('kcal', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">kcal</button>
+        <button class="sort-opt" onclick="setRecipesSort('protein', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Bílkoviny</button>
+        <button class="sort-opt" onclick="setRecipesSort('carbs', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Sacharidy</button>
+        <button class="sort-opt" onclick="setRecipesSort('fat', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Tuky</button>
+        <button class="sort-opt" onclick="setRecipesSort('fiber', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Vláknina</button>
+        <button class="sort-opt" onclick="setRecipesSort('foodCount', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Počet ingrediencí</button>
+        <button class="sort-opt" onclick="setRecipesSort('prepTime', this)" style="display:block;width:100%;text-align:left;padding:6px 10px;background:none;border:none;cursor:pointer;font-size:12px;color:var(--t);border-radius:4px">Doba přípravy</button>
+      </div>
+    </div>
+    <div style="margin-left:auto"><button class="btn primary" onclick="showToast('Editor receptu')">+ Přidat recept</button></div>
+  </div>
+
+  <div class="pc" style="padding:12px 80px">
+
+    <!-- Table view -->
+    <div id="recipes-table-view">
+      <div class="db-wrap">
+        <table class="db-table">
+          <thead>
+            <tr>
+              <th>Název</th>
+              <th style="width:100px">Ingrediencí</th>
+              <th style="width:100px">Doba</th>
+              <th style="width:80px">kcal</th>
+              <th style="width:70px">B</th>
+              <th style="width:70px">S</th>
+              <th style="width:70px">T</th>
+              <th style="width:70px">Vl</th>
+              <th style="width:44px"></th>
+            </tr>
+          </thead>
+          <tbody id="recipes-tbody"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- List view -->
+    <div id="recipes-list-view" style="display:none">
+      <div id="recipes-list" style="display:flex;flex-direction:column;gap:6px"></div>
+    </div>
+
+    <!-- Cards view -->
+    <div id="recipes-cards-view" style="display:none">
+      <div class="card-grid" id="recipes-cards-grid"></div>
+    </div>
+
+    <!-- Pagination -->
+    <div style="margin-top:14px;display:flex;align-items:center;justify-content:space-between;padding:0 4px">
+      <div style="font-size:12px;color:var(--t3)">Zobrazeno <strong style="color:var(--t)">1–8</strong> z 8</div>
+      <div style="display:flex;gap:4px">
+        <button class="btn" style="font-size:12px;padding:4px 10px" disabled>‹</button>
+        <button class="btn primary" style="font-size:12px;padding:4px 10px">1</button>
+        <button class="btn" style="font-size:12px;padding:4px 10px" disabled>›</button>
+      </div>
     </div>
   </div>
 </div>
@@ -3077,19 +3227,19 @@ var CLIENTS = [
 ];
 
 var FOODS_DB = [
-  {name:'Kuřecí prsa',cat:'Proteiny',catTag:'tag-blue',kcal:115,p:21.5,c:0,f:2.5,src:'OFF',custom:false},
-  {name:'Ovesné vločky',cat:'Sacharidy',catTag:'tag-orange',kcal:370,p:13,c:64,f:7,src:'OFF',custom:false},
-  {name:'Losos',cat:'Proteiny',catTag:'tag-blue',kcal:206,p:20,c:0,f:13,src:'OFF',custom:false},
-  {name:'Řecký jogurt 0%',cat:'Mléčné',catTag:'tag-gray',kcal:59,p:10,c:5,f:0.5,src:'OFF',custom:false},
-  {name:'Protein WPC 80',cat:'Suplementy',catTag:'tag-purple',kcal:113,p:24,c:3,f:1.5,src:'Vlastní',custom:true},
-  {name:'Batáty',cat:'Sacharidy',catTag:'tag-orange',kcal:86,p:1.6,c:20,f:0.1,src:'OFF',custom:false},
-  {name:'Vejce L',cat:'Proteiny',catTag:'tag-blue',kcal:155,p:13,c:1.1,f:11,src:'OFF',custom:false},
-  {name:'Avokádo',cat:'Tuky',catTag:'tag-green',kcal:160,p:2,c:9,f:15,src:'OFF',custom:false},
-  {name:'Borůvky',cat:'Ovoce',catTag:'tag-green',kcal:57,p:0.7,c:14,f:0.3,src:'OFF',custom:false},
-  {name:'Brokolice',cat:'Zelenina',catTag:'tag-green',kcal:34,p:3,c:5,f:0.4,src:'OFF',custom:false},
-  {name:'Tvaroh 0%',cat:'Mléčné',catTag:'tag-gray',kcal:73,p:12,c:4,f:0.6,src:'OFF',custom:false},
-  {name:'Banán',cat:'Ovoce',catTag:'tag-green',kcal:89,p:1.1,c:23,f:0.3,src:'OFF',custom:false},
-  {name:'Hnědá rýže',cat:'Sacharidy',catTag:'tag-orange',kcal:360,p:7.5,c:75,f:2.5,src:'OFF',custom:false},
+  {name:'Kuřecí prsa',cat:'Proteiny',catTag:'tag-blue',kcal:115,p:21.5,c:0,f:2.5,fi:0,note:'Libové, bez vidit. tuku',src:'OFF',custom:false},
+  {name:'Ovesné vločky',cat:'Sacharidy',catTag:'tag-orange',kcal:370,p:13,c:64,f:7,fi:10,note:'Jemné, ne instantní',src:'OFF',custom:false},
+  {name:'Losos',cat:'Proteiny',catTag:'tag-blue',kcal:206,p:20,c:0,f:13,fi:0,note:'Divoký aljašský',src:'OFF',custom:false},
+  {name:'Řecký jogurt 0%',cat:'Mléčné',catTag:'tag-gray',kcal:59,p:10,c:5,f:0.5,fi:0,note:null,src:'OFF',custom:false},
+  {name:'Protein WPC 80',cat:'Suplementy',catTag:'tag-purple',kcal:113,p:24,c:3,f:1.5,fi:0,note:'Vanilka',src:'Vlastní',custom:true},
+  {name:'Batáty',cat:'Sacharidy',catTag:'tag-orange',kcal:86,p:1.6,c:20,f:0.1,fi:3,note:null,src:'OFF',custom:false},
+  {name:'Vejce L',cat:'Proteiny',catTag:'tag-blue',kcal:155,p:13,c:1.1,f:11,fi:0,note:null,src:'OFF',custom:false},
+  {name:'Avokádo',cat:'Tuky',catTag:'tag-green',kcal:160,p:2,c:9,f:15,fi:7,note:null,src:'OFF',custom:false},
+  {name:'Borůvky',cat:'Ovoce',catTag:'tag-green',kcal:57,p:0.7,c:14,f:0.3,fi:2.4,note:null,src:'OFF',custom:false},
+  {name:'Brokolice',cat:'Zelenina',catTag:'tag-green',kcal:34,p:3,c:5,f:0.4,fi:2.6,note:'Syrová',src:'OFF',custom:false},
+  {name:'Tvaroh 0%',cat:'Mléčné',catTag:'tag-gray',kcal:73,p:12,c:4,f:0.6,fi:0,note:null,src:'OFF',custom:false},
+  {name:'Banán',cat:'Ovoce',catTag:'tag-green',kcal:89,p:1.1,c:23,f:0.3,fi:2.6,note:null,src:'OFF',custom:false},
+  {name:'Hnědá rýže',cat:'Sacharidy',catTag:'tag-orange',kcal:360,p:7.5,c:75,f:2.5,fi:3.4,note:null,src:'OFF',custom:false},
 ];
 
 var EXERCISES_DB = [
@@ -3161,7 +3311,8 @@ function buildSidebar(containerId, activeScreen){
   });
   html+='<div class="sb-item" onclick="openDialog(\'dlg-new-client\')" style="color:var(--t3)"><span class="sbi-icon">+</span><span class="sbi-lbl">Přidat klienta</span></div></div>';
   html+='<div class="sb-div"></div><div class="sb-sec"><div class="sb-sec-lbl">Databáze</div>';
-  html+='<div class="sb-item'+(activeScreen==='s-foods'?' active':'')+'" onclick="showScreen(\'s-foods\')"><span class="sbi-icon">📦</span><span class="sbi-lbl">Potraviny</span></div></div>';
+  html+='<div class="sb-item'+(activeScreen==='s-foods'?' active':'')+'" onclick="showScreen(\'s-foods\')"><span class="sbi-icon">📦</span><span class="sbi-lbl">Potraviny</span></div>';
+  html+='<div class="sb-item'+(activeScreen==='s-recipes'?' active':'')+'" onclick="showScreen(\'s-recipes\')"><span class="sbi-icon">📖</span><span class="sbi-lbl">Recepty</span></div></div>';
   html+='<div class="sb-user"><div class="sb-avatar">MT</div><div><div style="font-size:13px;font-weight:500">Marek Trenér</div><div style="font-size:11px;color:var(--t3)">Trenér & výživa</div></div></div>';
   el.innerHTML=html;
 }
@@ -3175,7 +3326,7 @@ function showScreen(id){
   document.querySelectorAll('.tn-btn').forEach(function(b){if(b.getAttribute('onclick')==="showScreen('"+id+"')") b.classList.add('active');});
   window.scrollTo(0,0);
   // Build sidebars
-  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins','s-client-photos':'sb-client-photos','s-profile':'sb-profile'};
+  var sbMap={'s-dashboard':'sb-dashboard','s-client':'sb-client','s-training':'sb-training','s-messages':'sb-messages','s-nutrition':'sb-nutrition','s-foods':'sb-foods','s-goals':'sb-goals','s-settings-checkins':'sb-settings-checkins','s-client-photos':'sb-client-photos','s-profile':'sb-profile','s-recipes':'sb-recipes'};
   if(sbMap[id]) buildSidebar(sbMap[id],id);
   // Init nutrition editor
   if(id==='s-nutrition'&&!_nutrInit){_nutrInit=true;initNutrition();}
@@ -3183,6 +3334,7 @@ function showScreen(id){
   if(id==='s-training'){renderTrainingExercises();}
   if(id==='s-messages'){renderMessages();}
   if(id==='s-foods'){renderFoods();}
+  if(id==='s-recipes'){renderRecipesGrid();}
   if(id==='s-dashboard'){renderDashboard();}
 }
 
@@ -3309,18 +3461,47 @@ function addClient(){
 }
 
 // ── FOODS ─────────────────────────────────────────────────────────────────────
+var _foodsSort={key:'name',dir:'asc'};
+var _recipesSort={key:'name',dir:'asc'};
+
 function switchFoodsView(v){
-  document.getElementById('foods-table-view').style.display=v==='table'?'block':'none';
-  document.getElementById('foods-cards-view').style.display=v==='cards'?'block':'none';
-  document.getElementById('fv-table').classList.toggle('active',v==='table');
-  document.getElementById('fv-cards').classList.toggle('active',v==='cards');
+  var tbl=document.getElementById('foods-table-view');
+  var lst=document.getElementById('foods-list-view');
+  var crd=document.getElementById('foods-cards-view');
+  if(tbl) tbl.style.display=v==='table'?'block':'none';
+  if(lst) lst.style.display=v==='list' ?'block':'none';
+  if(crd) crd.style.display=v==='cards'?'block':'none';
+  ['table','list','cards'].forEach(function(id){
+    var el=document.getElementById('fv-'+id); if(el) el.classList.toggle('active',id===v);
+  });
   renderFoods();
 }
 
 function filterFoods(cat,el){
   _foodsFilter=cat;
   document.querySelectorAll('#s-foods .chip').forEach(function(c){c.classList.remove('active');});
-  el.classList.add('active');
+  if(el) el.classList.add('active');
+  renderFoods();
+}
+
+function selectFoodCategory(value){
+  // select-driven filter; maps to same _foodsFilter values renderFoods() understands
+  _foodsFilter=value==='all'?'all':value;
+  renderFoods();
+}
+
+function toggleFoodsSortMenu(btn){
+  var menu=document.getElementById('foods-sort-menu'); if(!menu) return;
+  var open=menu.style.display==='block';
+  menu.style.display=open?'none':'block';
+}
+
+function setFoodsSort(key,el){
+  if(_foodsSort.key===key) _foodsSort.dir=_foodsSort.dir==='asc'?'desc':'asc';
+  else { _foodsSort.key=key; _foodsSort.dir='asc'; }
+  document.querySelectorAll('#foods-sort-menu .sort-opt').forEach(function(o){o.classList.remove('active');o.style.color='var(--t)';});
+  if(el){ el.classList.add('active'); el.style.color='var(--acc)'; }
+  document.getElementById('foods-sort-menu').style.display='none';
   renderFoods();
 }
 
@@ -3330,36 +3511,204 @@ function renderFoods(){
     if(_foodsFilter==='custom') return f.custom;
     if(_foodsFilter==='protein') return f.cat==='Proteiny';
     if(_foodsFilter==='carbs') return f.cat==='Sacharidy';
-    if(_foodsFilter==='veg') return f.cat==='Zelenina';
+    if(_foodsFilter==='veg'||_foodsFilter==='vegetables') return f.cat==='Zelenina';
+    if(_foodsFilter==='fruit') return f.cat==='Ovoce';
     if(_foodsFilter==='fat') return f.cat==='Tuky';
+    if(_foodsFilter==='dairy') return f.cat==='Mléčné';
+    if(_foodsFilter==='beverages') return f.cat==='Nápoje';
+    if(_foodsFilter==='other') return f.cat==='Ostatní';
     return true;
   }).filter(function(f){return !q||f.name.toLowerCase().includes(q);});
 
-  // table
-  var tb=document.getElementById('foods-tbody'); if(!tb) return;
-  var html='';
-  list.forEach(function(f){
-    html+='<tr><td><span class="row-title">'+f.name+'</span></td>';
-    html+='<td><span class="tag '+f.catTag+'">'+f.cat+'</span></td>';
-    html+='<td>'+f.kcal+'</td><td style="color:var(--blue)">'+f.p+'</td><td style="color:var(--orange)">'+f.c+'</td><td style="color:var(--purple)">'+f.f+'</td>';
-    html+='<td><span class="tag '+(f.custom?'tag-acc':'tag-gray')+'">'+f.src+'</span></td>';
-    html+='<td><div class="row-acts"><button onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')">Přidat</button><button>Upravit</button></div></td></tr>';
+  // Sort
+  var dir=_foodsSort.dir==='asc'?1:-1;
+  list.sort(function(a,b){
+    var cmp=0;
+    switch(_foodsSort.key){
+      case 'name': cmp=a.name.localeCompare(b.name); break;
+      case 'kcal': cmp=a.kcal-b.kcal; break;
+      case 'protein': cmp=a.p-b.p; break;
+      case 'carbs': cmp=a.c-b.c; break;
+      case 'fat': cmp=a.f-b.f; break;
+      case 'fiber': cmp=(a.fi||0)-(b.fi||0); break;
+      case 'category': cmp=(a.cat||'').localeCompare(b.cat||''); break;
+    }
+    return cmp*dir;
   });
-  tb.innerHTML=html;
+
+  var deleteBtn='<button class="row-act-btn" title="Smazat" onclick="event.stopPropagation();showToast(\'Potravina smazána\')" style="background:none;border:none;padding:4px;color:var(--t3);cursor:pointer">🗑</button>';
+
+  // table
+  var tb=document.getElementById('foods-tbody');
+  if(tb){
+    var html='';
+    list.forEach(function(f){
+      var note=f.note||'—';
+      html+='<tr onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')" style="cursor:pointer">';
+      html+='<td><span class="row-title">'+f.name+'</span></td>';
+      html+='<td style="color:var(--t3);font-style:italic;font-size:12px">'+note+'</td>';
+      html+='<td class="tabular-nums">'+f.kcal+'</td>';
+      html+='<td class="tabular-nums" style="color:var(--blue)">'+f.p+'g</td>';
+      html+='<td class="tabular-nums" style="color:var(--orange)">'+f.c+'g</td>';
+      html+='<td class="tabular-nums" style="color:var(--purple)">'+f.f+'g</td>';
+      html+='<td class="tabular-nums" style="color:var(--green)">'+(f.fi||0)+'g</td>';
+      html+='<td><span class="tag '+f.catTag+'" style="font-size:11px">'+f.cat+'</span></td>';
+      html+='<td>'+deleteBtn+'</td></tr>';
+    });
+    tb.innerHTML=html;
+  }
+
+  // list
+  var lv=document.getElementById('foods-list');
+  if(lv){
+    var html='';
+    list.forEach(function(f){
+      html+='<div onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')" style="display:flex;align-items:center;gap:10px;padding:8px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer">';
+      html+='<div style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;background:rgba(201,168,76,.12);color:var(--acc);flex-shrink:0">'+f.name.charAt(0).toUpperCase()+'</div>';
+      html+='<div style="flex:1;min-width:0">';
+      html+='<div style="font-size:13px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+f.name+'</div>';
+      html+='<div style="font-size:11px;color:var(--t3);display:flex;align-items:center;gap:8px;margin-top:2px"><span class="tag '+f.catTag+'" style="font-size:10px">'+f.cat+'</span><span class="tabular-nums">'+f.kcal+' kcal/100g</span></div>';
+      html+='</div>';
+      html+='<div style="display:flex;gap:4px;font-size:11px" class="tabular-nums">';
+      html+='<span style="color:var(--blue)">B '+f.p+'g</span><span style="color:var(--orange)">S '+f.c+'g</span><span style="color:var(--purple)">T '+f.f+'g</span><span style="color:var(--green)">Vl '+(f.fi||0)+'g</span>';
+      html+='</div>';
+      html+='<div style="margin-left:6px">'+deleteBtn+'</div>';
+      html+='</div>';
+    });
+    lv.innerHTML=html;
+  }
 
   // cards
-  var cg=document.getElementById('foods-cards-grid'); if(!cg) return;
-  html='';
-  list.forEach(function(f){
-    html+='<div class="n-card"><div class="card-cover" style="height:56px"><div class="card-pattern"></div></div><div class="card-body">';
-    html+='<div class="card-title" style="font-size:13px">'+f.name+'</div>';
-    html+='<div class="card-prop"><span class="tag '+f.catTag+'" style="font-size:11px">'+f.cat+'</span></div>';
-    html+='<div class="card-prop" style="margin-top:4px"><span class="card-prop-val" style="font-weight:600">'+f.kcal+' kcal</span></div>';
-    html+='<div class="card-prop" style="font-size:11px"><span style="color:var(--blue)">B'+f.p+'</span> <span style="color:var(--orange)">S'+f.c+'</span> <span style="color:var(--purple)">T'+f.f+'</span></div>';
-    html+='<button class="btn sm" style="margin-top:6px" onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')">+ Přidat</button>';
-    html+='</div></div>';
+  var cg=document.getElementById('foods-cards-grid');
+  if(cg){
+    var html='';
+    list.forEach(function(f){
+      html+='<div class="n-card" onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')" style="cursor:pointer"><div class="card-cover" style="height:80px;background:var(--bg3);display:flex;align-items:center;justify-content:center;font-size:28px;opacity:.5">📦</div><div class="card-body">';
+      html+='<div class="card-title" style="font-size:13px;font-weight:500;margin-bottom:6px">'+f.name+'</div>';
+      html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>kcal</span><span class="tabular-nums" style="color:var(--t);font-weight:600">'+f.kcal+'</span></div>';
+      html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>B / S / T / Vl</span><span class="tabular-nums"><span style="color:var(--blue)">'+f.p+'</span> <span style="color:var(--orange)">'+f.c+'</span> <span style="color:var(--purple)">'+f.f+'</span> <span style="color:var(--green)">'+(f.fi||0)+'</span></span></div>';
+      html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3)"><span>Kategorie</span><span class="tag '+f.catTag+'" style="font-size:10px">'+f.cat+'</span></div>';
+      html+='</div></div>';
+    });
+    cg.innerHTML=html;
+  }
+}
+
+// ── RECIPES DATABASE ──────────────────────────────────────────────────────────
+var RECIPES_DB = [
+  { recipeId:'r1', name:'Losos s quinoou a grilovanou zeleninou', foodCount:6, prepTime:25, kcal:485, p:38, c:36, f:18, fi:6 },
+  { recipeId:'r2', name:'Kuřecí salát Caesar', foodCount:8, prepTime:15, kcal:420, p:42, c:22, f:19, fi:4 },
+  { recipeId:'r3', name:'Ovesná kaše s ovocem a oříšky', foodCount:5, prepTime:10, kcal:390, p:18, c:58, f:12, fi:8 },
+  { recipeId:'r4', name:'Ryžové misky s tofu a zeleninou', foodCount:7, prepTime:20, kcal:510, p:28, c:72, f:14, fi:7 },
+  { recipeId:'r5', name:'Tuňákové tortilly', foodCount:6, prepTime:12, kcal:450, p:35, c:44, f:15, fi:5 },
+  { recipeId:'r6', name:'Vaječná omeleta se špenátem', foodCount:4, prepTime:8, kcal:310, p:26, c:8, f:20, fi:3 },
+  { recipeId:'r7', name:'Tvarohový dezert s lesním ovocem', foodCount:4, prepTime:5, kcal:220, p:25, c:22, f:4, fi:4 },
+  { recipeId:'r8', name:'Hovězí guláš s knedlíkem', foodCount:9, prepTime:90, kcal:620, p:38, c:58, f:24, fi:5 }
+];
+
+function switchRecipesView(v){
+  var tbl=document.getElementById('recipes-table-view');
+  var lst=document.getElementById('recipes-list-view');
+  var crd=document.getElementById('recipes-cards-view');
+  if(tbl) tbl.style.display=v==='table'?'block':'none';
+  if(lst) lst.style.display=v==='list' ?'block':'none';
+  if(crd) crd.style.display=v==='cards'?'block':'none';
+  ['table','list','cards'].forEach(function(id){
+    var el=document.getElementById('rv-'+id); if(el) el.classList.toggle('active',id===v);
   });
-  cg.innerHTML=html;
+  renderRecipesGrid();
+}
+
+function toggleRecipesSortMenu(btn){
+  var menu=document.getElementById('recipes-sort-menu'); if(!menu) return;
+  menu.style.display=menu.style.display==='block'?'none':'block';
+}
+
+function setRecipesSort(key,el){
+  if(_recipesSort.key===key) _recipesSort.dir=_recipesSort.dir==='asc'?'desc':'asc';
+  else { _recipesSort.key=key; _recipesSort.dir='asc'; }
+  document.querySelectorAll('#recipes-sort-menu .sort-opt').forEach(function(o){o.classList.remove('active');o.style.color='var(--t)';});
+  if(el){ el.classList.add('active'); el.style.color='var(--acc)'; }
+  document.getElementById('recipes-sort-menu').style.display='none';
+  renderRecipesGrid();
+}
+
+function renderRecipesGrid(){
+  var q=(document.getElementById('recipes-search')||{value:''}).value.toLowerCase();
+  var list=RECIPES_DB.filter(function(r){return !q||r.name.toLowerCase().includes(q);});
+
+  var dir=_recipesSort.dir==='asc'?1:-1;
+  list.sort(function(a,b){
+    var cmp=0;
+    switch(_recipesSort.key){
+      case 'name': cmp=a.name.localeCompare(b.name); break;
+      case 'kcal': cmp=a.kcal-b.kcal; break;
+      case 'protein': cmp=a.p-b.p; break;
+      case 'carbs': cmp=a.c-b.c; break;
+      case 'fat': cmp=a.f-b.f; break;
+      case 'fiber': cmp=(a.fi||0)-(b.fi||0); break;
+      case 'foodCount': cmp=a.foodCount-b.foodCount; break;
+      case 'prepTime': cmp=(a.prepTime||0)-(b.prepTime||0); break;
+    }
+    return cmp*dir;
+  });
+
+  var deleteBtn='<button title="Smazat" onclick="event.stopPropagation();showToast(\'Recept smazán\')" style="background:none;border:none;padding:4px;color:var(--t3);cursor:pointer">🗑</button>';
+
+  // table
+  var tb=document.getElementById('recipes-tbody');
+  if(tb){
+    var html='';
+    list.forEach(function(r){
+      html+='<tr onclick="showToast(\'Editor receptu: '+r.name+'\')" style="cursor:pointer">';
+      html+='<td><span class="row-title">'+r.name+'</span></td>';
+      html+='<td class="tabular-nums" style="color:var(--t2)">'+r.foodCount+'</td>';
+      html+='<td class="tabular-nums" style="color:var(--t3)">'+(r.prepTime?r.prepTime+' min':'—')+'</td>';
+      html+='<td class="tabular-nums">'+r.kcal+'</td>';
+      html+='<td class="tabular-nums" style="color:var(--blue)">'+r.p+'g</td>';
+      html+='<td class="tabular-nums" style="color:var(--orange)">'+r.c+'g</td>';
+      html+='<td class="tabular-nums" style="color:var(--purple)">'+r.f+'g</td>';
+      html+='<td class="tabular-nums" style="color:var(--green)">'+(r.fi||0)+'g</td>';
+      html+='<td>'+deleteBtn+'</td></tr>';
+    });
+    tb.innerHTML=html;
+  }
+
+  // list
+  var lv=document.getElementById('recipes-list');
+  if(lv){
+    var html='';
+    list.forEach(function(r){
+      html+='<div onclick="showToast(\'Editor receptu: '+r.name+'\')" style="display:flex;align-items:center;gap:10px;padding:8px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer">';
+      html+='<div style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:14px;background:var(--acc-bg);color:var(--acc);flex-shrink:0">📖</div>';
+      html+='<div style="flex:1;min-width:0">';
+      html+='<div style="font-size:13px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+r.name+'</div>';
+      html+='<div style="font-size:11px;color:var(--t3);display:flex;align-items:center;gap:8px;margin-top:2px"><span>'+r.foodCount+' ingrediencí</span>'+(r.prepTime?'<span>· '+r.prepTime+' min</span>':'')+'<span class="tabular-nums">· '+r.kcal+' kcal</span></div>';
+      html+='</div>';
+      html+='<div style="display:flex;gap:4px;font-size:11px" class="tabular-nums">';
+      html+='<span style="color:var(--blue)">B '+r.p+'g</span><span style="color:var(--orange)">S '+r.c+'g</span><span style="color:var(--purple)">T '+r.f+'g</span><span style="color:var(--green)">Vl '+(r.fi||0)+'g</span>';
+      html+='</div>';
+      html+='<div style="margin-left:6px">'+deleteBtn+'</div>';
+      html+='</div>';
+    });
+    lv.innerHTML=html;
+  }
+
+  // cards
+  var cg=document.getElementById('recipes-cards-grid');
+  if(cg){
+    var html='';
+    list.forEach(function(r){
+      html+='<div class="n-card" onclick="showToast(\'Editor receptu: '+r.name+'\')" style="cursor:pointer"><div class="card-cover" style="height:90px;background:linear-gradient(135deg,var(--acc-bg),var(--bg3));display:flex;align-items:center;justify-content:center;font-size:32px;opacity:.7">📖</div><div class="card-body">';
+      html+='<div class="card-title" style="font-size:13px;font-weight:500;margin-bottom:6px">'+r.name+'</div>';
+      html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>kcal</span><span class="tabular-nums" style="color:var(--t);font-weight:600">'+r.kcal+'</span></div>';
+      html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>B / S / T / Vl</span><span class="tabular-nums"><span style="color:var(--blue)">'+r.p+'</span> <span style="color:var(--orange)">'+r.c+'</span> <span style="color:var(--purple)">'+r.f+'</span> <span style="color:var(--green)">'+(r.fi||0)+'</span></span></div>';
+      html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>Ingredience</span><span class="tabular-nums" style="color:var(--t)">'+r.foodCount+'</span></div>';
+      if(r.prepTime){ html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3)"><span>Doba</span><span class="tabular-nums" style="color:var(--t)">'+r.prepTime+' min</span></div>'; }
+      html+='</div></div>';
+    });
+    cg.innerHTML=html;
+  }
 }
 
 // ── PLAN FOOD DIALOG ──────────────────────────────────────────────────────────

--- a/docs/notion_portal.html
+++ b/docs/notion_portal.html
@@ -2993,6 +2993,188 @@ body.dark .btn-auth-primary { color: #0d0900; }
 </div>
 
 <!-- Přidat potravinu do plánu -->
+<!-- ═══════ Food detail dialog (view + edit, mirrors FoodDialog.tsx) ═══════ -->
+<div class="overlay" id="dlg-food-detail" onclick="closeOnOverlay(event,'dlg-food-detail')">
+  <div class="dialog" id="dlg-food-detail-inner" style="max-width:500px;padding:0;overflow:hidden;display:flex;flex-direction:column">
+    <!-- Hero -->
+    <div style="height:120px;background:var(--bg3);position:relative;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+      <span style="font-size:40px;opacity:.2">📦</span>
+      <div id="food-dlg-hero-overlay" style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 30%,rgba(0,0,0,.4));display:flex;flex-direction:column;justify-content:flex-end;padding:12px 20px">
+        <div id="food-dlg-hero-name" style="font-size:20px;font-weight:700;color:#fff;letter-spacing:-.02em">Kuřecí prsa</div>
+        <div style="font-size:12px;color:rgba(255,255,255,.75);margin-top:2px;display:flex;align-items:center;gap:6px">
+          <span id="food-dlg-hero-cat" class="tag tag-blue" style="font-size:10px">Proteiny</span>
+          <span>na 100 g</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Header -->
+    <div style="display:flex;align-items:center;gap:12px;padding:10px 20px;border-bottom:1px solid var(--br);flex-shrink:0">
+      <div style="flex:1;min-width:0">
+        <div id="food-dlg-title" style="font-size:16px;font-weight:600;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Kuřecí prsa</div>
+        <div id="food-dlg-subtitle" style="font-size:12px;color:var(--t3);margin-top:2px">Libové, bez vidit. tuku</div>
+      </div>
+      <button onclick="closeDialog('dlg-food-detail')" style="background:none;border:none;cursor:pointer;font-size:18px;color:var(--t3);padding:4px">✕</button>
+    </div>
+
+    <!-- Body (scrollable) -->
+    <div style="flex:1;overflow-y:auto;padding:12px 20px;min-height:0">
+
+      <!-- VIEW MODE content -->
+      <div id="food-dlg-view">
+        <!-- Macro strip -->
+        <div style="display:flex;gap:8px;margin-bottom:14px">
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="food-dlg-kcal" style="font-size:16px;font-weight:700;color:var(--acc);letter-spacing:-.02em">115</div><div style="font-size:11px;color:var(--t3);margin-top:2px">kcal</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="food-dlg-p" style="font-size:16px;font-weight:700;color:var(--blue);letter-spacing:-.02em">21.5g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Bílkoviny</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="food-dlg-c" style="font-size:16px;font-weight:700;color:var(--orange);letter-spacing:-.02em">0g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Sacharidy</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="food-dlg-f" style="font-size:16px;font-weight:700;color:var(--purple);letter-spacing:-.02em">2.5g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Tuky</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="food-dlg-fi" style="font-size:16px;font-weight:700;color:var(--green);letter-spacing:-.02em">0g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Vláknina</div></div>
+        </div>
+
+        <!-- Localized names -->
+        <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em;margin-bottom:8px;margin-top:14px">Lokalizované názvy</div>
+        <div id="food-dlg-loc">
+          <div style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px"><span style="width:24px;text-align:center;font-size:10px;font-weight:600;color:var(--t3)">EN</span><span style="color:var(--t)">Chicken breast</span></div>
+          <div style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px"><span style="width:24px;text-align:center;font-size:10px;font-weight:600;color:var(--t3)">CS</span><span style="color:var(--t)">Kuřecí prsa</span></div>
+          <div style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px"><span style="width:24px;text-align:center;font-size:10px;font-weight:600;color:var(--t3)">DE</span><span style="color:var(--t)">Hähnchenbrust</span></div>
+        </div>
+
+        <!-- Note callout -->
+        <div id="food-dlg-note" style="background:var(--acc-bg);border:1px solid var(--acc-br);border-radius:6px;padding:10px 12px;font-size:13px;color:var(--t2);line-height:1.5;margin-top:14px;display:flex;gap:8px;align-items:center">
+          <span style="font-size:16px;flex-shrink:0">💡</span>
+          <span id="food-dlg-note-text">Libové, bez vidit. tuku</span>
+        </div>
+
+        <div style="height:16px"></div>
+      </div>
+
+      <!-- EDIT MODE content -->
+      <div id="food-dlg-edit" style="display:none">
+        <!-- Meta pills -->
+        <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:14px">
+          <div style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:var(--rm);background:var(--bg2);border:1px solid var(--br);font-size:12px">
+            <span style="font-weight:500;color:var(--t3)">Kategorie</span>
+            <select class="form-select" style="background:transparent;border:none;outline:none;font-size:12px;color:var(--t);padding:0;min-width:90px">
+              <option>Proteiny</option><option>Sacharidy</option><option>Zelenina</option>
+              <option>Ovoce</option><option>Tuky</option><option>Mléčné</option>
+              <option>Nápoje</option><option>Suplementy</option><option>Ostatní</option>
+            </select>
+          </div>
+          <div style="display:inline-flex;align-items:center;gap:8px;padding:4px 10px;border-radius:var(--rm);background:var(--bg2);border:1px solid var(--br);font-size:12px">
+            <span style="font-weight:500;color:var(--t3)">Veřejná</span>
+            <div class="toggle on" onclick="this.classList.toggle('on')" style="transform:scale(.75);transform-origin:right"><div class="toggle-thumb"></div></div>
+          </div>
+        </div>
+
+        <!-- Editable macros -->
+        <label style="display:block;font-size:11px;font-weight:500;color:var(--t3);margin-bottom:8px">Nutriční hodnoty na 100 g</label>
+        <div style="display:flex;gap:6px;margin-bottom:14px">
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:6px 4px"><input class="tabular-nums" type="number" value="115" style="width:100%;text-align:center;font-size:14px;font-weight:700;background:transparent;border:none;outline:none;color:var(--acc);letter-spacing:-.01em"><div style="font-size:10px;margin-top:1px;color:var(--t3)">kcal</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:6px 4px"><input class="tabular-nums" type="number" value="21.5" style="width:100%;text-align:center;font-size:14px;font-weight:700;background:transparent;border:none;outline:none;color:var(--blue)"><div style="font-size:10px;margin-top:1px;color:var(--t3)">B (g)</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:6px 4px"><input class="tabular-nums" type="number" value="0" style="width:100%;text-align:center;font-size:14px;font-weight:700;background:transparent;border:none;outline:none;color:var(--orange)"><div style="font-size:10px;margin-top:1px;color:var(--t3)">S (g)</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:6px 4px"><input class="tabular-nums" type="number" value="2.5" style="width:100%;text-align:center;font-size:14px;font-weight:700;background:transparent;border:none;outline:none;color:var(--purple)"><div style="font-size:10px;margin-top:1px;color:var(--t3)">T (g)</div></div>
+          <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);padding:6px 4px"><input class="tabular-nums" type="number" value="0" style="width:100%;text-align:center;font-size:14px;font-weight:700;background:transparent;border:none;outline:none;color:var(--green)"><div style="font-size:10px;margin-top:1px;color:var(--t3)">Vl (g)</div></div>
+        </div>
+
+        <!-- Localized names -->
+        <label style="display:block;font-size:11px;font-weight:500;color:var(--t3);margin-bottom:6px">Lokalizované názvy</label>
+        <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:14px">
+          <div style="display:flex;align-items:center;gap:8px"><span style="font-size:10px;font-weight:600;color:var(--t3);width:24px;text-align:center;flex-shrink:0">EN</span><input class="form-input" value="Chicken breast" placeholder="English name" style="flex:1;font-size:13px;padding:6px 10px"></div>
+          <div style="display:flex;align-items:center;gap:8px"><span style="font-size:10px;font-weight:600;color:var(--t3);width:24px;text-align:center;flex-shrink:0">CS</span><input class="form-input" value="Kuřecí prsa" placeholder="Český název" style="flex:1;font-size:13px;padding:6px 10px"></div>
+          <div style="display:flex;align-items:center;gap:8px"><span style="font-size:10px;font-weight:600;color:var(--t3);width:24px;text-align:center;flex-shrink:0">DE</span><input class="form-input" value="Hähnchenbrust" placeholder="Deutscher Name" style="flex:1;font-size:13px;padding:6px 10px"></div>
+        </div>
+
+        <!-- Note -->
+        <label style="display:block;font-size:11px;font-weight:500;color:var(--t3);margin-bottom:4px">Poznámka <span style="font-weight:400;color:var(--t4)">(volitelné)</span></label>
+        <textarea class="form-input" rows="2" placeholder="Poznámka pro klienty…" style="font-size:13px;padding:6px 10px;width:100%">Libové, bez vidit. tuku</textarea>
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div id="food-dlg-footer" style="display:flex;align-items:center;justify-content:space-between;padding:10px 20px;border-top:1px solid var(--br);flex-shrink:0">
+      <div id="food-dlg-footer-back"></div>
+      <div id="food-dlg-footer-actions" style="display:flex;align-items:center;gap:8px">
+        <!-- Populated by toggleFoodDlgMode -->
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- ═══════ Recipe detail dialog (view + edit, mirrors RecipeDialog.tsx) ═══════ -->
+<div class="overlay" id="dlg-recipe-detail" onclick="closeOnOverlay(event,'dlg-recipe-detail')">
+  <div class="dialog" style="max-width:600px;padding:0;overflow:hidden;display:flex;flex-direction:column">
+    <!-- Hero -->
+    <div style="height:160px;background:var(--bg3);position:relative;display:flex;align-items:center;justify-content:center;flex-shrink:0">
+      <span style="font-size:48px;opacity:.2">🍽️</span>
+      <div style="position:absolute;inset:0;background:linear-gradient(to bottom,transparent 40%,rgba(0,0,0,.45));display:flex;flex-direction:column;justify-content:flex-end;padding:14px 20px">
+        <div id="recipe-dlg-hero-name" style="font-size:22px;font-weight:700;color:#fff;letter-spacing:-.02em;line-height:1.2">Losos s quinoou a grilovanou zeleninou</div>
+        <div id="recipe-dlg-hero-meta" style="font-size:13px;color:rgba(255,255,255,.75);margin-top:3px">6 ingrediencí · 25 min</div>
+      </div>
+    </div>
+
+    <!-- Header -->
+    <div style="display:flex;align-items:center;gap:12px;padding:10px 20px;border-bottom:1px solid var(--br);flex-shrink:0">
+      <div style="flex:1;min-width:0">
+        <div id="recipe-dlg-title" style="font-size:16px;font-weight:600;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Losos s quinoou</div>
+        <div id="recipe-dlg-subtitle" style="font-size:12px;color:var(--t3);margin-top:2px">6 ingrediencí · 25 min</div>
+      </div>
+      <button onclick="closeDialog('dlg-recipe-detail')" style="background:none;border:none;cursor:pointer;font-size:18px;color:var(--t3);padding:4px">✕</button>
+    </div>
+
+    <!-- Body -->
+    <div style="flex:1;overflow-y:auto;padding:12px 20px;min-height:0">
+
+      <!-- Description -->
+      <div id="recipe-dlg-description" style="font-size:13px;color:var(--t2);margin-bottom:12px">Vyvážené jídlo bohaté na omega-3 mastné kyseliny a kvalitní bílkoviny. Ideální po tréninku pro regeneraci svalů.</div>
+
+      <!-- Macro strip -->
+      <div style="display:flex;gap:8px;margin-bottom:14px">
+        <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="recipe-dlg-kcal" style="font-size:16px;font-weight:700;color:var(--acc);letter-spacing:-.02em">485</div><div style="font-size:11px;color:var(--t3);margin-top:2px">kcal</div></div>
+        <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="recipe-dlg-p" style="font-size:16px;font-weight:700;color:var(--blue);letter-spacing:-.02em">38g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Bílkoviny</div></div>
+        <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="recipe-dlg-c" style="font-size:16px;font-weight:700;color:var(--orange);letter-spacing:-.02em">36g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Sacharidy</div></div>
+        <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="recipe-dlg-f" style="font-size:16px;font-weight:700;color:var(--purple);letter-spacing:-.02em">18g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Tuky</div></div>
+        <div style="flex:1;text-align:center;background:var(--bg2);border:1px solid var(--br);border-radius:6px;padding:8px 4px"><div id="recipe-dlg-fi" style="font-size:16px;font-weight:700;color:var(--green);letter-spacing:-.02em">6g</div><div style="font-size:11px;color:var(--t3);margin-top:2px">Vláknina</div></div>
+      </div>
+
+      <!-- Ingredients -->
+      <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em;margin-bottom:8px;margin-top:14px">Ingredience</div>
+      <div id="recipe-dlg-ingredients">
+        <div style="padding:5px 0;border-bottom:1px solid var(--br);font-size:13px"><div style="display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center"><span style="color:var(--t)">Losos filet</span><span class="tabular-nums" style="color:var(--t2);text-align:right">150g</span><span class="tabular-nums" style="color:var(--t3);font-size:12px;text-align:right;min-width:52px">280 kcal</span></div></div>
+        <div style="padding:5px 0;border-bottom:1px solid var(--br);font-size:13px"><div style="display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center"><span style="color:var(--t)">Quinoa</span><span class="tabular-nums" style="color:var(--t2);text-align:right">60g</span><span class="tabular-nums" style="color:var(--t3);font-size:12px;text-align:right;min-width:52px">110 kcal</span></div></div>
+        <div style="padding:5px 0;border-bottom:1px solid var(--br);font-size:13px"><div style="display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center"><span style="color:var(--t)">Cuketa</span><span class="tabular-nums" style="color:var(--t2);text-align:right">100g</span><span class="tabular-nums" style="color:var(--t3);font-size:12px;text-align:right;min-width:52px">17 kcal</span></div></div>
+        <div style="padding:5px 0;border-bottom:1px solid var(--br);font-size:13px"><div style="display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center"><span style="color:var(--t)">Paprika</span><span class="tabular-nums" style="color:var(--t2);text-align:right">80g</span><span class="tabular-nums" style="color:var(--t3);font-size:12px;text-align:right;min-width:52px">26 kcal</span></div></div>
+        <div style="padding:5px 0;border-bottom:1px solid var(--br);font-size:13px"><div style="display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center"><span style="color:var(--t)">Olivový olej</span><span class="tabular-nums" style="color:var(--t2);text-align:right">10ml</span><span class="tabular-nums" style="color:var(--t3);font-size:12px;text-align:right;min-width:52px">88 kcal</span></div></div>
+        <div style="padding:5px 0;font-size:13px"><div style="display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center"><span style="color:var(--t)">Citrón</span><span class="tabular-nums" style="color:var(--t2);text-align:right">15g</span><span class="tabular-nums" style="color:var(--t3);font-size:12px;text-align:right;min-width:52px">4 kcal</span></div></div>
+      </div>
+
+      <!-- Steps -->
+      <div style="font-size:11px;font-weight:600;color:var(--t3);text-transform:uppercase;letter-spacing:.04em;margin-bottom:8px;margin-top:14px">Postup přípravy</div>
+      <div id="recipe-dlg-steps" style="display:flex;flex-direction:column;gap:8px">
+        <div style="display:flex;align-items:center;gap:10px"><div style="width:22px;height:22px;border-radius:50%;background:var(--acc-bg);color:var(--acc);font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0">1</div><div style="font-size:13px;color:var(--t2);line-height:1.6">Quinou propláchni a vař 15 minut ve dvojnásobku vody. Nech odpočinout pod pokličkou.</div></div>
+        <div style="display:flex;align-items:center;gap:10px"><div style="width:22px;height:22px;border-radius:50%;background:var(--acc-bg);color:var(--acc);font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0">2</div><div style="font-size:13px;color:var(--t2);line-height:1.6">Lososa osoľ, opepři a potři olivovým olejem. Griluj na pánvi z každé strany 4 minuty.</div></div>
+        <div style="display:flex;align-items:center;gap:10px"><div style="width:22px;height:22px;border-radius:50%;background:var(--acc-bg);color:var(--acc);font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0">3</div><div style="font-size:13px;color:var(--t2);line-height:1.6">Cuketu a papriku nakrájej na plátky, griluj 3–4 minuty z každé strany.</div></div>
+        <div style="display:flex;align-items:center;gap:10px"><div style="width:22px;height:22px;border-radius:50%;background:var(--acc-bg);color:var(--acc);font-size:11px;font-weight:600;display:flex;align-items:center;justify-content:center;flex-shrink:0">4</div><div style="font-size:13px;color:var(--t2);line-height:1.6">Servíruj lososa na lůžku z quinoy s grilovanou zeleninou. Zakápni citrónem.</div></div>
+      </div>
+
+      <!-- Note -->
+      <div style="background:var(--acc-bg);border:1px solid var(--acc-br);border-radius:6px;padding:10px 12px;font-size:13px;color:var(--t2);line-height:1.5;margin-top:14px;display:flex;gap:8px;align-items:center">
+        <span style="font-size:16px;flex-shrink:0">💡</span>
+        <span>Lososa nekupuj farmového — ideálně divoký aljašský. Pokud nemáš quinou, nahraď bulghurem.</span>
+      </div>
+
+      <div style="height:16px"></div>
+    </div>
+
+    <!-- Footer -->
+    <div style="display:flex;align-items:center;justify-content:flex-end;gap:8px;padding:10px 20px;border-top:1px solid var(--br);flex-shrink:0">
+      <button class="btn" onclick="closeDialog('dlg-recipe-detail')">Zavřít</button>
+      <button class="btn primary" onclick="showToast('Recept se upraví')">✏ Upravit recept</button>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════ Original add-to-plan dialog (used from plan editor) ═══════ -->
 <div class="overlay" id="dlg-add-food-to-plan" onclick="closeOnOverlay(event,'dlg-add-food-to-plan')">
   <div class="dialog" style="max-width:560px">
     <div class="dlg-hdr"><div class="dlg-title">Přidat potravinu</div><button class="dlg-close" onclick="closeDialog('dlg-add-food-to-plan')">✕</button></div>
@@ -3544,7 +3726,7 @@ function renderFoods(){
     var html='';
     list.forEach(function(f){
       var note=f.note||'—';
-      html+='<tr onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')" style="cursor:pointer">';
+      html+='<tr onclick="openFoodDetail(\''+f.name+'\')" style="cursor:pointer">';
       html+='<td><span class="row-title">'+f.name+'</span></td>';
       html+='<td style="color:var(--t3);font-style:italic;font-size:12px">'+note+'</td>';
       html+='<td class="tabular-nums">'+f.kcal+'</td>';
@@ -3563,7 +3745,7 @@ function renderFoods(){
   if(lv){
     var html='';
     list.forEach(function(f){
-      html+='<div onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')" style="display:flex;align-items:center;gap:10px;padding:8px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer">';
+      html+='<div onclick="openFoodDetail(\''+f.name+'\')" style="display:flex;align-items:center;gap:10px;padding:8px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer">';
       html+='<div style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;background:rgba(201,168,76,.12);color:var(--acc);flex-shrink:0">'+f.name.charAt(0).toUpperCase()+'</div>';
       html+='<div style="flex:1;min-width:0">';
       html+='<div style="font-size:13px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+f.name+'</div>';
@@ -3583,7 +3765,7 @@ function renderFoods(){
   if(cg){
     var html='';
     list.forEach(function(f){
-      html+='<div class="n-card" onclick="openDialog(\'dlg-add-food-to-plan\');setSelectedFood(\''+f.name+'\')" style="cursor:pointer"><div class="card-cover" style="height:80px;background:var(--bg3);display:flex;align-items:center;justify-content:center;font-size:28px;opacity:.5">📦</div><div class="card-body">';
+      html+='<div class="n-card" onclick="openFoodDetail(\''+f.name+'\')" style="cursor:pointer"><div class="card-cover" style="height:80px;background:var(--bg3);display:flex;align-items:center;justify-content:center;font-size:28px;opacity:.5">📦</div><div class="card-body">';
       html+='<div class="card-title" style="font-size:13px;font-weight:500;margin-bottom:6px">'+f.name+'</div>';
       html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>kcal</span><span class="tabular-nums" style="color:var(--t);font-weight:600">'+f.kcal+'</span></div>';
       html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>B / S / T / Vl</span><span class="tabular-nums"><span style="color:var(--blue)">'+f.p+'</span> <span style="color:var(--orange)">'+f.c+'</span> <span style="color:var(--purple)">'+f.f+'</span> <span style="color:var(--green)">'+(f.fi||0)+'</span></span></div>';
@@ -3592,6 +3774,72 @@ function renderFoods(){
     });
     cg.innerHTML=html;
   }
+}
+
+// ── FOOD DETAIL DIALOG ────────────────────────────────────────────────────────
+function openFoodDetail(name){
+  var f = FOODS_DB.find(function(x){return x.name===name;});
+  if(!f) return;
+  // Hero + header
+  var heroName = document.getElementById('food-dlg-hero-name'); if(heroName) heroName.textContent = f.name;
+  var heroCat = document.getElementById('food-dlg-hero-cat'); if(heroCat){ heroCat.textContent = f.cat; heroCat.className = 'tag '+f.catTag; heroCat.style.fontSize = '10px'; }
+  var title = document.getElementById('food-dlg-title'); if(title) title.textContent = f.name;
+  var subtitle = document.getElementById('food-dlg-subtitle'); if(subtitle) subtitle.textContent = f.note || '';
+  // Macros
+  ['kcal','p','c','f','fi'].forEach(function(k){
+    var el = document.getElementById('food-dlg-'+k); if(!el) return;
+    var val = f[k] || 0;
+    el.textContent = k==='kcal' ? val : val+'g';
+  });
+  // Note
+  var noteBlock = document.getElementById('food-dlg-note');
+  var noteText = document.getElementById('food-dlg-note-text');
+  if(noteBlock && noteText){
+    if(f.note){ noteBlock.style.display = 'flex'; noteText.textContent = f.note; }
+    else { noteBlock.style.display = 'none'; }
+  }
+  // Default to view mode
+  setFoodDlgMode('view');
+  openDialog('dlg-food-detail');
+}
+
+function setFoodDlgMode(mode){
+  var view = document.getElementById('food-dlg-view');
+  var edit = document.getElementById('food-dlg-edit');
+  var inner = document.getElementById('food-dlg-detail-inner') || document.getElementById('dlg-food-detail-inner');
+  var back = document.getElementById('food-dlg-footer-back');
+  var actions = document.getElementById('food-dlg-footer-actions');
+  if(view) view.style.display = mode==='view' ? '' : 'none';
+  if(edit) edit.style.display = mode==='edit' ? '' : 'none';
+  if(inner) inner.style.maxWidth = mode==='edit' ? '560px' : '500px';
+  if(back){
+    back.innerHTML = mode==='edit'
+      ? '<button class="btn" onclick="setFoodDlgMode(\'view\')">← Zahodit změny</button>'
+      : '';
+  }
+  if(actions){
+    actions.innerHTML = mode==='view'
+      ? '<button class="btn" onclick="closeDialog(\'dlg-food-detail\')">Zavřít</button>'
+        +'<button class="btn primary" onclick="setFoodDlgMode(\'edit\')">✏ Upravit</button>'
+      : '<button class="btn" onclick="closeDialog(\'dlg-food-detail\')">Zrušit</button>'
+        +'<button class="btn primary" onclick="showToast(\'Potravina uložena\');setFoodDlgMode(\'view\')">Uložit změny</button>';
+  }
+}
+
+// ── RECIPE DETAIL DIALOG ──────────────────────────────────────────────────────
+function openRecipeDetail(recipeId){
+  var r = (typeof RECIPES_DB !== 'undefined') ? RECIPES_DB.find(function(x){return x.recipeId===recipeId;}) : null;
+  if(!r) return;
+  var heroName = document.getElementById('recipe-dlg-hero-name'); if(heroName) heroName.textContent = r.name;
+  var heroMeta = document.getElementById('recipe-dlg-hero-meta'); if(heroMeta) heroMeta.textContent = r.foodCount+' ingrediencí · '+(r.prepTime||'—')+' min';
+  var title = document.getElementById('recipe-dlg-title'); if(title) title.textContent = r.name;
+  var subtitle = document.getElementById('recipe-dlg-subtitle'); if(subtitle) subtitle.textContent = r.foodCount+' ingrediencí · '+(r.prepTime||'—')+' min';
+  ['kcal','p','c','f','fi'].forEach(function(k){
+    var el = document.getElementById('recipe-dlg-'+k); if(!el) return;
+    var val = r[k] || 0;
+    el.textContent = k==='kcal' ? val : val+'g';
+  });
+  openDialog('dlg-recipe-detail');
 }
 
 // ── RECIPES DATABASE ──────────────────────────────────────────────────────────
@@ -3660,7 +3908,7 @@ function renderRecipesGrid(){
   if(tb){
     var html='';
     list.forEach(function(r){
-      html+='<tr onclick="showToast(\'Editor receptu: '+r.name+'\')" style="cursor:pointer">';
+      html+='<tr onclick="openRecipeDetail(\''+r.recipeId+'\')" style="cursor:pointer">';
       html+='<td><span class="row-title">'+r.name+'</span></td>';
       html+='<td class="tabular-nums" style="color:var(--t2)">'+r.foodCount+'</td>';
       html+='<td class="tabular-nums" style="color:var(--t3)">'+(r.prepTime?r.prepTime+' min':'—')+'</td>';
@@ -3679,7 +3927,7 @@ function renderRecipesGrid(){
   if(lv){
     var html='';
     list.forEach(function(r){
-      html+='<div onclick="showToast(\'Editor receptu: '+r.name+'\')" style="display:flex;align-items:center;gap:10px;padding:8px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer">';
+      html+='<div onclick="openRecipeDetail(\''+r.recipeId+'\')" style="display:flex;align-items:center;gap:10px;padding:8px 12px;background:var(--bg2);border:1px solid var(--br);border-radius:var(--rm);cursor:pointer">';
       html+='<div style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:14px;background:var(--acc-bg);color:var(--acc);flex-shrink:0">📖</div>';
       html+='<div style="flex:1;min-width:0">';
       html+='<div style="font-size:13px;font-weight:500;color:var(--t);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">'+r.name+'</div>';
@@ -3699,7 +3947,7 @@ function renderRecipesGrid(){
   if(cg){
     var html='';
     list.forEach(function(r){
-      html+='<div class="n-card" onclick="showToast(\'Editor receptu: '+r.name+'\')" style="cursor:pointer"><div class="card-cover" style="height:90px;background:linear-gradient(135deg,var(--acc-bg),var(--bg3));display:flex;align-items:center;justify-content:center;font-size:32px;opacity:.7">📖</div><div class="card-body">';
+      html+='<div class="n-card" onclick="openRecipeDetail(\''+r.recipeId+'\')" style="cursor:pointer"><div class="card-cover" style="height:90px;background:linear-gradient(135deg,var(--acc-bg),var(--bg3));display:flex;align-items:center;justify-content:center;font-size:32px;opacity:.7">📖</div><div class="card-body">';
       html+='<div class="card-title" style="font-size:13px;font-weight:500;margin-bottom:6px">'+r.name+'</div>';
       html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>kcal</span><span class="tabular-nums" style="color:var(--t);font-weight:600">'+r.kcal+'</span></div>';
       html+='<div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;color:var(--t3);margin-bottom:3px"><span>B / S / T / Vl</span><span class="tabular-nums"><span style="color:var(--blue)">'+r.p+'</span> <span style="color:var(--orange)">'+r.c+'</span> <span style="color:var(--purple)">'+r.f+'</span> <span style="color:var(--green)">'+(r.fi||0)+'</span></span></div>';


### PR DESCRIPTION
## Summary

The notion-portal prototype was missing the coach **Profile** scene that exists in the implementation at [`web/src/pages/ProfilePage.tsx`](https://github.com/JanProkorat/fitness-platform/blob/develop/web/src/pages/ProfilePage.tsx). Three tabs restored:

1. **Osobní údaje** (default) — avatar + core fields, Roles section (Trainer + Výživový poradce toggles), Trainer public-profile block (bio, city, price, collab type, max clients), Specializace / Certifikáty / Jazyky chip inputs, Social links, Marketplace visibility toggles.
2. **Dotazníky** — list of ~3 sample templates with edit / delete + "+ Nová šablona" CTA. Clicking a template opens a minimal editor (name field + 6 sample question rows: single-select / number / text / scale types).
3. **Týdenní check-iny** — cross-links to the existing `s-settings-checkins` so the three surfaces behave as one Settings area.

Also fixes the stubbed "Profil" tab on `settings-checkins.html` that previously called `showToast('Profil')` — now replaced with two real cross-links (Osobní údaje / Dotazníky → `s-profile`) so the tab layouts match across scenes.

Fixes #63.

## Test plan

- [ ] Open `docs/notion_portal.html`; top-nav **Nastavení** exposes new "Profil" button that opens `s-profile`.
- [ ] Osobní údaje tab: form fields populated, Role toggles present, Marketplace visibility togglees operate.
- [ ] Dotazníky tab: list renders, clicking a row opens the editor; "‹ Zpět na seznam" returns to list.
- [ ] Týdenní check-iny tab jumps to `s-settings-checkins`.
- [ ] On `s-settings-checkins`, the two new cross-links navigate back to `s-profile` on the right tab.
- [ ] No hardcoded colors; tokens only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)