### PR TITLE
feat(web): wire Food admin image upload via <ImagePicker> (#75)

### DIFF
--- a/web/src/api/food-types.ts
+++ b/web/src/api/food-types.ts
@@ -40,6 +40,8 @@ export interface FoodSummary {
   commonServings: ServingSizeDto[];
   visibility?: FoodVisibility;
   isOwnedByCurrentUser?: boolean;
+  /** URL of the food hero image in blob storage. Null when no image has been uploaded. */
+  imageUrl?: string | null;
 }
 
 /** Paginated food search response. */

--- a/web/src/api/foods.ts
+++ b/web/src/api/foods.ts
@@ -1,4 +1,5 @@
 import api from '@/lib/api';
+import type { UploadFoodImageUrlRequest, ConfirmFoodImageRequest } from './generated';
 import type {
   SearchFoodsResponse,
   GetCustomFoodsResponse,
@@ -49,4 +50,22 @@ export async function getCustomFoods(params: {
 }): Promise<GetCustomFoodsResponse> {
   const { data } = await api.get<GetCustomFoodsResponse>('/foods/custom', { params });
   return data;
+}
+
+/** Request a pre-signed upload URL for a food item's hero image (Nutritionist only). */
+export async function requestFoodImageUploadUrl(
+  foodId: string,
+  request: UploadFoodImageUrlRequest,
+): Promise<{ uploadUrl: string; blobUrl: string }> {
+  const { data } = await api.post<{ uploadUrl: string; blobUrl: string }>(
+    `/foods/${foodId}/image/upload-url`,
+    request,
+  );
+  return data;
+}
+
+/** Confirm a completed food image upload by persisting its blob URL (Nutritionist only). */
+export async function confirmFoodImage(foodId: string, blobUrl: string): Promise<void> {
+  const body: ConfirmFoodImageRequest = { blobUrl };
+  await api.put(`/foods/${foodId}/image`, body);
 }

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -430,6 +430,863 @@ export class ApiClient {
     }
 
     /**
+     * Respond to a weekly check-in
+     * @param id Route parameter — check-in identifier.
+     * @return Success
+     */
+    respondToCheckInEndpoint(id: string, respondToCheckInRequest: RespondToCheckInRequest, signal?: AbortSignal): Promise<RespondToCheckInResponse> {
+        let url_ = this.baseUrl + "/client/weekly-check-ins/{id}/respond";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(respondToCheckInRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRespondToCheckInEndpoint(_response);
+        });
+    }
+
+    protected processRespondToCheckInEndpoint(response: AxiosResponse): Promise<RespondToCheckInResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<RespondToCheckInResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<RespondToCheckInResponse>(null as any);
+    }
+
+    /**
+     * Upsert weekly check-in setting
+     * @return Success
+     */
+    putSettingsEndpoint(putSettingsRequest: PutSettingsRequest, signal?: AbortSignal): Promise<PutSettingsResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/settings";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(putSettingsRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processPutSettingsEndpoint(_response);
+        });
+    }
+
+    protected processPutSettingsEndpoint(response: AxiosResponse): Promise<PutSettingsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<PutSettingsResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<PutSettingsResponse>(null as any);
+    }
+
+    /**
+     * Get weekly check-in settings
+     * @return Success
+     */
+    getSettingsEndpoint(signal?: AbortSignal): Promise<GetSettingsResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/settings";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetSettingsEndpoint(_response);
+        });
+    }
+
+    protected processGetSettingsEndpoint(response: AxiosResponse): Promise<GetSettingsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetSettingsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetSettingsResponse>(null as any);
+    }
+
+    /**
+     * Upsert per-client override
+     * @param clientUserId The client's ApplicationUser.Id (route parameter).
+     * @param profession Profession ("Training" or "Nutrition") (route parameter).
+     * @return Success
+     */
+    putOverrideEndpoint(clientUserId: string, profession: string, putOverrideRequest: PutOverrideRequest, signal?: AbortSignal): Promise<PutOverrideResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/overrides/{clientUserId}/{profession}";
+        if (clientUserId === undefined || clientUserId === null)
+            throw new globalThis.Error("The parameter 'clientUserId' must be defined.");
+        url_ = url_.replace("{clientUserId}", encodeURIComponent("" + clientUserId));
+        if (profession === undefined || profession === null)
+            throw new globalThis.Error("The parameter 'profession' must be defined.");
+        url_ = url_.replace("{profession}", encodeURIComponent("" + profession));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(putOverrideRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processPutOverrideEndpoint(_response);
+        });
+    }
+
+    protected processPutOverrideEndpoint(response: AxiosResponse): Promise<PutOverrideResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<PutOverrideResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<PutOverrideResponse>(null as any);
+    }
+
+    /**
+     * Delete per-client override
+     * @param clientUserId The client's ApplicationUser.Id (route parameter).
+     * @param profession Profession ("Training" or "Nutrition") (route parameter).
+     * @return No Content
+     */
+    deleteOverrideEndpoint(clientUserId: string, profession: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/overrides/{clientUserId}/{profession}";
+        if (clientUserId === undefined || clientUserId === null)
+            throw new globalThis.Error("The parameter 'clientUserId' must be defined.");
+        url_ = url_.replace("{clientUserId}", encodeURIComponent("" + clientUserId));
+        if (profession === undefined || profession === null)
+            throw new globalThis.Error("The parameter 'profession' must be defined.");
+        url_ = url_.replace("{profession}", encodeURIComponent("" + profession));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDeleteOverrideEndpoint(_response);
+        });
+    }
+
+    protected processDeleteOverrideEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Mark a check-in as reviewed (trainer)
+     * @param id Check-in identifier (route parameter).
+     * @return Success
+     */
+    markCheckInReviewedEndpoint(id: string, signal?: AbortSignal): Promise<MarkCheckInReviewedResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/{id}/mark-reviewed";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processMarkCheckInReviewedEndpoint(_response);
+        });
+    }
+
+    protected processMarkCheckInReviewedEndpoint(response: AxiosResponse): Promise<MarkCheckInReviewedResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<MarkCheckInReviewedResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MarkCheckInReviewedResponse>(null as any);
+    }
+
+    /**
+     * List check-ins for a week (trainer)
+     * @param weekStartDate ISO-week Monday to filter by (YYYY-MM-DD). Required.
+     * @return Success
+     */
+    getTrainerCheckInsEndpoint(weekStartDate: string, signal?: AbortSignal): Promise<GetTrainerCheckInsResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins?";
+        if (weekStartDate === undefined || weekStartDate === null)
+            throw new globalThis.Error("The parameter 'weekStartDate' must be defined and cannot be null.");
+        else
+            url_ += "weekStartDate=" + encodeURIComponent("" + weekStartDate) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetTrainerCheckInsEndpoint(_response);
+        });
+    }
+
+    protected processGetTrainerCheckInsEndpoint(response: AxiosResponse): Promise<GetTrainerCheckInsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetTrainerCheckInsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetTrainerCheckInsResponse>(null as any);
+    }
+
+    /**
+     * Get per-client overrides
+     * @return Success
+     */
+    getOverridesEndpoint(signal?: AbortSignal): Promise<GetOverridesResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/overrides";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetOverridesEndpoint(_response);
+        });
+    }
+
+    protected processGetOverridesEndpoint(response: AxiosResponse): Promise<GetOverridesResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetOverridesResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetOverridesResponse>(null as any);
+    }
+
+    /**
+     * Get current week's active check-ins (client)
+     * @return Success
+     */
+    getCurrentClientCheckInsEndpoint(signal?: AbortSignal): Promise<GetCurrentClientCheckInsResponse> {
+        let url_ = this.baseUrl + "/client/weekly-check-ins/current";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetCurrentClientCheckInsEndpoint(_response);
+        });
+    }
+
+    protected processGetCurrentClientCheckInsEndpoint(response: AxiosResponse): Promise<GetCurrentClientCheckInsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetCurrentClientCheckInsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetCurrentClientCheckInsResponse>(null as any);
+    }
+
+    /**
+     * Get current week's check-in for a client (trainer)
+     * @param clientUserId Client's ApplicationUser.Id (route parameter).
+     * @param profession (optional) Profession to filter by ("Training" or "Nutrition"). Optional.
+    When omitted, returns check-ins for all professions.
+     * @return Success
+     */
+    getClientCurrentCheckInEndpoint(clientUserId: string, profession?: string | null | undefined, signal?: AbortSignal): Promise<GetClientCurrentCheckInResponse> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientUserId}/weekly-check-ins/current?";
+        if (clientUserId === undefined || clientUserId === null)
+            throw new globalThis.Error("The parameter 'clientUserId' must be defined.");
+        url_ = url_.replace("{clientUserId}", encodeURIComponent("" + clientUserId));
+        if (profession !== undefined && profession !== null)
+            url_ += "profession=" + encodeURIComponent("" + profession) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetClientCurrentCheckInEndpoint(_response);
+        });
+    }
+
+    protected processGetClientCurrentCheckInEndpoint(response: AxiosResponse): Promise<GetClientCurrentCheckInResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetClientCurrentCheckInResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetClientCurrentCheckInResponse>(null as any);
+    }
+
+    /**
+     * Get check-in detail (trainer)
+     * @param id Check-in identifier (route parameter).
+     * @return Success
+     */
+    getCheckInDetailEndpoint(id: string, signal?: AbortSignal): Promise<GetCheckInDetailResponse> {
+        let url_ = this.baseUrl + "/trainer/weekly-check-ins/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetCheckInDetailEndpoint(_response);
+        });
+    }
+
+    protected processGetCheckInDetailEndpoint(response: AxiosResponse): Promise<GetCheckInDetailResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetCheckInDetailResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetCheckInDetailResponse>(null as any);
+    }
+
+    /**
+     * Dismiss a weekly check-in
+     * @param id Route parameter — check-in identifier.
+     * @return Success
+     */
+    dismissCheckInEndpoint(id: string, signal?: AbortSignal): Promise<DismissCheckInResponse> {
+        let url_ = this.baseUrl + "/client/weekly-check-ins/{id}/dismiss";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDismissCheckInEndpoint(_response);
+        });
+    }
+
+    protected processDismissCheckInEndpoint(response: AxiosResponse): Promise<DismissCheckInResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<DismissCheckInResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<DismissCheckInResponse>(null as any);
+    }
+
+    /**
+     * Update current user time zone
+     * @return No Content
+     */
+    updateTimeZoneEndpoint(updateTimeZoneRequest: UpdateTimeZoneRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/users/me/timezone";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(updateTimeZoneRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateTimeZoneEndpoint(_response);
+        });
+    }
+
+    protected processUpdateTimeZoneEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Update current user profile
      * @return No Content
      */
@@ -598,6 +1455,188 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Confirm avatar upload
+     * @return No Content
+     */
+    confirmAvatarEndpoint(confirmAvatarRequest: ConfirmAvatarRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/users/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmAvatarRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmAvatarEndpoint(_response);
+        });
+    }
+
+    protected processConfirmAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Delete avatar
+     * @return No Content
+     */
+    deleteAvatarEndpoint(signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/users/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDeleteAvatarEndpoint(_response);
+        });
+    }
+
+    protected processDeleteAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Generate avatar upload URL
+     * @return Success
+     */
+    generateAvatarUploadUrlEndpoint(generateAvatarUploadUrlRequest: GenerateAvatarUploadUrlRequest, signal?: AbortSignal): Promise<GenerateAvatarUploadUrlResponse> {
+        let url_ = this.baseUrl + "/users/me/avatar/upload-url";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateAvatarUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateAvatarUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateAvatarUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateAvatarUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateAvatarUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateAvatarUploadUrlResponse>(null as any);
     }
 
     /**
@@ -2485,6 +3524,87 @@ export class ApiClient {
     }
 
     /**
+     * Generate recipe image upload URL
+     * @param recipeId The recipe's public identifier (from route).
+     * @param slot Image slot: main (overwrites) or gallery (appends, max 6).
+    Provided as a query parameter: ?slot=main or ?slot=gallery.
+     * @return Success
+     */
+    uploadRecipeImageUrlEndpoint(recipeId: string, slot: string, uploadRecipeImageUrlRequest: UploadRecipeImageUrlRequest, signal?: AbortSignal): Promise<UploadRecipeImageUrlResponse> {
+        let url_ = this.baseUrl + "/recipes/{recipeId}/image/upload-url?";
+        if (recipeId === undefined || recipeId === null)
+            throw new globalThis.Error("The parameter 'recipeId' must be defined.");
+        url_ = url_.replace("{recipeId}", encodeURIComponent("" + recipeId));
+        if (slot === undefined || slot === null)
+            throw new globalThis.Error("The parameter 'slot' must be defined and cannot be null.");
+        else
+            url_ += "slot=" + encodeURIComponent("" + slot) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(uploadRecipeImageUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUploadRecipeImageUrlEndpoint(_response);
+        });
+    }
+
+    protected processUploadRecipeImageUrlEndpoint(response: AxiosResponse): Promise<UploadRecipeImageUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<UploadRecipeImageUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<UploadRecipeImageUrlResponse>(null as any);
+    }
+
+    /**
      * Update recipe
      * @param recipeId Public identifier of the recipe to update.
      * @return Success
@@ -2832,6 +3952,83 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetRecipeResponse>(null as any);
+    }
+
+    /**
+     * Confirm recipe image upload
+     * @param recipeId The recipe's public identifier (from route).
+     * @param slot Image slot: main (overwrites ImageUrl) or gallery (appends to GalleryImageUrls).
+    Provided as a query parameter: ?slot=main or ?slot=gallery.
+     * @return No Content
+     */
+    confirmRecipeImageEndpoint(recipeId: string, slot: string, confirmRecipeImageRequest: ConfirmRecipeImageRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/recipes/{recipeId}/image?";
+        if (recipeId === undefined || recipeId === null)
+            throw new globalThis.Error("The parameter 'recipeId' must be defined.");
+        url_ = url_.replace("{recipeId}", encodeURIComponent("" + recipeId));
+        if (slot === undefined || slot === null)
+            throw new globalThis.Error("The parameter 'slot' must be defined and cannot be null.");
+        else
+            url_ += "slot=" + encodeURIComponent("" + slot) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmRecipeImageRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmRecipeImageEndpoint(_response);
+        });
+    }
+
+    protected processConfirmRecipeImageEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -3975,6 +5172,200 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetPublicProfileResponse>(null as any);
+    }
+
+    /**
+     * Confirm professional avatar upload
+     * @return No Content
+     */
+    confirmProfessionalAvatarEndpoint(confirmProfessionalAvatarRequest: ConfirmProfessionalAvatarRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/professionals/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmProfessionalAvatarRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmProfessionalAvatarEndpoint(_response);
+        });
+    }
+
+    protected processConfirmProfessionalAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Delete professional avatar
+     * @return No Content
+     */
+    deleteProfessionalAvatarEndpoint(signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/professionals/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDeleteProfessionalAvatarEndpoint(_response);
+        });
+    }
+
+    protected processDeleteProfessionalAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Generate professional avatar upload URL
+     * @return Success
+     */
+    generateProfessionalAvatarUploadUrlEndpoint(generateProfessionalAvatarUploadUrlRequest: GenerateProfessionalAvatarUploadUrlRequest, signal?: AbortSignal): Promise<GenerateProfessionalAvatarUploadUrlResponse> {
+        let url_ = this.baseUrl + "/professionals/me/avatar/upload-url";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateProfessionalAvatarUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateProfessionalAvatarUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateProfessionalAvatarUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateProfessionalAvatarUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateProfessionalAvatarUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateProfessionalAvatarUploadUrlResponse>(null as any);
     }
 
     /**
@@ -5132,6 +6523,81 @@ export class ApiClient {
     }
 
     /**
+     * Generate food image upload URL
+     * @param foodId The food's public identifier (from route).
+     * @return Success
+     */
+    uploadFoodImageUrlEndpoint(foodId: string, uploadFoodImageUrlRequest: UploadFoodImageUrlRequest, signal?: AbortSignal): Promise<UploadFoodImageUrlResponse> {
+        let url_ = this.baseUrl + "/foods/{foodId}/image/upload-url";
+        if (foodId === undefined || foodId === null)
+            throw new globalThis.Error("The parameter 'foodId' must be defined.");
+        url_ = url_.replace("{foodId}", encodeURIComponent("" + foodId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(uploadFoodImageUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUploadFoodImageUrlEndpoint(_response);
+        });
+    }
+
+    protected processUploadFoodImageUrlEndpoint(response: AxiosResponse): Promise<UploadFoodImageUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<UploadFoodImageUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<UploadFoodImageUrlResponse>(null as any);
+    }
+
+    /**
      * Update custom food
      * @param foodId The food's public identifier (from route).
      * @return Success
@@ -5551,6 +7017,77 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<FoodSummary>(null as any);
+    }
+
+    /**
+     * Confirm food image upload
+     * @param foodId The food's public identifier (from route).
+     * @return No Content
+     */
+    confirmFoodImageEndpoint(foodId: string, confirmFoodImageRequest: ConfirmFoodImageRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/foods/{foodId}/image";
+        if (foodId === undefined || foodId === null)
+            throw new globalThis.Error("The parameter 'foodId' must be defined.");
+        url_ = url_.replace("{foodId}", encodeURIComponent("" + foodId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmFoodImageRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmFoodImageEndpoint(_response);
+        });
+    }
+
+    protected processConfirmFoodImageEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -9238,6 +10775,304 @@ export interface GetExerciseProgressRequest {
 export interface CompleteWorkoutRequest {
 }
 
+/** Response for POST /client/weekly-check-ins/{id}/respond. */
+export interface RespondToCheckInResponse {
+    /** Check-in identifier. */
+    id?: string;
+    /** Flags persisted. */
+    flags?: CheckInFlag[];
+    /** Note persisted. */
+    note?: string | undefined;
+    /** When the response was recorded (UTC). */
+    respondedAt?: string;
+}
+
+/** Flags a client can select when responding to a weekly check-in reminder, indicating events or circumstances that may affect the upcoming week's plan. */
+export enum CheckInFlag {
+    Traveling = "Traveling",
+    EventOrCelebration = "EventOrCelebration",
+    SickOrLowEnergy = "SickOrLowEnergy",
+    InjuryOrPain = "InjuryOrPain",
+    MoreTimeAvailable = "MoreTimeAvailable",
+    LessTimeAvailable = "LessTimeAvailable",
+}
+
+/** Request body for POST /client/weekly-check-ins/{id}/respond. */
+export interface RespondToCheckInRequest {
+    /** Zero or more flags selected by the client. */
+    flags?: CheckInFlag[];
+    /** Optional free-text note. ≤ 500 characters. */
+    note?: string | undefined;
+}
+
+/** Response for PUT /trainer/weekly-check-ins/settings. */
+export interface PutSettingsResponse {
+    /** The identifier of the created or updated setting. */
+    id?: string;
+    /** Profession this setting applies to. */
+    profession?: string;
+    /** Day of the week (0 = Sunday … 6 = Saturday). */
+    dayOfWeek?: number;
+    /** Hour-aligned time of day. */
+    timeOfDay?: string;
+    /** Whether the reminder is enabled. */
+    enabled?: boolean;
+    /** Optional addendum. */
+    defaultAddendum?: string | undefined;
+}
+
+/** Request body for PUT /trainer/weekly-check-ins/settings. */
+export interface PutSettingsRequest {
+    /** Profession this setting applies to. Must be one of the trainer's specializations.
+Accepted values: "Training", "Nutrition". */
+    profession: string;
+    /** Day of the week on which the reminder fires (0 = Sunday … 6 = Saturday). */
+    dayOfWeek?: number;
+    /** Hour-aligned local time of day for the reminder. Minutes, Seconds, and Milliseconds must all be zero. */
+    timeOfDay?: string;
+    /** Whether the reminder is enabled. */
+    enabled?: boolean;
+    /** Optional addendum appended to the default reminder message. ≤ 200 characters. */
+    defaultAddendum?: string | undefined;
+}
+
+/** Response for PUT /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. */
+export interface PutOverrideResponse {
+    /** Override identifier. */
+    id?: string;
+    /** The client's ApplicationUser.Id. */
+    clientUserId?: string;
+    /** Profession this override applies to. */
+    profession?: string;
+    /** Override day of week. Null = inherit. */
+    dayOfWeek?: number | undefined;
+    /** Override time of day. Null = inherit. */
+    timeOfDay?: string | undefined;
+    /** Override enabled flag. Null = inherit. */
+    enabled?: boolean | undefined;
+    /** Override addendum. Null = inherit. */
+    addendum?: string | undefined;
+}
+
+/** Request model for PUT /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. Route params identify the override; body provides the values (null = inherit from setting). */
+export interface PutOverrideRequest {
+    /** Override day of week (0 = Sunday … 6 = Saturday). Null = inherit. */
+    dayOfWeek?: number | undefined;
+    /** Override time of day (hour-aligned). Null = inherit. Minutes/Seconds/Milliseconds must be zero if set. */
+    timeOfDay?: string | undefined;
+    /** Override enabled flag. Null = inherit. */
+    enabled?: boolean | undefined;
+    /** Override addendum (≤ 200 chars). Null = inherit. */
+    addendum?: string | undefined;
+}
+
+/** Response for POST /trainer/weekly-check-ins/{id}/mark-reviewed. */
+export interface MarkCheckInReviewedResponse {
+    /** Check-in identifier. */
+    id?: string;
+    /** When the trainer marked the check-in reviewed (UTC). */
+    reviewedAt?: string;
+}
+
+/** Request for POST /trainer/weekly-check-ins/{id}/mark-reviewed. */
+export interface MarkCheckInReviewedRequest {
+}
+
+/** Response for GET /trainer/weekly-check-ins. */
+export interface GetTrainerCheckInsResponse {
+    /** Check-ins for the requested week, filtered to the caller's clients. */
+    checkIns?: TrainerCheckInDto[];
+}
+
+/** One check-in row as seen by the trainer. */
+export interface TrainerCheckInDto {
+    /** Check-in identifier. */
+    id?: string;
+    /** Client's ApplicationUser.Id. */
+    clientUserId?: string;
+    /** Client's display name. */
+    clientName?: string;
+    /** Profession context. */
+    profession?: string;
+    /** ISO-week Monday. */
+    weekStartDate?: string;
+    /** Flags selected by the client. Empty until responded. */
+    flags?: CheckInFlag[];
+    /** Client's note. Null until responded. */
+    note?: string | undefined;
+    /** When the scheduler sent this check-in. */
+    sentAt?: string;
+    /** When the client responded. Null if not yet responded. */
+    respondedAt?: string | undefined;
+    /** When the client dismissed. Null if not dismissed. */
+    dismissedByClientAt?: string | undefined;
+    /** When the trainer marked this reviewed. Null if not reviewed. */
+    reviewedByTrainerAt?: string | undefined;
+}
+
+/** Query parameters for GET /trainer/weekly-check-ins. */
+export interface GetTrainerCheckInsRequest {
+}
+
+/** Response model for GET /trainer/weekly-check-ins/settings. */
+export interface GetSettingsResponse {
+    /** The trainer's current weekly check-in settings (0–2 items). */
+    settings?: CheckInSettingDto[];
+}
+
+/** DTO for a single weekly check-in setting. */
+export interface CheckInSettingDto {
+    /** Setting identifier. */
+    id?: string;
+    /** Profession this setting applies to ("Training" or "Nutrition"). */
+    profession?: string;
+    /** Day of the week (0 = Sunday, 1 = Monday, …, 6 = Saturday). */
+    dayOfWeek?: number;
+    /** Hour-aligned time of day in "HH:mm:ss" format. */
+    timeOfDay?: string;
+    /** Whether the reminder is enabled. */
+    enabled?: boolean;
+    /** Optional addendum appended to the default reminder message. */
+    defaultAddendum?: string | undefined;
+}
+
+/** Response model for GET /trainer/weekly-check-ins/overrides. */
+export interface GetOverridesResponse {
+    /** All per-client overrides for the authenticated trainer. */
+    overrides?: CheckInOverrideDto[];
+}
+
+/** DTO for a single per-client weekly check-in override. Null values mean "inherit from the professional's default setting". */
+export interface CheckInOverrideDto {
+    /** Override identifier. */
+    id?: string;
+    /** The client's ApplicationUser.Id. */
+    clientUserId?: string;
+    /** Client's first name. */
+    clientFirstName?: string;
+    /** Client's last name. */
+    clientLastName?: string;
+    /** Profession this override applies to ("Training" or "Nutrition"). */
+    profession?: string;
+    /** Override day of week. Null = inherit. */
+    dayOfWeek?: number | undefined;
+    /** Override time of day. Null = inherit. */
+    timeOfDay?: string | undefined;
+    /** Override enabled flag. Null = inherit. */
+    enabled?: boolean | undefined;
+    /** Override addendum. Null = inherit. */
+    addendum?: string | undefined;
+}
+
+/** Response for GET /client/weekly-check-ins/current. Returns 0–2 active (not responded, not dismissed) check-ins for the current ISO week. */
+export interface GetCurrentClientCheckInsResponse {
+    /** Active check-ins for the current ISO week. */
+    checkIns?: CheckInSummary[];
+}
+
+/** Summary of a single active check-in. */
+export interface CheckInSummary {
+    /** Check-in identifier. */
+    id?: string;
+    /** Professional who sent the check-in. */
+    professionalUserId?: string;
+    /** Professional's display name. */
+    professionalName?: string;
+    /** Profession type (Training or Nutrition). */
+    profession?: string;
+    /** ISO-week Monday being planned. */
+    weekStartDate?: string;
+    /** When the scheduler sent this check-in. */
+    sentAt?: string;
+}
+
+/** Response for GET /trainer/clients/{clientUserId}/weekly-check-ins/current. */
+export interface GetClientCurrentCheckInResponse {
+    /** Latest check-in(s) for the current ISO week and the given client.
+Typically 0–2 items (one per profession). */
+    checkIns?: ClientCheckInDto[];
+}
+
+/** A single check-in as seen from the plan-editor banner. */
+export interface ClientCheckInDto {
+    /** Check-in identifier. */
+    id?: string;
+    /** Profession context. */
+    profession?: string;
+    /** ISO-week Monday. */
+    weekStartDate?: string;
+    /** Flags selected by the client. */
+    flags?: CheckInFlag[];
+    /** Client's note. */
+    note?: string | undefined;
+    /** When the scheduler sent this. */
+    sentAt?: string;
+    /** When the client responded. Null if pending. */
+    respondedAt?: string | undefined;
+    /** When the client dismissed. Null if not dismissed. */
+    dismissedByClientAt?: string | undefined;
+    /** When the trainer marked this reviewed. */
+    reviewedByTrainerAt?: string | undefined;
+}
+
+/** Request for GET /trainer/clients/{clientUserId}/weekly-check-ins/current. */
+export interface GetClientCurrentCheckInRequest {
+}
+
+/** Response for GET /trainer/weekly-check-ins/{id}. */
+export interface GetCheckInDetailResponse {
+    /** Check-in identifier. */
+    id?: string;
+    /** Client's ApplicationUser.Id. */
+    clientUserId?: string;
+    /** Client's display name. */
+    clientName?: string;
+    /** Professional's ApplicationUser.Id. */
+    professionalUserId?: string;
+    /** Profession context. */
+    profession?: string;
+    /** ISO-week Monday being planned. */
+    weekStartDate?: string;
+    /** Flags selected by the client. */
+    flags?: CheckInFlag[];
+    /** Client's optional note. */
+    note?: string | undefined;
+    /** When the scheduler sent this check-in. */
+    sentAt?: string;
+    /** When the client responded. Null if not yet responded. */
+    respondedAt?: string | undefined;
+    /** When the client dismissed. Null if not dismissed. */
+    dismissedByClientAt?: string | undefined;
+    /** When the trainer marked this reviewed. Null if not reviewed. */
+    reviewedByTrainerAt?: string | undefined;
+}
+
+/** Request for GET /trainer/weekly-check-ins/{id}. */
+export interface GetCheckInDetailRequest {
+}
+
+/** Response for POST /client/weekly-check-ins/{id}/dismiss. */
+export interface DismissCheckInResponse {
+    /** Check-in identifier. */
+    id?: string;
+    /** When the check-in was dismissed (UTC). */
+    dismissedAt?: string;
+}
+
+/** Request for POST /client/weekly-check-ins/{id}/dismiss. */
+export interface DismissCheckInRequest {
+}
+
+/** Request model for DELETE /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. Route parameters identify the override to remove. */
+export interface DeleteOverrideRequest {
+}
+
+/** Request model for updating the authenticated user's time zone. */
+export interface UpdateTimeZoneRequest {
+    /** IANA time zone identifier (e.g. "Europe/Prague", "America/New_York"). */
+    timeZone: string;
+}
+
 /** Request model for updating the authenticated user's profile. */
 export interface UpdateProfileRequest {
     /** Updated first name. */
@@ -9275,6 +11110,33 @@ export interface GetProfileResponse {
     /** Roles of professionals the client is actively linked with (e.g. ["Trainer"], ["Nutritionist"], or both).
 Empty for non-client users. */
     linkedRoles?: string[];
+    /** User's IANA time zone identifier (e.g. "Europe/Prague"). */
+    timeZone?: string;
+    /** Permanent blob URL of the user's avatar, or null if no avatar has been uploaded. */
+    avatarBlobUrl?: string | undefined;
+}
+
+/** Request model for confirming the uploaded avatar blob URL. */
+export interface ConfirmAvatarRequest {
+    /** The permanent blob URL returned by POST /users/me/avatar/upload-url. */
+    blobUrl: string;
+}
+
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface GenerateAvatarUploadUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the avatar will be accessible after a successful upload.
+Always starts with avatars/. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed avatar upload URL. */
+export interface GenerateAvatarUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
 }
 
 /** Response returned after successfully adding a role, containing fresh tokens with updated claims. */
@@ -9813,7 +11675,8 @@ export interface ClientTimelineItem {
     id?: string;
     /** Event kind — used on the client to pick icon/colour.
 One of: meal_day, workout, measurement, questionnaire,
-nutrition_plan_published, training_plan_published, linked. */
+nutrition_plan_published, training_plan_published, linked,
+personal_record. */
     type?: string;
     /** When this event occurred (UTC). */
     occurredAt?: string;
@@ -9823,6 +11686,27 @@ nutrition_plan_published, training_plan_published, linked. */
     description?: string | undefined;
     /** Optional emoji/icon hint for the client. */
     icon?: string | undefined;
+    /** Structured payload for personal_record items.
+Null for all other event types.
+Exposed as typed fields so the web/mobile i18n layer can compose
+locale-specific copy without depending on server-side strings. */
+    personalRecord?: PersonalRecordPayload | undefined;
+}
+
+/** Structured payload embedded in a personal_record timeline item. */
+export interface PersonalRecordPayload {
+    /** Public-facing identifier of the personal record document. */
+    externalId?: string;
+    /** ExternalId of the exercise for which the PR was achieved. */
+    exerciseExternalId?: string;
+    /** Snapshot of the exercise name at the time the PR was set. */
+    exerciseName?: string;
+    /** Weight lifted in kilograms. */
+    weightKg?: number;
+    /** Repetitions completed in the PR set. */
+    reps?: number;
+    /** ExternalId of the workout log that contains this PR set. */
+    workoutLogId?: string;
 }
 
 /** Request model for retrieving a client's activity timeline. */
@@ -10067,6 +11951,24 @@ export interface AssignQuestionnaireRequest {
     questionnairePublicId?: string;
 }
 
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface UploadRecipeImageUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the recipe image will be accessible after a successful upload.
+Main slot: recipes/{recipeId}/main.{ext}.
+Gallery slot: recipes/{recipeId}/gallery-{n}.{ext}. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed upload URL for a recipe image. */
+export interface UploadRecipeImageUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
+}
+
 /** Full recipe detail returned by get and create/update endpoints. */
 export interface GetRecipeResponse {
     /** Public identifier of the recipe. */
@@ -10087,6 +11989,11 @@ export interface GetRecipeResponse {
     totalNutrients?: NutrientTotals;
     /** Visibility of the recipe (Public = visible to all nutritionists, Private = visible only to its creator). */
     visibility?: RecipeVisibility;
+    /** URL of the recipe's main image in blob storage, or null if no image has been uploaded. */
+    imageUrl?: string | undefined;
+    /** URLs of gallery images (up to 6 entries). Each entry points to a blob at
+recipes/{recipeId}/gallery-{n}.{ext}. */
+    galleryImageUrls?: string[];
     /** True when the authenticated caller is the nutritionist who created this recipe.
 Clients of the API can use this flag to decide whether to show edit/delete affordances. */
     isOwnedByCurrentUser?: boolean;
@@ -10199,6 +12106,8 @@ export interface RecipeSummaryDto {
     prepTimeMinutes?: number | undefined;
     /** Visibility of the recipe (Public = visible to all nutritionists, Private = visible only to its creator). */
     visibility?: RecipeVisibility;
+    /** URL of the recipe's main image, or null if no image has been uploaded. */
+    imageUrl?: string | undefined;
     /** True when the authenticated caller is the nutritionist who created this recipe. */
     isOwnedByCurrentUser?: boolean;
     /** When the recipe was created. */
@@ -10235,6 +12144,12 @@ export interface CreateRecipeRequest {
     foods: RecipeFoodDto[];
     /** Visibility of the recipe. Defaults to Public when omitted. */
     visibility?: RecipeVisibility;
+}
+
+/** Request model for confirming the uploaded recipe image blob URL. */
+export interface ConfirmRecipeImageRequest {
+    /** The permanent blob URL returned by POST /recipes/{id}/image/upload-url. */
+    blobUrl: string;
 }
 
 export interface UpdateResponseRequest {
@@ -10448,6 +12363,7 @@ export interface ProfessionalSummaryDto {
     collaborationType?: string | undefined;
     languages?: string[];
     roles?: string[];
+    avatarBlobUrl?: string | undefined;
 }
 
 export interface SearchProfessionalsRequest {
@@ -10470,9 +12386,33 @@ export interface GetPublicProfileResponse {
     roles?: string[];
     hasPendingRequest?: boolean;
     isLinked?: boolean;
+    avatarBlobUrl?: string | undefined;
 }
 
 export interface GetPublicProfileRequest {
+}
+
+/** Request model for confirming the uploaded professional avatar blob URL. */
+export interface ConfirmProfessionalAvatarRequest {
+    /** The permanent blob URL returned by POST /professionals/me/avatar/upload-url. */
+    blobUrl: string;
+}
+
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface GenerateProfessionalAvatarUploadUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the avatar will be accessible after a successful upload.
+Always starts with avatars/. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed professional avatar upload URL. */
+export interface GenerateProfessionalAvatarUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
 }
 
 /** Detailed nutrition plan response including all weeks, days, meals, and foods. */
@@ -10886,6 +12826,23 @@ export interface GetConversationContextRequest {
 export interface ArchiveConversationRequest {
 }
 
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface UploadFoodImageUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the food image will be accessible after a successful upload.
+Always starts with foods/. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed upload URL for a food image. */
+export interface UploadFoodImageUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
+}
+
 /** Common response DTO for food items used across multiple endpoints. */
 export interface FoodSummary {
     /** Public-facing food identifier. */
@@ -10912,6 +12869,9 @@ export interface FoodSummary {
     note?: string | undefined;
     /** Visibility of the food (Public = visible to all nutritionists, Private = visible only to its creator). */
     visibility?: FoodVisibility;
+    /** URL of the food image in blob storage (e.g. foods/{foodId}.jpg).
+Null when no image has been uploaded. */
+    imageUrl?: string | undefined;
     /** True when the authenticated caller is the nutritionist who created this food.
 Clients can use this flag to decide whether to show edit/delete affordances. */
     isOwnedByCurrentUser?: boolean;
@@ -11055,6 +13015,12 @@ export interface CreateFoodRequest {
     allergens?: string[];
     /** Common serving sizes. */
     commonServings?: ServingSizeDto[];
+}
+
+/** Request model for confirming the uploaded food image blob URL. */
+export interface ConfirmFoodImageRequest {
+    /** The permanent blob URL returned by POST /foods/{id}/image/upload-url. */
+    blobUrl: string;
 }
 
 /** Lightweight exercise DTO for list views. */
@@ -11394,15 +13360,21 @@ concurrency. Required when a completion document already exists for this
     version?: number | undefined;
 }
 
-/** Response with today's planned training session. */
+/** Response with today's planned training session(s). */
 export interface GetTodaySessionResponse {
-    /** Whether there is a session planned for today. */
+    /** Whether there is at least one session planned for today. */
     hasSession?: boolean;
     /** The training plan's public ID. */
     planId?: string | undefined;
     /** The plan name. */
     planName?: string | undefined;
-    /** Today's session, if any. */
+    /** All training sessions scheduled for today, ordered by Order.
+Empty when there are none. */
+    sessions?: TrainingSession[];
+    /** The first training session for today, if any.
+Deprecated: use Sessions instead. This property mirrors
+Sessions[0] (or null when empty) and is kept for backwards
+compatibility with consumers that still reference the singular session. */
     session?: TrainingSession | undefined;
     /** Current week number in the plan cycle. */
     currentWeek?: number | undefined;
@@ -11414,6 +13386,28 @@ export interface GetTodaySessionResponse {
     questionnaireResponseId?: string | undefined;
     /** When this plan was marked as completed, if applicable. */
     dateCompleted?: string | undefined;
+    /** Per-exercise muscle groups, keyed by SessionExercise.ExerciseExternalId.
+Empty when an exercise no longer exists in the database. Populated by
+looking up Exercise documents for every exercise referenced by today's
+sessions. */
+    exerciseMuscleGroups?: { [key: string]: MuscleGroup[]; };
+    /** Per-session completed exercise IDs, keyed by SessionId. Sourced from
+TrainingCompletion documents for today. Empty dictionary when no session
+has any completed exercise for today (or when no active plan exists). */
+    completedExerciseIdsBySession?: { [key: string]: string[]; };
+    /** Per-session optimistic-concurrency version numbers for today, keyed by SessionId.
+Matches the Version on the TrainingCompletion document. Used by the client to
+send the If-Match-style version header on subsequent mark/unmark requests.
+Missing entries imply a fresh document (server will accept Version=null/1). */
+    versionBySession?: { [key: string]: number; };
+    /** Per-session, per-exercise completed set numbers for today. Keyed by
+SessionId → ExerciseExternalId → list of 1-based SetNumbers whose
+CompletedAt is non-null in the latest
+WorkoutLog for that session on today's date.
+Empty when no live-training progress has been logged for today.
+Keeps per-set state out of the planning-document tree (Sessions) which
+represents prescription, not actuals. */
+    completedSetsBySessionExercise?: { [key: string]: { [key: string]: number[]; }; };
 }
 
 /** Full training plan response for the client mobile view. Contains all published weeks enriched with completion state and muscle group data. */

--- a/web/src/components/nutrition/FoodDialog.tsx
+++ b/web/src/components/nutrition/FoodDialog.tsx
@@ -2,14 +2,14 @@ import { useState, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { createFood, updateFood } from '@/api/foods';
+import { createFood, updateFood, requestFoodImageUploadUrl, confirmFoodImage } from '@/api/foods';
 import { showApiError, showSuccess } from '@/lib/api-errors';
 import type { FoodSummary, FoodCategory, FoodVisibility } from '@/api/food-types';
 import { CATEGORY_CSS_COLORS, FOOD_CATEGORIES } from '@/components/nutrition/food-category';
 import { INPUT_CLASS_SM, CANCEL_BUTTON_CLASS } from '@/lib/styles';
-import { Toggle } from '@/components/ui';
+import { Toggle, ImagePicker } from '@/components/ui';
 
 
 const foodSchema = z.object({
@@ -43,10 +43,16 @@ interface FoodDialogProps {
 
 export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const isNew = !food;
   const [mode, setMode] = useState<Mode>('view');
   const [transitioning, setTransitioning] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
+  // Track the committed image URL independently from the food prop so the hero
+  // updates immediately after a successful upload without waiting for a refetch.
+  const [committedImageUrl, setCommittedImageUrl] = useState<string | null>(
+    food?.imageUrl ?? null,
+  );
 
   const { register, handleSubmit, reset, watch, setValue, formState: { errors } } = useForm<FoodFormInput, unknown, FoodForm>({
     resolver: zodResolver(foodSchema),
@@ -69,11 +75,13 @@ export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
     if (!open) { setMode('view'); return; }
     if (isNew) {
       setMode('edit');
+      setCommittedImageUrl(null);
       reset({ name: '', category: 'Other', kcal: 0, protein: 0, carbs: 0, fat: 0, fiber: 0, note: '', nameEn: '', nameCs: '', nameDe: '', visibility: 'Public' });
     } else {
+      setCommittedImageUrl(food?.imageUrl ?? null);
       setMode('view');
     }
-  }, [open, food?.foodId]);
+  }, [open, food?.foodId, food?.imageUrl]); // food.imageUrl syncs committedImageUrl when the parent updates the food prop
 
   // Handle Escape key
   useEffect(() => {
@@ -96,6 +104,19 @@ export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
       if (bodyRef.current) bodyRef.current.scrollTop = 0;
       setTimeout(() => setTransitioning(false), 20);
     }, 150);
+  };
+
+  const handleImageUploaded = async (blobUrl: string) => {
+    if (!food?.foodId) return;
+    try {
+      await confirmFoodImage(food.foodId, blobUrl);
+      setCommittedImageUrl(blobUrl);
+      // Invalidate the foods list so the thumbnail updates on next render
+      await queryClient.invalidateQueries({ queryKey: ['foods'] });
+      showSuccess('foods.imageUpdated');
+    } catch (err) {
+      showApiError(err, 'foods.imageUpdateError');
+    }
   };
 
   const mutation = useMutation({
@@ -138,11 +159,19 @@ export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
           style={{ width: mode === 'edit' ? 560 : 500, maxWidth: '95vw', maxHeight: '90vh', background: 'var(--bg)', borderRadius: 10, animation: 'dlg-slide-up .4s ease-out', transition: 'width .3s ease' }}
         >
           {/* Hero */}
-          <div className="flex items-center justify-center" style={{ height: mode === 'edit' ? 100 : 120, background: 'var(--bg3)', position: 'relative', transition: 'height .3s ease' }}>
-            <span style={{ fontSize: 40, opacity: 0.2 }}>📦</span>
+          <div className="flex items-center justify-center" style={{ height: mode === 'edit' ? 100 : 120, background: 'var(--bg3)', position: 'relative', transition: 'height .3s ease', overflow: 'hidden' }}>
+            {committedImageUrl ? (
+              <img
+                src={committedImageUrl}
+                alt={food?.name ?? t('foods.detail.image.empty')}
+                className="absolute inset-0 h-full w-full object-cover"
+              />
+            ) : (
+              <span style={{ fontSize: 40, opacity: 0.2 }}>📦</span>
+            )}
             {mode === 'view' && food && (
               <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(to bottom, transparent 30%, rgba(0,0,0,0.4))', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', padding: '12px 20px' }}>
-                <div style={{ fontSize: 20, fontWeight: 700, color: '#fff', letterSpacing: '-0.02em' }}>{food.name}</div>
+                <div className="text-white" style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em' }}>{food.name}</div>
                 <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.75)', marginTop: 2, display: 'flex', alignItems: 'center', gap: 6 }}>
                   <span style={{ padding: '1px 6px', borderRadius: 3, background: catColors.bg, color: catColors.color, fontSize: 10, fontWeight: 500 }}>
                     {t(`foods.category${cat}`)}
@@ -288,6 +317,23 @@ export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
                     <textarea {...register('note')} placeholder={t('foods.notePlaceholder')} rows={2} className={`${INPUT_CLASS_SM} resize-vertical`} />
                   </div>
 
+                  {/* Hero image — only shown when editing an existing food (not during create) */}
+                  {!isNew && food && (
+                    <div>
+                      <label className="mb-2 block text-xs font-medium text-text3">
+                        {t('foods.detail.image.heading')} <span className="font-normal" style={{ color: 'var(--text4)' }}>({t('common.optional')})</span>
+                      </label>
+                      <ImagePicker
+                        mode="free"
+                        initialPreviewUrl={committedImageUrl ?? undefined}
+                        requestUploadUrl={({ contentType, sizeBytes }) =>
+                          requestFoodImageUploadUrl(food.foodId, { contentType, sizeBytes })
+                        }
+                        onUploaded={handleImageUploaded}
+                      />
+                    </div>
+                  )}
+
                   {mutation.isError && (
                     <p style={{ fontSize: 12, color: 'var(--red)', margin: 0 }}>{t('common.error')}</p>
                   )}
@@ -307,7 +353,7 @@ export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
               {mode === 'view' ? (
                 <>
                   <button onClick={onClose} className={CANCEL_BUTTON_CLASS}>{t('common.close')}</button>
-                  <button onClick={() => switchMode('edit')} className="px-4 py-2 rounded-md text-[13px] font-medium transition-colors" style={{ background: 'var(--accent)', color: '#fff' }}>
+                  <button onClick={() => switchMode('edit')} className="px-4 py-2 rounded-md text-[13px] font-medium transition-colors text-white" style={{ background: 'var(--accent)' }}>
                     ✏ {t('foods.editFoodTitle')}
                   </button>
                 </>
@@ -315,8 +361,8 @@ export function FoodDialog({ open, food, onClose, onSaved }: FoodDialogProps) {
                 <>
                   <button onClick={onClose} className={CANCEL_BUTTON_CLASS}>{t('common.cancel')}</button>
                   <button onClick={handleSubmit((data) => mutation.mutate(data))} disabled={mutation.isPending}
-                    className="px-5 py-2 rounded-md text-[13px] font-medium transition-colors disabled:opacity-50"
-                    style={{ background: 'var(--accent)', color: '#fff' }}>
+                    className="px-5 py-2 rounded-md text-[13px] font-medium transition-colors disabled:opacity-50 text-white"
+                    style={{ background: 'var(--accent)' }}>
                     {mutation.isPending ? t('common.saving') : isNew ? t('foods.createFood') : t('foods.saveChanges')}
                   </button>
                 </>

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -430,7 +430,15 @@
     "categorySupplements": "Doplňky stravy",
     "visibilityPublic": "Veřejná",
     "visibilityPrivate": "Soukromá",
-    "visibilityHint": "Veřejné potraviny vidí všichni nutricionisté. Upravovat je můžete pouze vy."
+    "visibilityHint": "Veřejné potraviny vidí všichni nutricionisté. Upravovat je můžete pouze vy.",
+    "detail": {
+      "image": {
+        "heading": "Hlavní obrázek",
+        "empty": "Bez obrázku"
+      }
+    },
+    "imageUpdated": "Obrázek potraviny byl aktualizován",
+    "imageUpdateError": "Nepodařilo se aktualizovat obrázek potraviny"
   },
   "recipes": {
     "title": "Recepty",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -430,7 +430,15 @@
     "categorySupplements": "Nahrungsergänzung",
     "visibilityPublic": "Öffentlich",
     "visibilityPrivate": "Privat",
-    "visibilityHint": "Öffentliche Lebensmittel sind für alle Ernährungsberater sichtbar. Bearbeiten können Sie sie nur selbst."
+    "visibilityHint": "Öffentliche Lebensmittel sind für alle Ernährungsberater sichtbar. Bearbeiten können Sie sie nur selbst.",
+    "detail": {
+      "image": {
+        "heading": "Hauptbild",
+        "empty": "Kein Bild"
+      }
+    },
+    "imageUpdated": "Lebensmittelbild aktualisiert",
+    "imageUpdateError": "Lebensmittelbild konnte nicht aktualisiert werden"
   },
   "recipes": {
     "title": "Rezepte",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -431,7 +431,15 @@
     "categorySupplements": "Supplements",
     "visibilityPublic": "Public",
     "visibilityPrivate": "Private",
-    "visibilityHint": "Public foods are visible to all nutritionists. Only you can edit them."
+    "visibilityHint": "Public foods are visible to all nutritionists. Only you can edit them.",
+    "detail": {
+      "image": {
+        "heading": "Hero image",
+        "empty": "No image"
+      }
+    },
+    "imageUpdated": "Food image updated",
+    "imageUpdateError": "Failed to update food image"
   },
   "recipes": {
     "title": "Recipes",

--- a/web/src/pages/FoodsPage.tsx
+++ b/web/src/pages/FoodsPage.tsx
@@ -198,6 +198,21 @@ export default function FoodsPage() {
             <>
               <DatabaseTable
                 columns={[
+                  {
+                    key: 'image', label: '', width: '52px',
+                    render: (food: FoodSummary) => food.imageUrl ? (
+                      <img
+                        src={food.imageUrl}
+                        alt=""
+                        aria-hidden="true"
+                        className="h-10 w-10 rounded-sm object-cover shrink-0"
+                      />
+                    ) : (
+                      <div className="h-10 w-10 rounded-sm bg-bg3 flex items-center justify-center text-sm shrink-0" aria-hidden="true">
+                        📦
+                      </div>
+                    ),
+                  },
                   { key: 'name', label: t('foods.foodName'), render: (food: FoodSummary) => food.name },
                   { key: 'note', label: t('foods.note'), render: (food: FoodSummary) => <span className="text-text3 text-[12px] italic truncate">{food.note || '—'}</span> },
                   { key: 'kcal', label: 'kcal/100g', width: '90px', render: (food: FoodSummary) => <span className="tabular-nums">{food.nutrientValue.kcal}</span> },
@@ -234,10 +249,20 @@ export default function FoodsPage() {
                 items={sortedFoods}
                 itemKey={(food) => food.foodId}
                 renderAvatar={(food) => {
+                  if (food.imageUrl) {
+                    return (
+                      <img
+                        src={food.imageUrl}
+                        alt=""
+                        aria-hidden="true"
+                        className="w-10 h-10 rounded-sm object-cover shrink-0"
+                      />
+                    );
+                  }
                   const cat = food.category ?? 'Other';
                   const colors = CATEGORY_CSS_COLORS[cat] ?? CATEGORY_CSS_COLORS.Other;
                   return (
-                    <div className="w-8 h-8 rounded-full flex items-center justify-center text-[11px] font-bold"
+                    <div className="w-10 h-10 rounded-sm flex items-center justify-center text-[11px] font-bold"
                       style={{ background: colors.bg, color: colors.color }}>
                       {food.name.charAt(0).toUpperCase()}
                     </div>
@@ -277,9 +302,18 @@ export default function FoodsPage() {
                   onClick={isNutritionist ? () => foodDialog.openEdit(food) : undefined}
                 >
                   <CardCover>
-                    <div className="absolute inset-0 flex items-center justify-center text-2xl opacity-50">
-                      📦
-                    </div>
+                    {food.imageUrl ? (
+                      <img
+                        src={food.imageUrl}
+                        alt=""
+                        aria-hidden="true"
+                        className="absolute inset-0 h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center text-2xl opacity-50">
+                        📦
+                      </div>
+                    )}
                   </CardCover>
                   <CardBody>
                     <div className="text-[13px] font-medium text-text mb-1.5 truncate">


### PR DESCRIPTION
Fixes #75. Part of epic #65 (Platform photo primitives).

## Summary

- `web/src/api/generated.ts` regenerated against the live backend — now exposes `UploadFoodImageUrlRequest`, `ConfirmFoodImageRequest`, and `imageUrl` on Food DTOs.
- Thin wrappers in `web/src/api/foods.ts` (`requestFoodImageUploadUrl`, `confirmFoodImage`) use the generated request types. Matches the pattern of the other hand-maintained `api/` modules.
- `<ImagePicker mode='free'>` wired into `FoodDialog` edit mode (existing foods only — Create-new stays image-less until the first save).
- Upload flow: `requestUploadUrl → PUT blob (inside ImagePicker) → onUploaded(blobUrl) → confirmFoodImage(foodId, blobUrl) → invalidate ['foods']`.
- Hero image renders in both view and edit modes with the existing gradient + title overlay preserved.
- `FoodsPage` gets 40×40 thumbnails in table + list; cover image in cards view. Emoji-placeholder fallback when `imageUrl` is null.
- i18n keys in cs/en/de: `foods.detail.image.heading`, `foods.detail.image.empty`, `foods.imageUpdated`, `foods.imageUpdateError`.
- Three pre-existing inline `color: '#fff'` on touched lines replaced with Tailwind `text-white` to clear the hardcoded-color ban on the file.

## Acceptance criteria — status

- ✅ Edit mode shows hero preview — `<img>` driven by `committedImageUrl` state (updates independently after upload).
- ✅ Save flow PUTs blob then saves URL — confirmed in `handleImageUploaded`.
- ✅ List row thumbnail renders — table + list + cards, all three modes.
- ✅ i18n cs/en/de — identical key structure.

## Test plan

- [x] `npm run build` — green (typecheck embedded).
- [x] Regen landed cleanly (NSwag v14.6.3.0 output, `// @ts-nocheck` header).
- [x] No `any`, no hardcoded hex colors on touched lines.
- [ ] Interactive AC flow against running backend — deferred to `qa-tester` post-regen run.

## Notes

`food-types.ts` kept as the canonical internal type layer; generated `FoodSummary.imageUrl` is the auto-gen echo of the backend. Two types coexist intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)