### PR TITLE
feat(backend): Recipe ImageUrl + gallery upload endpoints (#72)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -57,6 +57,13 @@ public static class ErrorCodes
     /// <summary>User can only edit/delete their own custom foods.</summary>
     public const string FoodNotOwned = "FOOD_NOT_OWNED";
 
+    // ── Recipes ──────────────────────────────────────────────────────
+    /// <summary>User can only edit/delete/upload images for their own recipes.</summary>
+    public const string RecipeNotOwned = "RECIPE_NOT_OWNED";
+
+    /// <summary>Recipe gallery is at its 6-entry cap; no further images can be added.</summary>
+    public const string RecipeGalleryFull = "RECIPE_GALLERY_FULL";
+
     // ── Exercises ──────────────────────────────────────────────────
     /// <summary>User can only edit/delete their own custom exercises.</summary>
     public const string ExerciseNotOwned = "EXERCISE_NOT_OWNED";

--- a/backend/FitnessPlatform.Application/Domain/Documents/Recipe.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/Recipe.cs
@@ -90,6 +90,22 @@ public class Recipe
     public DateTime DateCreated { get; set; }
 
     /// <summary>
+    /// URL of the recipe's main image in blob storage (e.g. <c>recipes/{recipeId}/main.jpg</c>).
+    /// Null until the nutritionist uploads and confirms a main image.
+    /// </summary>
+    [BsonElement("imageUrl")]
+    [BsonIgnoreIfNull]
+    public string? ImageUrl { get; set; }
+
+    /// <summary>
+    /// URLs of the recipe's gallery images in blob storage.
+    /// Each entry looks like <c>recipes/{recipeId}/gallery-{n}.{ext}</c>.
+    /// Capped at 6 entries. Append-only via the confirm endpoint.
+    /// </summary>
+    [BsonElement("galleryImageUrls")]
+    public List<string> GalleryImageUrls { get; set; } = [];
+
+    /// <summary>
     /// When this document was last updated.
     /// </summary>
     [BsonElement("dateUpdated")]

--- a/backend/FitnessPlatform.Application/Features/Recipes/ConfirmRecipeImage/ConfirmRecipeImageEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/ConfirmRecipeImage/ConfirmRecipeImageEndpoint.cs
@@ -1,0 +1,105 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Recipes.ConfirmRecipeImage;
+
+/// <summary>
+/// Persists the recipe image blob URL on the recipe document.
+/// Main slot overwrites <c>ImageUrl</c>. Gallery slot appends to <c>GalleryImageUrls</c> (cap = 6).
+/// Only the nutritionist who created the recipe can set its images.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+public class ConfirmRecipeImageEndpoint(IMongoContext mongo) : Endpoint<ConfirmRecipeImageRequest>
+{
+    private const int GalleryCap = 6;
+
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Put("/recipes/{RecipeId}/image");
+        Roles(AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Confirm recipe image upload";
+            s.Description = "Sets the image URL on the recipe document after a successful blob upload. "
+                            + "Pass the blobUrl returned by POST /recipes/{id}/image/upload-url. "
+                            + "Use slot=main to set the main image (overwrites); slot=gallery to append "
+                            + "to the gallery (max 6 entries). "
+                            + "Only the nutritionist who created the recipe can confirm its images.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(ConfirmRecipeImageRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var nutritionistId = Guid.Parse(userId);
+
+        var filter = Builders<Recipe>.Filter.Eq(r => r.ExternalId, req.RecipeId);
+
+        using var cursor = await mongo.Recipes.FindAsync(filter, cancellationToken: ct);
+        var recipe = await cursor.FirstOrDefaultAsync(ct);
+
+        if (recipe is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (recipe.NutritionistId != nutritionistId)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.RecipeNotOwned,
+                "You can only set images on your own recipes.");
+            return;
+        }
+
+        var isGallery = req.Slot.Equals("gallery", StringComparison.OrdinalIgnoreCase);
+
+        UpdateDefinition<Recipe> update;
+
+        if (isGallery)
+        {
+            // Re-check gallery cap at confirm time (race: another confirm could have filled it
+            // between the upload-url call and this confirm call).
+            if (recipe.GalleryImageUrls.Count >= GalleryCap)
+            {
+                this.ThrowErrorWithCode(ErrorCodes.RecipeGalleryFull,
+                    $"The recipe gallery is full. Maximum {GalleryCap} gallery images are allowed.");
+                return;
+            }
+
+            update = Builders<Recipe>.Update
+                .Push(r => r.GalleryImageUrls, req.BlobUrl)
+                .Set(r => r.DateUpdated, DateTime.UtcNow);
+        }
+        else
+        {
+            update = Builders<Recipe>.Update
+                .Set(r => r.ImageUrl, req.BlobUrl)
+                .Set(r => r.DateUpdated, DateTime.UtcNow);
+        }
+
+        // Guard against a concurrent delete between the FindAsync above and this
+        // write: include ownership filter in the update so a race that removed or
+        // reassigned the recipe cannot cause a write to a no-longer-owned document.
+        await mongo.Recipes.UpdateOneAsync(
+            Builders<Recipe>.Filter.Eq(r => r.ExternalId, req.RecipeId)
+                & Builders<Recipe>.Filter.Eq(r => r.NutritionistId, nutritionistId),
+            update,
+            cancellationToken: ct);
+
+        await Send.NoContentAsync(ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Recipes/ConfirmRecipeImage/ConfirmRecipeImageRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/ConfirmRecipeImage/ConfirmRecipeImageRequest.cs
@@ -1,0 +1,26 @@
+using FastEndpoints;
+
+namespace FitnessPlatform.Application.Features.Recipes.ConfirmRecipeImage;
+
+/// <summary>
+/// Request model for confirming the uploaded recipe image blob URL.
+/// </summary>
+public class ConfirmRecipeImageRequest
+{
+    /// <summary>
+    /// The recipe's public identifier (from route).
+    /// </summary>
+    public Guid RecipeId { get; set; }
+
+    /// <summary>
+    /// Image slot: <c>main</c> (overwrites <c>ImageUrl</c>) or <c>gallery</c> (appends to <c>GalleryImageUrls</c>).
+    /// Provided as a query parameter: <c>?slot=main</c> or <c>?slot=gallery</c>.
+    /// </summary>
+    [QueryParam]
+    public string Slot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The permanent blob URL returned by <c>POST /recipes/{id}/image/upload-url</c>.
+    /// </summary>
+    public string BlobUrl { get; set; } = string.Empty;
+}

--- a/backend/FitnessPlatform.Application/Features/Recipes/ConfirmRecipeImage/ConfirmRecipeImageValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/ConfirmRecipeImage/ConfirmRecipeImageValidator.cs
@@ -1,0 +1,29 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.Recipes.ConfirmRecipeImage;
+
+/// <summary>
+/// Validates the <see cref="ConfirmRecipeImageRequest"/>.
+/// </summary>
+public class ConfirmRecipeImageValidator : Validator<ConfirmRecipeImageRequest>
+{
+    private static readonly HashSet<string> ValidSlots =
+        new(StringComparer.OrdinalIgnoreCase) { "main", "gallery" };
+
+    /// <summary>
+    /// Initializes validation rules for the recipe image confirmation request.
+    /// </summary>
+    public ConfirmRecipeImageValidator()
+    {
+        RuleFor(x => x.BlobUrl)
+            .NotEmpty().WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.Slot)
+            .NotEmpty().WithErrorCode(ErrorCodes.Required)
+            .Must(s => ValidSlots.Contains(s))
+            .WithErrorCode(ErrorCodes.OutOfRange)
+            .WithMessage("Slot must be 'main' or 'gallery'.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Recipes/Shared/GetRecipeResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/Shared/GetRecipeResponse.cs
@@ -54,6 +54,17 @@ public class GetRecipeResponse
     public RecipeVisibility Visibility { get; set; }
 
     /// <summary>
+    /// URL of the recipe's main image in blob storage, or null if no image has been uploaded.
+    /// </summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>
+    /// URLs of gallery images (up to 6 entries). Each entry points to a blob at
+    /// <c>recipes/{recipeId}/gallery-{n}.{ext}</c>.
+    /// </summary>
+    public List<string> GalleryImageUrls { get; set; } = [];
+
+    /// <summary>
     /// True when the authenticated caller is the nutritionist who created this recipe.
     /// Clients of the API can use this flag to decide whether to show edit/delete affordances.
     /// </summary>
@@ -86,6 +97,8 @@ public class GetRecipeResponse
         Foods = recipe.Foods,
         TotalNutrients = recipe.TotalNutrients,
         Visibility = recipe.Visibility,
+        ImageUrl = recipe.ImageUrl,
+        GalleryImageUrls = recipe.GalleryImageUrls,
         IsOwnedByCurrentUser = currentUserId.HasValue && recipe.NutritionistId == currentUserId.Value,
         DateCreated = recipe.DateCreated,
         DateUpdated = recipe.DateUpdated
@@ -122,6 +135,8 @@ public class GetRecipeResponse
         }).ToList(),
         TotalNutrients = recipe.TotalNutrients,
         Visibility = recipe.Visibility,
+        ImageUrl = recipe.ImageUrl,
+        GalleryImageUrls = recipe.GalleryImageUrls,
         IsOwnedByCurrentUser = currentUserId.HasValue && recipe.NutritionistId == currentUserId.Value,
         DateCreated = recipe.DateCreated,
         DateUpdated = recipe.DateUpdated

--- a/backend/FitnessPlatform.Application/Features/Recipes/Shared/RecipeSummaryDto.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/Shared/RecipeSummaryDto.cs
@@ -39,6 +39,11 @@ public class RecipeSummaryDto
     public RecipeVisibility Visibility { get; set; }
 
     /// <summary>
+    /// URL of the recipe's main image, or null if no image has been uploaded.
+    /// </summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary>
     /// True when the authenticated caller is the nutritionist who created this recipe.
     /// </summary>
     public bool IsOwnedByCurrentUser { get; set; }
@@ -67,6 +72,7 @@ public class RecipeSummaryDto
         TotalNutrients = recipe.TotalNutrients,
         PrepTimeMinutes = recipe.PrepTimeMinutes,
         Visibility = recipe.Visibility,
+        ImageUrl = recipe.ImageUrl,
         IsOwnedByCurrentUser = currentUserId.HasValue && recipe.NutritionistId == currentUserId.Value,
         DateCreated = recipe.DateCreated,
         FoodCategories = recipe.Foods

--- a/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlEndpoint.cs
@@ -1,0 +1,113 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Recipes.UploadImageUrl;
+
+/// <summary>
+/// Generates a pre-signed upload URL for a recipe image (main slot or gallery slot).
+/// Only the nutritionist who created the recipe can upload images.
+/// Gallery is capped at 6 entries; attempting to add a 7th returns 400.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="imageUpload">Image upload service — validates content type and size, then issues the signed URL.</param>
+public class UploadRecipeImageUrlEndpoint(IMongoContext mongo, IImageUploadService imageUpload)
+    : Endpoint<UploadRecipeImageUrlRequest, UploadRecipeImageUrlResponse>
+{
+    private const int GalleryCap = 6;
+
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/recipes/{RecipeId}/image/upload-url");
+        Roles(AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Generate recipe image upload URL";
+            s.Description = "Returns a time-limited pre-signed URL for direct recipe image upload to blob storage, "
+                            + "together with the permanent blob URL that should be confirmed via PUT /recipes/{id}/image. "
+                            + "Use ?slot=main to overwrite the main image; ?slot=gallery to append to the gallery (max 6 entries). "
+                            + "Only the nutritionist who created the recipe can upload its images.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(UploadRecipeImageUrlRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var nutritionistId = Guid.Parse(userId);
+
+        var filter = Builders<Recipe>.Filter.Eq(r => r.ExternalId, req.RecipeId);
+
+        using var cursor = await mongo.Recipes.FindAsync(filter, cancellationToken: ct);
+        var recipe = await cursor.FirstOrDefaultAsync(ct);
+
+        if (recipe is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        if (recipe.NutritionistId != nutritionistId)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.RecipeNotOwned,
+                "You can only upload images for your own recipes.");
+            return;
+        }
+
+        var isGallery = req.Slot.Equals("gallery", StringComparison.OrdinalIgnoreCase);
+
+        if (isGallery && recipe.GalleryImageUrls.Count >= GalleryCap)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.RecipeGalleryFull,
+                $"The recipe gallery is full. Maximum {GalleryCap} gallery images are allowed.");
+            return;
+        }
+
+        var extension = GetExtension(req.ContentType);
+
+        // subPath for main: "{recipeId}/main.{ext}"
+        // subPath for gallery: "{recipeId}/gallery-{nextIndex}.{ext}"
+        var subPath = isGallery
+            ? $"{req.RecipeId}/gallery-{recipe.GalleryImageUrls.Count}.{extension}"
+            : $"{req.RecipeId}/main.{extension}";
+
+        var result = await imageUpload.GenerateUploadUrlAsync(
+            ImageUploadScope.Recipe,
+            subPath,
+            req.ContentType,
+            req.SizeBytes,
+            ct);
+
+        await Send.OkAsync(new UploadRecipeImageUrlResponse
+        {
+            UploadUrl = result.UploadUrl,
+            BlobUrl = result.BlobUrl
+        }, ct);
+    }
+
+    // Returns a file extension for known image types.
+    // For unsupported types, returns a placeholder — the IImageUploadService
+    // validates the content type and will throw INVALID_IMAGE_CONTENT_TYPE before
+    // the subPath value reaches blob storage.
+    private static string GetExtension(string contentType) => contentType.ToLowerInvariant() switch
+    {
+        "image/jpeg" => "jpg",
+        "image/png"  => "png",
+        "image/webp" => "webp",
+        _            => "bin",
+    };
+}

--- a/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlRequest.cs
@@ -1,0 +1,31 @@
+using FastEndpoints;
+
+namespace FitnessPlatform.Application.Features.Recipes.UploadImageUrl;
+
+/// <summary>
+/// Request model for generating a pre-signed upload URL for a recipe image.
+/// </summary>
+public class UploadRecipeImageUrlRequest
+{
+    /// <summary>
+    /// The recipe's public identifier (from route).
+    /// </summary>
+    public Guid RecipeId { get; set; }
+
+    /// <summary>
+    /// Image slot: <c>main</c> (overwrites) or <c>gallery</c> (appends, max 6).
+    /// Provided as a query parameter: <c>?slot=main</c> or <c>?slot=gallery</c>.
+    /// </summary>
+    [QueryParam]
+    public string Slot { get; set; } = string.Empty;
+
+    /// <summary>
+    /// MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp").
+    /// </summary>
+    public string ContentType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Declared file size in bytes. Must not exceed 5 MiB.
+    /// </summary>
+    public long SizeBytes { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlResponse.cs
@@ -1,0 +1,19 @@
+namespace FitnessPlatform.Application.Features.Recipes.UploadImageUrl;
+
+/// <summary>
+/// Response model containing the pre-signed upload URL and the permanent blob URL.
+/// </summary>
+public class UploadRecipeImageUrlResponse
+{
+    /// <summary>
+    /// Time-limited pre-signed URL the client should PUT the image file to.
+    /// </summary>
+    public string UploadUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Permanent blob URL at which the recipe image will be accessible after a successful upload.
+    /// Main slot: <c>recipes/{recipeId}/main.{ext}</c>.
+    /// Gallery slot: <c>recipes/{recipeId}/gallery-{n}.{ext}</c>.
+    /// </summary>
+    public string BlobUrl { get; set; } = string.Empty;
+}

--- a/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Recipes/UploadImageUrl/UploadRecipeImageUrlValidator.cs
@@ -1,0 +1,34 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.Recipes.UploadImageUrl;
+
+/// <summary>
+/// Validates the <see cref="UploadRecipeImageUrlRequest"/>.
+/// Content-type and size enforcement is delegated to <c>IImageUploadService</c>;
+/// this validator asserts presence and slot validity.
+/// </summary>
+public class UploadRecipeImageUrlValidator : Validator<UploadRecipeImageUrlRequest>
+{
+    private static readonly HashSet<string> ValidSlots =
+        new(StringComparer.OrdinalIgnoreCase) { "main", "gallery" };
+
+    /// <summary>
+    /// Initializes validation rules for the recipe image upload-URL request.
+    /// </summary>
+    public UploadRecipeImageUrlValidator()
+    {
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.SizeBytes)
+            .GreaterThan(0).WithErrorCode(ErrorCodes.OutOfRange);
+
+        RuleFor(x => x.Slot)
+            .NotEmpty().WithErrorCode(ErrorCodes.Required)
+            .Must(s => ValidSlots.Contains(s))
+            .WithErrorCode(ErrorCodes.OutOfRange)
+            .WithMessage("Slot must be 'main' or 'gallery'.");
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Recipes/UploadImageUrl/RecipeImageEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Recipes/UploadImageUrl/RecipeImageEndpointTests.cs
@@ -1,0 +1,551 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Recipes.ConfirmRecipeImage;
+using FitnessPlatform.Application.Features.Recipes.UploadImageUrl;
+using FitnessPlatform.Tests.Endpoints;
+using FitnessPlatform.Tests.Endpoints.Recipes;
+using MongoDB.Driver;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FitnessPlatform.Tests.Endpoints.Recipes.UploadImageUrl;
+
+/// <summary>
+/// Unit tests for <see cref="UploadRecipeImageUrlEndpoint"/> and <see cref="ConfirmRecipeImageEndpoint"/>.
+/// </summary>
+public class UploadRecipeImageUrlEndpointTests
+{
+    private readonly Guid _nutritionistId = Guid.NewGuid();
+    private readonly IImageUploadService _imageUpload = Substitute.For<IImageUploadService>();
+
+    // ── Happy path: upload URL — main slot ─────────────────────────────────
+
+    [Fact]
+    public async Task UploadUrl_MainSlot_Nutritionist_RecipeExists_ReturnsUploadUrlAndBlobUrl()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var expectedBlobUrl = $"recipes/{recipeId}/main.jpg";
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                ImageUploadScope.Recipe,
+                $"{recipeId}/main.jpg",
+                "image/jpeg",
+                1024,
+                Arg.Any<CancellationToken>())
+            .Returns(new BlobUploadUrl("https://storage/upload?token=abc", expectedBlobUrl));
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        await ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, CancellationToken.None);
+
+        ep.Response.UploadUrl.Should().Be("https://storage/upload?token=abc");
+        ep.Response.BlobUrl.Should().Be(expectedBlobUrl);
+        ep.Response.BlobUrl.Should().Be($"recipes/{recipeId}/main.jpg");
+    }
+
+    // ── Happy path: upload URL — gallery slot (0th entry) ──────────────────
+
+    [Fact]
+    public async Task UploadUrl_GallerySlot_EmptyGallery_ReturnsGallery0BlobUrl()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        // Empty gallery
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var expectedBlobUrl = $"recipes/{recipeId}/gallery-0.jpg";
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                ImageUploadScope.Recipe,
+                $"{recipeId}/gallery-0.jpg",
+                "image/jpeg",
+                2048,
+                Arg.Any<CancellationToken>())
+            .Returns(new BlobUploadUrl("https://storage/upload?token=xyz", expectedBlobUrl));
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        await ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "gallery",
+            ContentType = "image/jpeg",
+            SizeBytes = 2048
+        }, CancellationToken.None);
+
+        ep.Response.BlobUrl.Should().Be($"recipes/{recipeId}/gallery-0.jpg");
+    }
+
+    // ── Gallery slot: next index based on existing count ───────────────────
+
+    [Fact]
+    public async Task UploadUrl_GallerySlot_ExistingEntries_UsesCorrectIndex()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        recipe.GalleryImageUrls.Add($"recipes/{recipeId}/gallery-0.jpg");
+        recipe.GalleryImageUrls.Add($"recipes/{recipeId}/gallery-1.png");
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                ImageUploadScope.Recipe,
+                $"{recipeId}/gallery-2.webp",
+                "image/webp",
+                512,
+                Arg.Any<CancellationToken>())
+            .Returns(new BlobUploadUrl("https://storage/upload", $"recipes/{recipeId}/gallery-2.webp"));
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        await ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "gallery",
+            ContentType = "image/webp",
+            SizeBytes = 512
+        }, CancellationToken.None);
+
+        await _imageUpload.Received(1).GenerateUploadUrlAsync(
+            ImageUploadScope.Recipe,
+            $"{recipeId}/gallery-2.webp",
+            "image/webp",
+            512,
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Gallery cap enforcement on upload ──────────────────────────────────
+
+    [Fact]
+    public async Task UploadUrl_GallerySlot_GalleryFull_Throws_RecipeGalleryFull()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        // Fill gallery to cap
+        for (var i = 0; i < 6; i++)
+            recipe.GalleryImageUrls.Add($"recipes/{recipeId}/gallery-{i}.jpg");
+
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        var act = () => ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "gallery",
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should()
+            .ContainSingle(f => f.ErrorCode == ErrorCodes.RecipeGalleryFull);
+
+        await _imageUpload.DidNotReceive().GenerateUploadUrlAsync(
+            Arg.Any<ImageUploadScope>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Non-owner ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadUrl_NonOwner_Throws_RecipeNotOwned()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: Guid.NewGuid());
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        var act = () => ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should()
+            .ContainSingle(f => f.ErrorCode == ErrorCodes.RecipeNotOwned);
+    }
+
+    // ── Recipe not found ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadUrl_RecipeNotFound_Returns404()
+    {
+        var mongo = RecipeTestHelpers.CreateMockMongo(); // no recipes
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        await ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = Guid.NewGuid(),
+            Slot = "main",
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+        await _imageUpload.DidNotReceive().GenerateUploadUrlAsync(
+            Arg.Any<ImageUploadScope>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Unauthenticated ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadUrl_NoClaims_Returns401()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(mongo, _imageUpload);
+
+        await ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    // ── Blob-path format ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("image/jpeg", "main",    "{0}/main.jpg")]
+    [InlineData("image/png",  "main",    "{0}/main.png")]
+    [InlineData("image/webp", "main",    "{0}/main.webp")]
+    [InlineData("image/jpeg", "gallery", "{0}/gallery-0.jpg")]
+    [InlineData("image/png",  "gallery", "{0}/gallery-0.png")]
+    public async Task UploadUrl_SubPathConstruction_MatchesBlobPathConvention(
+        string contentType, string slot, string expectedSubPathTemplate)
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var expectedSubPath = string.Format(expectedSubPathTemplate, recipeId);
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                ImageUploadScope.Recipe,
+                expectedSubPath,
+                contentType,
+                512,
+                Arg.Any<CancellationToken>())
+            .Returns(new BlobUploadUrl("https://storage/upload", $"recipes/{expectedSubPath}"));
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        await ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = slot,
+            ContentType = contentType,
+            SizeBytes = 512
+        }, CancellationToken.None);
+
+        await _imageUpload.Received(1).GenerateUploadUrlAsync(
+            ImageUploadScope.Recipe,
+            expectedSubPath,
+            contentType,
+            512,
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Service-level rejections ───────────────────────────────────────────
+
+    [Fact]
+    public async Task UploadUrl_InvalidContentType_ServiceThrows_PropagatesException()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                Arg.Any<ImageUploadScope>(), Arg.Any<string>(), "application/pdf",
+                Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Throws(new ValidationFailureException(
+                [new FluentValidation.Results.ValidationFailure("contentType", "invalid")
+                    { ErrorCode = ErrorCodes.InvalidImageContentType }],
+                "Invalid content type."));
+
+        var ep = Factory.Create<UploadRecipeImageUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, _imageUpload);
+
+        var act = () => ep.HandleAsync(new UploadRecipeImageUrlRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            ContentType = "application/pdf",
+            SizeBytes = 1024
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should()
+            .ContainSingle(f => f.ErrorCode == ErrorCodes.InvalidImageContentType);
+    }
+}
+
+/// <summary>
+/// Unit tests for <see cref="ConfirmRecipeImageEndpoint"/>.
+/// </summary>
+public class ConfirmRecipeImageEndpointTests
+{
+    private readonly Guid _nutritionistId = Guid.NewGuid();
+
+    // ── Happy path: main slot ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfirmImage_MainSlot_Owner_SetsImageUrl_Returns204()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<ConfirmRecipeImageEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        await ep.HandleAsync(new ConfirmRecipeImageRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            BlobUrl = $"recipes/{recipeId}/main.jpg"
+        }, CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        await mongo.Recipes.Received(1).UpdateOneAsync(
+            Arg.Any<FilterDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Happy path: gallery slot ───────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfirmImage_GallerySlot_Owner_AppendsToGallery_Returns204()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<ConfirmRecipeImageEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        await ep.HandleAsync(new ConfirmRecipeImageRequest
+        {
+            RecipeId = recipeId,
+            Slot = "gallery",
+            BlobUrl = $"recipes/{recipeId}/gallery-0.jpg"
+        }, CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+        await mongo.Recipes.Received(1).UpdateOneAsync(
+            Arg.Any<FilterDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Gallery cap enforcement on confirm ────────────────────────────────
+
+    [Fact]
+    public async Task ConfirmImage_GallerySlot_GalleryFull_Throws_RecipeGalleryFull()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        for (var i = 0; i < 6; i++)
+            recipe.GalleryImageUrls.Add($"recipes/{recipeId}/gallery-{i}.jpg");
+
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<ConfirmRecipeImageEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        var act = () => ep.HandleAsync(new ConfirmRecipeImageRequest
+        {
+            RecipeId = recipeId,
+            Slot = "gallery",
+            BlobUrl = $"recipes/{recipeId}/gallery-6.jpg"
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should()
+            .ContainSingle(f => f.ErrorCode == ErrorCodes.RecipeGalleryFull);
+
+        await mongo.Recipes.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Ownership gate ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfirmImage_NonOwner_Throws_RecipeNotOwned()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: Guid.NewGuid());
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<ConfirmRecipeImageEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(Guid.NewGuid(), AppRoles.Nutritionist))),
+            mongo);
+
+        var act = () => ep.HandleAsync(new ConfirmRecipeImageRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            BlobUrl = $"recipes/{recipeId}/main.jpg"
+        }, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should()
+            .ContainSingle(f => f.ErrorCode == ErrorCodes.RecipeNotOwned);
+
+        await mongo.Recipes.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Recipe not found ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfirmImage_RecipeNotFound_Returns404()
+    {
+        var mongo = RecipeTestHelpers.CreateMockMongo(); // no recipes
+
+        var ep = Factory.Create<ConfirmRecipeImageEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        await ep.HandleAsync(new ConfirmRecipeImageRequest
+        {
+            RecipeId = Guid.NewGuid(),
+            Slot = "main",
+            BlobUrl = "recipes/nonexistent/main.jpg"
+        }, CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+        await mongo.Recipes.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Unauthenticated ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfirmImage_NoClaims_Returns401()
+    {
+        var recipeId = Guid.NewGuid();
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        var mongo = RecipeTestHelpers.CreateMockMongo(recipes: [recipe]);
+
+        var ep = Factory.Create<ConfirmRecipeImageEndpoint>(mongo);
+
+        await ep.HandleAsync(new ConfirmRecipeImageRequest
+        {
+            RecipeId = recipeId,
+            Slot = "main",
+            BlobUrl = $"recipes/{recipeId}/main.jpg"
+        }, CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+        await mongo.Recipes.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateDefinition<Application.Domain.Documents.Recipe>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Get reflects stored image (unit-level) ─────────────────────────────
+
+    [Fact]
+    public void ConfirmImage_AfterConfirm_GetRecipe_ReflectsImageUrlAndGallery()
+    {
+        var recipeId = Guid.NewGuid();
+        var blobUrl = $"recipes/{recipeId}/main.jpg";
+        var galleryUrl = $"recipes/{recipeId}/gallery-0.png";
+
+        // Simulate what a recipe document looks like after both confirms
+        var recipe = RecipeTestHelpers.CreateRecipe(externalId: recipeId, nutritionistId: _nutritionistId);
+        recipe.ImageUrl = blobUrl;
+        recipe.GalleryImageUrls.Add(galleryUrl);
+
+        var response = Application.Features.Recipes.Shared.GetRecipeResponse.FromDocument(recipe, _nutritionistId);
+
+        response.ImageUrl.Should().Be(blobUrl);
+        response.GalleryImageUrls.Should().ContainSingle(u => u == galleryUrl);
+        response.RecipeId.Should().Be(recipeId);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Recipes/UploadImageUrl/RecipeImageIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Recipes/UploadImageUrl/RecipeImageIntegrationTests.cs
@@ -1,0 +1,466 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Tests.Infrastructure;
+
+namespace FitnessPlatform.Tests.Endpoints.Recipes.UploadImageUrl;
+
+/// <summary>
+/// Integration tests for the recipe image upload flow:
+///   POST /recipes/{recipeId}/image/upload-url?slot={main|gallery}  (UploadRecipeImageUrlEndpoint)
+///   PUT  /recipes/{recipeId}/image?slot={main|gallery}             (ConfirmRecipeImageEndpoint)
+///   GET  /recipes/{recipeId}                                       (GetRecipeEndpoint — image reflection)
+///
+/// These tests use a real HTTP stack (FitnessApiFactory with Testcontainers) so
+/// the authentication/authorisation middleware and the full DI pipeline are
+/// exercised.  NSubstitute unit tests in the sibling file cover logic-level
+/// branches; this file fills the AC gap by proving the role gate actually fires.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class RecipeImageIntegrationTests(FitnessApiFactory factory)
+{
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static string UniqueEmail(string tag) => $"{Guid.NewGuid():N}@recipe-img-{tag}.test";
+
+    private static async Task<string> SeedUserAsync(
+        HttpClient client, string role, string tag = "")
+    {
+        var email = UniqueEmail(tag.Length > 0 ? tag : role.ToLowerInvariant());
+        await TestHelpers.RegisterAsync(client, email, "TestPass1!", "Test", "User", role);
+        var (accessToken, _) = await TestHelpers.LoginAsync(client, email, "TestPass1!");
+        return accessToken;
+    }
+
+    private static async Task<Guid> CreateFoodAsync(HttpClient client, string ownerToken)
+    {
+        TestHelpers.SetBearerToken(client, ownerToken);
+        var response = await client.PostAsJsonAsync("/foods", new
+        {
+            Name = $"Test Food {Guid.NewGuid():N}",
+            NutrientValue = new { Kcal = 125m, Protein = 10m, Carbs = 10m, Fat = 5m },
+            Allergens = Array.Empty<string>(),
+            CommonServings = Array.Empty<object>()
+        }, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "food creation must succeed so a recipe can reference it");
+
+        var body = await response.Content.ReadFromJsonAsync<FoodRef>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        return body!.FoodId;
+    }
+
+    private static async Task<Guid> CreateRecipeAsync(HttpClient client, string ownerToken, Guid foodId)
+    {
+        TestHelpers.SetBearerToken(client, ownerToken);
+        var response = await client.PostAsJsonAsync("/recipes", new
+        {
+            Name = $"Test Recipe {Guid.NewGuid():N}",
+            Foods = new[]
+            {
+                new { FoodExternalId = foodId, AmountGrams = 100m }
+            }
+        }, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "recipe creation must succeed for the integration test to proceed");
+
+        var body = await response.Content.ReadFromJsonAsync<RecipeRef>(
+            cancellationToken: TestContext.Current.CancellationToken);
+        return body!.RecipeId;
+    }
+
+    // ── Happy path: upload-url — main slot ─────────────────────────────────────
+
+    /// <summary>
+    /// A nutritionist requests an upload URL for the main slot of their own recipe.
+    /// Expects 200 with both <c>uploadUrl</c> and <c>blobUrl</c>;
+    /// <c>blobUrl</c> must equal <c>recipes/{recipeId}/main.jpg</c>.
+    /// </summary>
+    [Fact]
+    public async Task UploadUrl_Nutritionist_MainSlot_HappyPath_Returns200WithBlobUrl()
+    {
+        var client = factory.CreateClient();
+        var token = await SeedUserAsync(client, "Nutritionist", "main-happy");
+        var foodId = await CreateFoodAsync(client, token);
+        var recipeId = await CreateRecipeAsync(client, token, foodId);
+
+        TestHelpers.SetBearerToken(client, token);
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=main",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<UploadUrlResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        body!.UploadUrl.Should().NotBeNullOrEmpty();
+        body.BlobUrl.Should().Be($"recipes/{recipeId}/main.jpg");
+    }
+
+    // ── Happy path: upload-url — gallery slot (0th entry) ──────────────────────
+
+    /// <summary>
+    /// A nutritionist requests an upload URL for the 0th gallery slot.
+    /// <c>blobUrl</c> must equal <c>recipes/{recipeId}/gallery-0.jpg</c>.
+    /// </summary>
+    [Fact]
+    public async Task UploadUrl_Nutritionist_GallerySlot_FirstEntry_Returns200WithGallery0BlobUrl()
+    {
+        var client = factory.CreateClient();
+        var token = await SeedUserAsync(client, "Nutritionist", "gallery-happy");
+        var foodId = await CreateFoodAsync(client, token);
+        var recipeId = await CreateRecipeAsync(client, token, foodId);
+
+        TestHelpers.SetBearerToken(client, token);
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=gallery",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<UploadUrlResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        body!.BlobUrl.Should().Be($"recipes/{recipeId}/gallery-0.jpg");
+    }
+
+    // ── Role gate: upload-url ──────────────────────────────────────────────────
+
+    /// <summary>Trainer token → 403 on POST /recipes/{id}/image/upload-url.</summary>
+    [Fact]
+    public async Task UploadUrl_TrainerRole_Returns403()
+    {
+        var client = factory.CreateClient();
+
+        var nutritionistToken = await SeedUserAsync(client, "Nutritionist", "upload-trainer-owner");
+        var foodId = await CreateFoodAsync(client, nutritionistToken);
+        var recipeId = await CreateRecipeAsync(client, nutritionistToken, foodId);
+
+        var trainerToken = await SeedUserAsync(client, "Trainer", "upload-trainer");
+        TestHelpers.SetBearerToken(client, trainerToken);
+
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=main",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>Client token → 403 on POST /recipes/{id}/image/upload-url.</summary>
+    [Fact]
+    public async Task UploadUrl_ClientRole_Returns403()
+    {
+        var client = factory.CreateClient();
+
+        var nutritionistToken = await SeedUserAsync(client, "Nutritionist", "upload-client-owner");
+        var foodId = await CreateFoodAsync(client, nutritionistToken);
+        var recipeId = await CreateRecipeAsync(client, nutritionistToken, foodId);
+
+        var clientToken = await SeedUserAsync(client, "Client", "upload-client");
+        TestHelpers.SetBearerToken(client, clientToken);
+
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=main",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>No token → 401 on POST /recipes/{id}/image/upload-url.</summary>
+    [Fact]
+    public async Task UploadUrl_Unauthenticated_Returns401()
+    {
+        var client = factory.CreateClient();
+
+        var nutritionistToken = await SeedUserAsync(client, "Nutritionist", "upload-unauth-owner");
+        var foodId = await CreateFoodAsync(client, nutritionistToken);
+        var recipeId = await CreateRecipeAsync(client, nutritionistToken, foodId);
+
+        client.DefaultRequestHeaders.Authorization = null;
+
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=main",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Ownership gate: upload-url ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Nutritionist B requests an upload URL for a recipe owned by nutritionist A.
+    /// Expects 400 with RECIPE_NOT_OWNED.
+    /// </summary>
+    [Fact]
+    public async Task UploadUrl_NonOwner_Returns400WithRecipeNotOwnedError()
+    {
+        var client = factory.CreateClient();
+
+        var tokenA = await SeedUserAsync(client, "Nutritionist", "upload-owner-a");
+        var foodId = await CreateFoodAsync(client, tokenA);
+        var recipeId = await CreateRecipeAsync(client, tokenA, foodId);
+
+        var tokenB = await SeedUserAsync(client, "Nutritionist", "upload-owner-b");
+        TestHelpers.SetBearerToken(client, tokenB);
+
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=main",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        raw.Should().Contain("RECIPE_NOT_OWNED",
+            "the Problem Details payload must carry the RECIPE_NOT_OWNED error code");
+    }
+
+    // ── Gallery cap: upload-url ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Gallery is filled to 6 entries via confirm, then a 7th upload-url request returns 400 RECIPE_GALLERY_FULL.
+    /// </summary>
+    [Fact]
+    public async Task UploadUrl_GalleryFull_Returns400WithRecipeGalleryFullError()
+    {
+        var client = factory.CreateClient();
+        var token = await SeedUserAsync(client, "Nutritionist", "gallery-full-upload");
+        var foodId = await CreateFoodAsync(client, token);
+        var recipeId = await CreateRecipeAsync(client, token, foodId);
+
+        TestHelpers.SetBearerToken(client, token);
+
+        // Confirm 6 gallery entries
+        for (var i = 0; i < 6; i++)
+        {
+            var confirmResponse = await client.PutAsJsonAsync(
+                $"/recipes/{recipeId}/image?slot=gallery",
+                new { BlobUrl = $"recipes/{recipeId}/gallery-{i}.jpg" },
+                TestContext.Current.CancellationToken);
+
+            confirmResponse.StatusCode.Should().Be(HttpStatusCode.NoContent,
+                $"confirming gallery entry {i} should succeed");
+        }
+
+        // Now try to request a 7th upload URL
+        var response = await client.PostAsJsonAsync(
+            $"/recipes/{recipeId}/image/upload-url?slot=gallery",
+            new { ContentType = "image/jpeg", SizeBytes = 102400L },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        raw.Should().Contain("RECIPE_GALLERY_FULL",
+            "the Problem Details payload must carry the RECIPE_GALLERY_FULL error code");
+    }
+
+    // ── Happy path: confirm + GET reflection — main slot ──────────────────────
+
+    /// <summary>
+    /// Nutritionist confirms a main image via PUT /recipes/{id}/image?slot=main.
+    /// Subsequent GET /recipes/{id} must return the DTO with imageUrl set.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmImage_MainSlot_HappyPath_Returns204_AndGetReflectsImageUrl()
+    {
+        var client = factory.CreateClient();
+        var token = await SeedUserAsync(client, "Nutritionist", "confirm-main-happy");
+        var foodId = await CreateFoodAsync(client, token);
+        var recipeId = await CreateRecipeAsync(client, token, foodId);
+
+        var blobUrl = $"recipes/{recipeId}/main.jpg";
+
+        TestHelpers.SetBearerToken(client, token);
+
+        var putResponse = await client.PutAsJsonAsync(
+            $"/recipes/{recipeId}/image?slot=main",
+            new { BlobUrl = blobUrl },
+            TestContext.Current.CancellationToken);
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var getResponse = await client.GetAsync(
+            $"/recipes/{recipeId}",
+            TestContext.Current.CancellationToken);
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var recipe = await getResponse.Content.ReadFromJsonAsync<RecipeDetailResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        recipe.Should().NotBeNull();
+        recipe!.RecipeId.Should().Be(recipeId);
+        recipe.ImageUrl.Should().Be(blobUrl);
+    }
+
+    // ── Happy path: confirm + GET reflection — gallery slot ───────────────────
+
+    /// <summary>
+    /// Nutritionist confirms a gallery image via PUT /recipes/{id}/image?slot=gallery.
+    /// Subsequent GET /recipes/{id} must include the new entry in galleryImageUrls.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmImage_GallerySlot_HappyPath_Returns204_AndGetReflectsGalleryImageUrls()
+    {
+        var client = factory.CreateClient();
+        var token = await SeedUserAsync(client, "Nutritionist", "confirm-gallery-happy");
+        var foodId = await CreateFoodAsync(client, token);
+        var recipeId = await CreateRecipeAsync(client, token, foodId);
+
+        var galleryBlobUrl = $"recipes/{recipeId}/gallery-0.jpg";
+
+        TestHelpers.SetBearerToken(client, token);
+
+        var putResponse = await client.PutAsJsonAsync(
+            $"/recipes/{recipeId}/image?slot=gallery",
+            new { BlobUrl = galleryBlobUrl },
+            TestContext.Current.CancellationToken);
+
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var getResponse = await client.GetAsync(
+            $"/recipes/{recipeId}",
+            TestContext.Current.CancellationToken);
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var recipe = await getResponse.Content.ReadFromJsonAsync<RecipeDetailResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        recipe.Should().NotBeNull();
+        recipe!.GalleryImageUrls.Should().ContainSingle(u => u == galleryBlobUrl);
+    }
+
+    // ── Gallery cap: confirm ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Attempting to confirm a 7th gallery entry via PUT /recipes/{id}/image?slot=gallery
+    /// when the gallery already has 6 entries returns 400 RECIPE_GALLERY_FULL.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmImage_GalleryOverflow_Returns400WithRecipeGalleryFullError()
+    {
+        var client = factory.CreateClient();
+        var token = await SeedUserAsync(client, "Nutritionist", "gallery-full-confirm");
+        var foodId = await CreateFoodAsync(client, token);
+        var recipeId = await CreateRecipeAsync(client, token, foodId);
+
+        TestHelpers.SetBearerToken(client, token);
+
+        // Confirm 6 gallery entries
+        for (var i = 0; i < 6; i++)
+        {
+            var confirmResponse = await client.PutAsJsonAsync(
+                $"/recipes/{recipeId}/image?slot=gallery",
+                new { BlobUrl = $"recipes/{recipeId}/gallery-{i}.jpg" },
+                TestContext.Current.CancellationToken);
+
+            confirmResponse.StatusCode.Should().Be(HttpStatusCode.NoContent,
+                $"confirming gallery entry {i} should succeed");
+        }
+
+        // Attempt a 7th confirm — must fail with RECIPE_GALLERY_FULL
+        var response = await client.PutAsJsonAsync(
+            $"/recipes/{recipeId}/image?slot=gallery",
+            new { BlobUrl = $"recipes/{recipeId}/gallery-6.jpg" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        raw.Should().Contain("RECIPE_GALLERY_FULL",
+            "the Problem Details payload must carry the RECIPE_GALLERY_FULL error code");
+    }
+
+    // ── Role gate: confirm ─────────────────────────────────────────────────────
+
+    /// <summary>Trainer token → 403 on PUT /recipes/{id}/image.</summary>
+    [Fact]
+    public async Task ConfirmImage_TrainerRole_Returns403()
+    {
+        var client = factory.CreateClient();
+
+        var nutritionistToken = await SeedUserAsync(client, "Nutritionist", "confirm-trainer-owner");
+        var foodId = await CreateFoodAsync(client, nutritionistToken);
+        var recipeId = await CreateRecipeAsync(client, nutritionistToken, foodId);
+
+        var trainerToken = await SeedUserAsync(client, "Trainer", "confirm-trainer");
+        TestHelpers.SetBearerToken(client, trainerToken);
+
+        var response = await client.PutAsJsonAsync(
+            $"/recipes/{recipeId}/image?slot=main",
+            new { BlobUrl = $"recipes/{recipeId}/main.jpg" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>Client token → 403 on PUT /recipes/{id}/image.</summary>
+    [Fact]
+    public async Task ConfirmImage_ClientRole_Returns403()
+    {
+        var client = factory.CreateClient();
+
+        var nutritionistToken = await SeedUserAsync(client, "Nutritionist", "confirm-client-owner");
+        var foodId = await CreateFoodAsync(client, nutritionistToken);
+        var recipeId = await CreateRecipeAsync(client, nutritionistToken, foodId);
+
+        var clientToken = await SeedUserAsync(client, "Client", "confirm-client");
+        TestHelpers.SetBearerToken(client, clientToken);
+
+        var response = await client.PutAsJsonAsync(
+            $"/recipes/{recipeId}/image?slot=main",
+            new { BlobUrl = $"recipes/{recipeId}/main.jpg" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Ownership check on confirm ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Nutritionist B tries to confirm an image on a recipe owned by nutritionist A.
+    /// Expects 400 with RECIPE_NOT_OWNED.
+    /// </summary>
+    [Fact]
+    public async Task ConfirmImage_NonOwner_Returns400WithRecipeNotOwnedError()
+    {
+        var client = factory.CreateClient();
+
+        var tokenA = await SeedUserAsync(client, "Nutritionist", "confirm-owner-a");
+        var foodId = await CreateFoodAsync(client, tokenA);
+        var recipeId = await CreateRecipeAsync(client, tokenA, foodId);
+
+        var tokenB = await SeedUserAsync(client, "Nutritionist", "confirm-owner-b");
+        TestHelpers.SetBearerToken(client, tokenB);
+
+        var response = await client.PutAsJsonAsync(
+            $"/recipes/{recipeId}/image?slot=main",
+            new { BlobUrl = $"recipes/{recipeId}/main.jpg" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var raw = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        raw.Should().Contain("RECIPE_NOT_OWNED",
+            "the Problem Details payload must carry the RECIPE_NOT_OWNED error code");
+    }
+
+    // ── Local response DTOs (per slice rules — no cross-feature imports) ────────
+
+    private record UploadUrlResponse(string UploadUrl, string BlobUrl);
+    private record FoodRef(Guid FoodId);
+    private record RecipeRef(Guid RecipeId);
+    private record RecipeDetailResponse(Guid RecipeId, string Name, string? ImageUrl, List<string> GalleryImageUrls);
+}


### PR DESCRIPTION
Fixes #72. Part of epic #65 (Platform photo primitives).

## Summary

- `Recipe.ImageUrl` (main, overwrite) + `Recipe.GalleryImageUrls` (append-only, capped at 6) — Mongo document fields, no migration.
- `POST /recipes/{RecipeId}/image/upload-url?slot={main|gallery}` → `{ uploadUrl, blobUrl }`.
- `PUT /recipes/{RecipeId}/image?slot={main|gallery}` with `{ blobUrl }` → 204.
- Nutritionist role + creator-ownership guard (`RECIPE_NOT_OWNED`).
- Gallery cap (`RECIPE_GALLERY_FULL`) enforced at both upload-url AND confirm (race protection).
- Read-side DTOs updated: `GetRecipeResponse` includes both fields, `RecipeSummaryDto` includes only `ImageUrl` (list view doesn't need the gallery).

## Blob-path layout

- Main: `recipes/<recipeId>/main.<ext>`
- Gallery: `recipes/<recipeId>/gallery-<n>.<ext>` where `n = GalleryImageUrls.Count` at upload-url time (0..5). Each gallery entry gets a unique path.

## Acceptance criteria — status

- ✅ Main slot overwrites (`Update.Set` semantics); gallery appends up to 6 (`Update.Push`, cap-checked twice).
- ✅ Blob path `recipes/{recipeId}/{slot}.{ext}` — integration tests assert exact strings for both slots.
- ✅ Testcontainers coverage — 16 integration tests through `FitnessApiFactory` cover every AC + role gate + ownership + cap overflow.

## Test plan

- [x] `dotnet build` — 0 errors.
- [x] Full suite — **645/645 green** (baseline 611 + 34 new).
- [x] New tests: 18 unit + 16 Testcontainers = 34.

## Known non-AC follow-up

Same blobUrl-origin deferred note as #69/#70/#71. Recipe uses hard-delete (no `IsDeleted`), so the #71 soft-delete filter pattern doesn't apply here — the confirm's `UpdateOneAsync` uses combined `ExternalId` + ownership filter which is equivalent-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)