### PR TITLE
chore(backend): generic image upload-URL helper + validation (#68)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -151,6 +151,19 @@ public static class ErrorCodes
     /// <summary>The weekly check-in belongs to another professional.</summary>
     public const string CheckInNotOwned = "CHECK_IN_NOT_OWNED";
 
+    // ── Image Uploads ────────────────────────────────────────────────
+    /// <summary>Content type is not in the allowed image whitelist (image/jpeg, image/png, image/webp).</summary>
+    public const string InvalidImageContentType = "INVALID_IMAGE_CONTENT_TYPE";
+
+    /// <summary>Image file size exceeds the 5 MiB limit.</summary>
+    public const string ImageTooLarge = "IMAGE_TOO_LARGE";
+
+    /// <summary>
+    /// subPath tried to escape the scope prefix: it contains <c>..</c>, a backslash (<c>\</c>),
+    /// starts with a leading <c>/</c>, or is null/empty/whitespace.
+    /// </summary>
+    public const string InvalidImageSubPath = "INVALID_IMAGE_SUB_PATH";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Domain/Enums/ImageUploadScope.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/ImageUploadScope.cs
@@ -1,0 +1,38 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Identifies the logical bucket scope for an image upload request.
+/// Each scope maps to a specific blob-path convention under the storage root.
+/// </summary>
+public enum ImageUploadScope
+{
+    /// <summary>
+    /// User or professional avatar.
+    /// Blob path: <c>avatars/{userId}.{ext}</c>
+    /// </summary>
+    Avatar,
+
+    /// <summary>
+    /// Food item image.
+    /// Blob path: <c>foods/{foodId}.{ext}</c>
+    /// </summary>
+    Food,
+
+    /// <summary>
+    /// Recipe image (primary or gallery slot).
+    /// Blob path: <c>recipes/{recipeId}/{slot}.{ext}</c>
+    /// </summary>
+    Recipe,
+
+    /// <summary>
+    /// Nutrition or training plan photo.
+    /// Blob path: <c>plan-photos/{planId}/{photoId}.{ext}</c>
+    /// </summary>
+    PlanPhoto,
+
+    /// <summary>
+    /// Client diary photo (progress photo, etc.).
+    /// Blob path: <c>diary/{diaryId}/{photoId}.{ext}</c>
+    /// </summary>
+    Diary,
+}

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IImageUploadService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IImageUploadService.cs
@@ -1,0 +1,84 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Interfaces;
+
+/// <summary>
+/// Validates and generates pre-signed upload URLs for image assets.
+///
+/// <para>
+/// This service is the single gateway for all image uploads across the platform.
+/// It enforces a content-type whitelist and a maximum file size, then delegates
+/// the signed-URL generation to <see cref="IBlobStorageService"/>.
+/// </para>
+///
+/// <para><b>Blob-path conventions by scope:</b></para>
+/// <list type="bullet">
+///   <item><description><see cref="ImageUploadScope.Avatar"/>    — <c>avatars/{userId}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.Food"/>      — <c>foods/{foodId}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.Recipe"/>    — <c>recipes/{recipeId}/{slot}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.PlanPhoto"/> — <c>plan-photos/{planId}/{photoId}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.Diary"/>     — <c>diary/{diaryId}/{photoId}.{ext}</c></description></item>
+/// </list>
+///
+/// <para>
+/// The <c>subPath</c> argument on
+/// <see cref="GenerateUploadUrlAsync(ImageUploadScope,string,string,long,CancellationToken)"/>
+/// carries the scope-specific portion of the path that follows the scope prefix.
+/// The service prepends the correct root segment automatically.
+/// </para>
+/// </summary>
+public interface IImageUploadService
+{
+    /// <summary>
+    /// Validates the content type and declared size, then returns a pre-signed PUT URL
+    /// for direct client upload together with the permanent blob URL.
+    ///
+    /// <para><b>Allowed content types:</b> <c>image/jpeg</c>, <c>image/png</c>, <c>image/webp</c>.</para>
+    /// <para><b>Maximum file size:</b> 5 MiB (5 × 1024 × 1024 bytes).</para>
+    ///
+    /// <para><b>Blob-path conventions by scope:</b></para>
+    /// <list type="bullet">
+    ///   <item><description><see cref="ImageUploadScope.Avatar"/>    — <c>avatars/{userId}.{ext}</c></description></item>
+    ///   <item><description><see cref="ImageUploadScope.Food"/>      — <c>foods/{foodId}.{ext}</c></description></item>
+    ///   <item><description><see cref="ImageUploadScope.Recipe"/>    — <c>recipes/{recipeId}/{slot}.{ext}</c></description></item>
+    ///   <item><description><see cref="ImageUploadScope.PlanPhoto"/> — <c>plan-photos/{planId}/{photoId}.{ext}</c></description></item>
+    ///   <item><description><see cref="ImageUploadScope.Diary"/>     — <c>diary/{diaryId}/{photoId}.{ext}</c></description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="scope">
+    /// Logical bucket scope that determines the blob-path prefix
+    /// (e.g. <see cref="ImageUploadScope.Avatar"/> yields <c>avatars/…</c>).
+    /// </param>
+    /// <param name="subPath">
+    /// The scope-specific portion of the path after the prefix, without a
+    /// leading slash. Callers are responsible for constructing this from their
+    /// domain identifiers according to the conventions listed above.
+    /// Examples: <c>"{userId}.jpg"</c> for avatars,
+    /// <c>"{recipeId}/cover.jpg"</c> for recipes.
+    /// </param>
+    /// <param name="contentType">
+    /// MIME type declared by the client (e.g. <c>"image/jpeg"</c>).
+    /// Must be one of the allowed types or a validation error is thrown.
+    /// </param>
+    /// <param name="sizeBytes">
+    /// Declared file size in bytes. Must not exceed 5 MiB or a validation error is thrown.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="BlobUploadUrl"/> with the time-limited upload URL and the
+    /// permanent blob URL at which the image will be accessible after upload.
+    /// </returns>
+    /// <exception cref="FastEndpoints.ValidationFailureException">
+    /// Thrown with error code <c>INVALID_IMAGE_CONTENT_TYPE</c> when the content type is not
+    /// in the whitelist, or <c>IMAGE_TOO_LARGE</c> when <paramref name="sizeBytes"/>
+    /// exceeds the limit, or <c>INVALID_IMAGE_SUB_PATH</c> when <paramref name="subPath"/>
+    /// is null, empty, whitespace, or contains path-traversal sequences (<c>..</c>, <c>\</c>,
+    /// or a leading <c>/</c>).
+    /// </exception>
+    Task<BlobUploadUrl> GenerateUploadUrlAsync(
+        ImageUploadScope scope,
+        string subPath,
+        string contentType,
+        long sizeBytes,
+        CancellationToken ct);
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/ImageUploadService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/ImageUploadService.cs
@@ -1,0 +1,123 @@
+using FastEndpoints;
+using FluentValidation.Results;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Validates image uploads and delegates signed-URL generation to
+/// <see cref="IBlobStorageService"/>.
+///
+/// <para><b>Allowed content types:</b> <c>image/jpeg</c>, <c>image/png</c>, <c>image/webp</c>.</para>
+/// <para><b>Maximum file size:</b> <see cref="MaxImageSizeBytes"/> (5 MiB).</para>
+///
+/// <para><b>Blob-path conventions by scope:</b></para>
+/// <list type="bullet">
+///   <item><description><see cref="ImageUploadScope.Avatar"/>    — <c>avatars/{userId}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.Food"/>      — <c>foods/{foodId}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.Recipe"/>    — <c>recipes/{recipeId}/{slot}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.PlanPhoto"/> — <c>plan-photos/{planId}/{photoId}.{ext}</c></description></item>
+///   <item><description><see cref="ImageUploadScope.Diary"/>     — <c>diary/{diaryId}/{photoId}.{ext}</c></description></item>
+/// </list>
+/// </summary>
+public class ImageUploadService(IBlobStorageService blobStorage) : IImageUploadService
+{
+    /// <summary>Maximum allowed image file size: 5 MiB.</summary>
+    public const long MaxImageSizeBytes = 5L * 1024 * 1024;
+
+    private static readonly IReadOnlyDictionary<string, string> AllowedContentTypes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["image/jpeg"] = "jpg",
+            ["image/png"] = "png",
+            ["image/webp"] = "webp",
+        };
+
+    /// <summary>Pre-signed URL validity window for image uploads.</summary>
+    private static readonly TimeSpan UploadUrlExpiry = TimeSpan.FromMinutes(15);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Blob-path conventions by scope:
+    /// <list type="bullet">
+    ///   <item><description>Avatar    — <c>avatars/{userId}.{ext}</c></description></item>
+    ///   <item><description>Food      — <c>foods/{foodId}.{ext}</c></description></item>
+    ///   <item><description>Recipe    — <c>recipes/{recipeId}/{slot}.{ext}</c></description></item>
+    ///   <item><description>PlanPhoto — <c>plan-photos/{planId}/{photoId}.{ext}</c></description></item>
+    ///   <item><description>Diary     — <c>diary/{diaryId}/{photoId}.{ext}</c></description></item>
+    /// </list>
+    /// </remarks>
+    /// <exception cref="ValidationFailureException">
+    /// Also thrown with error code <c>INVALID_IMAGE_SUB_PATH</c> when <paramref name="subPath"/>
+    /// is null, empty, or contains path-traversal sequences (<c>..</c>, <c>\</c>, or a leading <c>/</c>).
+    /// </exception>
+    public async Task<BlobUploadUrl> GenerateUploadUrlAsync(
+        ImageUploadScope scope,
+        string subPath,
+        string contentType,
+        long sizeBytes,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(subPath) ||
+            subPath.Contains("..", StringComparison.Ordinal) ||
+            subPath.StartsWith('/') ||
+            subPath.Contains('\\', StringComparison.Ordinal))
+        {
+            var failures = new List<ValidationFailure>
+            {
+                new(nameof(subPath), "Invalid blob sub-path.")
+                {
+                    ErrorCode = ErrorCodes.InvalidImageSubPath
+                }
+            };
+            throw new ValidationFailureException(failures, "Invalid blob sub-path.");
+        }
+
+        if (!AllowedContentTypes.TryGetValue(contentType, out _))
+        {
+            var allowed = string.Join(", ", AllowedContentTypes.Keys);
+            var failures = new List<ValidationFailure>
+            {
+                new("contentType", $"Content type must be one of: {allowed}.")
+                {
+                    ErrorCode = ErrorCodes.InvalidImageContentType
+                }
+            };
+            throw new ValidationFailureException(failures, "Invalid image content type.");
+        }
+
+        if (sizeBytes > MaxImageSizeBytes)
+        {
+            var limitMb = MaxImageSizeBytes / (1024 * 1024);
+            var failures = new List<ValidationFailure>
+            {
+                new("sizeBytes", $"Image must not exceed {limitMb} MB.")
+                {
+                    ErrorCode = ErrorCodes.ImageTooLarge
+                }
+            };
+            throw new ValidationFailureException(failures, "Image exceeds maximum allowed size.");
+        }
+
+        var prefix = ScopeToPrefix(scope);
+        var containerPath = $"{prefix}/{subPath}";
+
+        return await blobStorage.GenerateUploadUrlAsync(
+            containerPath,
+            contentType,
+            UploadUrlExpiry,
+            ct);
+    }
+
+    private static string ScopeToPrefix(ImageUploadScope scope) => scope switch
+    {
+        ImageUploadScope.Avatar    => "avatars",
+        ImageUploadScope.Food      => "foods",
+        ImageUploadScope.Recipe    => "recipes",
+        ImageUploadScope.PlanPhoto => "plan-photos",
+        ImageUploadScope.Diary     => "diary",
+        _                          => throw new ArgumentOutOfRangeException(nameof(scope), scope, null)
+    };
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -69,6 +69,7 @@ builder.Services.AddHostedService<MongoIndexInitializer>();
 
 // Blob Storage (MinIO)
 builder.Services.AddSingleton<IBlobStorageService, MinioBlobStorageService>();
+builder.Services.AddSingleton<IImageUploadService, ImageUploadService>();
 
 // ASP.NET Identity
 builder.Services.AddIdentityCore<ApplicationUser>(options =>

--- a/backend/FitnessPlatform.Tests/Services/ImageUploadServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/ImageUploadServiceTests.cs
@@ -1,0 +1,183 @@
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Services;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ImageUploadService"/>.
+/// </summary>
+public class ImageUploadServiceTests
+{
+    private readonly IBlobStorageService _blobStorage = Substitute.For<IBlobStorageService>();
+    private readonly ImageUploadService _sut;
+
+    public ImageUploadServiceTests()
+    {
+        _blobStorage
+            .GenerateUploadUrlAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new BlobUploadUrl("https://minio/upload?token=abc", "https://minio/bucket/avatars/user.jpg"));
+
+        _sut = new ImageUploadService(_blobStorage);
+    }
+
+    // ── Content-type whitelist ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("image/webp")]
+    [InlineData("IMAGE/JPEG")] // case-insensitive
+    public async Task GenerateUploadUrlAsync_AllowedContentType_ReturnsUploadUrl(string contentType)
+    {
+        var result = await _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Avatar,
+            "user123.jpg",
+            contentType,
+            1024,
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.UploadUrl.Should().NotBeNullOrEmpty();
+    }
+
+    [Theory]
+    [InlineData("application/pdf")]
+    [InlineData("image/gif")]
+    [InlineData("image/bmp")]
+    [InlineData("image/svg+xml")]
+    [InlineData("video/mp4")]
+    [InlineData("text/plain")]
+    [InlineData("")]
+    public async Task GenerateUploadUrlAsync_InvalidContentType_ThrowsWithErrorCode(string contentType)
+    {
+        var act = () => _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Avatar,
+            "user123.jpg",
+            contentType,
+            1024,
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures
+            .Should().ContainSingle(f => f.ErrorCode == ErrorCodes.InvalidImageContentType);
+    }
+
+    // ── Size cap ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GenerateUploadUrlAsync_ExactlyAtLimit_ReturnsUploadUrl()
+    {
+        var result = await _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Food,
+            "food456.jpg",
+            "image/jpeg",
+            ImageUploadService.MaxImageSizeBytes, // exactly at the limit — allowed
+            CancellationToken.None);
+
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GenerateUploadUrlAsync_OneBytePastLimit_ThrowsWithErrorCode()
+    {
+        var act = () => _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Food,
+            "food456.jpg",
+            "image/jpeg",
+            ImageUploadService.MaxImageSizeBytes + 1,
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures
+            .Should().ContainSingle(f => f.ErrorCode == ErrorCodes.ImageTooLarge);
+    }
+
+    [Fact]
+    public async Task GenerateUploadUrlAsync_SixMegabytes_ThrowsWithErrorCode()
+    {
+        const long sixMb = 6L * 1024 * 1024;
+
+        var act = () => _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Diary,
+            "diary789/photo1.jpg",
+            "image/jpeg",
+            sixMb,
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures
+            .Should().ContainSingle(f => f.ErrorCode == ErrorCodes.ImageTooLarge);
+    }
+
+    // ── Blob-path conventions ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(ImageUploadScope.Avatar,    "user-id.jpg",               "avatars/user-id.jpg")]
+    [InlineData(ImageUploadScope.Food,      "food-id.png",               "foods/food-id.png")]
+    [InlineData(ImageUploadScope.Recipe,    "recipe-id/cover.jpg",       "recipes/recipe-id/cover.jpg")]
+    [InlineData(ImageUploadScope.PlanPhoto, "plan-id/photo-id.webp",     "plan-photos/plan-id/photo-id.webp")]
+    [InlineData(ImageUploadScope.Diary,     "diary-id/photo-id.jpg",     "diary/diary-id/photo-id.jpg")]
+    public async Task GenerateUploadUrlAsync_CorrectScope_UsesExpectedBlobPath(
+        ImageUploadScope scope,
+        string subPath,
+        string expectedContainerPath)
+    {
+        await _sut.GenerateUploadUrlAsync(scope, subPath, "image/jpeg", 1024, CancellationToken.None);
+
+        await _blobStorage.Received(1).GenerateUploadUrlAsync(
+            expectedContainerPath,
+            "image/jpeg",
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Sub-path escape prevention ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("../foo.jpg")]
+    [InlineData("foo/../../bar.jpg")]
+    [InlineData("/absolute.jpg")]
+    [InlineData("foo\\bar.jpg")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateUploadUrlAsync_SubPathTriesToEscape_ThrowsWithErrorCode(string subPath)
+    {
+        var act = () => _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Avatar,
+            subPath,
+            "image/jpeg",
+            1024,
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures
+            .Should().ContainSingle(f => f.ErrorCode == ErrorCodes.InvalidImageSubPath);
+    }
+
+    // ── Validation priority: content-type checked before size ───────────────
+
+    [Fact]
+    public async Task GenerateUploadUrlAsync_InvalidContentTypeAndOversize_ThrowsContentTypeError()
+    {
+        // When both are wrong, the content-type check fires first
+        var act = () => _sut.GenerateUploadUrlAsync(
+            ImageUploadScope.Avatar,
+            "file.pdf",
+            "application/pdf",
+            ImageUploadService.MaxImageSizeBytes + 1,
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures
+            .Should().ContainSingle(f => f.ErrorCode == ErrorCodes.InvalidImageContentType);
+    }
+}


### PR DESCRIPTION
Fixes #68. Part of epic #65 (Platform photo primitives).

## Summary

- New `IImageUploadService` under `Infrastructure/Services/` — centralises signed-PUT-URL generation for every image upload surface (avatars, Food, Recipe, PlanPhoto, diary).
- Content-type whitelist: `image/jpeg`, `image/png`, `image/webp`. Anything else rejected with `INVALID_IMAGE_CONTENT_TYPE`.
- 5 MiB size cap. Oversize rejected with `IMAGE_TOO_LARGE` (5 MiB exact is allowed — `<=`).
- `subPath` containment guard: rejects `..`, leading `/`, backslashes, empty/whitespace with `INVALID_IMAGE_SUB_PATH`. Defense-in-depth against a caller escaping the scope prefix.
- `ImageUploadScope` enum maps Avatar → `avatars/`, Food → `foods/`, Recipe → `recipes/`, PlanPhoto → `plan-photos/`, Diary → `diary/`. XML docs on both the interface and impl list all five conventions literally (AC requirement).

## Acceptance criteria — status

- ✅ Helper lives under `Infrastructure/Services/` — `Infrastructure/Services/ImageUploadService.cs`.
- ✅ Unit test covers invalid content-types + oversize — 7 rejected content-type cases, 2 oversize cases (1-byte-past-limit and 6 MiB), plus 6-way sub-path escape theory.
- ✅ Blob-path conventions documented in XML docs on `IImageUploadService` and `ImageUploadService` — all 5 conventions present.

## Downstream follow-ups

Enables #69 (ApplicationUser avatar), #70 (ProfessionalProfile avatar), #71 (Food ImageUrl), #72 (Recipe ImageUrl + gallery) — each will call this service instead of `IBlobStorageService` directly. The calling pattern is documented in the dev-report: `service.GenerateUploadUrlAsync(ImageUploadScope.Avatar, $"{userId}.{ext}", contentType, sizeBytes, ct)`.

## Test plan

- [x] `dotnet build backend/FitnessPlatform.Application` — 0 errors (2 pre-existing MailKit NU1902 warnings unchanged).
- [x] `ImageUploadServiceTests` — 26 tests, all green (20 original + 6 sub-path escape theory).
- [x] No hand-edits to `generated.ts` (backend-only change; `regen-api` not needed — no new endpoint yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)