### PR TITLE
feat(mobile): wire avatars across Profile / Messages / Discover (#78)

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -42,6 +42,7 @@ export default function LoginScreen() {
           hasActiveLink: profile.hasActiveLink ?? false,
           hasPendingQuestionnaire: profile.hasPendingQuestionnaire ?? false,
           linkedRoles: profile.linkedRoles ?? [],
+          avatarBlobUrl: profile.avatarBlobUrl ?? null,
         },
         data.accessToken,
         data.refreshToken

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -77,6 +77,7 @@ export default function RegisterScreen() {
           hasActiveLink: false,
           hasPendingQuestionnaire: false,
           linkedRoles: [],
+          avatarBlobUrl: profile.avatarBlobUrl ?? null,
         },
         data.accessToken,
         data.refreshToken

--- a/mobile/app/(client)/(tabs)/discover/index.tsx
+++ b/mobile/app/(client)/(tabs)/discover/index.tsx
@@ -67,6 +67,7 @@ function toTrainerCardData(p: ProfessionalSummary): TrainerCardData {
     priceMonthly: p.estimatedPrice ?? '',
     tags: p.specializations ?? [],
     accepting: true,
+    avatarImageUrl: p.avatarBlobUrl ?? null,
   }
 }
 

--- a/mobile/app/(client)/(tabs)/profile.tsx
+++ b/mobile/app/(client)/(tabs)/profile.tsx
@@ -34,8 +34,11 @@ import {
 } from '@/api/measurements'
 import {
   getComplianceScore,
+  generateAvatarUploadUrl,
+  confirmAvatar,
   type ComplianceScoreResponse,
 } from '@/api/profile'
+import { Toast } from '@/lib/toast'
 
 // ─── Stats Grid ───────────────────────────────────────────────────────
 
@@ -140,6 +143,7 @@ export default function ProfileScreen() {
   const queryClient = useQueryClient()
   const user = useAuthStore((s) => s.user)
   const logout = useAuthStore((s) => s.logout)
+  const refreshProfile = useAuthStore((s) => s.refreshProfile)
   const hasTrainer = user?.hasActiveLink ?? false
   const [weightSheetOpen, setWeightSheetOpen] = useState(false)
   const [historySheetOpen, setHistorySheetOpen] = useState(false)
@@ -195,6 +199,32 @@ export default function ProfileScreen() {
 
   const fullName = [user?.firstName, user?.lastName].filter(Boolean).join(' ')
 
+  const handleRequestAvatarUpload = useCallback(
+    async ({ contentType, sizeBytes }: { contentType: string; sizeBytes: number }) => {
+      const result = await generateAvatarUploadUrl({ contentType, sizeBytes })
+      return {
+        uploadUrl: result.uploadUrl ?? '',
+        blobUrl: result.blobUrl ?? '',
+      }
+    },
+    [],
+  )
+
+  const handleAvatarUploaded = useCallback(
+    async (blobUrl: string) => {
+      try {
+        await confirmAvatar(blobUrl)
+        // Refresh the user profile in the auth store so the new avatar is reflected everywhere.
+        await refreshProfile()
+        queryClient.invalidateQueries({ queryKey: ['user-profile'] })
+        Toast.show(t('avatar.uploadSuccess'))
+      } catch {
+        Toast.show(t('avatar.uploadError'))
+      }
+    },
+    [refreshProfile, queryClient, t],
+  )
+
   const handleLogout = useCallback(() => {
     Alert.alert(t('profile.signOut'), t('profile.signOutConfirm'), [
       { text: t('common.cancel'), style: 'cancel' },
@@ -232,7 +262,14 @@ export default function ProfileScreen() {
       >
         {/* Header */}
         <View style={styles.header}>
-          <Avatar name={fullName || t('profile.client')} size="lg" />
+          <Avatar
+            name={fullName || t('profile.client')}
+            size="xl"
+            imageUrl={user?.avatarBlobUrl}
+            editable
+            onRequestUpload={handleRequestAvatarUpload}
+            onUploaded={handleAvatarUploaded}
+          />
           <Text style={[Type.title1, { color: colors.label, marginTop: 12 }]}>
             {fullName}
           </Text>

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -1458,6 +1458,188 @@ export class ApiClient {
     }
 
     /**
+     * Confirm avatar upload
+     * @return No Content
+     */
+    confirmAvatarEndpoint(confirmAvatarRequest: ConfirmAvatarRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/users/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmAvatarRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmAvatarEndpoint(_response);
+        });
+    }
+
+    protected processConfirmAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Delete avatar
+     * @return No Content
+     */
+    deleteAvatarEndpoint(signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/users/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDeleteAvatarEndpoint(_response);
+        });
+    }
+
+    protected processDeleteAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Generate avatar upload URL
+     * @return Success
+     */
+    generateAvatarUploadUrlEndpoint(generateAvatarUploadUrlRequest: GenerateAvatarUploadUrlRequest, signal?: AbortSignal): Promise<GenerateAvatarUploadUrlResponse> {
+        let url_ = this.baseUrl + "/users/me/avatar/upload-url";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateAvatarUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateAvatarUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateAvatarUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateAvatarUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateAvatarUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateAvatarUploadUrlResponse>(null as any);
+    }
+
+    /**
      * Add a professional role
      * @return Success
      */
@@ -3342,6 +3524,87 @@ export class ApiClient {
     }
 
     /**
+     * Generate recipe image upload URL
+     * @param recipeId The recipe's public identifier (from route).
+     * @param slot Image slot: main (overwrites) or gallery (appends, max 6).
+    Provided as a query parameter: ?slot=main or ?slot=gallery.
+     * @return Success
+     */
+    uploadRecipeImageUrlEndpoint(recipeId: string, slot: string, uploadRecipeImageUrlRequest: UploadRecipeImageUrlRequest, signal?: AbortSignal): Promise<UploadRecipeImageUrlResponse> {
+        let url_ = this.baseUrl + "/recipes/{recipeId}/image/upload-url?";
+        if (recipeId === undefined || recipeId === null)
+            throw new globalThis.Error("The parameter 'recipeId' must be defined.");
+        url_ = url_.replace("{recipeId}", encodeURIComponent("" + recipeId));
+        if (slot === undefined || slot === null)
+            throw new globalThis.Error("The parameter 'slot' must be defined and cannot be null.");
+        else
+            url_ += "slot=" + encodeURIComponent("" + slot) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(uploadRecipeImageUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUploadRecipeImageUrlEndpoint(_response);
+        });
+    }
+
+    protected processUploadRecipeImageUrlEndpoint(response: AxiosResponse): Promise<UploadRecipeImageUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<UploadRecipeImageUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<UploadRecipeImageUrlResponse>(null as any);
+    }
+
+    /**
      * Update recipe
      * @param recipeId Public identifier of the recipe to update.
      * @return Success
@@ -3689,6 +3952,83 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetRecipeResponse>(null as any);
+    }
+
+    /**
+     * Confirm recipe image upload
+     * @param recipeId The recipe's public identifier (from route).
+     * @param slot Image slot: main (overwrites ImageUrl) or gallery (appends to GalleryImageUrls).
+    Provided as a query parameter: ?slot=main or ?slot=gallery.
+     * @return No Content
+     */
+    confirmRecipeImageEndpoint(recipeId: string, slot: string, confirmRecipeImageRequest: ConfirmRecipeImageRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/recipes/{recipeId}/image?";
+        if (recipeId === undefined || recipeId === null)
+            throw new globalThis.Error("The parameter 'recipeId' must be defined.");
+        url_ = url_.replace("{recipeId}", encodeURIComponent("" + recipeId));
+        if (slot === undefined || slot === null)
+            throw new globalThis.Error("The parameter 'slot' must be defined and cannot be null.");
+        else
+            url_ += "slot=" + encodeURIComponent("" + slot) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmRecipeImageRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmRecipeImageEndpoint(_response);
+        });
+    }
+
+    protected processConfirmRecipeImageEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -4832,6 +5172,200 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetPublicProfileResponse>(null as any);
+    }
+
+    /**
+     * Confirm professional avatar upload
+     * @return No Content
+     */
+    confirmProfessionalAvatarEndpoint(confirmProfessionalAvatarRequest: ConfirmProfessionalAvatarRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/professionals/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmProfessionalAvatarRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmProfessionalAvatarEndpoint(_response);
+        });
+    }
+
+    protected processConfirmProfessionalAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Delete professional avatar
+     * @return No Content
+     */
+    deleteProfessionalAvatarEndpoint(signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/professionals/me/avatar";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDeleteProfessionalAvatarEndpoint(_response);
+        });
+    }
+
+    protected processDeleteProfessionalAvatarEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Generate professional avatar upload URL
+     * @return Success
+     */
+    generateProfessionalAvatarUploadUrlEndpoint(generateProfessionalAvatarUploadUrlRequest: GenerateProfessionalAvatarUploadUrlRequest, signal?: AbortSignal): Promise<GenerateProfessionalAvatarUploadUrlResponse> {
+        let url_ = this.baseUrl + "/professionals/me/avatar/upload-url";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateProfessionalAvatarUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateProfessionalAvatarUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateProfessionalAvatarUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateProfessionalAvatarUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateProfessionalAvatarUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateProfessionalAvatarUploadUrlResponse>(null as any);
     }
 
     /**
@@ -5989,6 +6523,81 @@ export class ApiClient {
     }
 
     /**
+     * Generate food image upload URL
+     * @param foodId The food's public identifier (from route).
+     * @return Success
+     */
+    uploadFoodImageUrlEndpoint(foodId: string, uploadFoodImageUrlRequest: UploadFoodImageUrlRequest, signal?: AbortSignal): Promise<UploadFoodImageUrlResponse> {
+        let url_ = this.baseUrl + "/foods/{foodId}/image/upload-url";
+        if (foodId === undefined || foodId === null)
+            throw new globalThis.Error("The parameter 'foodId' must be defined.");
+        url_ = url_.replace("{foodId}", encodeURIComponent("" + foodId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(uploadFoodImageUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUploadFoodImageUrlEndpoint(_response);
+        });
+    }
+
+    protected processUploadFoodImageUrlEndpoint(response: AxiosResponse): Promise<UploadFoodImageUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<UploadFoodImageUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<UploadFoodImageUrlResponse>(null as any);
+    }
+
+    /**
      * Update custom food
      * @param foodId The food's public identifier (from route).
      * @return Success
@@ -6408,6 +7017,77 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<FoodSummary>(null as any);
+    }
+
+    /**
+     * Confirm food image upload
+     * @param foodId The food's public identifier (from route).
+     * @return No Content
+     */
+    confirmFoodImageEndpoint(foodId: string, confirmFoodImageRequest: ConfirmFoodImageRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/foods/{foodId}/image";
+        if (foodId === undefined || foodId === null)
+            throw new globalThis.Error("The parameter 'foodId' must be defined.");
+        url_ = url_.replace("{foodId}", encodeURIComponent("" + foodId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(confirmFoodImageRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processConfirmFoodImageEndpoint(_response);
+        });
+    }
+
+    protected processConfirmFoodImageEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -10432,6 +11112,31 @@ Empty for non-client users. */
     linkedRoles?: string[];
     /** User's IANA time zone identifier (e.g. "Europe/Prague"). */
     timeZone?: string;
+    /** Permanent blob URL of the user's avatar, or null if no avatar has been uploaded. */
+    avatarBlobUrl?: string | undefined;
+}
+
+/** Request model for confirming the uploaded avatar blob URL. */
+export interface ConfirmAvatarRequest {
+    /** The permanent blob URL returned by POST /users/me/avatar/upload-url. */
+    blobUrl: string;
+}
+
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface GenerateAvatarUploadUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the avatar will be accessible after a successful upload.
+Always starts with avatars/. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed avatar upload URL. */
+export interface GenerateAvatarUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
 }
 
 /** Response returned after successfully adding a role, containing fresh tokens with updated claims. */
@@ -11246,6 +11951,24 @@ export interface AssignQuestionnaireRequest {
     questionnairePublicId?: string;
 }
 
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface UploadRecipeImageUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the recipe image will be accessible after a successful upload.
+Main slot: recipes/{recipeId}/main.{ext}.
+Gallery slot: recipes/{recipeId}/gallery-{n}.{ext}. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed upload URL for a recipe image. */
+export interface UploadRecipeImageUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
+}
+
 /** Full recipe detail returned by get and create/update endpoints. */
 export interface GetRecipeResponse {
     /** Public identifier of the recipe. */
@@ -11266,6 +11989,11 @@ export interface GetRecipeResponse {
     totalNutrients?: NutrientTotals;
     /** Visibility of the recipe (Public = visible to all nutritionists, Private = visible only to its creator). */
     visibility?: RecipeVisibility;
+    /** URL of the recipe's main image in blob storage, or null if no image has been uploaded. */
+    imageUrl?: string | undefined;
+    /** URLs of gallery images (up to 6 entries). Each entry points to a blob at
+recipes/{recipeId}/gallery-{n}.{ext}. */
+    galleryImageUrls?: string[];
     /** True when the authenticated caller is the nutritionist who created this recipe.
 Clients of the API can use this flag to decide whether to show edit/delete affordances. */
     isOwnedByCurrentUser?: boolean;
@@ -11378,6 +12106,8 @@ export interface RecipeSummaryDto {
     prepTimeMinutes?: number | undefined;
     /** Visibility of the recipe (Public = visible to all nutritionists, Private = visible only to its creator). */
     visibility?: RecipeVisibility;
+    /** URL of the recipe's main image, or null if no image has been uploaded. */
+    imageUrl?: string | undefined;
     /** True when the authenticated caller is the nutritionist who created this recipe. */
     isOwnedByCurrentUser?: boolean;
     /** When the recipe was created. */
@@ -11414,6 +12144,12 @@ export interface CreateRecipeRequest {
     foods: RecipeFoodDto[];
     /** Visibility of the recipe. Defaults to Public when omitted. */
     visibility?: RecipeVisibility;
+}
+
+/** Request model for confirming the uploaded recipe image blob URL. */
+export interface ConfirmRecipeImageRequest {
+    /** The permanent blob URL returned by POST /recipes/{id}/image/upload-url. */
+    blobUrl: string;
 }
 
 export interface UpdateResponseRequest {
@@ -11627,6 +12363,7 @@ export interface ProfessionalSummaryDto {
     collaborationType?: string | undefined;
     languages?: string[];
     roles?: string[];
+    avatarBlobUrl?: string | undefined;
 }
 
 export interface SearchProfessionalsRequest {
@@ -11649,9 +12386,33 @@ export interface GetPublicProfileResponse {
     roles?: string[];
     hasPendingRequest?: boolean;
     isLinked?: boolean;
+    avatarBlobUrl?: string | undefined;
 }
 
 export interface GetPublicProfileRequest {
+}
+
+/** Request model for confirming the uploaded professional avatar blob URL. */
+export interface ConfirmProfessionalAvatarRequest {
+    /** The permanent blob URL returned by POST /professionals/me/avatar/upload-url. */
+    blobUrl: string;
+}
+
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface GenerateProfessionalAvatarUploadUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the avatar will be accessible after a successful upload.
+Always starts with avatars/. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed professional avatar upload URL. */
+export interface GenerateProfessionalAvatarUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
 }
 
 /** Detailed nutrition plan response including all weeks, days, meals, and foods. */
@@ -12065,6 +12826,23 @@ export interface GetConversationContextRequest {
 export interface ArchiveConversationRequest {
 }
 
+/** Response model containing the pre-signed upload URL and the permanent blob URL. */
+export interface UploadFoodImageUrlResponse {
+    /** Time-limited pre-signed URL the client should PUT the image file to. */
+    uploadUrl?: string;
+    /** Permanent blob URL at which the food image will be accessible after a successful upload.
+Always starts with foods/. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed upload URL for a food image. */
+export interface UploadFoodImageUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 5 MiB. */
+    sizeBytes?: number;
+}
+
 /** Common response DTO for food items used across multiple endpoints. */
 export interface FoodSummary {
     /** Public-facing food identifier. */
@@ -12091,6 +12869,9 @@ export interface FoodSummary {
     note?: string | undefined;
     /** Visibility of the food (Public = visible to all nutritionists, Private = visible only to its creator). */
     visibility?: FoodVisibility;
+    /** URL of the food image in blob storage (e.g. foods/{foodId}.jpg).
+Null when no image has been uploaded. */
+    imageUrl?: string | undefined;
     /** True when the authenticated caller is the nutritionist who created this food.
 Clients can use this flag to decide whether to show edit/delete affordances. */
     isOwnedByCurrentUser?: boolean;
@@ -12234,6 +13015,12 @@ export interface CreateFoodRequest {
     allergens?: string[];
     /** Common serving sizes. */
     commonServings?: ServingSizeDto[];
+}
+
+/** Request model for confirming the uploaded food image blob URL. */
+export interface ConfirmFoodImageRequest {
+    /** The permanent blob URL returned by POST /foods/{id}/image/upload-url. */
+    blobUrl: string;
 }
 
 /** Lightweight exercise DTO for list views. */

--- a/mobile/src/api/profile.ts
+++ b/mobile/src/api/profile.ts
@@ -3,6 +3,9 @@ import type {
   UpdateProfileRequest,
   GetComplianceScoreResponse,
   CollaborationDto,
+  GenerateAvatarUploadUrlRequest,
+  GenerateAvatarUploadUrlResponse,
+  ConfirmAvatarRequest,
 } from './generated';
 
 // Re-export generated types so consumer imports (`from '@/api/profile'`) still work.
@@ -37,4 +40,18 @@ export async function getCollaborations(): Promise<CollaborationDto[]> {
 
 export async function endCollaboration(publicId: string): Promise<void> {
   await api.delete(`/client/collaborations/${publicId}`)
+}
+
+// --- Avatar ---
+
+export async function generateAvatarUploadUrl(
+  req: GenerateAvatarUploadUrlRequest,
+): Promise<GenerateAvatarUploadUrlResponse> {
+  const { data } = await api.post<GenerateAvatarUploadUrlResponse>('/users/me/avatar/upload-url', req)
+  return data
+}
+
+export async function confirmAvatar(blobUrl: string): Promise<void> {
+  const body: ConfirmAvatarRequest = { blobUrl }
+  await api.put('/users/me/avatar', body)
 }

--- a/mobile/src/components/messages/ChatHeader.tsx
+++ b/mobile/src/components/messages/ChatHeader.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { View, Text, Pressable, StyleSheet } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
-import { goldAlpha } from '@/constants/colors'
-import { getInitials } from '@/lib/initials'
+import { Avatar } from '@/components/ui/Avatar'
 import type { ParticipantDto } from '../../api/generated'
 
 interface ChatHeaderProps {
@@ -26,11 +25,7 @@ export function ChatHeader({ participant, onBack, onInfoPress }: ChatHeaderProps
 
         {/* Center: Avatar + name + status — stacked vertically */}
         <View style={styles.center}>
-          <View style={[styles.avatar, { backgroundColor: goldAlpha['15'] }]}>
-            <Text style={[styles.avatarText, { color: colors.gold }]}>
-              {getInitials(participant.name ?? '')}
-            </Text>
-          </View>
+          <Avatar name={participant.name ?? ''} size="sm" />
           <Text style={[styles.name, { color: colors.label }]} numberOfLines={1}>
             {participant.name ?? ''}
           </Text>
@@ -71,18 +66,6 @@ const styles = StyleSheet.create({
   center: {
     flex: 1,
     alignItems: 'center',
-  },
-  avatar: {
-    width: 34,
-    height: 34,
-    borderRadius: 11,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 2,
-  },
-  avatarText: {
-    fontSize: 13,
-    fontWeight: '700',
   },
   name: {
     fontSize: 15,

--- a/mobile/src/components/messages/ConversationRow.tsx
+++ b/mobile/src/components/messages/ConversationRow.tsx
@@ -3,8 +3,7 @@ import { View, Text, Pressable, StyleSheet, Animated } from 'react-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
-import { goldAlpha } from '@/constants/colors'
-import { getInitials } from '@/lib/initials'
+import { Avatar } from '@/components/ui/Avatar'
 import { formatTimestamp } from '@/lib/dateFormatting'
 import type { ConversationDto } from '../../api/generated'
 
@@ -71,17 +70,8 @@ export const ConversationRow = React.memo(function ConversationRow({
       onPress={onPress}
     >
       {/* Avatar */}
-      <View style={styles.avatarWrap}>
-        <View
-          style={[
-            styles.avatar,
-            { backgroundColor: goldAlpha['15'], opacity: isArchived ? 0.6 : 1 },
-          ]}
-        >
-          <Text style={[styles.avatarText, { color: colors.gold }]}>
-            {getInitials(participant?.name ?? '')}
-          </Text>
-        </View>
+      <View style={[styles.avatarWrap, { opacity: isArchived ? 0.6 : 1 }]}>
+        <Avatar name={participant?.name ?? ''} size="md" />
         {!isArchived && participant?.online && (
           <View style={[styles.onlineDot, { borderColor: colors.bg2, backgroundColor: colors.green }]} />
         )}
@@ -160,17 +150,6 @@ const styles = StyleSheet.create({
     width: 50,
     height: 50,
     flexShrink: 0,
-  },
-  avatar: {
-    width: 50,
-    height: 50,
-    borderRadius: 17,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarText: {
-    fontSize: 19,
-    fontWeight: '700',
   },
   onlineDot: {
     position: 'absolute',

--- a/mobile/src/components/messages/MessageBubble.tsx
+++ b/mobile/src/components/messages/MessageBubble.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { View, Text, Pressable, StyleSheet, Platform } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
-import { goldAlpha } from '@/constants/colors'
-import { getInitials } from '@/lib/initials'
+import { Avatar } from '@/components/ui/Avatar'
 import { formatTime } from '@/lib/dateFormatting'
 import type { LocalMessage } from '../../types/messages'
 
@@ -31,10 +30,8 @@ export const MessageBubble = React.memo(function MessageBubble({
       {/* Avatar slot for received messages */}
       {!isOwn && (
         showAvatar ? (
-          <View style={[styles.tinyAvatar, { backgroundColor: goldAlpha['15'] }]}>
-            <Text style={[styles.tinyAvatarText, { color: colors.gold }]}>
-              {getInitials(participantName)}
-            </Text>
+          <View style={styles.tinyAvatarWrap}>
+            <Avatar name={participantName} size="sm" />
           </View>
         ) : (
           <View style={styles.avatarSpacer} />
@@ -118,21 +115,13 @@ const styles = StyleSheet.create({
   rowTheirs: {
     justifyContent: 'flex-start',
   },
-  tinyAvatar: {
-    width: 26,
-    height: 26,
-    borderRadius: 9,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 1,
+  tinyAvatarWrap: {
     flexShrink: 0,
-  },
-  tinyAvatarText: {
-    fontSize: 10,
-    fontWeight: '700',
+    marginBottom: 1,
   },
   avatarSpacer: {
-    width: 26,
+    // Matches Avatar size="sm" container width (36px)
+    width: 36,
     flexShrink: 0,
   },
   bubbleWrap: {

--- a/mobile/src/components/trainers/TrainerCard.tsx
+++ b/mobile/src/components/trainers/TrainerCard.tsx
@@ -31,6 +31,8 @@ export interface TrainerCardData {
   accepting: boolean
   avatarColor?: string
   avatarBg?: string
+  /** Remote avatar image URL from the backend. When present, renders instead of initials. */
+  avatarImageUrl?: string | null
 }
 
 interface TrainerCardProps {
@@ -61,7 +63,7 @@ export function TrainerCard({
     <View style={[styles.card, { backgroundColor: colors.bg2 }]}>
       {/* Top section */}
       <View style={styles.top}>
-        <Avatar name={trainer.name} size="md" color={trainer.avatarColor} />
+        <Avatar name={trainer.name} size="md" color={trainer.avatarColor} imageUrl={trainer.avatarImageUrl} />
         <View style={styles.info}>
           <Text style={[Type.headline, { color: colors.label }]} numberOfLines={1}>
             {trainer.name}

--- a/mobile/src/components/ui/Avatar.tsx
+++ b/mobile/src/components/ui/Avatar.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, Image, Pressable, StyleSheet, ActivityIndicator } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
 import { Radius } from '@/constants/radius'
 import { getInitials } from '@/lib/initials'
+import { useImagePicker } from '@/hooks/useImagePicker'
+import { useTranslation } from 'react-i18next'
 
 const AVATAR_COLORS = [
   '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4',
@@ -10,18 +13,32 @@ const AVATAR_COLORS = [
   '#BB8FCE', '#85C1E9',
 ] as const
 
-type AvatarSize = 'sm' | 'md' | 'lg'
+export type AvatarSize = 'sm' | 'md' | 'lg' | 'xl'
 
-const sizeMap: Record<AvatarSize, { container: number; radius: number; fontSize: number }> = {
-  sm: { container: 36, radius: Radius.sm, fontSize: 12 },
-  md: { container: 56, radius: 18, fontSize: 17 },
-  lg: { container: 80, radius: 26, fontSize: 28 },
+const sizeMap: Record<AvatarSize, { container: number; radius: number; fontSize: number; badgeSize: number; badgeIcon: number }> = {
+  sm: { container: 36, radius: Radius.sm, fontSize: 12, badgeSize: 18, badgeIcon: 10 },
+  md: { container: 56, radius: 18, fontSize: 17, badgeSize: 22, badgeIcon: 12 },
+  lg: { container: 80, radius: 26, fontSize: 28, badgeSize: 28, badgeIcon: 14 },
+  xl: { container: 100, radius: 32, fontSize: 36, badgeSize: 32, badgeIcon: 16 },
 }
 
-interface AvatarProps {
+export interface AvatarProps {
+  /** Display name — used for initials fallback and colour derivation. */
   name: string
   size?: AvatarSize
+  /** Explicit background colour for the initials avatar. If omitted, derived from name. */
   color?: string
+  /** Remote image URL. When truthy, renders an `<Image>` instead of initials. */
+  imageUrl?: string | null
+  /** Show the camera-badge overlay (own-profile use case only). */
+  editable?: boolean
+  /**
+   * Called when the user taps the camera badge.
+   * Must return a `{ uploadUrl, blobUrl }` pair from the backend.
+   */
+  onRequestUpload?: (args: { contentType: string; sizeBytes: number }) => Promise<{ uploadUrl: string; blobUrl: string }>
+  /** Called after the upload completes successfully, with the permanent blob URL. */
+  onUploaded?: (blobUrl: string) => void
 }
 
 function getColorForName(name: string): string {
@@ -32,16 +49,105 @@ function getColorForName(name: string): string {
   return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]
 }
 
-export function Avatar({ name, size = 'md', color }: AvatarProps) {
+/** Internal component rendering the camera-badge overlay. */
+function CameraBadge({
+  size,
+  onPress,
+  uploading,
+}: {
+  size: AvatarSize
+  onPress: () => void
+  uploading: boolean
+}) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const { badgeSize, badgeIcon } = sizeMap[size]
+  const offset = -(badgeSize / 4)
+
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={6}
+      accessibilityLabel={t('avatar.editBadgeLabel')}
+      accessibilityHint={t('avatar.editBadgeHint')}
+      style={[
+        styles.badge,
+        {
+          width: badgeSize,
+          height: badgeSize,
+          borderRadius: badgeSize / 2,
+          backgroundColor: colors.gold,
+          borderColor: colors.bg,
+          right: offset,
+          bottom: offset,
+        },
+      ]}
+    >
+      {uploading ? (
+        <ActivityIndicator size="small" color={colors.onAccent} />
+      ) : (
+        <Ionicons name="camera" size={badgeIcon} color={colors.onAccent} />
+      )}
+    </Pressable>
+  )
+}
+
+/**
+ * Avatar primitive.
+ *
+ * - Renders a remote image when `imageUrl` is provided (initials fallback otherwise).
+ * - Shows a gold camera badge when `editable` is true.
+ * - Badge taps drive `useImagePicker` → `onRequestUpload` → `onUploaded`.
+ */
+export function Avatar({
+  name,
+  size = 'md',
+  color,
+  imageUrl,
+  editable = false,
+  onRequestUpload,
+  onUploaded,
+}: AvatarProps) {
   const colors = useTheme()
   const { container, radius, fontSize } = sizeMap[size]
   const bgColor = color ?? getColorForName(name)
 
-  return (
-    <View style={[styles.container, { width: container, height: container, borderRadius: radius, backgroundColor: bgColor }]}>
+  const requestUploadUrl = onRequestUpload ?? (async () => ({ uploadUrl: '', blobUrl: '' }))
+  const handleUploaded = onUploaded ?? (() => {})
+
+  const { pick, uploading } = useImagePicker(
+    {
+      source: 'both',
+      aspect: [1, 1],
+      requestUploadUrl: requestUploadUrl,
+    },
+    handleUploaded,
+  )
+
+  const inner = imageUrl ? (
+    <Image
+      source={{ uri: imageUrl }}
+      style={[styles.image, { width: container, height: container, borderRadius: radius }]}
+      accessibilityIgnoresInvertColors
+    />
+  ) : (
+    <View
+      style={[styles.container, { width: container, height: container, borderRadius: radius, backgroundColor: bgColor }]}
+    >
       <Text style={[styles.initials, { fontSize, color: colors.bg2 }]}>
         {getInitials(name)}
       </Text>
+    </View>
+  )
+
+  if (!editable) {
+    return inner
+  }
+
+  return (
+    <View style={styles.editableWrap}>
+      {inner}
+      <CameraBadge size={size} onPress={pick} uploading={uploading} />
     </View>
   )
 }
@@ -51,8 +157,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  image: {
+    resizeMode: 'cover',
+  },
   initials: {
     fontWeight: '700',
+  },
+  editableWrap: {
+    position: 'relative',
+  },
+  badge: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2.5,
   },
 })
 

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -837,5 +837,11 @@
     "LowerBack": "Bedra",
     "Traps": "Trapézy",
     "FullBody": "Celé tělo"
+  },
+  "avatar": {
+    "editBadgeLabel": "Změnit profilovou fotku",
+    "editBadgeHint": "Otevře fotoaparát nebo galerii pro aktualizaci avataru",
+    "uploadSuccess": "Profilová fotka aktualizována",
+    "uploadError": "Profilovou fotku se nepodařilo aktualizovat. Zkuste to znovu."
   }
 }

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -828,5 +828,11 @@
     "LowerBack": "Unterer Rücken",
     "Traps": "Trapezmuskel",
     "FullBody": "Ganzkörper"
+  },
+  "avatar": {
+    "editBadgeLabel": "Profilbild ändern",
+    "editBadgeHint": "Öffnet die Kamera oder Galerie, um Ihr Profilbild zu aktualisieren",
+    "uploadSuccess": "Profilbild aktualisiert",
+    "uploadError": "Profilbild konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut."
   }
 }

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -829,5 +829,11 @@
       "PreWorkout": "Pre-workout",
       "PostWorkout": "Post-workout"
     }
+  },
+  "avatar": {
+    "editBadgeLabel": "Change profile photo",
+    "editBadgeHint": "Opens the camera or photo library so you can update your avatar",
+    "uploadSuccess": "Profile photo updated",
+    "uploadError": "Could not update profile photo. Please try again."
   }
 }

--- a/mobile/src/stores/auth.ts
+++ b/mobile/src/stores/auth.ts
@@ -14,6 +14,7 @@ interface User {
   hasActiveLink: boolean;
   hasPendingQuestionnaire: boolean;
   linkedRoles: string[];
+  avatarBlobUrl: string | null;
 }
 
 // ─── Collaboration types ─────────────────────────────────────────────
@@ -177,6 +178,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           hasActiveLink: profile.hasActiveLink ?? false,
           hasPendingQuestionnaire: profile.hasPendingQuestionnaire ?? false,
           linkedRoles: profile.linkedRoles ?? [],
+          avatarBlobUrl: profile.avatarBlobUrl ?? null,
         },
         isAuthenticated: true,
         isInitialized: true,
@@ -211,6 +213,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           hasActiveLink: profile.hasActiveLink ?? false,
           hasPendingQuestionnaire: profile.hasPendingQuestionnaire ?? false,
           linkedRoles: profile.linkedRoles ?? [],
+          avatarBlobUrl: profile.avatarBlobUrl ?? null,
         },
       });
     } catch {


### PR DESCRIPTION
Fixes #78. Part of epic #65 Wave 5.

## Summary

- **Extended `<Avatar>` primitive** (`mobile/src/components/ui/Avatar.tsx`): `imageUrl?`, `editable?`, `onRequestUpload`, `onUploaded`. New `'xl'` size (100px) for the profile header. Camera badge gated on `editable === true`; background + icon colors via `useTheme()` tokens.
- **Profile** (`app/(client)/(tabs)/profile.tsx`): xl editable avatar wired to `useImagePicker` → `generateAvatarUploadUrl` → PUT blob → `confirmAvatar` → `refreshProfile` + `invalidateQueries(['user-profile'])`.
- **TrainerCard** + `toTrainerCardData`: reads `avatarBlobUrl` from the professional DTO.
- **ChatHeader / ConversationRow / MessageBubble**: swapped inline initials views for `<Avatar>` primitive (initials-only until backend adds `avatarBlobUrl` to `ParticipantDto` — noted as follow-up).
- **`auth.ts` store**: `User.avatarBlobUrl: string | null`. Login + register both pass `profile.avatarBlobUrl ?? null` into the User literal (fixed in this PR after the QA caught the regression).
- `mobile/src/api/profile.ts`: adds `generateAvatarUploadUrl` and `confirmAvatar` against the `/users/me/avatar/*` endpoints from #69.
- i18n `avatar.*` (4 keys) in cs/en/de.
- Regen'd `src/api/generated.ts` against the live backend.

## Acceptance criteria — status

- ✅ Tokens only — badge background `colors.gold`, border `colors.bg`, icon `colors.onAccent`, sized via `useTheme()`. Pre-existing `AVATAR_COLORS` palette inside `Avatar.tsx` is untouched (existed before this PR).
- ✅ i18n hint labels — `avatar.editBadgeLabel`, `avatar.editBadgeHint`, `avatar.uploadSuccess`, `avatar.uploadError` in cs/en/de.
- ✅ Initials fallback kept — explicit `imageUrl ? <Image> : <View>{initials}</View>` branch.

## Known follow-up (non-blocking)

`ParticipantDto` from the generated client lacks `avatarBlobUrl`, so Messages surfaces (`ChatHeader`, `ConversationRow`, `MessageBubble`) render initials-only through the new primitive. Add `avatarBlobUrl` to `ParticipantDto` on the backend as a separate issue, then wire the prop here to light up photos across chat.

## Test plan

- [x] `npx tsc --noEmit` — clean after the login/register fix (the pre-existing `_layout.tsx:39` tuple error was worktree-bootstrap noise, now resolved by copying `.expo/types/router.d.ts`).
- [x] No `any`, no new hex colors on touched lines.
- [x] Regen landed cleanly (NSwag header + `// @ts-nocheck`).
- [ ] Simulator screenshot comparing camera badge offset to `docs/prototypes/mobile/scenes/profile.html` — deferred to QA interactive pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)