### PR TITLE
chore(#128): replace residual hardcoded color literals with tokens

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'expo-router';
 import api from '@/api/client';
 import { useAuthStore } from '@/stores/auth';
 import { useTheme } from '@/hooks/useTheme';
+import { Colors } from '@/constants/colors';
 
 export default function LoginScreen() {
   const colors = useTheme();
@@ -149,7 +150,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   buttonText: {
-    color: '#000',
+    color: Colors.light.onGoldChip,
     fontSize: 14,
     fontWeight: '800',
     textTransform: 'uppercase',

--- a/mobile/app/(auth)/questionnaire.tsx
+++ b/mobile/app/(auth)/questionnaire.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next'
 import { Ionicons } from '@expo/vector-icons'
 import { useAuthStore } from '@/stores/auth'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { GoldButton } from '@/components/ui/GoldButton'
@@ -583,7 +584,7 @@ const styles = StyleSheet.create({
   summaryHeaderRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
   summaryCard: {
     borderRadius: Radius.lg, overflow: 'hidden', marginBottom: 14,
-    shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3, elevation: 2,
+    shadowColor: Colors.dark.shadow, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3, elevation: 2,
   },
   summaryCardHeader: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'expo-router';
 import api from '@/api/client';
 import { useAuthStore } from '@/stores/auth';
 import { useTheme } from '@/hooks/useTheme';
+import { Colors } from '@/constants/colors';
 
 const ROLES = ['Client', 'Trainer', 'Nutritionist'] as const;
 
@@ -280,7 +281,7 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
   },
   rolePillTextActive: {
-    color: '#000',
+    color: Colors.light.onGoldChip,
   },
   consentRow: {
     flexDirection: 'row',
@@ -299,7 +300,7 @@ const styles = StyleSheet.create({
   },
   checkboxChecked: {},
   checkmark: {
-    color: '#000',
+    color: Colors.light.onGoldChip,
     fontSize: 14,
     fontWeight: '800',
   },
@@ -318,7 +319,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   buttonText: {
-    color: '#000',
+    color: Colors.light.onGoldChip,
     fontSize: 14,
     fontWeight: '800',
     textTransform: 'uppercase',

--- a/mobile/app/(auth)/verify-email.tsx
+++ b/mobile/app/(auth)/verify-email.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useAuthStore } from '@/stores/auth';
 import { useTheme } from '@/hooks/useTheme';
+import { Colors } from '@/constants/colors';
 import { resendVerification } from '@/api/verification';
 import { connect, onEvent, disconnect } from '@/api/signalr';
 
@@ -224,7 +225,7 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '800',
     letterSpacing: 2,
-    color: '#000',
+    color: Colors.light.onGoldChip,
     textTransform: 'uppercase',
   },
   secondaryBtn: {

--- a/mobile/app/(client)/(tabs)/discover/[trainerId].tsx
+++ b/mobile/app/(client)/(tabs)/discover/[trainerId].tsx
@@ -15,6 +15,7 @@ import { Ionicons } from '@expo/vector-icons'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useQuery } from '@tanstack/react-query'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { Avatar } from '@/components/ui/Avatar'
@@ -390,7 +391,7 @@ const styles = StyleSheet.create({
   bioCardInner: {
     borderRadius: 16,
     padding: 16,
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,
     shadowRadius: 3,

--- a/mobile/app/(client)/(tabs)/discover/invite.tsx
+++ b/mobile/app/(client)/(tabs)/discover/invite.tsx
@@ -13,6 +13,7 @@ import { BlurView } from 'expo-blur'
 import { Ionicons } from '@expo/vector-icons'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { href } from '@/lib/navigation'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
@@ -232,7 +233,7 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 4,
     padding: 14,
     maxWidth: 280,
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,
     shadowRadius: 3,

--- a/mobile/app/(client)/(tabs)/measurements/new.tsx
+++ b/mobile/app/(client)/(tabs)/measurements/new.tsx
@@ -15,6 +15,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTheme } from '@/hooks/useTheme';
+import { Colors } from '@/constants/colors';
 import { addMeasurement, getLatestMeasurement } from '@/api/measurements';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { addPendingMutation } from '@/stores/offline';
@@ -201,7 +202,7 @@ export default function NewMeasurementScreen() {
             disabled={isSaving}
           >
             {isSaving ? (
-              <ActivityIndicator size="small" color="#000" />
+              <ActivityIndicator size="small" color={colors.onGoldChip} />
             ) : (
               <Text style={styles.saveButtonText}>SAVE MEASUREMENT</Text>
             )}
@@ -356,7 +357,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   saveButtonText: {
-    color: '#000',
+    color: Colors.light.onGoldChip,
     fontWeight: '800',
     fontSize: 15,
     letterSpacing: 0.5,

--- a/mobile/app/(client)/(tabs)/nutrition/food-detail.tsx
+++ b/mobile/app/(client)/(tabs)/nutrition/food-detail.tsx
@@ -20,6 +20,7 @@ import { useRouter, useLocalSearchParams } from 'expo-router'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import type { MealFood } from '@/api/nutrition'
@@ -581,7 +582,7 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     borderRadius: Radius.lg,
     padding: 16,
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,
     shadowRadius: 6,

--- a/mobile/app/(client)/(tabs)/nutrition/recipe-detail.tsx
+++ b/mobile/app/(client)/(tabs)/nutrition/recipe-detail.tsx
@@ -22,6 +22,7 @@ import { hrefParams } from '@/lib/navigation'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import type { MealRecipe, RecipeDetail, MealFood } from '@/api/nutrition'
@@ -712,7 +713,7 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     borderRadius: Radius.lg,
     padding: 16,
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,
     shadowRadius: 6,

--- a/mobile/app/(client)/(tabs)/nutrition/shopping.tsx
+++ b/mobile/app/(client)/(tabs)/nutrition/shopping.tsx
@@ -19,6 +19,7 @@ import { createMMKV } from 'react-native-mmkv'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { Brand } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import i18n from '@/i18n'
 import {
@@ -42,7 +43,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   Meat: '#8b5e3c',
   FishAndSeafood: '#0b6e99',
   Dairy: '#9b9a97',
-  GrainsAndCereals: '#c9a84c',
+  GrainsAndCereals: Brand.gold,
   Legumes: '#6d8c54',
   NutsAndSeeds: '#ad5700',
   OilsAndFats: '#7a8b3c',

--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -483,7 +483,7 @@ function NutritionPlanDetail({ plan }: { plan: FullPlanResponse }) {
           <Pressable style={styles.weekGridBackdrop} onPress={handleToggleWeekGrid} />
           <Animated.View
             entering={FadeIn.duration(200)}
-            style={[styles.weekGrid, { backgroundColor: colors.bg2, shadowColor: '#000' }]}
+            style={[styles.weekGrid, { backgroundColor: colors.bg2, shadowColor: colors.shadow }]}
           >
             {(plan.weeks ?? []).map((w) => (
               <Pressable
@@ -1058,7 +1058,7 @@ function TrainingPlanDetail({ plan }: { plan: FullTrainingPlanResponse }) {
           <Pressable style={styles.weekGridBackdrop} onPress={handleToggleWeekGrid} />
           <Animated.View
             entering={FadeIn.duration(200)}
-            style={[styles.weekGrid, { backgroundColor: colors.bg2, shadowColor: '#000' }]}
+            style={[styles.weekGrid, { backgroundColor: colors.bg2, shadowColor: colors.shadow }]}
           >
             {(plan.weeks ?? []).map((w) => (
               <Pressable

--- a/mobile/app/(client)/(tabs)/training/index.tsx
+++ b/mobile/app/(client)/(tabs)/training/index.tsx
@@ -93,7 +93,7 @@ const getStyles = (colors: ReturnType<typeof useTheme>) =>
     exerciseName: { fontSize: 13, fontWeight: '600', color: colors.label2, flex: 1 },
     exerciseSets: { fontSize: 12, color: colors.label3 },
     startButton: { backgroundColor: colors.gold, borderRadius: 6, paddingVertical: 14, alignItems: 'center', marginTop: 16 },
-    startButtonText: { color: '#000', fontSize: 13, fontWeight: '800', textTransform: 'uppercase', letterSpacing: 1 },
+    startButtonText: { color: colors.onGoldChip, fontSize: 13, fontWeight: '800', textTransform: 'uppercase', letterSpacing: 1 },
     emptyCard: { marginHorizontal: 16, backgroundColor: colors.bg2, borderRadius: 8, borderWidth: 1, borderColor: colors.sep, padding: 32, alignItems: 'center' },
     emptyIcon: { fontSize: 40 },
     emptyText: { fontSize: 15, fontWeight: '700', color: colors.label2, marginTop: 12 },

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -34,6 +34,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { Brand } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { href } from '@/lib/navigation'
@@ -84,7 +85,7 @@ const MUSCLE_COLORS: Record<string, string> = {
   Obliques: '#ff9500',
   LowerBack: '#3ed7be',
   Traps: '#3ed7be',
-  FullBody: '#c9a84c',
+  FullBody: Brand.gold,
   // Czech translations (the API may return localized strings)
   Hrudník: '#0b6e99',
   Ramena: '#af52de',
@@ -94,7 +95,7 @@ const MUSCLE_COLORS: Record<string, string> = {
 
 function muscleColorFor(exercise: SessionExercise): string {
   // exerciseName as fallback when no muscle group info is available
-  const fallback = '#c9a84c'
+  const fallback = Brand.gold
   if (!exercise.exerciseName) return fallback
   // Scan muscle color keys against exercise name fragments
   for (const [key, color] of Object.entries(MUSCLE_COLORS)) {

--- a/mobile/app/(discover)/[professionalId].tsx
+++ b/mobile/app/(discover)/[professionalId].tsx
@@ -295,7 +295,7 @@ export default function ProfessionalProfileScreen() {
                 disabled={requestMutation.isPending}
               >
                 {requestMutation.isPending ? (
-                  <ActivityIndicator size="small" color="#000" />
+                  <ActivityIndicator size="small" color={colors.onGoldChip} />
                 ) : (
                   <Text style={styles.modalSendText}>Odeslat</Text>
                 )}
@@ -509,7 +509,7 @@ const getStyles = (colors: ReturnType<typeof useTheme>) =>
     actionButtonText: {
       fontSize: 15,
       fontWeight: '700',
-      color: '#000',
+      color: colors.onGoldChip,
     },
     actionButtonDisabled: {
       backgroundColor: colors.bg2,
@@ -598,6 +598,6 @@ const getStyles = (colors: ReturnType<typeof useTheme>) =>
     modalSendText: {
       fontSize: 14,
       fontWeight: '700',
-      color: '#000',
+      color: colors.onGoldChip,
     },
   });

--- a/mobile/src/components/messages/MessageBubble.tsx
+++ b/mobile/src/components/messages/MessageBubble.tsx
@@ -52,7 +52,7 @@ export const MessageBubble = React.memo(function MessageBubble({
                     backgroundColor: colors.bg2,
                     ...Platform.select({
                       ios: {
-                        shadowColor: '#000',
+                        shadowColor: colors.shadow,
                         shadowOffset: { width: 0, height: 1 },
                         shadowOpacity: 0.06,
                         shadowRadius: 2,

--- a/mobile/src/components/notifications/InviteBanner.tsx
+++ b/mobile/src/components/notifications/InviteBanner.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { View, Text, Pressable, StyleSheet, Animated } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
-import { goldAlpha } from '@/constants/colors'
+import { goldAlpha, Brand } from '@/constants/colors'
 import { cardShadow } from '@/constants/shadows'
 
 interface InviteBannerProps {
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 13,
     borderWidth: 1,
-    shadowColor: '#c9a84c',
+    shadowColor: Brand.gold,
     ...cardShadow,
   },
   iconWrap: {

--- a/mobile/src/components/notifications/InviteCard.tsx
+++ b/mobile/src/components/notifications/InviteCard.tsx
@@ -62,7 +62,7 @@ export function InviteCard({ invite, onAccept, onDecline }: InviteCardProps) {
           {
             backgroundColor: colors.bg2,
             borderColor: goldAlpha['25'],
-            shadowColor: '#c9a84c',
+            shadowColor: colors.gold,
           },
         ]}
       >

--- a/mobile/src/components/notifications/NotificationRow.tsx
+++ b/mobile/src/components/notifications/NotificationRow.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, Pressable } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
 import { Type } from '@/constants/typography'
-import { goldAlpha } from '@/constants/colors'
+import { goldAlpha, Brand } from '@/constants/colors'
 import type { Notification } from '@/hooks/useNotifications'
 
 const NOTIF_CONFIG: Record<Notification['type'], {
@@ -11,13 +11,13 @@ const NOTIF_CONFIG: Record<Notification['type'], {
   icon: keyof typeof Ionicons.glyphMap;
   color: string;
 }> = {
-  invitation:     { bg: goldAlpha['12'],                 icon: 'person-add',         color: '#c9a84c' },
-  questionnaire:  { bg: goldAlpha['12'],                 icon: 'clipboard',          color: '#c9a84c' },
+  invitation:     { bg: goldAlpha['12'],                 icon: 'person-add',         color: Brand.gold },
+  questionnaire:  { bg: goldAlpha['12'],                 icon: 'clipboard',          color: Brand.gold },
   new_plan:       { bg: 'rgba(11,110,153,0.10)',         icon: 'calendar',           color: '#0b6e99' },
   message:        { bg: 'rgba(0,122,255,0.10)',          icon: 'chatbubble',         color: '#007aff' },
   training_done:  { bg: 'rgba(52,199,89,0.10)',          icon: 'checkmark-circle',   color: '#34c759' },
   alarm:          { bg: 'rgba(255,59,48,0.10)',          icon: 'alert-circle',       color: '#ff3b30' },
-  weekly_checkin: { bg: goldAlpha['12'],                 icon: 'calendar-number',    color: '#c9a84c' },
+  weekly_checkin: { bg: goldAlpha['12'],                 icon: 'calendar-number',    color: Brand.gold },
 }
 
 function timeAgo(timestamp: string): string {
@@ -89,7 +89,7 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#c9a84c',
+    backgroundColor: Brand.gold,
   },
   body: {
     flex: 1,

--- a/mobile/src/components/nutrition/MealCard.tsx
+++ b/mobile/src/components/nutrition/MealCard.tsx
@@ -17,7 +17,7 @@ import { getFoodCategoryColor, RECIPE_CHIP_COLOR } from '@/constants/foodCategor
 import { NoteBanner } from '@/components/ui/NoteBanner'
 import { ImageLightbox } from '@/components/ui/ImageLightbox'
 import type { MealFood, MealRecipe, PlanMeal } from '@/api/nutrition'
-import { goldAlpha } from '@/constants/colors'
+import { goldAlpha, Colors } from '@/constants/colors'
 import i18n from '@/i18n'
 import {
   computeFoodKcal,
@@ -399,7 +399,7 @@ const styles = StyleSheet.create({
     borderRadius: Radius.lg,
     overflow: 'hidden',
     // iOS shadow
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.12,
     shadowRadius: 12,

--- a/mobile/src/components/questionnaire/IntroScreen.tsx
+++ b/mobile/src/components/questionnaire/IntroScreen.tsx
@@ -1,6 +1,7 @@
 import { View, Text, ScrollView, Pressable, StyleSheet } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { GoldButton } from '@/components/ui/GoldButton'
@@ -104,7 +105,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row', alignItems: 'center', gap: 12,
     marginTop: 28, padding: 14, paddingHorizontal: 16,
     borderRadius: Radius.lg, width: '100%',
-    shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3, elevation: 2,
+    shadowColor: Colors.dark.shadow, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3, elevation: 2,
   },
   metaChips: { flexDirection: 'row', gap: 8, marginTop: 24, flexWrap: 'wrap', justifyContent: 'center' },
   metaChip: { paddingHorizontal: 12, paddingVertical: 5, borderRadius: Radius.full },

--- a/mobile/src/components/questionnaire/QuestionInput.tsx
+++ b/mobile/src/components/questionnaire/QuestionInput.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Radius } from '@/constants/radius'
 import { useTranslation } from 'react-i18next'
 import { RadioGroup } from './RadioGroup'
@@ -290,13 +291,13 @@ const styles = StyleSheet.create({
     borderRadius: Radius.md, borderWidth: 1.5,
     paddingHorizontal: 16, paddingVertical: 14,
     fontSize: 17, fontFamily: 'System', minHeight: 48,
-    shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 3,
+    shadowColor: Colors.dark.shadow, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 3,
   },
   numberWrap: {
     flexDirection: 'row', alignItems: 'center',
     borderRadius: Radius.md, borderWidth: 1.5,
     paddingHorizontal: 16, minHeight: 48,
-    shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 3,
+    shadowColor: Colors.dark.shadow, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 3,
   },
   numberInput: { flex: 1, fontSize: 17, paddingVertical: 14 },
   numberUnit: { fontSize: 15, marginLeft: 4 },
@@ -304,7 +305,7 @@ const styles = StyleSheet.create({
   choiceRow: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
     padding: 14, paddingHorizontal: 18, borderRadius: Radius.md, borderWidth: 1.5,
-    shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 3,
+    shadowColor: Colors.dark.shadow, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 3,
   },
   choiceText: { fontSize: 16, flex: 1 },
   choiceCheck: { width: 22, height: 22, borderRadius: 11, borderWidth: 1.5, alignItems: 'center', justifyContent: 'center' },

--- a/mobile/src/components/questionnaire/ScaleInput.tsx
+++ b/mobile/src/components/questionnaire/ScaleInput.tsx
@@ -35,7 +35,7 @@ export function ScaleInput({ min = 1, max = 10, value, onChange }: ScaleInputPro
               <Text
                 style={[
                   styles.text,
-                  { color: selected ? '#000' : colors.label2 },
+                  { color: selected ? colors.onGoldChip : colors.label2 },
                 ]}
               >
                 {num}

--- a/mobile/src/components/trainers/ActiveCollaboratorCard.tsx
+++ b/mobile/src/components/trainers/ActiveCollaboratorCard.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Pressable, Alert } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { Avatar } from '@/components/ui/Avatar'
@@ -141,7 +142,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     marginHorizontal: 0,
     marginBottom: 12,
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,
     shadowRadius: 3,

--- a/mobile/src/components/trainers/PendingRequestCard.tsx
+++ b/mobile/src/components/trainers/PendingRequestCard.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View, Text, StyleSheet, Pressable, Animated } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { Avatar } from '@/components/ui/Avatar'
@@ -60,7 +61,7 @@ const styles = StyleSheet.create({
     borderRadius: 14,
     overflow: 'hidden',
     marginBottom: 8,
-    shadowColor: '#000',
+    shadowColor: Colors.dark.shadow,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.06,
     shadowRadius: 3,

--- a/mobile/src/components/trainers/TrainerCard.tsx
+++ b/mobile/src/components/trainers/TrainerCard.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, Pressable, ScrollView, Alert } from 'react-nati
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { Type } from '@/constants/typography'
-import { goldAlpha } from '@/constants/colors'
+import { goldAlpha, Brand } from '@/constants/colors'
 import { Radius } from '@/constants/radius'
 import { Avatar } from '@/components/ui/Avatar'
 
@@ -13,7 +13,7 @@ const ROLE_BADGE_COLORS: Record<string, { bg: string; text: string }> = {
   'Osobní trenér': { bg: 'rgba(0,122,255,0.10)', text: '#007aff' },
   'Výž. poradce': { bg: 'rgba(52,199,89,0.10)', text: '#34c759' },
   'Výživový poradce': { bg: 'rgba(52,199,89,0.10)', text: '#34c759' },
-  'Trenér & poradce': { bg: goldAlpha['10'], text: '#c9a84c' },
+  'Trenér & poradce': { bg: goldAlpha['10'], text: Brand.gold },
   Trainer: { bg: 'rgba(0,122,255,0.10)', text: '#007aff' },
   Nutritionist: { bg: 'rgba(52,199,89,0.10)', text: '#34c759' },
 }

--- a/mobile/src/components/training/ExpandableExerciseCard.tsx
+++ b/mobile/src/components/training/ExpandableExerciseCard.tsx
@@ -9,6 +9,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 
@@ -210,7 +211,7 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     ...Platform.select({
       ios: {
-        shadowColor: '#000',
+        shadowColor: Colors.dark.shadow,
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.04,
         shadowRadius: 4,

--- a/mobile/src/components/training/ExpandableSessionCard.tsx
+++ b/mobile/src/components/training/ExpandableSessionCard.tsx
@@ -9,6 +9,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated'
 import { useTheme } from '@/hooks/useTheme'
+import { Colors } from '@/constants/colors'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 
@@ -136,7 +137,7 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     ...Platform.select({
       ios: {
-        shadowColor: '#000',
+        shadowColor: Colors.dark.shadow,
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.06,
         shadowRadius: 8,

--- a/mobile/src/components/training/SessionChip.tsx
+++ b/mobile/src/components/training/SessionChip.tsx
@@ -26,7 +26,7 @@ export function SessionChip({ label, active, onPress }: SessionChipProps) {
       <Text
         style={[
           styles.label,
-          { color: active ? '#000' : colors.label2 },
+          { color: active ? colors.onGoldChip : colors.label2 },
         ]}
         numberOfLines={1}
       >

--- a/mobile/src/constants/colors.ts
+++ b/mobile/src/constants/colors.ts
@@ -1,3 +1,13 @@
+/**
+ * Brand colors that don't shift with the active theme. Use these in
+ * module-scope constants and hand-written data maps where `useTheme()`
+ * isn't reachable. Inside React components, prefer `useTheme().gold`
+ * (which has the same value).
+ */
+export const Brand = {
+  gold: '#c9a84c',
+} as const
+
 /** Shared gold alpha values used across components */
 export const goldAlpha = {
   '04': 'rgba(201,168,76,0.04)',
@@ -40,7 +50,7 @@ const light = {
   purple: '#af52de',
 
   // Brand
-  gold: '#c9a84c',
+  gold: Brand.gold,
   goldBg: 'rgba(201,168,76,0.10)',
 
   // Static (constant regardless of theme)
@@ -52,6 +62,8 @@ const light = {
   /** Foreground for content on the gold-tinted chip backgrounds — stays black
    *  in both light and dark themes because the chip itself is mid-luminance. */
   onGoldChip: '#000000',
+  /** Conventional iOS shadowColor — same value in both themes. */
+  shadow: '#000000',
 
   // Macros — match the system colours used in the NutritionCardHero chips
   macroProtein: '#007aff',  // blue
@@ -81,7 +93,7 @@ const dark = {
   orange: '#ff9f0a',
   purple: '#bf5af2',
 
-  gold: '#c9a84c',
+  gold: Brand.gold,
   goldBg: 'rgba(201,168,76,0.15)',
 
   // Static (constant regardless of theme)
@@ -93,6 +105,8 @@ const dark = {
   /** Foreground for content on the gold-tinted chip backgrounds — stays black
    *  in both light and dark themes because the chip itself is mid-luminance. */
   onGoldChip: '#000000',
+  /** Conventional iOS shadowColor — same value in both themes. */
+  shadow: '#000000',
 
   // Macros — match the system colours used in the NutritionCardHero chips
   macroProtein: '#0a84ff',  // blue
@@ -125,6 +139,7 @@ export interface ColorScheme {
   readonly nutritionHeroEnd: string
   readonly systemGray: string
   readonly onGoldChip: string
+  readonly shadow: string
   readonly macroProtein: string
   readonly macroCarbs: string
   readonly macroFat: string

--- a/mobile/src/constants/foodCategories.ts
+++ b/mobile/src/constants/foodCategories.ts
@@ -1,10 +1,12 @@
+import { Brand } from './colors'
+
 export const FOOD_CATEGORY_COLORS: Record<string, string> = {
   Fruit: '#c0392b',
   Vegetables: '#0f7b6c',
   Meat: '#8b5e3c',
   FishAndSeafood: '#0b6e99',
   Dairy: '#9b9a97',
-  GrainsAndCereals: '#c9a84c',
+  GrainsAndCereals: Brand.gold,
   Legumes: '#6d8c54',
   NutsAndSeeds: '#ad5700',
   OilsAndFats: '#7a8b3c',

--- a/mobile/src/hooks/useTodayState.ts
+++ b/mobile/src/hooks/useTodayState.ts
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useTodayStore, type PendingPlan } from '@/stores/todayStore'
 import { getFullPlan, getClientPlans, type FullPlanResponse } from '@/api/nutrition'
 import { getCollaborations } from '@/api/profile'
+import { Brand } from '@/constants/colors'
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 
@@ -150,7 +151,7 @@ export function useTodayState() {
             trainerName,
             chips: [],
             startDate: item.startDate ?? '',
-            accentColor: '#c9a84c',
+            accentColor: Brand.gold,
           }
           pending.push(pendingTraining)
         }


### PR DESCRIPTION
## Summary

Closes #128.

Eliminates every `'#000'`, `'#c9a84c'` literal across `/mobile/src` and `/mobile/app` (outside the constants file and generated client), as required by the AC.

### New tokens added to `mobile/src/constants/colors.ts`

- **`Brand.gold`** (`'#c9a84c'`) — module-scope export for use in static data maps and hooks where `useTheme()` is not reachable. Both `light.gold` and `dark.gold` now reference `Brand.gold` as their single source of truth.
- **`Colors.{light,dark}.shadow`** (`'#000000'`) — conventional iOS `shadowColor` value; `ColorScheme` interface extended with `readonly shadow: string`.

### Migration breakdown

| Category | Count | Token used |
|---|---|---|
| `shadowColor: '#000'` in module-scope `StyleSheet.create` | 14 | `Colors.dark.shadow` |
| `shadowColor: '#000'` in render-time inline style | 3 | `colors.shadow` |
| `'#c9a84c'` in module-scope data maps / hooks | 9 | `Brand.gold` |
| `shadowColor: '#c9a84c'` in render-time inline style | 1 | `colors.gold` |
| `shadowColor: '#c9a84c'` in module-scope `StyleSheet.create` | 1 | `Brand.gold` |
| `'#000'` text/icon on gold-chip surfaces (render-time) | 3 | `colors.onGoldChip` |
| `'#000'` text/icon on gold-chip surfaces (module-scope styles) | 6 | `Colors.light.onGoldChip` |

**31 files touched, 0 TypeScript errors (`npx tsc --noEmit` clean).**

### Remaining grep result

```
mobile/src/stores/todayStore.ts:21:  accentColor: string     // '#c9a84c' training, '#34c759' nutrition
```

This is a `// comment` inside a type definition documenting example values — not a color literal in use. No fix needed (same rationale as the `isDark = colors.bg === '#1c1c1e'` heuristic excluded in the issue).

## Test plan

- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] Spot-check Today screen, Messages, Questionnaire, Discover trainer profile in both light and dark mode (visual regression: none expected since all replaced values are identical at runtime)
- [ ] Confirm `grep -rn "'#000'\|\"#000\"\|'#c9a84c'\|\"#c9a84c\"" mobile/src mobile/app | grep -v constants/colors.ts | grep -v generated.ts` returns only the comment line above

🤖 Generated with [Claude Code](https://claude.com/claude-code)