### PR TITLE
feat: plan detail Photos tab (nutrition + training)

### DIFF
--- a/web/src/api/photos.ts
+++ b/web/src/api/photos.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/api/client';
+import type { PlanPhotoCategory, PlanPhotoResponse } from '@/api/generated';
+
+export type { PlanPhotoCategory, PlanPhotoResponse };
+
+/** Fetch paginated list of photos for a plan, optionally filtered by category. */
+export async function getPlanPhotos(
+  planId: string,
+  page: number,
+  pageSize: number,
+  category?: PlanPhotoCategory | null,
+): Promise<PlanPhotoResponse[]> {
+  return apiClient.getPlanPhotosEndpoint(planId, page, pageSize, category);
+}
+
+/** Delete a single plan photo by its ID. */
+export async function deletePlanPhoto(photoId: string): Promise<void> {
+  return apiClient.deletePlanPhotoEndpoint(photoId);
+}

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -193,7 +193,7 @@ export function AppShell() {
       // Key shape verified: DashboardPage.tsx line 88 uses ['dashboard-summary'].
       queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
     },
-    planPhotoUploaded: (payload: unknown) => {
+    planphotouploaded: (payload: unknown) => {
       const data = payload as { planId?: string } | undefined;
       const planId = data?.planId;
       if (planId) {

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -193,6 +193,16 @@ export function AppShell() {
       // Key shape verified: DashboardPage.tsx line 88 uses ['dashboard-summary'].
       queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
     },
+    planPhotoUploaded: (payload: unknown) => {
+      const data = payload as { planId?: string } | undefined;
+      const planId = data?.planId;
+      if (planId) {
+        queryClient.invalidateQueries({ queryKey: ['planPhotos', planId] });
+      } else {
+        // Broad invalidation if planId is missing
+        queryClient.invalidateQueries({ queryKey: ['planPhotos'] });
+      }
+    },
     weeklycheckinupdated: (payload: unknown) => {
       if (import.meta.env.DEV) {
         console.debug('weeklycheckinupdated', payload);

--- a/web/src/components/nutrition/PlanPhotosTab.tsx
+++ b/web/src/components/nutrition/PlanPhotosTab.tsx
@@ -127,9 +127,10 @@ export function PlanPhotosTab({ planId }: PlanPhotosTabProps) {
                 {photo.category && (
                   <span className={cn(
                     'absolute top-1 left-1 text-[9px] font-semibold px-[5px] py-[1px] rounded-full',
-                    photo.category === PlanPhotoCategory.Food && 'bg-orange-100 text-orange-700',
-                    photo.category === PlanPhotoCategory.Body && 'bg-blue-100 text-blue-700',
-                    photo.category === PlanPhotoCategory.FreeForm && 'bg-purple-100 text-purple-700',
+                    // Semantic tokens from index.css — matches Tag component orange/blue/purple variants
+                    photo.category === PlanPhotoCategory.Food && 'bg-orange-bg text-orange',
+                    photo.category === PlanPhotoCategory.Body && 'bg-blue-bg text-blue',
+                    photo.category === PlanPhotoCategory.FreeForm && 'bg-purple-bg text-purple',
                   )}>
                     {t(`nutrition.photos.badge${photo.category}`)}
                   </span>

--- a/web/src/components/nutrition/PlanPhotosTab.tsx
+++ b/web/src/components/nutrition/PlanPhotosTab.tsx
@@ -1,0 +1,159 @@
+/**
+ * PlanPhotosTab — Photos tab for the NutritionPlanPage.
+ *
+ * Shows a category chip row (Food / Body / FreeForm) and a 3-column thumbnail
+ * grid loaded via TanStack Query. Clicking a thumbnail opens the ImageLightbox.
+ * SignalR invalidation is handled at the AppShell level.
+ */
+
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/cn';
+import { ImageLightbox } from '@/components/ui/ImageLightbox';
+import { getPlanPhotos } from '@/api/photos';
+import { PlanPhotoCategory } from '@/api/generated';
+
+interface PlanPhotosTabProps {
+  planId: string;
+}
+
+const CATEGORIES: Array<{ key: PlanPhotoCategory | null; labelKey: string }> = [
+  { key: null, labelKey: 'nutrition.photos.categoryAll' },
+  { key: PlanPhotoCategory.Food, labelKey: 'nutrition.photos.categoryFood' },
+  { key: PlanPhotoCategory.Body, labelKey: 'nutrition.photos.categoryBody' },
+  { key: PlanPhotoCategory.FreeForm, labelKey: 'nutrition.photos.categoryFreeForm' },
+];
+
+const PAGE_SIZE = 60;
+
+export function PlanPhotosTab({ planId }: PlanPhotosTabProps) {
+  const { t } = useTranslation();
+  const [activeCategory, setActiveCategory] = useState<PlanPhotoCategory | null>(null);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+
+  const { data: photos = [], isLoading } = useQuery({
+    queryKey: ['planPhotos', planId, activeCategory],
+    queryFn: () => getPlanPhotos(planId, 1, PAGE_SIZE, activeCategory),
+    staleTime: 30_000,
+  });
+
+  const imageUrls = useMemo(
+    () => photos.map((p) => p.blobUrl ?? '').filter(Boolean),
+    [photos],
+  );
+
+  const openLightbox = (index: number) => {
+    setLightboxIndex(index);
+    setLightboxOpen(true);
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Category chips */}
+      <div className="shrink-0 flex items-center gap-2 px-5 py-3 border-b border-border">
+        {CATEGORIES.map(({ key, labelKey }) => {
+          const isActive = activeCategory === key;
+          return (
+            <button
+              key={String(key)}
+              type="button"
+              onClick={() => setActiveCategory(key)}
+              className={cn(
+                'px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+                isActive
+                  ? 'bg-accent text-bg border-accent'
+                  : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+              )}
+            >
+              {t(labelKey)}
+              {isActive && photos.length > 0 && (
+                <span className="ml-1 opacity-70">({photos.length})</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Photo grid */}
+      <div className="flex-1 overflow-y-auto p-5">
+        {isLoading && (
+          <div className="text-center py-12 text-[13px] text-text3">
+            {t('common.loading')}
+          </div>
+        )}
+
+        {!isLoading && photos.length === 0 && (
+          <div className="text-center py-16">
+            <div className="text-[32px] mb-3">📷</div>
+            <div className="text-[14px] font-medium text-text2 mb-1">
+              {t('nutrition.photos.emptyTitle')}
+            </div>
+            <div className="text-[12px] text-text3">
+              {t('nutrition.photos.emptyHint')}
+            </div>
+          </div>
+        )}
+
+        {!isLoading && photos.length > 0 && (
+          <div className="grid grid-cols-3 gap-2">
+            {photos.map((photo, idx) => (
+              <button
+                key={photo.id ?? idx}
+                type="button"
+                className={cn(
+                  'relative aspect-square rounded-md overflow-hidden',
+                  'border border-border hover:border-border-md',
+                  'bg-bg2 transition-all duration-100',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+                )}
+                onClick={() => openLightbox(idx)}
+                title={photo.description ?? t('nutrition.photos.viewPhoto')}
+              >
+                {photo.blobUrl ? (
+                  <img
+                    src={photo.blobUrl}
+                    alt={photo.description ?? `${t('nutrition.photos.photoAlt')} ${idx + 1}`}
+                    className="w-full h-full object-cover"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-text4 text-[20px]">
+                    📷
+                  </div>
+                )}
+                {/* Category badge */}
+                {photo.category && (
+                  <span className={cn(
+                    'absolute top-1 left-1 text-[9px] font-semibold px-[5px] py-[1px] rounded-full',
+                    photo.category === PlanPhotoCategory.Food && 'bg-orange-100 text-orange-700',
+                    photo.category === PlanPhotoCategory.Body && 'bg-blue-100 text-blue-700',
+                    photo.category === PlanPhotoCategory.FreeForm && 'bg-purple-100 text-purple-700',
+                  )}>
+                    {t(`nutrition.photos.badge${photo.category}`)}
+                  </span>
+                )}
+                {/* Date overlay */}
+                {photo.takenAt && (
+                  <div className="absolute bottom-0 left-0 right-0 bg-black/40 px-1.5 py-0.5 text-[9px] text-white/90 text-right">
+                    {new Date(photo.takenAt).toLocaleDateString()}
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Lightbox */}
+      <ImageLightbox
+        images={imageUrls}
+        startIndex={lightboxIndex}
+        open={lightboxOpen}
+        onClose={() => setLightboxOpen(false)}
+        altPrefix={t('nutrition.photos.photoAlt')}
+      />
+    </div>
+  );
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -654,7 +654,21 @@
     "planSubtitle": "Tvorba a správa jídelníčku klienta",
     "planStatus": "Status",
     "planGoalKcal": "Cíl kcal",
-    "concept": "Koncept"
+    "concept": "Koncept",
+    "photos": {
+      "tab": "Fotky",
+      "categoryAll": "Vše",
+      "categoryFood": "Jídlo",
+      "categoryBody": "Postup",
+      "categoryFreeForm": "Volné",
+      "emptyTitle": "Zatím žádné fotky",
+      "emptyHint": "Fotky nahrané klientem se zobrazí zde.",
+      "viewPhoto": "Zobrazit fotku",
+      "photoAlt": "Fotka plánu",
+      "badgeFood": "Jídlo",
+      "badgeBody": "Postup",
+      "badgeFreeForm": "Volné"
+    }
   },
   "apiErrors": {
     "INVALID_CREDENTIALS": "Neplatný email nebo heslo.",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -654,7 +654,21 @@
     "planSubtitle": "Ernährungsplan des Klienten erstellen und verwalten",
     "planStatus": "Status",
     "planGoalKcal": "Ziel kcal",
-    "concept": "Entwurf"
+    "concept": "Entwurf",
+    "photos": {
+      "tab": "Fotos",
+      "categoryAll": "Alle",
+      "categoryFood": "Essen",
+      "categoryBody": "Fortschritt",
+      "categoryFreeForm": "Frei",
+      "emptyTitle": "Noch keine Fotos",
+      "emptyHint": "Vom Klienten hochgeladene Fotos erscheinen hier.",
+      "viewPhoto": "Foto anzeigen",
+      "photoAlt": "Planfoto",
+      "badgeFood": "Essen",
+      "badgeBody": "Fortschritt",
+      "badgeFreeForm": "Frei"
+    }
   },
   "apiErrors": {
     "INVALID_CREDENTIALS": "Ungültige E-Mail oder Passwort.",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -655,7 +655,21 @@
     "planSubtitle": "Create and manage client's meal plan",
     "planStatus": "Status",
     "planGoalKcal": "Goal kcal",
-    "concept": "Draft"
+    "concept": "Draft",
+    "photos": {
+      "tab": "Photos",
+      "categoryAll": "All",
+      "categoryFood": "Food",
+      "categoryBody": "Body",
+      "categoryFreeForm": "Free",
+      "emptyTitle": "No photos yet",
+      "emptyHint": "Photos uploaded by the client will appear here.",
+      "viewPhoto": "View photo",
+      "photoAlt": "Plan photo",
+      "badgeFood": "Food",
+      "badgeBody": "Body",
+      "badgeFreeForm": "Free"
+    }
   },
   "apiErrors": {
     "INVALID_CREDENTIALS": "Invalid email or password.",

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/cn';
 import { type MealKind } from '@/components/nutrition/meal-kind';
 import { DayNoteInput } from '@/components/common/DayNoteInput';
 import { CheckInBanner } from '@/components/weekly-checkin/CheckInBanner';
+import { PlanPhotosTab } from '@/components/nutrition/PlanPhotosTab';
 
 export default function NutritionPlanPage() {
   const { t, i18n } = useTranslation();
@@ -61,6 +62,7 @@ export default function NutritionPlanPage() {
   const moveMealToDay = useNutritionPlanStore((s) => s.moveMealToDay);
 
   // ── Local UI state ──
+  const [pageTab, setPageTab] = useState<'meals' | 'photos'>('meals');
   const [selectedDay, setSelectedDay] = useState(1);
   const [weekViewExpanded, setWeekViewExpanded] = useState(false);
   const [dragOverDay, setDragOverDay] = useState<number | null>(null);
@@ -368,7 +370,43 @@ export default function NutritionPlanPage() {
         <CheckInBanner clientUserId={plan.clientId} profession="Nutrition" />
       )}
 
-      {/* ── Week tabs ── */}
+      {/* ── Page-level tabs: Meals / Photos ── */}
+      <div className="shrink-0 flex items-center gap-1 px-4 py-2 border-b border-border bg-bg">
+        <button
+          type="button"
+          onClick={() => setPageTab('meals')}
+          className={cn(
+            'px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+            pageTab === 'meals'
+              ? 'bg-accent text-bg border-accent'
+              : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+          )}
+        >
+          {t('nutrition.tabMealPlan')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setPageTab('photos')}
+          className={cn(
+            'px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+            pageTab === 'photos'
+              ? 'bg-accent text-bg border-accent'
+              : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+          )}
+        >
+          {t('nutrition.photos.tab')}
+        </button>
+      </div>
+
+      {/* ── Photos tab content ── */}
+      {pageTab === 'photos' && planId && (
+        <div className="flex-1 overflow-hidden">
+          <PlanPhotosTab planId={planId} />
+        </div>
+      )}
+
+      {/* ── Meals tab content ── */}
+      {pageTab === 'meals' && <>
       <WeekDayTabs
         weeks={weekTabs}
         days={[]}
@@ -739,6 +777,7 @@ export default function NutritionPlanPage() {
           />
         </div>
       </div>
+      </>}
 
       {/* ── Leave Page Confirmation Dialog ── */}
       <Dialog

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -19,6 +19,7 @@ import { TrainingSidebar } from '@/components/training/TrainingSidebar';
 import { cn } from '@/lib/cn';
 import { DayNoteInput } from '@/components/common/DayNoteInput';
 import { CheckInBanner } from '@/components/weekly-checkin/CheckInBanner';
+import { PlanPhotosTab } from '@/components/nutrition/PlanPhotosTab';
 import { DAY_KEYS, MUSCLE_ICONS, MUSCLE_COLORS } from '@/constants/training';
 import { SessionDragWrapper } from '@/components/training/SessionDragWrapper';
 import { ExerciseDropZone } from '@/components/training/ExerciseDropZone';
@@ -63,6 +64,7 @@ export default function TrainingPlanPage() {
   const reorderExercises = useTrainingPlanStore((s) => s.reorderExercises);
 
   // ── Local UI state ──
+  const [pageTab, setPageTab] = useState<'sessions' | 'photos'>('sessions');
   const [selectedDay, setSelectedDay] = useState(1);
   const [collapsedSessions, setCollapsedSessions] = useState<Set<string>>(new Set());
   const [collapsedExercises, setCollapsedExercises] = useState<Set<string>>(new Set());
@@ -365,7 +367,43 @@ export default function TrainingPlanPage() {
         <CheckInBanner clientUserId={plan.clientId} profession="Training" />
       )}
 
-      {/* ── Week tabs ── */}
+      {/* ── Page-level tabs: Sessions / Photos ── */}
+      <div className="shrink-0 flex items-center gap-1 px-4 py-2 border-b border-border bg-bg">
+        <button
+          type="button"
+          onClick={() => setPageTab('sessions')}
+          className={cn(
+            'px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+            pageTab === 'sessions'
+              ? 'bg-accent text-bg border-accent'
+              : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+          )}
+        >
+          {t('sidebar.trainingPlan')}
+        </button>
+        <button
+          type="button"
+          onClick={() => setPageTab('photos')}
+          className={cn(
+            'px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+            pageTab === 'photos'
+              ? 'bg-accent text-bg border-accent'
+              : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+          )}
+        >
+          {t('nutrition.photos.tab')}
+        </button>
+      </div>
+
+      {/* ── Photos tab content ── */}
+      {pageTab === 'photos' && planId && (
+        <div className="flex-1 overflow-hidden">
+          <PlanPhotosTab planId={planId} />
+        </div>
+      )}
+
+      {/* ── Sessions tab content ── */}
+      {pageTab === 'sessions' && <>
       <WeekDayTabs
         weeks={weekTabs}
         days={[]}
@@ -875,6 +913,7 @@ export default function TrainingPlanPage() {
           />
         </div>
       </div>
+      </>}
 
       {/* ── Leave Page Confirmation Dialog ── */}
       <Dialog


### PR DESCRIPTION
## Summary

- Adds a Photos tab to both `NutritionPlanPage` and `TrainingPlanPage` showing a 3-column thumbnail grid of client-uploaded progress photos.
- Category chip row (All / Food / Body / Free) filters the TanStack Query fetch; photos load paginated (60 per page).
- SignalR `planPhotoUploaded` event invalidates the `['planPhotos', planId]` query cache for live refresh.
- Clicking a thumbnail opens the existing `ImageLightbox` component.

## Related issue

Fixes #85

## Scope

web

## QA verdict (from qa-tester)

OVERALL ✅ PASS — `npm run build` 0 errors, all ACs verified, i18n keys present in cs/en/de.

## Test plan

- [ ] TanStack Query + SignalR invalidation.
- [ ] i18n cs/en/de for all photo-related strings.
- [ ] Tokens only (no hardcoded colors, spacing, or fonts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)