### PR TITLE
feat: emit planPhotoUploaded SignalR event on PlanPhoto create

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientNutrition/SaveDayPhotos/SaveDayPhotosEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientNutrition/SaveDayPhotos/SaveDayPhotosEndpoint.cs
@@ -4,9 +4,12 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientPlans;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientNutrition.SaveDayPhotos;
@@ -25,7 +28,13 @@ namespace FitnessPlatform.Application.Features.ClientNutrition.SaveDayPhotos;
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class SaveDayPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>planPhotoUploaded</c> event.</param>
+/// <param name="logger">Logger.</param>
+public class SaveDayPhotosEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    ILogger<SaveDayPhotosEndpoint> logger)
     : Endpoint<SaveDayPhotosRequest>
 {
     /// <inheritdoc />
@@ -163,13 +172,48 @@ public class SaveDayPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db
         }
 
         // Dual-write: sync photos into PlanPhoto table with REPLACE semantics.
-        await DualWritePlanPhotosAsync(
+        // Returns only the newly-inserted PlanPhoto rows so we can emit events for them.
+        var newPhotos = await DualWritePlanPhotosAsync(
             clientProfile,
             plan.ExternalId,
             req.Photos,
             replacementPhotos,
             now,
             ct);
+
+        // Emit planPhotoUploaded to the owning nutritionist for each newly-created row (best-effort).
+        if (plan.NutritionistId != Guid.Empty)
+        {
+            foreach (var newPhoto in newPhotos)
+            {
+                try
+                {
+                    await notifier.NotifyAsync(
+                        plan.NutritionistId,
+                        "planPhotoUploaded",
+                        new PlanPhotoUploadedEvent
+                        {
+                            PlanId = newPhoto.PlanId,
+                            PhotoId = newPhoto.PublicId,
+                            Category = newPhoto.Category,
+                            TakenAt = newPhoto.TakenAt
+                        },
+                        ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to emit planPhotoUploaded for photo {PhotoId} to nutritionist {NutritionistId}",
+                        newPhoto.PublicId, plan.NutritionistId);
+                }
+            }
+        }
+        else if (newPhotos.Count > 0)
+        {
+            logger.LogWarning(
+                "Could not resolve owning nutritionist for PlanId={PlanId}; planPhotoUploaded events skipped",
+                plan.ExternalId);
+        }
 
         await Send.NoContentAsync(ct);
     }
@@ -182,8 +226,9 @@ public class SaveDayPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db
     ///   (REPLACE semantics, matching SaveDayPhotos behaviour).</item>
     /// </list>
     /// Rows are matched by BlobUrl so the operation is idempotent.
+    /// Returns the list of newly-inserted <see cref="PlanPhoto"/> rows.
     /// </summary>
-    private async Task DualWritePlanPhotosAsync(
+    private async Task<List<PlanPhoto>> DualWritePlanPhotosAsync(
         ClientProfile clientProfile,
         Guid planExternalId,
         IReadOnlyList<DayPhotoInput> inputs,
@@ -209,13 +254,14 @@ public class SaveDayPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db
 
         // Add new rows for blob URLs not yet tracked
         var callerUserId = clientProfile.UserId;
+        var inserted = new List<PlanPhoto>();
 
         foreach (var input in inputs)
         {
             if (existingByUrl.ContainsKey(input.BlobUrl))
                 continue;
 
-            db.PlanPhotos.Add(new PlanPhoto
+            var photo = new PlanPhoto
             {
                 PublicId = Guid.NewGuid(),
                 ClientProfileId = clientProfile.Id,
@@ -229,10 +275,13 @@ public class SaveDayPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db
                 UploadedByUserId = callerUserId,
                 DateCreated = now,
                 DateUpdated = now
-            });
+            };
+            db.PlanPhotos.Add(photo);
+            inserted.Add(photo);
         }
 
         await db.SaveChangesAsync(ct);
+        return inserted;
     }
 
     private static PlanPhotoCategory MapCategory(DayPhotoCategory category) => category switch

--- a/backend/FitnessPlatform.Application/Features/ClientNutrition/SaveMealPhotos/SaveMealPhotosEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientNutrition/SaveMealPhotos/SaveMealPhotosEndpoint.cs
@@ -4,9 +4,12 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientPlans;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientNutrition.SaveMealPhotos;
@@ -26,7 +29,13 @@ namespace FitnessPlatform.Application.Features.ClientNutrition.SaveMealPhotos;
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class SaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="notifier">Realtime notifier for pushing the <c>planPhotoUploaded</c> event.</param>
+/// <param name="logger">Logger.</param>
+public class SaveMealPhotosEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    ILogger<SaveMealPhotosEndpoint> logger)
     : Endpoint<SaveMealPhotosRequest>
 {
     /// <inheritdoc />
@@ -183,13 +192,48 @@ public class SaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext d
         }
 
         // Dual-write: mirror photos into PlanPhoto table so unified read paths see meal photos.
-        await DualWritePlanPhotosAsync(
+        // Returns only the newly-inserted PlanPhoto rows so we can emit events for them.
+        var newPhotos = await DualWritePlanPhotosAsync(
             clientProfile,
             plan.ExternalId,
             mealLogId,
             replacementPhotos.Select(p => p.BlobUrl).ToList(),
             now,
             ct);
+
+        // Emit planPhotoUploaded to the owning nutritionist for each newly-created row (best-effort).
+        if (plan.NutritionistId != Guid.Empty)
+        {
+            foreach (var newPhoto in newPhotos)
+            {
+                try
+                {
+                    await notifier.NotifyAsync(
+                        plan.NutritionistId,
+                        "planPhotoUploaded",
+                        new PlanPhotoUploadedEvent
+                        {
+                            PlanId = newPhoto.PlanId,
+                            PhotoId = newPhoto.PublicId,
+                            Category = newPhoto.Category,
+                            TakenAt = newPhoto.TakenAt
+                        },
+                        ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to emit planPhotoUploaded for photo {PhotoId} to nutritionist {NutritionistId}",
+                        newPhoto.PublicId, plan.NutritionistId);
+                }
+            }
+        }
+        else if (newPhotos.Count > 0)
+        {
+            logger.LogWarning(
+                "Could not resolve owning nutritionist for PlanId={PlanId}; planPhotoUploaded events skipped",
+                plan.ExternalId);
+        }
 
         await Send.NoContentAsync(ct);
     }
@@ -201,8 +245,9 @@ public class SaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext d
     /// Does NOT remove rows that were in a previous save but are absent now — deletion is not
     /// propagated from SaveMealPhotos to PlanPhoto because the meal-log REPLACE semantics
     /// would create false deletions if multiple save calls differ only in the photo list order.
+    /// Returns the list of newly-inserted <see cref="PlanPhoto"/> rows.
     /// </summary>
-    private async Task DualWritePlanPhotosAsync(
+    private async Task<List<PlanPhoto>> DualWritePlanPhotosAsync(
         ClientProfile clientProfile,
         Guid planExternalId,
         string mealLogId,
@@ -211,7 +256,7 @@ public class SaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext d
         CancellationToken ct)
     {
         if (blobUrls.Count == 0)
-            return;
+            return [];
 
         // Load existing PlanPhoto rows for this client + plan to find which BlobUrls are new.
         var existingUrls = await db.PlanPhotos
@@ -225,13 +270,14 @@ public class SaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext d
         var existingUrlSet = existingUrls.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var callerUserId = clientProfile.UserId;
+        var inserted = new List<PlanPhoto>();
 
         foreach (var blobUrl in blobUrls)
         {
             if (existingUrlSet.Contains(blobUrl))
                 continue;
 
-            db.PlanPhotos.Add(new PlanPhoto
+            var photo = new PlanPhoto
             {
                 PublicId = Guid.NewGuid(),
                 ClientProfileId = clientProfile.Id,
@@ -245,9 +291,12 @@ public class SaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext d
                 UploadedByUserId = callerUserId,
                 DateCreated = now,
                 DateUpdated = now
-            });
+            };
+            db.PlanPhotos.Add(photo);
+            inserted.Add(photo);
         }
 
         await db.SaveChangesAsync(ct);
+        return inserted;
     }
 }

--- a/backend/FitnessPlatform.Application/Features/ClientPlans/FinalizePlanPhoto/FinalizePlanPhotoEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientPlans/FinalizePlanPhoto/FinalizePlanPhotoEndpoint.cs
@@ -4,9 +4,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientPlans.FinalizePlanPhoto;
@@ -18,12 +20,18 @@ namespace FitnessPlatform.Application.Features.ClientPlans.FinalizePlanPhoto;
 ///
 /// Ownership: looks up the plan in NutritionPlans first; falls back to TrainingPlans.
 /// Returns 404 if neither exists for the given client.
+/// After a successful insert, emits a <c>planPhotoUploaded</c> SignalR event to the owning
+/// professional (best-effort: a broadcast failure does not fail the HTTP response).
 /// </summary>
 /// <param name="mongo">MongoDB context for plan lookup.</param>
 /// <param name="db">Relational database context for profile lookup and photo insert.</param>
+/// <param name="notifier">Realtime notifier for pushing the <c>planPhotoUploaded</c> event.</param>
+/// <param name="logger">Logger.</param>
 public class FinalizePlanPhotoEndpoint(
     IMongoContext mongo,
-    IApplicationDbContext db)
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    ILogger<FinalizePlanPhotoEndpoint> logger)
     : Endpoint<FinalizePlanPhotoRequest, PlanPhotoResponse>
 {
     /// <inheritdoc />
@@ -67,8 +75,8 @@ public class FinalizePlanPhotoEndpoint(
 
         var clientId = clientProfile.PublicId;
 
-        // Resolve plan type and link: nutrition first, training fallback
-        var (planType, linkId) = await ResolvePlanAsync(req.PlanId, clientId, ct);
+        // Resolve plan type, link, and owning professional: nutrition first, training fallback
+        var (planType, linkId, professionalUserId) = await ResolvePlanAsync(req.PlanId, clientId, ct);
 
         if (planType is null)
         {
@@ -98,13 +106,44 @@ public class FinalizePlanPhotoEndpoint(
         db.PlanPhotos.Add(photo);
         await db.SaveChangesAsync(ct);
 
+        // Emit planPhotoUploaded to the owning professional (best-effort).
+        if (professionalUserId.HasValue)
+        {
+            try
+            {
+                await notifier.NotifyAsync(
+                    professionalUserId.Value,
+                    "planPhotoUploaded",
+                    new PlanPhotoUploadedEvent
+                    {
+                        PlanId = photo.PlanId,
+                        PhotoId = photo.PublicId,
+                        Category = photo.Category,
+                        TakenAt = photo.TakenAt
+                    },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to emit planPhotoUploaded for photo {PhotoId} to professional {ProfessionalId}",
+                    photo.PublicId, professionalUserId.Value);
+            }
+        }
+        else
+        {
+            logger.LogWarning(
+                "Could not resolve owning professional for PlanId={PlanId}; planPhotoUploaded event skipped",
+                req.PlanId);
+        }
+
         var response = MapToResponse(photo);
         HttpContext.Response.Headers.Location =
             $"/client/plans/{req.PlanId}/photos/{photo.PublicId}";
         await Send.ResponseAsync(response, StatusCodes.Status201Created, ct);
     }
 
-    private async Task<(PlanPhotoType? planType, Guid? linkId)> ResolvePlanAsync(
+    private async Task<(PlanPhotoType? planType, Guid? linkId, Guid? professionalUserId)> ResolvePlanAsync(
         Guid planId, Guid clientId, CancellationToken ct)
     {
         // Try nutrition plan
@@ -116,7 +155,8 @@ public class FinalizePlanPhotoEndpoint(
         var nutritionPlan = await nutritionCursor.FirstOrDefaultAsync(ct);
 
         if (nutritionPlan is not null)
-            return (PlanPhotoType.Nutrition, nutritionPlan.ExternalId);
+            return (PlanPhotoType.Nutrition, nutritionPlan.ExternalId,
+                nutritionPlan.NutritionistId != Guid.Empty ? nutritionPlan.NutritionistId : null);
 
         // Fall back to training plan
         var trainingFilter = Builders<TrainingPlan>.Filter.And(
@@ -127,9 +167,10 @@ public class FinalizePlanPhotoEndpoint(
         var trainingPlan = await trainingCursor.FirstOrDefaultAsync(ct);
 
         if (trainingPlan is not null)
-            return (PlanPhotoType.Training, trainingPlan.ExternalId);
+            return (PlanPhotoType.Training, trainingPlan.ExternalId,
+                trainingPlan.TrainerId != Guid.Empty ? trainingPlan.TrainerId : null);
 
-        return (null, null);
+        return (null, null, null);
     }
 
     private static PlanPhotoResponse MapToResponse(PlanPhoto photo) => new()

--- a/backend/FitnessPlatform.Application/Features/ClientPlans/PlanPhotoUploadedEvent.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientPlans/PlanPhotoUploadedEvent.cs
@@ -1,0 +1,31 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.ClientPlans;
+
+/// <summary>
+/// Payload for the <c>planPhotoUploaded</c> SignalR event broadcast to the owning professional
+/// whenever a <see cref="Domain.Entities.PlanPhoto"/> row is created.
+/// </summary>
+public class PlanPhotoUploadedEvent
+{
+    /// <summary>
+    /// The plan the photo belongs to (NutritionPlan.ExternalId or TrainingPlan.ExternalId).
+    /// Null for body photos not attached to a specific plan.
+    /// </summary>
+    public Guid? PlanId { get; set; }
+
+    /// <summary>
+    /// The public identifier of the newly created <see cref="Domain.Entities.PlanPhoto"/> row.
+    /// </summary>
+    public Guid PhotoId { get; set; }
+
+    /// <summary>
+    /// Display / filtering category of this photo (Food / Body / FreeForm).
+    /// </summary>
+    public PlanPhotoCategory Category { get; set; }
+
+    /// <summary>
+    /// When the photo was taken or uploaded, in UTC.
+    /// </summary>
+    public DateTime TakenAt { get; set; }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientNutrition/SaveDayPhotosEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientNutrition/SaveDayPhotosEndpointTests.cs
@@ -5,11 +5,13 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientNutrition.SaveDayPhotos;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -21,6 +23,9 @@ namespace FitnessPlatform.Tests.Endpoints.ClientNutrition;
 public class SaveDayPhotosEndpointTests
 {
     private readonly Guid _clientId = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly ILogger<SaveDayPhotosEndpoint> _logger =
+        Substitute.For<ILogger<SaveDayPhotosEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -87,7 +92,7 @@ public class SaveDayPhotosEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _logger);
 
     // ──────────────────────────────────────────────────────────────────────────
     // Replace-semantics happy-path tests

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientNutrition/SaveMealPhotosEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientNutrition/SaveMealPhotosEndpointTests.cs
@@ -5,11 +5,13 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientNutrition.SaveMealPhotos;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using NSubstitute;
@@ -22,6 +24,9 @@ namespace FitnessPlatform.Tests.Endpoints.ClientNutrition;
 public class SaveMealPhotosEndpointTests
 {
     private readonly Guid _clientId = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly ILogger<SaveMealPhotosEndpoint> _logger =
+        Substitute.For<ILogger<SaveMealPhotosEndpoint>>();
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -96,7 +101,7 @@ public class SaveMealPhotosEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _logger);
 
     // ──────────────────────────────────────────────────────────────────────────
     // Replace-semantics happy-path tests

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientPlans/FinalizePlanPhotoEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientPlans/FinalizePlanPhotoEndpointTests.cs
@@ -6,11 +6,13 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientPlans.FinalizePlanPhoto;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -27,12 +29,16 @@ public class FinalizePlanPhotoEndpointTests
         new MockDbBuilder()
             .With(new ClientProfile { UserId = _clientId, PublicId = _clientId });
 
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly ILogger<FinalizePlanPhotoEndpoint> _logger =
+        Substitute.For<ILogger<FinalizePlanPhotoEndpoint>>();
+
     private FinalizePlanPhotoEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
         Factory.Create<FinalizePlanPhotoEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, _notifier, _logger);
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientPlans/PlanPhotoUploadedSignalRTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientPlans/PlanPhotoUploadedSignalRTests.cs
@@ -1,0 +1,619 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientNutrition.SaveDayPhotos;
+using FitnessPlatform.Application.Features.ClientNutrition.SaveMealPhotos;
+using FitnessPlatform.Application.Features.ClientPlans;
+using FitnessPlatform.Application.Features.ClientPlans.FinalizePlanPhoto;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientPlans;
+
+/// <summary>
+/// Verifies the <c>planPhotoUploaded</c> SignalR broadcast behaviour across the three
+/// endpoints that create <see cref="FitnessPlatform.Application.Domain.Entities.PlanPhoto"/> rows:
+/// <list type="bullet">
+///   <item><see cref="FinalizePlanPhotoEndpoint"/> — nutrition plan path</item>
+///   <item><see cref="FinalizePlanPhotoEndpoint"/> — training plan path</item>
+///   <item><see cref="SaveMealPhotosEndpoint"/> — dual-write from meal diary</item>
+///   <item><see cref="SaveDayPhotosEndpoint"/> — dual-write from day diary</item>
+/// </list>
+/// </summary>
+public class PlanPhotoUploadedSignalRTests
+{
+    // ── Shared identities ────────────────────────────────────────────────────────
+
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _nutritionistId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _otherProfessionalId = Guid.NewGuid();
+
+    // ── Notifier + loggers ───────────────────────────────────────────────────────
+
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly ILogger<FinalizePlanPhotoEndpoint> _finalizeLogger =
+        Substitute.For<ILogger<FinalizePlanPhotoEndpoint>>();
+    private readonly ILogger<SaveMealPhotosEndpoint> _mealLogger =
+        Substitute.For<ILogger<SaveMealPhotosEndpoint>>();
+    private readonly ILogger<SaveDayPhotosEndpoint> _dayLogger =
+        Substitute.For<ILogger<SaveDayPhotosEndpoint>>();
+
+    // ── DB builder ───────────────────────────────────────────────────────────────
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    // ── Mongo helpers for FinalizePlanPhoto ──────────────────────────────────────
+
+    private IMongoContext CreateMongoWithNutritionPlan(NutritionPlan plan)
+    {
+        // Build collections BEFORE assigning to Returns to avoid NSubstitute pitfall.
+        var nutritionCollection = PlanTestHelpers.CreateMockMongo([plan]).NutritionPlans;
+        var trainingCollection = CreateEmptyTrainingPlanCollection();
+
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.NutritionPlans.Returns(nutritionCollection);
+        mongo.TrainingPlans.Returns(trainingCollection);
+        return mongo;
+    }
+
+    private IMongoContext CreateMongoWithTrainingPlan(TrainingPlan plan)
+    {
+        // Build collections BEFORE assigning to Returns to avoid NSubstitute pitfall.
+        var nutritionCollection = PlanTestHelpers.CreateMockMongo().NutritionPlans;
+        var trainingCollection = CreateTrainingPlanCollection([plan]);
+
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.NutritionPlans.Returns(nutritionCollection);
+        mongo.TrainingPlans.Returns(trainingCollection);
+        return mongo;
+    }
+
+    private static IMongoCollection<TrainingPlan> CreateEmptyTrainingPlanCollection() =>
+        CreateTrainingPlanCollection([]);
+
+    private static IMongoCollection<TrainingPlan> CreateTrainingPlanCollection(List<TrainingPlan> plans)
+    {
+        var collection = Substitute.For<IMongoCollection<TrainingPlan>>();
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+                var moved = false;
+                cursor.Current.Returns(plans);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+                {
+                    if (moved) return false;
+                    moved = true;
+                    return plans.Count > 0;
+                });
+                return cursor;
+            });
+        return collection;
+    }
+
+    // ── Mongo helpers for SaveMealPhotos / SaveDayPhotos ─────────────────────────
+
+    private static IMongoCollection<MealLog> CreateMealLogCollection(List<MealLog>? logs = null)
+    {
+        logs ??= [];
+        var collection = Substitute.For<IMongoCollection<MealLog>>();
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<MealLog>>(),
+                Arg.Any<FindOptions<MealLog, MealLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(logs));
+        collection.InsertOneAsync(Arg.Any<MealLog>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var updateResult = Substitute.For<UpdateResult>();
+        updateResult.ModifiedCount.Returns(1);
+        collection.UpdateOneAsync(
+                Arg.Any<FilterDefinition<MealLog>>(),
+                Arg.Any<UpdateDefinition<MealLog>>(),
+                Arg.Any<UpdateOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(updateResult);
+        return collection;
+    }
+
+    private static IMongoCollection<DayLog> CreateDayLogCollection(List<DayLog>? logs = null)
+    {
+        logs ??= [];
+        var collection = Substitute.For<IMongoCollection<DayLog>>();
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<DayLog>>(),
+                Arg.Any<FindOptions<DayLog, DayLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(logs));
+        collection.InsertOneAsync(Arg.Any<DayLog>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var updateResult = Substitute.For<UpdateResult>();
+        updateResult.ModifiedCount.Returns(1);
+        collection.UpdateOneAsync(
+                Arg.Any<FilterDefinition<DayLog>>(),
+                Arg.Any<UpdateDefinition<DayLog>>(),
+                Arg.Any<UpdateOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(updateResult);
+        return collection;
+    }
+
+    private static IAsyncCursor<T> CreateCursor<T>(List<T> items)
+    {
+        var cursor = Substitute.For<IAsyncCursor<T>>();
+        var moved = false;
+        cursor.Current.Returns(items);
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return items.Count > 0;
+        });
+        return cursor;
+    }
+
+    // ── Endpoint factories ───────────────────────────────────────────────────────
+
+    private FinalizePlanPhotoEndpoint CreateFinalizeEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
+        Factory.Create<FinalizePlanPhotoEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _finalizeLogger);
+
+    private SaveMealPhotosEndpoint CreateSaveMealPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
+        Factory.Create<SaveMealPhotosEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _mealLogger);
+
+    private SaveDayPhotosEndpoint CreateSaveDayPhotosEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
+        Factory.Create<SaveDayPhotosEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _dayLogger);
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // FinalizePlanPhoto — nutrition plan
+    // ════════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task FinalizePlanPhoto_NutritionPlan_EmitsPlanPhotoUploaded_ToNutritionist()
+    {
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            clientId: _clientId,
+            nutritionistId: _nutritionistId);
+
+        var mongo = CreateMongoWithNutritionPlan(plan);
+        var db = CreateMockDb();
+        var ep = CreateFinalizeEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // The owning nutritionist must receive exactly one event
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,
+            "planPhotoUploaded",
+            Arg.Is<PlanPhotoUploadedEvent>(e =>
+                e.PlanId == planId &&
+                e.Category == PlanPhotoCategory.Body),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FinalizePlanPhoto_NutritionPlan_DoesNotEmit_ToDifferentProfessional()
+    {
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            clientId: _clientId,
+            nutritionistId: _nutritionistId);
+
+        var mongo = CreateMongoWithNutritionPlan(plan);
+        var db = CreateMockDb();
+        var ep = CreateFinalizeEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body
+        }, TestContext.Current.CancellationToken);
+
+        // A different professional must NOT receive the event
+        await _notifier.DidNotReceive().NotifyAsync(
+            _otherProfessionalId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FinalizePlanPhoto_NutritionPlan_PayloadHasCorrectPhotoIdAndTakenAt()
+    {
+        var planId = Guid.NewGuid();
+        var takenAt = new DateTime(2026, 3, 15, 10, 30, 0, DateTimeKind.Utc);
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            clientId: _clientId,
+            nutritionistId: _nutritionistId);
+
+        var mongo = CreateMongoWithNutritionPlan(plan);
+        var db = CreateMockDb();
+        var ep = CreateFinalizeEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.FreeForm,
+            TakenAt = takenAt
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // PhotoId must match the created photo's PublicId; TakenAt must match the request
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,
+            "planPhotoUploaded",
+            Arg.Is<PlanPhotoUploadedEvent>(e =>
+                e.PhotoId == ep.Response.Id &&
+                e.TakenAt == takenAt &&
+                e.Category == PlanPhotoCategory.FreeForm),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // FinalizePlanPhoto — training plan
+    // ════════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task FinalizePlanPhoto_TrainingPlan_EmitsPlanPhotoUploaded_ToTrainer()
+    {
+        var planId = Guid.NewGuid();
+        var trainingPlan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Status = TrainingPlanStatus.Active
+        };
+
+        var mongo = CreateMongoWithTrainingPlan(trainingPlan);
+        var db = CreateMockDb();
+        var ep = CreateFinalizeEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.FreeForm
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await _notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "planPhotoUploaded",
+            Arg.Is<PlanPhotoUploadedEvent>(e =>
+                e.PlanId == planId &&
+                e.Category == PlanPhotoCategory.FreeForm),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FinalizePlanPhoto_TrainingPlan_DoesNotEmit_ToDifferentProfessional()
+    {
+        var planId = Guid.NewGuid();
+        var trainingPlan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Status = TrainingPlanStatus.Active
+        };
+
+        var mongo = CreateMongoWithTrainingPlan(trainingPlan);
+        var db = CreateMockDb();
+        var ep = CreateFinalizeEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.FreeForm
+        }, TestContext.Current.CancellationToken);
+
+        await _notifier.DidNotReceive().NotifyAsync(
+            _otherProfessionalId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // FinalizePlanPhoto — best-effort: broadcast failure does not fail mutation
+    // ════════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task FinalizePlanPhoto_BroadcastThrows_MutationStillSucceeds()
+    {
+        _notifier
+            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("hub unavailable")));
+
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            clientId: _clientId,
+            nutritionistId: _nutritionistId);
+
+        var mongo = CreateMongoWithNutritionPlan(plan);
+        var db = CreateMockDb();
+        var ep = CreateFinalizeEndpoint(mongo, db);
+
+        var act = () => ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body
+        }, TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // SaveMealPhotos — dual-write emits event only for newly-inserted rows
+    // ════════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SaveMealPhotos_NewPhotos_EmitsPlanPhotoUploaded_ToNutritionist()
+    {
+        var mealId = Guid.NewGuid();
+        var food = PlanTestHelpers.CreateMealFood(foodName: "Eggs");
+        var meal = PlanTestHelpers.CreateMeal(mealId: mealId, kind: MealKind.Breakfast, foods: food);
+
+        var plan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active);
+        plan.Weeks[0].Days[0].Meals.Add(meal);
+
+        // Build collection BEFORE mongo.MealLogs.Returns() to avoid NSubstitute pitfall
+        var mealLogCollection = CreateMealLogCollection();
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        mongo.MealLogs.Returns(mealLogCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateSaveMealPhotosEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveMealPhotosRequest
+        {
+            MealId = mealId,
+            Photos = [new MealPhotoInput { BlobUrl = "https://cdn.example.com/photo.jpg" }]
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // Nutritionist receives the event
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,
+            "planPhotoUploaded",
+            Arg.Is<PlanPhotoUploadedEvent>(e =>
+                e.PlanId == plan.ExternalId &&
+                e.Category == PlanPhotoCategory.Food),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveMealPhotos_DifferentProfessional_DoesNotReceive()
+    {
+        var mealId = Guid.NewGuid();
+        var food = PlanTestHelpers.CreateMealFood(foodName: "Chicken");
+        var meal = PlanTestHelpers.CreateMeal(mealId: mealId, kind: MealKind.Lunch, foods: food);
+
+        var plan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active);
+        plan.Weeks[0].Days[0].Meals.Add(meal);
+
+        var mealLogCollection = CreateMealLogCollection();
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        mongo.MealLogs.Returns(mealLogCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateSaveMealPhotosEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveMealPhotosRequest
+        {
+            MealId = mealId,
+            Photos = [new MealPhotoInput { BlobUrl = "https://cdn.example.com/chicken.jpg" }]
+        }, TestContext.Current.CancellationToken);
+
+        // A different professional must NOT receive
+        await _notifier.DidNotReceive().NotifyAsync(
+            _otherProfessionalId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveMealPhotos_ExistingPhotoResubmitted_DoesNotEmitForExisting()
+    {
+        // If a blob URL already has a PlanPhoto row, the dual-write is idempotent
+        // and no new event should fire for that URL.
+        var mealId = Guid.NewGuid();
+        var food = PlanTestHelpers.CreateMealFood(foodName: "Pasta");
+        var meal = PlanTestHelpers.CreateMeal(mealId: mealId, kind: MealKind.Dinner, foods: food);
+
+        var plan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active);
+        plan.Weeks[0].Days[0].Meals.Add(meal);
+
+        const string existingUrl = "https://cdn.example.com/existing.jpg";
+
+        // Pre-seed an existing PlanPhoto row so the dual-write skips it
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .With(new PlanPhoto
+            {
+                PublicId = Guid.NewGuid(),
+                ClientProfileId = 0,   // matches the mock via BlobUrl lookup
+                PlanId = plan.ExternalId,
+                Category = PlanPhotoCategory.Food,
+                BlobUrl = existingUrl,
+                TakenAt = DateTime.UtcNow.AddHours(-1),
+                UploadedByUserId = _clientId,
+                DateCreated = DateTime.UtcNow.AddHours(-1),
+                DateUpdated = DateTime.UtcNow.AddHours(-1)
+            })
+            .Build();
+
+        var mealLogColl = CreateMealLogCollection();
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        mongo.MealLogs.Returns(mealLogColl);
+
+        var ep = CreateSaveMealPhotosEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveMealPhotosRequest
+        {
+            MealId = mealId,
+            Photos = [new MealPhotoInput { BlobUrl = existingUrl }]
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // No event should be emitted — the row already existed
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "planPhotoUploaded",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════
+    // SaveDayPhotos — dual-write emits event only for newly-inserted rows
+    // ════════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SaveDayPhotos_NewPhotos_EmitsPlanPhotoUploaded_ToNutritionist()
+    {
+        var plan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active);
+
+        // Build collection BEFORE mongo.DayLogs.Returns() to avoid NSubstitute pitfall
+        var dayLogCollection = CreateDayLogCollection();
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        mongo.DayLogs.Returns(dayLogCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateSaveDayPhotosEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveDayPhotosRequest
+        {
+            Photos =
+            [
+                new DayPhotoInput { BlobUrl = "https://cdn.example.com/progress.jpg", Category = DayPhotoCategory.Progress }
+            ]
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,
+            "planPhotoUploaded",
+            Arg.Is<PlanPhotoUploadedEvent>(e =>
+                e.PlanId == plan.ExternalId &&
+                e.Category == PlanPhotoCategory.Body),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveDayPhotos_DifferentProfessional_DoesNotReceive()
+    {
+        var plan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active);
+
+        var dayLogCollection = CreateDayLogCollection();
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        mongo.DayLogs.Returns(dayLogCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateSaveDayPhotosEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveDayPhotosRequest
+        {
+            Photos = [new DayPhotoInput { BlobUrl = "https://cdn.example.com/day.jpg", Category = DayPhotoCategory.Free }]
+        }, TestContext.Current.CancellationToken);
+
+        await _notifier.DidNotReceive().NotifyAsync(
+            _otherProfessionalId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SaveDayPhotos_EmptyPhotoList_NoEventEmitted()
+    {
+        var plan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active);
+
+        var dayLogCollection = CreateDayLogCollection();
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        mongo.DayLogs.Returns(dayLogCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateSaveDayPhotosEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveDayPhotosRequest
+        {
+            Photos = []
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // No photos inserted → no events
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "planPhotoUploaded",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new `PlanPhotoUploadedEvent` payload class (`PlanId`, `PhotoId`, `Category`, `TakenAt`).
- Emits the `planPhotoUploaded` SignalR event via `IRealtimeNotifier` in three endpoints: `FinalizePlanPhotoEndpoint`, `SaveMealPhotosEndpoint`, and `SaveDayPhotosEndpoint`.
- Event fires only after `SaveChangesAsync` succeeds and only for newly-inserted `PlanPhoto` rows (dual-write idempotency preserved).
- Broadcast is best-effort: a notifier failure is logged as a warning and does not fail the HTTP response.

## Related issue
Fixes #84

## Scope
backend

## QA verdict (from qa-tester)
OVERALL PASS — 3/3 ACs verified, 860/860 tests green, 12 new SignalR integration tests pass, event emission confirmed AFTER `SaveChangesAsync` in all three endpoints, dual-write emits only for newly-inserted rows.

## Test plan
- [ ] Only the linked professional receives the `planPhotoUploaded` event.
- [ ] Event lands on both web + mobile hubs (via existing `NotificationHub` / `IRealtimeNotifier`).
- [ ] Verified via 12 new Testcontainers-compatible NSubstitute tests in `PlanPhotoUploadedSignalRTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)