### PR TITLE
fix(mobile,#130): Today banner order, no-training card, chat i18n + gold polish

### DIFF
--- a/mobile/app/(client)/(tabs)/messages/index.tsx
+++ b/mobile/app/(client)/(tabs)/messages/index.tsx
@@ -75,7 +75,7 @@ export default function MessagesScreen() {
         <View style={styles.header}>
           <Text style={[Type.largeTitle, { color: colors.label }]}>{t('messages.title')}</Text>
           <Pressable style={[styles.composeBtn, { backgroundColor: colors.fill }]}>
-            <Ionicons name="create-outline" size={18} color={colors.blue} />
+            <Ionicons name="create-outline" size={18} color={colors.gold} />
           </Pressable>
         </View>
 
@@ -152,10 +152,10 @@ export default function MessagesScreen() {
               style={styles.archivedLink}
               onPress={() => router.push(href('/(client)/messages/archived'))}
             >
-              <Text style={[styles.archivedText, { color: colors.blue }]}>
+              <Text style={[styles.archivedText, { color: colors.gold }]}>
                 {t('messages.archivedConversations')}
               </Text>
-              <Ionicons name="chevron-forward" size={14} color={colors.blue} />
+              <Ionicons name="chevron-forward" size={14} color={colors.gold} />
             </Pressable>
           </ScrollView>
         )}

--- a/mobile/src/components/messages/ChatHeader.tsx
+++ b/mobile/src/components/messages/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { View, Text, Pressable, StyleSheet } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { Avatar } from '@/components/ui/Avatar'
 import type { ParticipantDto } from '../../api/generated'
@@ -13,6 +14,7 @@ interface ChatHeaderProps {
 
 export function ChatHeader({ participant, onBack, onInfoPress }: ChatHeaderProps) {
   const colors = useTheme()
+  const { t } = useTranslation()
 
   return (
     <View style={[styles.container, { backgroundColor: colors.bg }]}>
@@ -20,7 +22,7 @@ export function ChatHeader({ participant, onBack, onInfoPress }: ChatHeaderProps
         {/* Left: Back button */}
         <Pressable onPress={onBack} hitSlop={8} style={styles.backBtn}>
           <Ionicons name="chevron-back" size={28} color={colors.gold} />
-          <Text style={{ fontSize: 16, color: colors.gold, marginLeft: 2 }}>Messages</Text>
+          <Text style={{ fontSize: 16, color: colors.gold, marginLeft: 2 }}>{t('messages.title')}</Text>
         </Pressable>
 
         {/* Center: Avatar + name + status — stacked vertically */}
@@ -37,7 +39,7 @@ export function ChatHeader({ participant, onBack, onInfoPress }: ChatHeaderProps
         {/* Right: Action buttons in circles */}
         <View style={styles.rightActions}>
           <Pressable onPress={onInfoPress} style={[styles.actionBtn, { backgroundColor: colors.fill }]}>
-            <Ionicons name="information-circle-outline" size={16} color={colors.blue} />
+            <Ionicons name="information-circle-outline" size={16} color={colors.gold} />
           </Pressable>
         </View>
       </View>

--- a/mobile/src/components/messages/ChatInputBar.tsx
+++ b/mobile/src/components/messages/ChatInputBar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { View, TextInput, Pressable, StyleSheet } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Ionicons } from '@expo/vector-icons'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 
 interface ChatInputBarProps {
@@ -12,6 +13,7 @@ interface ChatInputBarProps {
 
 export function ChatInputBar({ onSend, onAttachPress, onTyping }: ChatInputBarProps) {
   const colors = useTheme()
+  const { t } = useTranslation()
   const insets = useSafeAreaInsets()
   const [text, setText] = useState('')
 
@@ -59,7 +61,7 @@ export function ChatInputBar({ onSend, onAttachPress, onTyping }: ChatInputBarPr
         >
           <TextInput
             style={[styles.input, { color: colors.label }]}
-            placeholder="Message"
+            placeholder={t('messages.inputPlaceholder')}
             placeholderTextColor={colors.label3}
             value={text}
             onChangeText={handleChangeText}

--- a/mobile/src/components/messages/DateSeparator.tsx
+++ b/mobile/src/components/messages/DateSeparator.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 
 interface DateSeparatorProps {
   timestamp: string
 }
 
-function formatDate(iso: string): string {
+function formatDate(iso: string, locale: string): string {
   const date = new Date(iso)
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString(locale, {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
@@ -17,11 +18,12 @@ function formatDate(iso: string): string {
 
 export const DateSeparator = React.memo(function DateSeparator({ timestamp }: DateSeparatorProps) {
   const colors = useTheme()
+  const { i18n } = useTranslation()
 
   return (
     <View style={styles.container}>
       <Text style={[styles.text, { color: colors.label3 }]}>
-        {formatDate(timestamp)}
+        {formatDate(timestamp, i18n.language)}
       </Text>
     </View>
   )

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -81,6 +81,36 @@ function NoDayNutritionCard({ planName }: NoDayNutritionCardProps) {
   )
 }
 
+// ─── NoDayTrainingCard ────────────────────────────────────────────────────────
+// Shown when the user has an active training plan but today has no session
+// (rest day, week-cycle gap, or every published week is in the past on a
+// not-yet-completed plan). Prevents the "waiting for training plan" banner
+// from appearing when the plan actually exists.
+
+interface NoDayTrainingCardProps {
+  planName?: string
+}
+
+function NoDayTrainingCard({ planName }: NoDayTrainingCardProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  return (
+    <>
+      <SectionHeader title={t('today.todaysTraining')} />
+      <View style={[noDayCardStyles.card, { backgroundColor: colors.bg2, borderRadius: Radius.lg }]}>
+        <Text style={[noDayCardStyles.title, { color: colors.label }]}>
+          {t('today.noTrainingForToday')}
+        </Text>
+        {planName ? (
+          <Text style={[noDayCardStyles.sub, { color: colors.label2 }]}>
+            {planName}
+          </Text>
+        ) : null}
+      </View>
+    </>
+  )
+}
+
 const noDayCardStyles = StyleSheet.create({
   card: {
     marginHorizontal: 16,
@@ -269,15 +299,29 @@ export function HasTrainerState() {
     [fullPlanQuery.data?.planId, plan],
   )
 
+  // True when the user has an active training plan but today has no session
+  // (rest day, week-cycle gap, or every published week sits in the past on a
+  // not-yet-completed plan — the backend filters Active-only, so a non-null
+  // planId implies the plan is still Active). Distinguishes "plan exists but
+  // today is empty" from "no plan at all".
+  const hasActivePlanButNoTrainingToday = useMemo(
+    () => !!(training?.planId && !training.hasSession),
+    [training?.planId, training?.hasSession],
+  )
+
   const { waitingForTraining, waitingForNutrition, isWaitingForAnyPlan } = useMemo(() => {
     const hasTrainerLink = collabs.some((c) => c.role === 'Trainer')
     const hasNutritionistLink = collabs.some((c) => c.role === 'Nutritionist')
-    const wTraining = !training?.hasSession && hasTrainerLink && !hasPendingTraining
+    // Only show "waiting for training plan" when the user truly has NO active
+    // training plan assigned. If a plan exists but today has no session, we
+    // show NoDayTrainingCard instead — the plan isn't being prepared, today
+    // just doesn't have one.
+    const wTraining = !training?.planId && hasTrainerLink && !hasPendingTraining
     // Only show "waiting for nutrition plan" when the user truly has NO plan assigned.
     // If they have a plan but today is not covered, we show a different card instead.
     const wNutrition = !plan && !hasActivePlanButNoDayToday && hasNutritionistLink && !hasPendingNutrition
     return { waitingForTraining: wTraining, waitingForNutrition: wNutrition, isWaitingForAnyPlan: wTraining || wNutrition }
-  }, [collabs, training?.hasSession, plan, hasActivePlanButNoDayToday, hasPendingTraining, hasPendingNutrition])
+  }, [collabs, training?.planId, plan, hasActivePlanButNoDayToday, hasPendingTraining, hasPendingNutrition])
 
   // ── Next-week shopping prep banner ──
   const showShoppingBanner = useMemo(() => {
@@ -860,99 +904,114 @@ export function HasTrainerState() {
         </View>
       )}
 
-      {/* Today's training */}
-      {training?.hasSession && todaySessions.length > 0 && (
-        <View style={styles.section}>
-          <SectionHeader
-            title={t('today.todaysTraining')}
-            actionLabel={training.planId ? t('today.sectionActionDetail') : undefined}
-            onActionPress={
-              training.planId
-                ? () => {
-                    router.push(
-                      hrefParams('/(client)/(tabs)/plans/[planId]', {
-                        planId: training.planId!,
-                        type: 'training',
-                      }),
-                    )
-                  }
-                : undefined
-            }
-          />
-          <TrainingCard
-            planName={trainingPlanSubtitle || t('today.trainingPlan')}
-            sessions={todaySessions}
-            completedIdsBySession={completedIdsBySession}
-            sessionCompleteMap={sessionCompleteMap}
-            onToggleExercise={handleToggleExercise}
-            onToggleSession={handleToggleSession}
-            sessionCtaStateBySession={sessionCtaStateBySession}
-            onSessionCta={handleSessionCta}
-            exerciseMuscleGroups={training?.exerciseMuscleGroups ?? {}}
-            completedSetsBySessionExercise={trainingQuery.data?.completedSetsBySessionExercise ?? {}}
-          />
-        </View>
-      )}
-
-      {/* Today's nutrition */}
-      {plan && (
-        <View style={styles.section}>
-          <SectionHeader
-            title={t('today.todaysNutrition')}
-            action={
-              <Pressable
-                onPress={handlePhotoGridPress}
-                hitSlop={8}
-                accessibilityRole="button"
-                accessibilityLabel={t('nutrition.photoCta')}
-                style={styles.photoCtaBtn}
-              >
-                <View
-                  style={[
-                    styles.photoCtaIconChip,
-                    { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
-                  ]}
-                >
-                  <Ionicons name="camera" size={13} color={colors.onGoldChip} />
-                </View>
-                <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
-                  {t('nutrition.photoCta')}
-                </Text>
-              </Pressable>
-            }
-          />
-          <NutritionCard
-            consumed={consumed}
-            targets={nutritionTargets}
-            meals={sortedMeals}
-            eatenMealIds={eatenMealIds}
-            eatenMealIdsWithPhotos={eatenMealIdsWithPhotos}
-            mealPhotosByMealId={mealPhotosByMealId}
-            mealNoteByMealId={mealNoteByMealId}
-            eyebrow={t('today.nutritionEyebrow', { week: plan.weekNumber })}
-            subline=""
-            dayNote={plan.dayNote}
-            onToggleEaten={handleToggleEaten}
-            onPhotoPress={handlePhotoPress}
-            onMarkAllEaten={handleMarkAllEaten}
-            isMarkAllLoading={markAllEatenMutation.isPending}
-          />
-        </View>
-      )}
-
-      {/* "No nutrition for today" — plan exists but today is not covered by a published week */}
-      {hasActivePlanButNoDayToday && (
-        <View style={styles.section}>
-          <NoDayNutritionCard planName={fullPlanQuery.data?.planName} />
-        </View>
-      )}
-
-      {/* Next-week shopping prep banner */}
+      {/* Next-week shopping prep banner — top-of-page banner under the stat
+          strip / pending banners, ahead of any plan cards below. */}
       {showShoppingBanner !== null && (
         <View style={styles.section}>
           <ShoppingPrepBanner week={showShoppingBanner} />
         </View>
       )}
+
+      {/* Training + nutrition slots.
+          Default order is training → nutrition. Swapped when today has a
+          nutrition plan but no training session, so the "no training for
+          today" placeholder sits below the actual nutrition card instead of
+          above it. The mirrored case (training today, no nutrition today)
+          already lands correctly in the default order. */}
+      {(() => {
+        const hasTrainingToday = !!training?.hasSession && todaySessions.length > 0
+        const hasNutritionToday = !!plan
+        const trainingSlot = hasTrainingToday ? (
+          <View style={styles.section} key="training">
+            <SectionHeader
+              title={t('today.todaysTraining')}
+              actionLabel={training?.planId ? t('today.sectionActionDetail') : undefined}
+              onActionPress={
+                training?.planId
+                  ? () => {
+                      router.push(
+                        hrefParams('/(client)/(tabs)/plans/[planId]', {
+                          planId: training.planId!,
+                          type: 'training',
+                        }),
+                      )
+                    }
+                  : undefined
+              }
+            />
+            <TrainingCard
+              planName={trainingPlanSubtitle || t('today.trainingPlan')}
+              sessions={todaySessions}
+              completedIdsBySession={completedIdsBySession}
+              sessionCompleteMap={sessionCompleteMap}
+              onToggleExercise={handleToggleExercise}
+              onToggleSession={handleToggleSession}
+              sessionCtaStateBySession={sessionCtaStateBySession}
+              onSessionCta={handleSessionCta}
+              exerciseMuscleGroups={training?.exerciseMuscleGroups ?? {}}
+              completedSetsBySessionExercise={trainingQuery.data?.completedSetsBySessionExercise ?? {}}
+            />
+          </View>
+        ) : hasActivePlanButNoTrainingToday ? (
+          <View style={styles.section} key="training">
+            <NoDayTrainingCard planName={training?.planName} />
+          </View>
+        ) : null
+
+        const nutritionSlot = hasNutritionToday ? (
+          <View style={styles.section} key="nutrition">
+            <SectionHeader
+              title={t('today.todaysNutrition')}
+              action={
+                <Pressable
+                  onPress={handlePhotoGridPress}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('nutrition.photoCta')}
+                  style={styles.photoCtaBtn}
+                >
+                  <View
+                    style={[
+                      styles.photoCtaIconChip,
+                      { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                    ]}
+                  >
+                    <Ionicons name="camera" size={13} color={colors.onGoldChip} />
+                  </View>
+                  <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                    {t('nutrition.photoCta')}
+                  </Text>
+                </Pressable>
+              }
+            />
+            <NutritionCard
+              consumed={consumed}
+              targets={nutritionTargets}
+              meals={sortedMeals}
+              eatenMealIds={eatenMealIds}
+              eatenMealIdsWithPhotos={eatenMealIdsWithPhotos}
+              mealPhotosByMealId={mealPhotosByMealId}
+              mealNoteByMealId={mealNoteByMealId}
+              eyebrow={t('today.nutritionEyebrow', { week: plan!.weekNumber })}
+              subline=""
+              dayNote={plan!.dayNote}
+              onToggleEaten={handleToggleEaten}
+              onPhotoPress={handlePhotoPress}
+              onMarkAllEaten={handleMarkAllEaten}
+              isMarkAllLoading={markAllEatenMutation.isPending}
+            />
+          </View>
+        ) : hasActivePlanButNoDayToday ? (
+          <View style={styles.section} key="nutrition">
+            <NoDayNutritionCard planName={fullPlanQuery.data?.planName} />
+          </View>
+        ) : null
+
+        const nutritionFirst = hasNutritionToday && !hasTrainingToday
+        return nutritionFirst
+          ? <>{nutritionSlot}{trainingSlot}</>
+          : <>{trainingSlot}{nutritionSlot}</>
+      })()}
 
       {/* Waiting for plan card */}
       {isWaitingForAnyPlan && (

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -329,7 +329,8 @@
       "finished": "Dokončeno",
       "startError": "Trénink se nepodařilo spustit. Zkus to znovu."
     },
-    "noNutritionPlanForToday": "Na dnes nemáte naplánovaný jídelníček"
+    "noNutritionPlanForToday": "Na dnes nemáte naplánovaný jídelníček",
+    "noTrainingForToday": "Na dnes nemáte naplánovaný trénink"
   },
   "questionnaire": {
     "allDone": "Hotovo!",
@@ -377,6 +378,7 @@
   "messages": {
     "title": "Zprávy",
     "search": "Hledat",
+    "inputPlaceholder": "Zpráva",
     "noConversations": "Žádné konverzace nenalezeny",
     "noMessages": "Zatím žádné zprávy",
     "archived": "Archivováno",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -324,7 +324,8 @@
       "finished": "Abgeschlossen",
       "startError": "Training konnte nicht gestartet werden. Bitte versuche es erneut."
     },
-    "noNutritionPlanForToday": "Heute ist kein Ernährungsplan geplant"
+    "noNutritionPlanForToday": "Heute ist kein Ernährungsplan geplant",
+    "noTrainingForToday": "Heute ist kein Training geplant"
   },
   "questionnaire": {
     "allDone": "Fertig!",
@@ -372,6 +373,7 @@
   "messages": {
     "title": "Nachrichten",
     "search": "Suchen",
+    "inputPlaceholder": "Nachricht",
     "noConversations": "Keine Konversationen gefunden",
     "noMessages": "Noch keine Nachrichten",
     "archived": "Archiviert",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -324,7 +324,8 @@
       "finished": "Completed",
       "startError": "Could not start training. Please try again."
     },
-    "noNutritionPlanForToday": "No nutrition plan for today"
+    "noNutritionPlanForToday": "No nutrition plan for today",
+    "noTrainingForToday": "No training planned for today"
   },
   "questionnaire": {
     "allDone": "All done!",
@@ -372,6 +373,7 @@
   "messages": {
     "title": "Messages",
     "search": "Search",
+    "inputPlaceholder": "Message",
     "noConversations": "No conversations found",
     "noMessages": "No messages yet",
     "archived": "Archived",


### PR DESCRIPTION
## Summary

Eight small mobile UI polish bugs reported in this session. Batched into a single PR because they all live on adjacent surfaces (Today screen, messages list, chat).

Closes #130.

## Changes

**Today screen — `HasTrainerState.tsx`**
- `ShoppingPrepBanner` now renders directly under the stat strip / pending-plan banners, ahead of the plan cards.
- New `NoDayTrainingCard` ("Na dnes nemáte naplánovaný trénink") for the case where an Active training plan exists but today has no session — covers rest days and the "all published weeks in the past, plan not yet completed" case. Mirrors the existing `NoDayNutritionCard`.
- `WaitingForPlanCard` ("Tréninkový plán se připravuje") now keys off `!training?.planId` instead of `!training?.hasSession`, so it only appears when there is genuinely no Active plan plus a trainer link plus no pending plan.
- Training/nutrition rendering extracted into slots — when nutrition is for today but training is not, the slot order swaps so the "no training for today" placeholder lands below the active nutrition card. The mirrored case (training today, no nutrition today) already lands correctly under the default order.
- New i18n key `today.noTrainingForToday` in cs/en/de.

**Messages — `messages/index.tsx`, `ChatHeader.tsx`, `ChatInputBar.tsx`, `DateSeparator.tsx`**
- Compose-new-chat icon, "Archivované konverzace" link text + chevron, and chat-header information-circle icon all switched from `colors.blue` → `colors.gold`.
- Chat back-button label now reads `t('messages.title')` (was hardcoded "Messages").
- `DateSeparator` passes `i18n.language` to `toLocaleDateString` (was `undefined` → device locale).
- Chat input placeholder reads `t('messages.inputPlaceholder')` (was hardcoded "Message"). New key in cs/en/de.

## Out of scope

The local-only mobile prototype scenes under `docs/prototypes/mobile/scenes/` (today.html, nutrition-plan-detail.html) were also refreshed in this session to reflect the photos-upload feature shipped in #126 — but `/docs/` is gitignored ("local design specs") so those edits aren't part of this diff. They live on Jan's working copy.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Today screen: Active training plan + no session today + has nutrition for today → see NutritionCard then "Na dnes nemáte naplánovaný trénink" below it (NOT "Tréninkový plán se připravuje").
- [ ] Today screen: every published week of training plan in the past, plan still Active → "Na dnes nemáte naplánovaný trénink" appears.
- [ ] Today screen: no Active training plan + trainer linked → "Tréninkový plán se připravuje" still appears (regression check).
- [ ] Today screen: nutrition currentDayOfWeek ≥ 5 with a published next week → ShoppingPrepBanner appears directly under stat strip, not below nutrition card.
- [ ] Messages list: compose icon + "Archivované konverzace" link render in gold, not blue.
- [ ] Open chat: information icon gold; back-button label localized in cs/en/de; date separators localized; input placeholder localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)