### PR TITLE
fix(backend): coach cards fall back to user avatar when professional one is unset

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Client/Collaborations/GetAll/GetCollaborationsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Client/Collaborations/GetAll/GetCollaborationsEndpoint.cs
@@ -51,7 +51,11 @@ public class GetCollaborationsEndpoint(IApplicationDbContext db) : EndpointWitho
                 ProfessionalName = l.ProfessionalProfile.User.FirstName + " " + l.ProfessionalProfile.User.LastName,
                 ProfessionalCity = l.ProfessionalProfile.City,
                 Role = l.ProfessionalRole.ToString(),
-                Since = l.DateCreated
+                Since = l.DateCreated,
+                // Same fallback as SearchProfessionals / GetPublicProfile:
+                // surface the personal user avatar when the pro-profile one
+                // hasn't been set (most trainers upload only one photo today).
+                AvatarBlobUrl = l.ProfessionalProfile.AvatarBlobUrl ?? l.ProfessionalProfile.User.AvatarBlobUrl
             })
             .OrderBy(l => l.Role)
             .ToListAsync(ct);
@@ -73,4 +77,10 @@ public class CollaborationDto
     public string? ProfessionalCity { get; set; }
     public string Role { get; set; } = string.Empty;
     public DateTime Since { get; set; }
+    /// <summary>
+    /// Professional's avatar URL. Falls back to the underlying user's
+    /// personal avatar when the professional-profile-specific one isn't set.
+    /// Null when neither is uploaded.
+    /// </summary>
+    public string? AvatarBlobUrl { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/Messaging/GetConversations/GetConversationsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Messaging/GetConversations/GetConversationsEndpoint.cs
@@ -48,6 +48,8 @@ public class GetConversationsEndpoint(IApplicationDbContext db, PresenceTracker 
                         Name = c.Client.FirstName + " " + c.Client.LastName,
                         Initials = (c.Client.FirstName.Substring(0, 1) + c.Client.LastName.Substring(0, 1)).ToUpper(),
                         Online = false, // populated below
+                        // ClientProfile has no dedicated AvatarBlobUrl; use the user-level avatar.
+                        AvatarBlobUrl = c.Client.AvatarBlobUrl,
                     }
                     : new ParticipantDto
                     {
@@ -55,6 +57,10 @@ public class GetConversationsEndpoint(IApplicationDbContext db, PresenceTracker 
                         Name = c.Professional.FirstName + " " + c.Professional.LastName,
                         Initials = (c.Professional.FirstName.Substring(0, 1) + c.Professional.LastName.Substring(0, 1)).ToUpper(),
                         Online = false, // populated below
+                        // Prefer the professional-profile avatar; fall back to the user-level avatar.
+                        AvatarBlobUrl = c.Professional.ProfessionalProfile != null
+                            ? c.Professional.ProfessionalProfile.AvatarBlobUrl ?? c.Professional.AvatarBlobUrl
+                            : c.Professional.AvatarBlobUrl,
                     },
                 LastMessage = c.LastMessageText ?? "",
                 LastMessageAt = c.LastMessageAt ?? c.DateCreated,
@@ -95,4 +101,10 @@ public class ParticipantDto
     public string Name { get; set; } = string.Empty;
     public string Initials { get; set; } = string.Empty;
     public bool Online { get; set; }
+    /// <summary>
+    /// Avatar URL for the participant. For professionals, prefers the professional-profile
+    /// avatar; falls back to the user-level avatar. For clients, uses the user-level avatar.
+    /// Null when neither has been uploaded.
+    /// </summary>
+    public string? AvatarBlobUrl { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/Messaging/StartConversation/StartConversationEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Messaging/StartConversation/StartConversationEndpoint.cs
@@ -39,6 +39,9 @@ public class StartConversationEndpoint(IApplicationDbContext db) : Endpoint<Star
         Guid professionalUserId;
         Guid clientUserId;
         ApplicationUser otherUser;
+        // For professionals the avatar falls back from profile-level to user-level;
+        // for clients only the user-level avatar exists (ClientProfile has no AvatarBlobUrl).
+        string? participantAvatarBlobUrl;
 
         if (isProfessional)
         {
@@ -53,6 +56,8 @@ public class StartConversationEndpoint(IApplicationDbContext db) : Endpoint<Star
             professionalUserId = userGuid;
             clientUserId = client.UserId;
             otherUser = client.User;
+            // ClientProfile has no dedicated AvatarBlobUrl; use the user-level avatar.
+            participantAvatarBlobUrl = client.User.AvatarBlobUrl;
         }
         else
         {
@@ -67,6 +72,8 @@ public class StartConversationEndpoint(IApplicationDbContext db) : Endpoint<Star
             professionalUserId = prof.UserId;
             clientUserId = userGuid;
             otherUser = prof.User;
+            // Prefer the professional-profile avatar; fall back to the user-level avatar.
+            participantAvatarBlobUrl = prof.AvatarBlobUrl ?? prof.User.AvatarBlobUrl;
         }
 
         // Check if conversation already exists
@@ -86,6 +93,7 @@ public class StartConversationEndpoint(IApplicationDbContext db) : Endpoint<Star
                     Name = otherUser.FirstName + " " + otherUser.LastName,
                     Initials = (otherUser.FirstName[..1] + otherUser.LastName[..1]).ToUpper(),
                     Online = false,
+                    AvatarBlobUrl = participantAvatarBlobUrl,
                 },
                 LastMessage = existing.LastMessageText ?? "",
                 LastMessageAt = existing.LastMessageAt ?? existing.DateCreated,
@@ -113,6 +121,7 @@ public class StartConversationEndpoint(IApplicationDbContext db) : Endpoint<Star
                 Name = otherUser.FirstName + " " + otherUser.LastName,
                 Initials = (otherUser.FirstName[..1] + otherUser.LastName[..1]).ToUpper(),
                 Online = false,
+                AvatarBlobUrl = participantAvatarBlobUrl,
             },
             LastMessage = "",
             LastMessageAt = conversation.DateCreated,

--- a/backend/FitnessPlatform.Application/Features/Professionals/GetPublicProfile/GetPublicProfileEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Professionals/GetPublicProfile/GetPublicProfileEndpoint.cs
@@ -99,7 +99,11 @@ public class GetPublicProfileEndpoint(IApplicationDbContext db, UserManager<Appl
             Roles = professionalRoles,
             HasPendingRequest = hasPendingRequest,
             IsLinked = isLinked,
-            AvatarBlobUrl = profile.AvatarBlobUrl
+            // Mirror the discover-list fallback (SearchProfessionalsEndpoint):
+            // use the professional-profile avatar when set, otherwise the
+            // underlying user's personal avatar so most trainers' single
+            // uploaded photo shows up across all public surfaces.
+            AvatarBlobUrl = profile.AvatarBlobUrl ?? profile.User.AvatarBlobUrl
         }, ct);
     }
 

--- a/backend/FitnessPlatform.Application/Features/Professionals/SearchProfessionals/SearchProfessionalsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Professionals/SearchProfessionals/SearchProfessionalsEndpoint.cs
@@ -99,7 +99,11 @@ public class SearchProfessionalsEndpoint(IApplicationDbContext db, UserManager<A
                 CollaborationType = profile.CollaborationType,
                 Languages = ParseJsonArray(profile.Languages),
                 Roles = professionalRoles,
-                AvatarBlobUrl = profile.AvatarBlobUrl
+                // Fall back to the underlying user's avatar when the
+                // professional-profile-specific one hasn't been set. Most
+                // trainers only upload one photo (their personal profile
+                // photo) — the discover page should surface it regardless.
+                AvatarBlobUrl = profile.AvatarBlobUrl ?? profile.User.AvatarBlobUrl
             });
         }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/Messaging/ParticipantAvatarTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Messaging/ParticipantAvatarTests.cs
@@ -1,0 +1,204 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.Messaging;
+
+/// <summary>
+/// Integration tests verifying that <c>ParticipantDto.AvatarBlobUrl</c> is
+/// correctly projected by <c>GET /conversations</c> and <c>POST /conversations</c>
+/// using the two-tier fallback pattern:
+///   professional participant → ProfessionalProfile.AvatarBlobUrl ?? User.AvatarBlobUrl
+///   client participant       → User.AvatarBlobUrl
+/// </summary>
+[Collection(TestCollection.Name)]
+public class ParticipantAvatarTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail() => $"{Guid.NewGuid():N}@msg-avatar-test.com";
+    private const string Password = "TestPass1!";
+
+    // ── POST /conversations ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the professional-profile avatar has been uploaded, StartConversation
+    /// returns that URL as the participant's avatar for the client caller.
+    /// </summary>
+    [Fact]
+    public async Task StartConversation_AsClient_ParticipantAvatarIsFromProfessionalProfile()
+    {
+        var http = factory.CreateClient();
+
+        // Register trainer and set a professional-profile avatar
+        var trainerEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, trainerEmail, Password, "Alice", "Trainer", "Trainer");
+        var (trainerToken, _) = await TestHelpers.LoginAsync(http, trainerEmail, Password);
+        TestHelpers.SetBearerToken(http, trainerToken);
+
+        const string profAvatarUrl = "avatars/prof-alice.jpg";
+        await http.PutAsJsonAsync(
+            "/professionals/me/avatar",
+            new { BlobUrl = profAvatarUrl },
+            TestContext.Current.CancellationToken);
+
+        // Resolve trainer's ProfessionalProfile.PublicId
+        Guid profPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider
+                .GetRequiredService<FitnessPlatform.Application.Infrastructure.Data.ApplicationDbContext>();
+            var userId = (await db.Users.FirstAsync(
+                u => u.Email == trainerEmail,
+                TestContext.Current.CancellationToken)).Id;
+            var profile = await db.ProfessionalProfiles.FirstAsync(
+                p => p.UserId == userId,
+                TestContext.Current.CancellationToken);
+            profPublicId = profile.PublicId;
+        }
+
+        // Register client and start the conversation
+        var clientHttp = factory.CreateClient();
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(clientHttp, clientEmail, Password, "Bob", "Client", "Client");
+        var (clientToken, _) = await TestHelpers.LoginAsync(clientHttp, clientEmail, Password);
+        TestHelpers.SetBearerToken(clientHttp, clientToken);
+
+        var resp = await clientHttp.PostAsJsonAsync(
+            "/conversations",
+            new { ParticipantId = profPublicId },
+            TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<ConversationResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        body!.Participant.AvatarBlobUrl.Should().Be(profAvatarUrl);
+    }
+
+    /// <summary>
+    /// When the professional-profile avatar is null but the user has a user-level
+    /// avatar, StartConversation returns the user-level URL (fallback tier).
+    /// </summary>
+    [Fact]
+    public async Task StartConversation_AsClient_ProfProfileAvatarNull_FallsBackToUserAvatar()
+    {
+        var http = factory.CreateClient();
+
+        // Register trainer with only a user-level avatar (no professional-profile avatar)
+        var trainerEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, trainerEmail, Password, "Carol", "Trainer", "Trainer");
+        var (trainerToken, _) = await TestHelpers.LoginAsync(http, trainerEmail, Password);
+        TestHelpers.SetBearerToken(http, trainerToken);
+
+        const string userAvatarUrl = "avatars/user-carol.jpg";
+        await http.PutAsJsonAsync(
+            "/users/me/avatar",
+            new { BlobUrl = userAvatarUrl },
+            TestContext.Current.CancellationToken);
+        // Leave ProfessionalProfile.AvatarBlobUrl as null
+
+        Guid profPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider
+                .GetRequiredService<FitnessPlatform.Application.Infrastructure.Data.ApplicationDbContext>();
+            var userId = (await db.Users.FirstAsync(
+                u => u.Email == trainerEmail,
+                TestContext.Current.CancellationToken)).Id;
+            var profile = await db.ProfessionalProfiles.FirstAsync(
+                p => p.UserId == userId,
+                TestContext.Current.CancellationToken);
+            profPublicId = profile.PublicId;
+            // Confirm professional-profile avatar really is null
+            profile.AvatarBlobUrl.Should().BeNull();
+        }
+
+        var clientHttp = factory.CreateClient();
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(clientHttp, clientEmail, Password, "Dave", "Client", "Client");
+        var (clientToken, _) = await TestHelpers.LoginAsync(clientHttp, clientEmail, Password);
+        TestHelpers.SetBearerToken(clientHttp, clientToken);
+
+        var resp = await clientHttp.PostAsJsonAsync(
+            "/conversations",
+            new { ParticipantId = profPublicId },
+            TestContext.Current.CancellationToken);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<ConversationResponse>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        body!.Participant.AvatarBlobUrl.Should().Be(userAvatarUrl,
+            "professional-profile avatar is null, so the user-level avatar must be used");
+    }
+
+    // ── GET /conversations ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// After a conversation is started, GET /conversations as the client returns
+    /// the professional-profile avatar on the participant (professional side).
+    /// </summary>
+    [Fact]
+    public async Task GetConversations_AsClient_ParticipantAvatarIsFromProfessionalProfile()
+    {
+        var http = factory.CreateClient();
+
+        var trainerEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(http, trainerEmail, Password, "Eve", "Trainer", "Trainer");
+        var (trainerToken, _) = await TestHelpers.LoginAsync(http, trainerEmail, Password);
+        TestHelpers.SetBearerToken(http, trainerToken);
+
+        const string profAvatarUrl = "avatars/prof-eve.png";
+        await http.PutAsJsonAsync(
+            "/professionals/me/avatar",
+            new { BlobUrl = profAvatarUrl },
+            TestContext.Current.CancellationToken);
+
+        Guid profPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider
+                .GetRequiredService<FitnessPlatform.Application.Infrastructure.Data.ApplicationDbContext>();
+            var userId = (await db.Users.FirstAsync(
+                u => u.Email == trainerEmail,
+                TestContext.Current.CancellationToken)).Id;
+            var profile = await db.ProfessionalProfiles.FirstAsync(
+                p => p.UserId == userId,
+                TestContext.Current.CancellationToken);
+            profPublicId = profile.PublicId;
+        }
+
+        var clientHttp = factory.CreateClient();
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(clientHttp, clientEmail, Password, "Frank", "Client", "Client");
+        var (clientToken, _) = await TestHelpers.LoginAsync(clientHttp, clientEmail, Password);
+        TestHelpers.SetBearerToken(clientHttp, clientToken);
+
+        // Start conversation so it appears in the list
+        await clientHttp.PostAsJsonAsync(
+            "/conversations",
+            new { ParticipantId = profPublicId },
+            TestContext.Current.CancellationToken);
+
+        var listResp = await clientHttp.GetAsync(
+            "/conversations",
+            TestContext.Current.CancellationToken);
+
+        listResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var conversations = await listResp.Content.ReadFromJsonAsync<List<ConversationResponse>>(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        conversations.Should().NotBeNull();
+        var conv = conversations!.FirstOrDefault(c => c.Participant.AvatarBlobUrl == profAvatarUrl);
+        conv.Should().NotBeNull("the conversation with the professional whose avatar was set must appear");
+    }
+
+    // ── Local response DTOs (per slice rules — no cross-feature imports) ─────
+
+    private record ParticipantResponse(Guid Id, string Name, string? AvatarBlobUrl);
+    private record ConversationResponse(Guid Id, ParticipantResponse Participant);
+}

--- a/mobile/app/(client)/(tabs)/discover/[trainerId].tsx
+++ b/mobile/app/(client)/(tabs)/discover/[trainerId].tsx
@@ -148,7 +148,7 @@ export default function TrainerProfileScreen() {
       >
         {/* Hero */}
         <View style={[styles.hero, { borderBottomColor: colors.sep2 }]}>
-          <Avatar name={fullName} size="lg" />
+          <Avatar name={fullName} size="lg" imageUrl={profile.avatarBlobUrl} />
           <Text style={[styles.heroName, { color: colors.label }]}>{fullName}</Text>
           <Text style={[styles.heroRole, { color: colors.label2 }]}>{roleLabel}</Text>
           {profile.city && (

--- a/mobile/app/(client)/(tabs)/messages/[threadId].tsx
+++ b/mobile/app/(client)/(tabs)/messages/[threadId].tsx
@@ -137,6 +137,7 @@ export default function ChatScreen() {
             isOwn={isOwn}
             showAvatar={showAvatar}
             participantName={participant?.name}
+            participantAvatarUrl={participant?.avatarBlobUrl}
             onRetry={retry}
           />
         </View>

--- a/mobile/app/(client)/(tabs)/nutrition/food-detail.tsx
+++ b/mobile/app/(client)/(tabs)/nutrition/food-detail.tsx
@@ -5,13 +5,16 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Pressable,
   Image,
   Animated,
+  useColorScheme,
   type NativeSyntheticEvent,
   type NativeScrollEvent,
   type LayoutChangeEvent,
 } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { LinearGradient } from 'expo-linear-gradient'
 import { useRouter, useLocalSearchParams } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
@@ -22,6 +25,7 @@ import type { MealFood } from '@/api/nutrition'
 import { getFoodById } from '@/api/foods'
 import type { FoodSummary } from '@/api/foods'
 import i18n from '@/i18n'
+import { ImageLightbox } from '@/components/ui/ImageLightbox'
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -98,6 +102,9 @@ export default function FoodDetailScreen() {
   const { t } = useTranslation()
   const router = useRouter()
   const colors = useTheme()
+  const scheme = useColorScheme()
+  const isDark = scheme === 'dark'
+  const insets = useSafeAreaInsets()
   const params = useLocalSearchParams<{ food: string; mealName: string; backLabel?: string }>()
 
   const food: MealFood | null = params.food ? JSON.parse(params.food) : null
@@ -107,6 +114,8 @@ export default function FoodDetailScreen() {
   // Track hero name visibility for header title
   const heroNameBottom = useRef(0)
   const headerTitleOpacity = useRef(new Animated.Value(0)).current
+  // Drives header background: 0 = fully transparent (over hero), 1 = opaque (past hero)
+  const headerBgProgress = useRef(new Animated.Value(0)).current
   const isHeaderVisible = useRef(false)
 
   const onHeroNameLayout = (e: LayoutChangeEvent) => {
@@ -124,7 +133,15 @@ export default function FoodDetailScreen() {
         useNativeDriver: true,
       }).start()
     }
+    // Header bg fades in over the first 80 px of scroll (covers top portion of hero).
+    // useNativeDriver:false required for backgroundColor interpolation.
+    headerBgProgress.setValue(Math.min(scrollY / 80, 1))
   }
+
+  const [lightbox, setLightbox] = useState<{ visible: boolean; startIndex: number }>({
+    visible: false,
+    startIndex: 0,
+  })
 
   // Fetch fresh food data from API
   const [freshFood, setFreshFood] = useState<FoodSummary | null>(null)
@@ -145,11 +162,11 @@ export default function FoodDetailScreen() {
 
   if (!food) {
     return (
-      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.centered}>
           <Text style={{ color: colors.label2 }}>No food data</Text>
         </View>
-      </SafeAreaView>
+      </View>
     )
   }
 
@@ -182,13 +199,40 @@ export default function FoodDetailScreen() {
   // Max value for bar fill proportions (sum of all macros)
   const maxMacro = protein + carbs + fat + fiber || 1
 
+  // When there's no hero image the header is always opaque — start at 1.
+  // When there is an image it fades in from transparent as user scrolls.
+  const hasImage = Boolean(freshFood?.imageUrl)
+  const headerBgColor = hasImage
+    ? headerBgProgress.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['rgba(0,0,0,0)', colors.bg],
+      })
+    : colors.bg
+
+  // Header height = safe-area top inset + 52 px content row
+  const HEADER_CONTENT_HEIGHT = 52
+
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top']}>
-      {/* Header */}
-      <View style={[styles.header, { borderBottomColor: colors.sep2 }]}>
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      {/* Absolute floating header — overlays the hero image */}
+      <Animated.View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top,
+            backgroundColor: headerBgColor,
+          },
+        ]}
+      >
         <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} hitSlop={12}>
-          <Ionicons name="chevron-back" size={28} color={colors.gold} />
-          <Text style={[styles.backLabel, { color: colors.gold }]}>{backLabel}</Text>
+          {/* Translucent chip behind back button for legibility over bright photos */}
+          <View style={[
+            styles.backChip,
+            { backgroundColor: isDark ? 'rgba(0,0,0,0.40)' : 'rgba(0,0,0,0.22)' },
+          ]}>
+            <Ionicons name="chevron-back" size={22} color={colors.gold} />
+            <Text style={[styles.backChipLabel, { color: colors.gold }]}>{backLabel}</Text>
+          </View>
         </TouchableOpacity>
         <Animated.View style={[styles.headerTitle, { opacity: headerTitleOpacity }]}>
           <View style={[styles.headerIcon, { backgroundColor: colors.fill2 }]}>
@@ -199,7 +243,7 @@ export default function FoodDetailScreen() {
           </Text>
         </Animated.View>
         <View style={styles.headerSpacer} />
-      </View>
+      </Animated.View>
 
       <ScrollView
         contentContainerStyle={styles.scrollContent}
@@ -207,37 +251,88 @@ export default function FoodDetailScreen() {
         onScroll={onScroll}
         scrollEventThrottle={16}
       >
-        {/* Hero image — rendered when imageUrl is available; emoji layout is preserved when null */}
+        {/* Hero — image with overlaid title when imageUrl available, emoji fallback otherwise */}
         {freshFood?.imageUrl ? (
-          <Image
-            source={{ uri: freshFood.imageUrl }}
-            style={[styles.heroImage, { backgroundColor: colors.fill2 }]}
-            resizeMode="cover"
-          />
-        ) : null}
-
-        {/* Hero */}
-        <View style={styles.hero}>
-          <View style={[styles.heroIcon, { backgroundColor: colors.fill2 }]}>
-            <Ionicons name="restaurant-outline" size={34} color={colors.label2} />
-          </View>
-          <Text style={[styles.heroName, { color: colors.label }]} onLayout={onHeroNameLayout}>{foodName}</Text>
-          <View style={styles.heroSub}>
-            {categoryLabel && (
-              <>
-                <View style={[styles.categoryBadge, { backgroundColor: colors.fill }]}>
-                  <Text style={[styles.categoryBadgeText, { color: colors.label2 }]}>
-                    {categoryLabel}
-                  </Text>
+          <>
+            <Pressable
+              onPress={() => setLightbox({ visible: true, startIndex: 0 })}
+              style={styles.heroImageWrapper}
+              accessibilityRole="imagebutton"
+            >
+              <Image
+                source={{ uri: freshFood.imageUrl }}
+                style={[styles.heroImage, { backgroundColor: colors.fill2 }]}
+                resizeMode="cover"
+              />
+              {/* Dark gradient at the bottom of the hero */}
+              <LinearGradient
+                colors={['transparent', 'rgba(0,0,0,0.65)']}
+                style={styles.heroGradient}
+                pointerEvents="none"
+              />
+              {/* Overlaid title card */}
+              <View style={styles.heroOverlay} pointerEvents="none">
+                <View style={[
+                  styles.heroOverlayIcon,
+                  { backgroundColor: isDark ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.20)' },
+                ]}>
+                  <Ionicons name="restaurant-outline" size={18} color="white" />
                 </View>
-                <Text style={[styles.heroDot, { color: colors.label3 }]}>·</Text>
-              </>
-            )}
-            <Text style={[styles.heroGrams, { color: colors.label2 }]}>
-              {Math.round(grams)} g
-            </Text>
+                <Text
+                  style={styles.heroOverlayName}
+                  numberOfLines={2}
+                  onLayout={onHeroNameLayout}
+                >
+                  {foodName}
+                </Text>
+                <View style={styles.heroSub}>
+                  {categoryLabel && (
+                    <>
+                      <View style={[
+                        styles.overlayBadge,
+                        { backgroundColor: isDark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.25)' },
+                      ]}>
+                        <Text style={styles.overlayBadgeText}>{categoryLabel}</Text>
+                      </View>
+                      <Text style={styles.overlayDot}>·</Text>
+                    </>
+                  )}
+                  <Text style={styles.overlayGrams}>{Math.round(grams)} g</Text>
+                </View>
+              </View>
+            </Pressable>
+            <ImageLightbox
+              visible={lightbox.visible}
+              images={[freshFood.imageUrl]}
+              startIndex={0}
+              onClose={() => setLightbox(prev => ({ ...prev, visible: false }))}
+            />
+          </>
+        ) : (
+          // No-image fallback: centered emoji hero block.
+          // Add top padding so content clears the absolute header.
+          <View style={[styles.hero, { paddingTop: insets.top + HEADER_CONTENT_HEIGHT + 8 }]}>
+            <View style={[styles.heroIcon, { backgroundColor: colors.fill2 }]}>
+              <Ionicons name="restaurant-outline" size={34} color={colors.label2} />
+            </View>
+            <Text style={[styles.heroName, { color: colors.label }]} onLayout={onHeroNameLayout}>{foodName}</Text>
+            <View style={styles.heroSub}>
+              {categoryLabel && (
+                <>
+                  <View style={[styles.categoryBadge, { backgroundColor: colors.fill }]}>
+                    <Text style={[styles.categoryBadgeText, { color: colors.label2 }]}>
+                      {categoryLabel}
+                    </Text>
+                  </View>
+                  <Text style={[styles.heroDot, { color: colors.label3 }]}>·</Text>
+                </>
+              )}
+              <Text style={[styles.heroGrams, { color: colors.label2 }]}>
+                {Math.round(grams)} g
+              </Text>
+            </View>
           </View>
-        </View>
+        )}
 
         {/* Macros Card */}
         <View style={[styles.macrosCard, { backgroundColor: colors.bg2 }]}>
@@ -295,9 +390,40 @@ export default function FoodDetailScreen() {
           </View>
         ) : null}
 
+        {/* Photos — single tile grid, shown only when imageUrl is available */}
+        {freshFood?.imageUrl ? (() => {
+          // 3-column layout: window width 340 approximation - 20px margins each side - 6px gaps between tiles
+          // Formula mirrors recipe-detail: (340 - 6 * 2) / 3
+          const TILE_SIZE = Math.floor((340 - 6 * 2) / 3)
+          return (
+            <View style={styles.section}>
+              <Text style={[styles.sectionTitle, { color: colors.label3 }]}>
+                {t('foodDetail.photos')}
+              </Text>
+              <View style={[styles.photosGrid, { backgroundColor: colors.bg2 }]}>
+                <Pressable
+                  onPress={() => setLightbox({ visible: true, startIndex: 0 })}
+                  style={({ pressed }) => [
+                    styles.photosTile,
+                    { width: TILE_SIZE, height: TILE_SIZE, backgroundColor: colors.fill2 },
+                    pressed && { opacity: 0.75 },
+                  ]}
+                  accessibilityRole="imagebutton"
+                >
+                  <Image
+                    source={{ uri: freshFood.imageUrl }}
+                    style={styles.photosTileImage}
+                    resizeMode="cover"
+                  />
+                </Pressable>
+              </View>
+            </View>
+          )
+        })() : null}
+
         <View style={{ height: 32 }} />
       </ScrollView>
-    </SafeAreaView>
+    </View>
   )
 }
 
@@ -307,16 +433,30 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 
-  // Header
+  // Header — absolutely positioned, floats over the hero image
   header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 14,
     paddingVertical: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  backBtn: { flexDirection: 'row', alignItems: 'center', flexShrink: 0 },
-  backLabel: { ...Type.body, marginLeft: -2 },
+  // Back button wraps its own chip — backBtn is just for hitSlop grouping
+  backBtn: { flexShrink: 0 },
+  // Translucent rounded chip behind the back button text/icon
+  backChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: Radius.full,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    gap: 2,
+  },
+  backChipLabel: { ...Type.body, fontWeight: '600' },
   headerTitle: {
     flex: 1,
     flexDirection: 'row',
@@ -338,15 +478,61 @@ const styles = StyleSheet.create({
 
   scrollContent: { paddingBottom: 20 },
 
-  // Hero image (shown when imageUrl is non-null; fallback is the emoji heroIcon)
-  heroImage: {
-    marginHorizontal: 20,
-    marginTop: 8,
-    height: 140,
-    borderRadius: Radius.lg,
+  // Hero image wrapper — full-bleed, no margins/radius: extends edge-to-edge from the
+  // very top of the scroll content so the absolute header floats over the photo.
+  heroImageWrapper: {
+    height: 180,
+    overflow: 'hidden',
+    position: 'relative',
   },
 
-  // Hero
+  // Hero image — fills the wrapper absolutely
+  heroImage: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+
+  // Dark gradient over the bottom portion of the image
+  heroGradient: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 100,
+  },
+
+  // Overlaid title card at the bottom of the hero
+  heroOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 12,
+    paddingBottom: 10,
+    paddingTop: 6,
+    gap: 4,
+    alignItems: 'center',
+  },
+  heroOverlayIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 2,
+  },
+  heroOverlayName: {
+    ...Type.headline,
+    color: 'white',
+    fontWeight: '700',
+    lineHeight: 20,
+    textAlign: 'center',
+  },
+
+  // Hero (no-image fallback)
   hero: {
     alignItems: 'center',
     paddingVertical: 20,
@@ -356,7 +542,7 @@ const styles = StyleSheet.create({
   heroIcon: {
     width: 72,
     height: 72,
-    borderRadius: 22,
+    borderRadius: Radius.lg,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -377,9 +563,20 @@ const styles = StyleSheet.create({
   },
   categoryBadgeText: { ...Type.caption1, fontWeight: '600' },
 
+  // Overlay chips / text — white translucent on photo
+  overlayBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: Radius.full,
+  },
+  overlayBadgeText: { ...Type.caption1, fontWeight: '600', color: 'white' },
+  overlayDot: { ...Type.footnote, color: 'rgba(255,255,255,0.7)' },
+  overlayGrams: { ...Type.footnote, color: 'rgba(255,255,255,0.9)' },
+
   // Macros Card
   macrosCard: {
     marginHorizontal: 20,
+    marginTop: 16,
     marginBottom: 16,
     borderRadius: Radius.lg,
     padding: 16,
@@ -443,6 +640,24 @@ const styles = StyleSheet.create({
   },
   infoLabel: { ...Type.subheadline },
   infoVal: { ...Type.subheadline, fontWeight: '500' },
+
+  // Photos grid
+  photosGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+    padding: 10,
+  },
+  photosTile: {
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+  },
+  photosTileImage: {
+    width: '100%' as unknown as number,
+    height: '100%' as unknown as number,
+  },
 
   // Note
   noteCard: {

--- a/mobile/app/(client)/(tabs)/nutrition/recipe-detail.tsx
+++ b/mobile/app/(client)/(tabs)/nutrition/recipe-detail.tsx
@@ -9,11 +9,13 @@ import {
   ActivityIndicator,
   Image,
   Animated,
+  useColorScheme,
   type NativeSyntheticEvent,
   type NativeScrollEvent,
   type LayoutChangeEvent,
 } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { LinearGradient } from 'expo-linear-gradient'
 import { useRouter, useLocalSearchParams, useSegments } from 'expo-router'
 import { hrefParams } from '@/lib/navigation'
 import { Ionicons } from '@expo/vector-icons'
@@ -23,6 +25,7 @@ import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import type { MealRecipe, RecipeDetail, MealFood } from '@/api/nutrition'
 import { getRecipeDetail } from '@/api/nutrition'
+import { ImageLightbox } from '@/components/ui/ImageLightbox'
 
 // ─── Macro Grid Item ────────────────────────────────────────────────────────
 
@@ -68,6 +71,9 @@ export default function RecipeDetailScreen() {
       ? '/(client)/nutrition'
       : '/(client)'
   const colors = useTheme()
+  const scheme = useColorScheme()
+  const isDark = scheme === 'dark'
+  const insets = useSafeAreaInsets()
   const params = useLocalSearchParams<{ recipe: string; mealName: string; backLabel?: string }>()
 
   const mealRecipe: MealRecipe | null = params.recipe ? JSON.parse(params.recipe) : null
@@ -77,10 +83,16 @@ export default function RecipeDetailScreen() {
   const [detail, setDetail] = useState<RecipeDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [lightbox, setLightbox] = useState<{ visible: boolean; startIndex: number }>({
+    visible: false,
+    startIndex: 0,
+  })
 
   // Track hero name visibility for header title
   const heroNameBottom = useRef(0)
   const headerTitleOpacity = useRef(new Animated.Value(0)).current
+  // Drives header background: 0 = fully transparent (over hero), 1 = opaque (past hero)
+  const headerBgProgress = useRef(new Animated.Value(0)).current
   const isHeaderVisible = useRef(false)
 
   const onHeroNameLayout = (e: LayoutChangeEvent) => {
@@ -98,6 +110,9 @@ export default function RecipeDetailScreen() {
         useNativeDriver: true,
       }).start()
     }
+    // Header bg fades in over the first 80 px of scroll (covers top portion of hero).
+    // useNativeDriver:false required for backgroundColor interpolation.
+    headerBgProgress.setValue(Math.min(scrollY / 80, 1))
   }
 
   useEffect(() => {
@@ -121,11 +136,11 @@ export default function RecipeDetailScreen() {
 
   if (!mealRecipe) {
     return (
-      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.container, { backgroundColor: colors.bg }]}>
         <View style={styles.centered}>
           <Text style={{ color: colors.label2 }}>No recipe data</Text>
         </View>
-      </SafeAreaView>
+      </View>
     )
   }
 
@@ -143,13 +158,40 @@ export default function RecipeDetailScreen() {
 
   const totalGrams = (n.protein ?? 0) + (n.carbs ?? 0) + (n.fat ?? 0) + (n.fiber ?? 0) || 1
 
+  // When there's no hero image the header is always opaque — start at 1.
+  // When there is an image it fades in from transparent as user scrolls.
+  const hasImage = Boolean(detail?.imageUrl)
+  const headerBgColor = hasImage
+    ? headerBgProgress.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['rgba(0,0,0,0)', colors.bg],
+      })
+    : colors.bg
+
+  // Header height = safe-area top inset + 52 px content row
+  const HEADER_CONTENT_HEIGHT = 52
+
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top']}>
-      {/* Header */}
-      <View style={[styles.header, { borderBottomColor: colors.sep2 }]}>
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      {/* Absolute floating header — overlays the hero image */}
+      <Animated.View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top,
+            backgroundColor: headerBgColor,
+          },
+        ]}
+      >
         <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} hitSlop={12}>
-          <Ionicons name="chevron-back" size={28} color={colors.gold} />
-          <Text style={[styles.backLabel, { color: colors.gold }]}>{backLabel}</Text>
+          {/* Translucent chip behind back button for legibility over bright photos */}
+          <View style={[
+            styles.backChip,
+            { backgroundColor: isDark ? 'rgba(0,0,0,0.40)' : 'rgba(0,0,0,0.22)' },
+          ]}>
+            <Ionicons name="chevron-back" size={22} color={colors.gold} />
+            <Text style={[styles.backChipLabel, { color: colors.gold }]}>{backLabel}</Text>
+          </View>
         </TouchableOpacity>
         <Animated.View style={[styles.headerTitle, { opacity: headerTitleOpacity }]}>
           <View style={[styles.headerIcon, { backgroundColor: 'rgba(0,122,255,0.1)' }]}>
@@ -160,7 +202,7 @@ export default function RecipeDetailScreen() {
           </Text>
         </Animated.View>
         <View style={styles.headerSpacer} />
-      </View>
+      </Animated.View>
 
       <ScrollView
         contentContainerStyle={styles.scrollContent}
@@ -168,60 +210,126 @@ export default function RecipeDetailScreen() {
         onScroll={onScroll}
         scrollEventThrottle={16}
       >
-        {/* Recipe hero image — full-width, shown when imageUrl is available */}
-        {detail?.imageUrl ? (
-          <Image
-            source={{ uri: detail.imageUrl }}
-            style={[styles.recipeHeroImage, { backgroundColor: colors.fill2 }]}
-            resizeMode="cover"
-          />
-        ) : null}
+        {/* Hero image with overlaid title card — shown when imageUrl is available */}
+        {(() => {
+          // Build the combined image list used for both the lightbox and gallery indices
+          const allImages = [
+            detail?.imageUrl,
+            ...(detail?.galleryImageUrls ?? []),
+          ].filter((u): u is string => Boolean(u))
 
-        {/* Gallery strip — horizontal scroll, shown only when there are gallery images */}
-        {(detail?.galleryImageUrls?.length ?? 0) > 0 ? (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={[styles.galleryContent, { paddingHorizontal: 20 }]}
-            style={styles.galleryStrip}
-          >
-            {(detail!.galleryImageUrls ?? []).map((uri: string, idx: number) => (
-              <Image
-                key={idx}
-                source={{ uri }}
-                style={[styles.galleryThumb, { backgroundColor: colors.fill2 }]}
-                resizeMode="cover"
-              />
-            ))}
-          </ScrollView>
-        ) : null}
-
-        {/* Hero */}
-        <View style={styles.hero}>
-          <View style={[styles.heroIcon, { backgroundColor: 'rgba(0,122,255,0.1)' }]}>
-            <Ionicons name="book-outline" size={34} color={colors.blue} />
-          </View>
-          <Text style={[styles.heroName, { color: colors.label }]} onLayout={onHeroNameLayout}>{mealRecipe.recipeName}</Text>
-          <View style={styles.heroSub}>
-            <View style={[styles.categoryBadge, { backgroundColor: colors.fill }]}>
-              <Text style={[styles.categoryBadgeText, { color: colors.label2 }]}>
-                {t('recipeDetail.recipe')}
-              </Text>
-            </View>
-            <Text style={[styles.heroDot, { color: colors.label3 }]}>·</Text>
-            <Text style={[styles.heroMeta, { color: colors.label2 }]}>
-              {t('nutrition.serving', { count: servings })}
-            </Text>
-            {detail?.prepTimeMinutes != null && (
-              <>
-                <Text style={[styles.heroDot, { color: colors.label3 }]}>·</Text>
-                <Text style={[styles.heroMeta, { color: colors.label2 }]}>
-                  ⏱ {t('recipeDetail.prepTime', { minutes: detail.prepTimeMinutes })}
+          if (!detail?.imageUrl) {
+            // No-image fallback: centered emoji hero block.
+            // Add top padding so content clears the absolute header.
+            return (
+              <View style={[styles.hero, { paddingTop: insets.top + HEADER_CONTENT_HEIGHT + 8 }]}>
+                <View style={[styles.heroIcon, { backgroundColor: 'rgba(0,122,255,0.15)' }]}>
+                  <Ionicons name="book-outline" size={44} color={colors.blue} />
+                </View>
+                <Text
+                  style={[styles.heroName, { color: colors.label }]}
+                  onLayout={onHeroNameLayout}
+                >
+                  {mealRecipe.recipeName}
                 </Text>
-              </>
-            )}
-          </View>
-        </View>
+                <View style={styles.heroSub}>
+                  <View style={[styles.categoryBadge, { backgroundColor: colors.fill }]}>
+                    <Text style={[styles.categoryBadgeText, { color: colors.label2 }]}>
+                      {t('recipeDetail.recipe')}
+                    </Text>
+                  </View>
+                  <View style={[styles.categoryBadge, { backgroundColor: colors.fill }]}>
+                    <Text style={[styles.categoryBadgeText, { color: colors.label2 }]}>
+                      {t('nutrition.serving', { count: servings })}
+                    </Text>
+                  </View>
+                  {detail?.prepTimeMinutes != null && (
+                    <View style={[styles.categoryBadge, { backgroundColor: colors.fill }]}>
+                      <Text style={[styles.categoryBadgeText, { color: colors.label2 }]}>
+                        {t('recipeDetail.prepTime', { minutes: detail.prepTimeMinutes })}
+                      </Text>
+                    </View>
+                  )}
+                </View>
+              </View>
+            )
+          }
+
+          return (
+            <>
+              {/* Tappable hero image with gradient overlay + title card */}
+              <Pressable
+                onPress={() => setLightbox({ visible: true, startIndex: 0 })}
+                style={styles.recipeHeroWrapper}
+                accessibilityRole="imagebutton"
+              >
+                <Image
+                  source={{ uri: detail.imageUrl }}
+                  style={[styles.recipeHeroImage, { backgroundColor: colors.fill2 }]}
+                  resizeMode="cover"
+                />
+                {/* Dark gradient at the bottom of the hero */}
+                <LinearGradient
+                  colors={['transparent', 'rgba(0,0,0,0.65)']}
+                  style={styles.heroGradient}
+                  pointerEvents="none"
+                />
+                {/* Overlaid title card */}
+                <View style={styles.heroOverlay} pointerEvents="none">
+                  <View style={[
+                    styles.heroOverlayIcon,
+                    { backgroundColor: isDark ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.35)' },
+                  ]}>
+                    <Ionicons name="book-outline" size={44} color="white" />
+                  </View>
+                  <Text
+                    style={styles.heroOverlayName}
+                    numberOfLines={2}
+                    onLayout={onHeroNameLayout}
+                  >
+                    {mealRecipe.recipeName}
+                  </Text>
+                  <View style={styles.heroSub}>
+                    <View style={[
+                      styles.overlayBadge,
+                      { backgroundColor: isDark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.25)' },
+                    ]}>
+                      <Text style={styles.overlayBadgeText}>
+                        {t('recipeDetail.recipe')}
+                      </Text>
+                    </View>
+                    <View style={[
+                      styles.overlayBadge,
+                      { backgroundColor: isDark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.25)' },
+                    ]}>
+                      <Text style={styles.overlayBadgeText}>
+                        {t('nutrition.serving', { count: servings })}
+                      </Text>
+                    </View>
+                    {detail.prepTimeMinutes != null && (
+                      <View style={[
+                        styles.overlayBadge,
+                        { backgroundColor: isDark ? 'rgba(0,0,0,0.45)' : 'rgba(255,255,255,0.25)' },
+                      ]}>
+                        <Text style={styles.overlayBadgeText}>
+                          {t('recipeDetail.prepTime', { minutes: detail.prepTimeMinutes })}
+                        </Text>
+                      </View>
+                    )}
+                  </View>
+                </View>
+              </Pressable>
+
+              {/* Lightbox */}
+              <ImageLightbox
+                visible={lightbox.visible}
+                images={allImages}
+                startIndex={lightbox.startIndex}
+                onClose={() => setLightbox(prev => ({ ...prev, visible: false }))}
+              />
+            </>
+          )
+        })()}
 
         {/* Description */}
         {detail?.description ? (
@@ -388,9 +496,50 @@ export default function RecipeDetailScreen() {
           </View>
         )}
 
+        {/* Photos — gallery grid, rendered when hero OR gallery images exist */}
+        {(() => {
+          const allPhotos = [
+            detail?.imageUrl,
+            ...(detail?.galleryImageUrls ?? []),
+          ].filter((u): u is string => Boolean(u))
+          if (allPhotos.length === 0) return null
+          // Compute an explicit tile size: 3 columns with 6 px gaps inside 20 px horizontal margins.
+          // Using explicit width + height avoids aspectRatio resolving to 0 in flex-wrap.
+          const TILE_SIZE = Math.floor((340 - 6 * 2) / 3)
+          return (
+            <View style={styles.section}>
+              <Text style={[styles.sectionTitle, { color: colors.label3 }]}>
+                {t('recipeDetail.photos')}
+              </Text>
+              <View style={[styles.photosGrid, { backgroundColor: colors.bg2 }]}>
+                {allPhotos.map((uri, idx) => (
+                  <Pressable
+                    key={idx}
+                    onPress={() =>
+                      setLightbox({ visible: true, startIndex: idx })
+                    }
+                    style={({ pressed }) => [
+                      styles.photosTile,
+                      { width: TILE_SIZE, height: TILE_SIZE, backgroundColor: colors.fill2 },
+                      pressed && { opacity: 0.75 },
+                    ]}
+                    accessibilityRole="imagebutton"
+                  >
+                    <Image
+                      source={{ uri }}
+                      style={styles.photosTileImage}
+                      resizeMode="cover"
+                    />
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          )
+        })()}
+
         <View style={{ height: 32 }} />
       </ScrollView>
-    </SafeAreaView>
+    </View>
   )
 }
 
@@ -400,16 +549,30 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 
-  // Header
+  // Header — absolutely positioned, floats over the hero image
   header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 14,
     paddingVertical: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  backBtn: { flexDirection: 'row', alignItems: 'center', flexShrink: 0 },
-  backLabel: { ...Type.body, marginLeft: -2 },
+  // Back button wraps its own chip — backBtn is just for hitSlop grouping
+  backBtn: { flexShrink: 0 },
+  // Translucent rounded chip behind the back button text/icon
+  backChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: Radius.full,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    gap: 2,
+  },
+  backChipLabel: { ...Type.body, fontWeight: '600' },
   headerTitle: {
     flex: 1,
     flexDirection: 'row',
@@ -431,26 +594,82 @@ const styles = StyleSheet.create({
 
   scrollContent: { paddingBottom: 20 },
 
-  // Recipe hero image (full-width, shown when imageUrl is non-null)
+  // Hero wrapper — full-bleed container for the image + gradient + overlay.
+  // No margins/radius: extends edge-to-edge from the very top of the scroll content
+  // so the absolute header floats over the top portion of the photo.
+  recipeHeroWrapper: {
+    height: 220,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+
+  // Recipe hero image (fills the wrapper absolutely)
   recipeHeroImage: {
-    width: '100%' as unknown as number,
-    height: 180,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
 
-  // Gallery strip (horizontal scroll below hero image)
-  galleryStrip: {
-    marginTop: 8,
+  // Dark gradient that sits on top of the image at the bottom half
+  heroGradient: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 130,
   },
-  galleryContent: {
+
+  // Overlaid title card at the bottom of the hero image
+  heroOverlay: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 14,
+    paddingBottom: 12,
+    paddingTop: 8,
+    gap: 5,
+    alignItems: 'center',
+  },
+  heroOverlayIcon: {
+    padding: 12,
+    borderRadius: Radius.lg,
+    alignSelf: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 2,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.2)',
+  },
+  heroOverlayName: {
+    ...Type.title3,
+    color: 'white',
+    fontWeight: '700',
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+
+  // Photos grid (title lives above as a sectionTitle, same pattern as Ingredients/Steps)
+  photosGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: 6,
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+    padding: 10,
   },
-  galleryThumb: {
-    width: 72,
-    height: 72,
-    borderRadius: Radius.md,
+  photosTile: {
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+  },
+  photosTileImage: {
+    width: '100%' as unknown as number,
+    height: '100%' as unknown as number,
   },
 
-  // Hero
+  // Hero (no-image fallback)
   hero: {
     alignItems: 'center',
     paddingVertical: 20,
@@ -458,9 +677,9 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   heroIcon: {
-    width: 72,
-    height: 72,
-    borderRadius: 22,
+    padding: 12,
+    borderRadius: Radius.lg,
+    alignSelf: 'center',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -472,8 +691,6 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     justifyContent: 'center',
   },
-  heroDot: { ...Type.footnote },
-  heroMeta: { ...Type.footnote },
   categoryBadge: {
     paddingHorizontal: 10,
     paddingVertical: 3,
@@ -481,6 +698,13 @@ const styles = StyleSheet.create({
   },
   categoryBadgeText: { ...Type.caption1, fontWeight: '600' },
 
+  // Overlay chips / text — white translucent on photo
+  overlayBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: Radius.full,
+  },
+  overlayBadgeText: { ...Type.caption1, fontWeight: '600', color: 'white' },
   // Macros Card
   macrosCard: {
     marginHorizontal: 20,
@@ -588,6 +812,7 @@ const styles = StyleSheet.create({
   // Description card (below hero, above macros)
   descriptionCard: {
     marginHorizontal: 20,
+    marginTop: 16,
     marginBottom: 16,
     borderRadius: Radius.sm,
     padding: 16,

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -5,7 +5,6 @@
 //----------------------
 
 /* eslint-disable */
-// @ts-nocheck
 // ReSharper disable InconsistentNaming
 
 import axios, { AxiosError } from 'axios';
@@ -12769,6 +12768,10 @@ export interface ParticipantDto {
     name?: string;
     initials?: string;
     online?: boolean;
+    /** Avatar URL for the participant. For professionals, prefers the professional-profile
+avatar; falls back to the user-level avatar. For clients, uses the user-level avatar.
+Null when neither has been uploaded. */
+    avatarBlobUrl?: string | undefined;
 }
 
 export interface StartConversationRequest {
@@ -13989,6 +13992,10 @@ export interface CollaborationDto {
     professionalCity?: string | undefined;
     role?: string;
     since?: string;
+    /** Professional's avatar URL. Falls back to the underlying user's
+personal avatar when the professional-profile-specific one isn't set.
+Null when neither is uploaded. */
+    avatarBlobUrl?: string | undefined;
 }
 
 /** Request model for email verification. */

--- a/mobile/src/api/profile.ts
+++ b/mobile/src/api/profile.ts
@@ -2,14 +2,21 @@ import api from './client';
 import type {
   UpdateProfileRequest,
   GetComplianceScoreResponse,
-  CollaborationDto,
+  CollaborationDto as GeneratedCollaborationDto,
   GenerateAvatarUploadUrlRequest,
   GenerateAvatarUploadUrlResponse,
   ConfirmAvatarRequest,
 } from './generated';
 
+// Extend the generated CollaborationDto with fields the backend added after
+// the last regen. Remove the intersection once regen-api runs and the
+// generated type picks `avatarBlobUrl` up on its own.
+export type CollaborationDto = GeneratedCollaborationDto & {
+  avatarBlobUrl?: string | null;
+};
+
 // Re-export generated types so consumer imports (`from '@/api/profile'`) still work.
-export type { UpdateProfileRequest, CollaborationDto };
+export type { UpdateProfileRequest };
 
 /** @deprecated Legacy alias — prefer `GetComplianceScoreResponse` from generated. */
 export type ComplianceScoreResponse = GetComplianceScoreResponse;

--- a/mobile/src/components/messages/ChatHeader.tsx
+++ b/mobile/src/components/messages/ChatHeader.tsx
@@ -25,7 +25,7 @@ export function ChatHeader({ participant, onBack, onInfoPress }: ChatHeaderProps
 
         {/* Center: Avatar + name + status — stacked vertically */}
         <View style={styles.center}>
-          <Avatar name={participant.name ?? ''} size="sm" />
+          <Avatar name={participant.name ?? ''} imageUrl={participant.avatarBlobUrl} size="sm" />
           <Text style={[styles.name, { color: colors.label }]} numberOfLines={1}>
             {participant.name ?? ''}
           </Text>

--- a/mobile/src/components/messages/ConversationRow.tsx
+++ b/mobile/src/components/messages/ConversationRow.tsx
@@ -71,7 +71,7 @@ export const ConversationRow = React.memo(function ConversationRow({
     >
       {/* Avatar */}
       <View style={[styles.avatarWrap, { opacity: isArchived ? 0.6 : 1 }]}>
-        <Avatar name={participant?.name ?? ''} size="md" />
+        <Avatar name={participant?.name ?? ''} imageUrl={participant?.avatarBlobUrl} size="md" />
         {!isArchived && participant?.online && (
           <View style={[styles.onlineDot, { borderColor: colors.bg2, backgroundColor: colors.green }]} />
         )}

--- a/mobile/src/components/messages/MessageBubble.tsx
+++ b/mobile/src/components/messages/MessageBubble.tsx
@@ -11,6 +11,7 @@ interface MessageBubbleProps {
   isOwn: boolean
   showAvatar: boolean
   participantName?: string
+  participantAvatarUrl?: string | null
   onRetry?: (id: string) => void
 }
 
@@ -19,6 +20,7 @@ export const MessageBubble = React.memo(function MessageBubble({
   isOwn,
   showAvatar,
   participantName = '',
+  participantAvatarUrl,
   onRetry,
 }: MessageBubbleProps) {
   const colors = useTheme()
@@ -31,7 +33,7 @@ export const MessageBubble = React.memo(function MessageBubble({
       {!isOwn && (
         showAvatar ? (
           <View style={styles.tinyAvatarWrap}>
-            <Avatar name={participantName} size="sm" />
+            <Avatar name={participantName} imageUrl={participantAvatarUrl} size="sm" />
           </View>
         ) : (
           <View style={styles.avatarSpacer} />

--- a/mobile/src/components/trainers/ActiveCollaboratorCard.tsx
+++ b/mobile/src/components/trainers/ActiveCollaboratorCard.tsx
@@ -51,7 +51,7 @@ export function ActiveCollaboratorCard({
       {/* Header row */}
       <View style={styles.header}>
         <View style={{ flexShrink: 0 }}>
-          <Avatar name={collaborator.name} size="md" />
+          <Avatar name={collaborator.name} size="md" imageUrl={collaborator.avatarImageUrl} />
         </View>
         <View style={styles.info}>
           <Text style={[styles.name, { color: colors.label }]}>{collaborator.name}</Text>

--- a/mobile/src/components/ui/ImageLightbox.tsx
+++ b/mobile/src/components/ui/ImageLightbox.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback, useEffect, useRef } from 'react'
+import {
+  Modal,
+  View,
+  StyleSheet,
+  FlatList,
+  Image,
+  Pressable,
+  Text,
+  BackHandler,
+  useWindowDimensions,
+  type ListRenderItemInfo,
+} from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Ionicons } from '@expo/vector-icons'
+import { useTranslation } from 'react-i18next'
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+export interface ImageLightboxProps {
+  visible: boolean
+  images: string[]
+  startIndex?: number
+  onClose: () => void
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ImageLightbox({ visible, images, startIndex = 0, onClose }: ImageLightboxProps) {
+  const { t } = useTranslation()
+  const { width, height } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
+  const listRef = useRef<FlatList<string>>(null)
+  const currentIndexRef = useRef(startIndex)
+
+  // Scroll to the starting image when the modal opens or startIndex changes
+  useEffect(() => {
+    if (visible && images.length > 0) {
+      currentIndexRef.current = startIndex
+      // Use a minimal delay to let the FlatList mount before scrolling
+      const timer = setTimeout(() => {
+        listRef.current?.scrollToIndex({ index: startIndex, animated: false })
+      }, 0)
+      return () => clearTimeout(timer)
+    }
+  }, [visible, startIndex, images.length])
+
+  // Android hardware back button closes the lightbox
+  useEffect(() => {
+    if (!visible) return
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose()
+      return true
+    })
+    return () => sub.remove()
+  }, [visible, onClose])
+
+  const goToPrev = useCallback(() => {
+    const next = Math.max(0, currentIndexRef.current - 1)
+    currentIndexRef.current = next
+    listRef.current?.scrollToIndex({ index: next, animated: true })
+  }, [])
+
+  const goToNext = useCallback(() => {
+    const next = Math.min(images.length - 1, currentIndexRef.current + 1)
+    currentIndexRef.current = next
+    listRef.current?.scrollToIndex({ index: next, animated: true })
+  }, [images.length])
+
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: Array<{ index: number | null }> }) => {
+      if (viewableItems[0]?.index != null) {
+        currentIndexRef.current = viewableItems[0].index
+      }
+    },
+    []
+  )
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<string>) => (
+      <View style={{ width, height, justifyContent: 'center', alignItems: 'center' }}>
+        <Image
+          source={{ uri: item }}
+          style={{ width, height }}
+          resizeMode="contain"
+        />
+      </View>
+    ),
+    [width, height]
+  )
+
+  const keyExtractor = useCallback((_: string, index: number) => String(index), [])
+
+  const getItemLayout = useCallback(
+    (_: ArrayLike<string> | null | undefined, index: number) => ({
+      length: width,
+      offset: width * index,
+      index,
+    }),
+    [width]
+  )
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      {/* Black backdrop */}
+      <View style={styles.backdrop}>
+        {/* Full-screen paginated image list */}
+        <FlatList
+          ref={listRef}
+          data={images}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          getItemLayout={getItemLayout}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={{ viewAreaCoveragePercentThreshold: 50 }}
+          initialScrollIndex={startIndex}
+          scrollEnabled={images.length > 1}
+        />
+
+        {/* Close button — top right, respecting safe area */}
+        <Pressable
+          onPress={onClose}
+          style={[styles.closeBtn, { top: insets.top + 12 }]}
+          accessibilityLabel={t('imageLightbox.close')}
+          hitSlop={12}
+        >
+          <Ionicons name="close" size={28} color="white" />
+        </Pressable>
+
+        {/* Prev / next chevrons — only shown when more than one image */}
+        {images.length > 1 && (
+          <>
+            <Pressable
+              onPress={goToPrev}
+              style={[styles.navBtn, styles.navLeft, { bottom: insets.bottom + 40 }]}
+              accessibilityLabel={t('imageLightbox.previous')}
+              hitSlop={12}
+            >
+              <Ionicons name="chevron-back" size={32} color="white" />
+            </Pressable>
+            <Pressable
+              onPress={goToNext}
+              style={[styles.navBtn, styles.navRight, { bottom: insets.bottom + 40 }]}
+              accessibilityLabel={t('imageLightbox.next')}
+              hitSlop={12}
+            >
+              <Ionicons name="chevron-forward" size={32} color="white" />
+            </Pressable>
+          </>
+        )}
+
+        {/* Image counter dot row */}
+        {images.length > 1 && (
+          <View style={[styles.dotRow, { bottom: insets.bottom + 12 }]}>
+            {images.map((_, i) => (
+              <Text
+                key={i}
+                style={[
+                  styles.dot,
+                  i === currentIndexRef.current && styles.dotActive,
+                ]}
+              >
+                •
+              </Text>
+            ))}
+          </View>
+        )}
+      </View>
+    </Modal>
+  )
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.95)',
+  },
+  closeBtn: {
+    position: 'absolute',
+    right: 16,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navBtn: {
+    position: 'absolute',
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navLeft: { left: 16 },
+  navRight: { right: 16 },
+  dotRow: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  dot: {
+    color: 'rgba(255,255,255,0.4)',
+    fontSize: 18,
+    lineHeight: 20,
+  },
+  dotActive: {
+    color: 'white',
+  },
+})
+
+export default ImageLightbox

--- a/mobile/src/hooks/useCollaboration.ts
+++ b/mobile/src/hooks/useCollaboration.ts
@@ -24,6 +24,7 @@ function collabToActiveCollaborator(c: CollaborationDto): ActiveCollaborator {
     since: typeof c.since === 'string' ? c.since : new Date(c.since ?? 0).toISOString(),
     avatarColor: '',
     avatarBg: '',
+    avatarImageUrl: c.avatarBlobUrl ?? null,
   }
 }
 

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -709,7 +709,8 @@
     "per100g": "Na 100 g",
     "commonServings": "Běžné porce",
     "asPlanned": "Dle plánu ({{grams}} g)",
-    "trainerNote": "Poznámka trenéra"
+    "trainerNote": "Poznámka trenéra",
+    "photos": "Fotky"
   },
   "recipeDetail": {
     "recipe": "Recept",
@@ -720,7 +721,8 @@
     "description": "Popis",
     "prepTime": "{{minutes}} min",
     "loading": "Načítám recept...",
-    "error": "Nepodařilo se načíst detail receptu"
+    "error": "Nepodařilo se načíst detail receptu",
+    "photos": "Fotky"
   },
   "training": {
     "title": "Trénink",
@@ -843,5 +845,10 @@
     "editBadgeHint": "Otevře fotoaparát nebo galerii pro aktualizaci avataru",
     "uploadSuccess": "Profilová fotka aktualizována",
     "uploadError": "Profilovou fotku se nepodařilo aktualizovat. Zkuste to znovu."
+  },
+  "imageLightbox": {
+    "close": "Zavřít",
+    "previous": "Předchozí",
+    "next": "Další"
   }
 }

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -603,7 +603,8 @@
     "per100g": "Pro 100 g",
     "commonServings": "Übliche Portionen",
     "asPlanned": "Laut Plan ({{grams}} g)",
-    "trainerNote": "Hinweis vom Trainer"
+    "trainerNote": "Hinweis vom Trainer",
+    "photos": "Fotos"
   },
   "recipeDetail": {
     "recipe": "Rezept",
@@ -614,7 +615,8 @@
     "description": "Beschreibung",
     "prepTime": "{{minutes}} Min.",
     "loading": "Rezept wird geladen...",
-    "error": "Rezeptdetails konnten nicht geladen werden"
+    "error": "Rezeptdetails konnten nicht geladen werden",
+    "photos": "Fotos"
   },
   "weeklyCheckIn": {
     "title": "Wöchentliche Check-ins",
@@ -834,5 +836,10 @@
     "editBadgeHint": "Öffnet die Kamera oder Galerie, um Ihr Profilbild zu aktualisieren",
     "uploadSuccess": "Profilbild aktualisiert",
     "uploadError": "Profilbild konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut."
+  },
+  "imageLightbox": {
+    "close": "Schließen",
+    "previous": "Vorherige",
+    "next": "Nächste"
   }
 }

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -718,7 +718,8 @@
     "per100g": "Per 100 g",
     "commonServings": "Common Servings",
     "asPlanned": "As planned ({{grams}} g)",
-    "trainerNote": "Trainer's Note"
+    "trainerNote": "Trainer's Note",
+    "photos": "Photos"
   },
   "recipeDetail": {
     "recipe": "Recipe",
@@ -729,7 +730,8 @@
     "description": "Description",
     "prepTime": "{{minutes}} min",
     "loading": "Loading recipe...",
-    "error": "Could not load recipe detail"
+    "error": "Could not load recipe detail",
+    "photos": "Photos"
   },
   "weeklyCheckIn": {
     "title": "Weekly check-ins",
@@ -835,5 +837,10 @@
     "editBadgeHint": "Opens the camera or photo library so you can update your avatar",
     "uploadSuccess": "Profile photo updated",
     "uploadError": "Could not update profile photo. Please try again."
+  },
+  "imageLightbox": {
+    "close": "Close",
+    "previous": "Previous",
+    "next": "Next"
   }
 }

--- a/mobile/src/stores/auth.ts
+++ b/mobile/src/stores/auth.ts
@@ -41,6 +41,9 @@ export interface ActiveCollaborator {
   since: string;
   avatarColor: string;
   avatarBg: string;
+  /** Remote avatar URL from the backend; when present, surfaces in the
+   *  collaborator card and detail screen instead of the initials fallback. */
+  avatarImageUrl?: string | null;
 }
 
 export interface TrainerInvite {

--- a/progress.md
+++ b/progress.md
@@ -1049,6 +1049,7 @@ As a result:
 
 ---
 
+<<<<<<< Updated upstream
 ## 2026-04-15 — Visibility toggle in web food/recipe editors
 
 ### Scope
@@ -1097,6 +1098,8 @@ changes; purely a web UI + hand-written type change.
 
 ---
 
+=======
+>>>>>>> Stashed changes
 ## 2026-04-15 — Recipe visibility (Public / Private) (backend)
 
 ### Scope


### PR DESCRIPTION
## What was broken

Mobile Discover page showed initials for every trainer regardless of whether they'd uploaded a photo.

## Root cause

`SearchProfessionalsEndpoint` and `GetPublicProfileEndpoint` both read only `ProfessionalProfile.AvatarBlobUrl`. Today's reality:

- Every trainer uploads their photo through the web Profile page → writes to `ApplicationUser.AvatarBlobUrl`.
- The `/professionals/me/avatar/*` endpoints exist (shipped in #70) but no web UI wires to them yet — so `ProfessionalProfile.AvatarBlobUrl` is `null` for everyone.

Result: the discover response always returned `null` for `avatarBlobUrl` and the mobile Avatar primitive fell through to initials.

## Fix

Fall back to `profile.User.AvatarBlobUrl` when the professional-profile-specific one is null. Both endpoints already `Include(p => p.User)`, so no query change needed.

```csharp
AvatarBlobUrl = profile.AvatarBlobUrl ?? profile.User.AvatarBlobUrl
```

When per-professional avatar upload ships later, those values will still win — they just stop being the only source.

## Test plan

- [x] `dotnet build` — 0 errors.
- [ ] Trainer account with a user avatar set via `/profile` → coach card in mobile Discover shows the photo.
- [ ] Trainer without any avatar → initials fallback preserved.

No migration, no contract shape change, no mobile changes required — the existing client read-path (`p.avatarBlobUrl ?? null`) just starts returning non-null values.