### PR TITLE
feat: Photos timeline tab on client detail page (#86)

### DIFF
--- a/web/src/api/client-photos.ts
+++ b/web/src/api/client-photos.ts
@@ -1,0 +1,36 @@
+import { apiClient } from '@/api/client';
+import type {
+  GetTrainerClientPhotosResponse,
+  MonthGroupResponse,
+  PlanPhotoResponse2,
+  PlanPhotoCategory,
+} from '@/api/generated';
+
+export type { GetTrainerClientPhotosResponse, MonthGroupResponse, PlanPhotoResponse2, PlanPhotoCategory };
+
+export interface GetClientPhotosParams {
+  clientId: string;
+  page?: number;
+  pageSize?: number;
+  category?: PlanPhotoCategory | null;
+  from?: string | null;
+  to?: string | null;
+}
+
+/**
+ * Fetch a client's progress photos, grouped by calendar month.
+ * Always passes groupByMonth=true; pagination applies to month groups.
+ */
+export async function getClientPhotoGroups(
+  params: GetClientPhotosParams,
+): Promise<GetTrainerClientPhotosResponse> {
+  return apiClient.getTrainerClientPhotosEndpoint(
+    params.clientId,
+    params.page ?? 1,
+    params.pageSize ?? 50,
+    true,
+    params.category ?? undefined,
+    params.from ?? undefined,
+    params.to ?? undefined,
+  );
+}

--- a/web/src/components/domain/ClientPhotosTimeline.tsx
+++ b/web/src/components/domain/ClientPhotosTimeline.tsx
@@ -129,9 +129,15 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
   const [lightboxOpen, setLightboxOpen] = useState(false);
 
   function openLightbox(allPhotos: PlanPhotoResponse2[], clickedIndex: number) {
+    // Build the URL list from only the photos that have a blobUrl (same
+    // compression as before), but re-derive the index so it points into
+    // that filtered array rather than the unfiltered one.
     const urls = allPhotos.map((p) => p.blobUrl ?? '').filter(Boolean);
+    const filteredIndex = allPhotos
+      .slice(0, clickedIndex)
+      .filter((p) => !!p.blobUrl).length;
     setLightboxImages(urls);
-    setLightboxIndex(clickedIndex);
+    setLightboxIndex(filteredIndex);
     setLightboxOpen(true);
   }
 
@@ -201,26 +207,34 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
 
               {/* Photo grid — 4 columns */}
               <div className="grid grid-cols-4 gap-1.5">
-                {photos.map((photo, idx) => (
-                  <button
-                    key={photo.id ?? idx}
-                    type="button"
-                    onClick={() => openLightbox(photos, idx)}
-                    aria-label={
-                      photo.description ||
-                      t('imageLightbox.open')
-                    }
-                    className="group relative aspect-square overflow-hidden rounded-md bg-bg3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                  >
-                    {photo.blobUrl ? (
+                {photos.map((photo, idx) =>
+                  photo.blobUrl ? (
+                    <button
+                      key={photo.id ?? idx}
+                      type="button"
+                      onClick={() => openLightbox(photos, idx)}
+                      aria-label={photo.description || t('imageLightbox.open')}
+                      className="group relative aspect-square overflow-hidden rounded-md bg-bg3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                    >
                       <img
                         src={photo.blobUrl}
                         alt={photo.description ?? ''}
                         className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
                         loading="lazy"
                       />
-                    ) : (
-                      /* Placeholder for photos without a URL */
+                      {/* Category badge */}
+                      {photo.category && (
+                        <span className="absolute bottom-1 left-1 rounded px-1 py-0.5 text-[9px] font-medium bg-black/50 text-white">
+                          {t(`clientDetail.photos.category${photo.category}`)}
+                        </span>
+                      )}
+                    </button>
+                  ) : (
+                    /* Placeholder tile — no blobUrl, not interactive */
+                    <div
+                      key={photo.id ?? idx}
+                      className="relative aspect-square overflow-hidden rounded-md bg-bg3"
+                    >
                       <span
                         className="flex h-full w-full items-center justify-center text-2xl"
                         aria-hidden="true"
@@ -231,16 +245,15 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
                             ? '🏃'
                             : '📷'}
                       </span>
-                    )}
-
-                    {/* Category badge */}
-                    {photo.category && (
-                      <span className="absolute bottom-1 left-1 rounded px-1 py-0.5 text-[9px] font-medium bg-black/50 text-white">
-                        {t(`clientDetail.photos.category${photo.category}`)}
-                      </span>
-                    )}
-                  </button>
-                ))}
+                      {/* Category badge */}
+                      {photo.category && (
+                        <span className="absolute bottom-1 left-1 rounded px-1 py-0.5 text-[9px] font-medium bg-black/50 text-white">
+                          {t(`clientDetail.photos.category${photo.category}`)}
+                        </span>
+                      )}
+                    </div>
+                  ),
+                )}
               </div>
             </div>
           );

--- a/web/src/components/domain/ClientPhotosTimeline.tsx
+++ b/web/src/components/domain/ClientPhotosTimeline.tsx
@@ -1,0 +1,259 @@
+/**
+ * ClientPhotosTimeline
+ *
+ * Renders a client's progress photos grouped by calendar month, with
+ * filters for Category (Food / Body / FreeForm) and Plan (dropdown).
+ *
+ * Filter state is owned by this component and keyed to `clientId` so that
+ * switching clients automatically resets both filters.
+ */
+
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { getClientPhotoGroups } from '@/api/client-photos';
+import { getPlans } from '@/api/plans';
+import { getTrainingPlans } from '@/api/training-plans';
+import { PlanPhotoCategory } from '@/api/generated';
+import type { MonthGroupResponse, PlanPhotoResponse2 } from '@/api/client-photos';
+import { FilterChips } from '@/components/domain/FilterChips';
+import { Select } from '@/components/ui';
+import { ImageLightbox } from '@/components/ui';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ClientPhotosTimelineProps {
+  /** Public client identifier (route param). Changing this resets all filters. */
+  clientId: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Format a YYYY-MM key as a localised month+year label. */
+function formatYearMonth(yearMonth: string, locale: string): string {
+  const [year, month] = yearMonth.split('-');
+  const date = new Date(Number(year), Number(month) - 1, 1);
+  return date.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
+  const { t, i18n } = useTranslation();
+
+  // Locale string for date formatting
+  const locale = i18n.language === 'de' ? 'de-DE' : i18n.language === 'en' ? 'en-GB' : 'cs-CZ';
+
+  // ── Filter state ────────────────────────────────────────────────────────────
+  // Both reset when clientId changes via `key` prop on the parent or here via
+  // explicit reset in an effect — but the simplest approach is to store filters
+  // in a sub-object keyed to clientId so stale state is never visible.
+  const [selectedCategory, setSelectedCategory] = useState<PlanPhotoCategory | ''>('');
+  const [selectedPlanId, setSelectedPlanId] = useState<string>('');
+
+  // ── Category filter chips ────────────────────────────────────────────────────
+  const categoryChips = useMemo(
+    () => [
+      { id: '', label: t('clientDetail.photos.categoryAll') },
+      { id: PlanPhotoCategory.Food, label: t('clientDetail.photos.categoryFood') },
+      { id: PlanPhotoCategory.Body, label: t('clientDetail.photos.categoryBody') },
+      { id: PlanPhotoCategory.FreeForm, label: t('clientDetail.photos.categoryFreeForm') },
+    ],
+    [t],
+  );
+
+  // ── Fetch photos ─────────────────────────────────────────────────────────────
+  const { data: photosData, isLoading: photosLoading } = useQuery({
+    queryKey: [
+      'client-photos',
+      clientId,
+      selectedCategory || null,
+      selectedPlanId || null,
+    ],
+    queryFn: () =>
+      getClientPhotoGroups({
+        clientId,
+        category: selectedCategory ? (selectedCategory as PlanPhotoCategory) : null,
+      }),
+    enabled: !!clientId,
+  });
+
+  // ── Fetch nutrition plans for the Plan dropdown ──────────────────────────────
+  const { data: nutritionPlansData } = useQuery({
+    queryKey: ['plans', clientId],
+    queryFn: () => getPlans({ clientId, pageSize: 100 }),
+    enabled: !!clientId,
+  });
+
+  // ── Fetch training plans for the Plan dropdown ───────────────────────────────
+  const { data: trainingPlansData } = useQuery({
+    queryKey: ['training-plans', clientId],
+    queryFn: () => getTrainingPlans({ clientId, pageSize: 100 }),
+    enabled: !!clientId,
+  });
+
+  // ── Build unified plan options ───────────────────────────────────────────────
+  const planOptions = useMemo(() => {
+    const opts: Array<{ value: string; label: string }> = [
+      { value: '', label: t('clientDetail.photos.planAll') },
+    ];
+    for (const p of nutritionPlansData?.plans ?? []) {
+      opts.push({ value: p.planId, label: p.name });
+    }
+    for (const p of trainingPlansData?.plans ?? []) {
+      opts.push({ value: p.planId, label: p.name });
+    }
+    return opts;
+  }, [nutritionPlansData, trainingPlansData, t]);
+
+  // ── Filter groups by selected plan (client-side) ─────────────────────────────
+  // The backend endpoint doesn't support planId filtering directly, so we
+  // do a lightweight client-side pass when a plan is selected.
+  const groups: MonthGroupResponse[] = useMemo(() => {
+    const raw = photosData?.groups ?? [];
+    if (!selectedPlanId) return raw;
+    return raw
+      .map((group) => ({
+        ...group,
+        photos: (group.photos ?? []).filter(
+          (p: PlanPhotoResponse2) => p.planId === selectedPlanId,
+        ),
+      }))
+      .filter((group) => (group.photos ?? []).length > 0);
+  }, [photosData, selectedPlanId]);
+
+  // ── Lightbox state ────────────────────────────────────────────────────────────
+  const [lightboxImages, setLightboxImages] = useState<string[]>([]);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  function openLightbox(allPhotos: PlanPhotoResponse2[], clickedIndex: number) {
+    const urls = allPhotos.map((p) => p.blobUrl ?? '').filter(Boolean);
+    setLightboxImages(urls);
+    setLightboxIndex(clickedIndex);
+    setLightboxOpen(true);
+  }
+
+  // ── Empty state ────────────────────────────────────────────────────────────────
+  const isEmpty = !photosLoading && groups.length === 0;
+
+  return (
+    <div className="py-3">
+      {/* ── Filter bar ─────────────────────────────────────────────────────── */}
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        {/* Category chips */}
+        <FilterChips
+          chips={categoryChips}
+          activeId={selectedCategory}
+          onChange={(id) => setSelectedCategory(id as PlanPhotoCategory | '')}
+        />
+
+        {/* Plan dropdown */}
+        <div className="w-52">
+          <Select
+            value={selectedPlanId}
+            onChange={(e) => setSelectedPlanId(e.target.value)}
+            aria-label={t('clientDetail.photos.planLabel')}
+          >
+            {planOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {/* ── Loading ────────────────────────────────────────────────────────── */}
+      {photosLoading && (
+        <p className="text-[13px] text-text3">{t('common.loading')}</p>
+      )}
+
+      {/* ── Empty state ─────────────────────────────────────────────────────── */}
+      {isEmpty && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <span className="text-4xl mb-3" aria-hidden="true">📷</span>
+          <p className="text-[15px] font-medium text-text mb-1">
+            {t('clientDetail.photos.emptyTitle')}
+          </p>
+          <p className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.photos.emptyDescription')}
+          </p>
+        </div>
+      )}
+
+      {/* ── Timeline grouped by month ──────────────────────────────────────── */}
+      {!photosLoading &&
+        groups.map((group) => {
+          const photos = group.photos ?? [];
+          if (photos.length === 0) return null;
+          const label = group.yearMonth
+            ? formatYearMonth(group.yearMonth, locale)
+            : group.yearMonth ?? '';
+
+          return (
+            <div key={group.yearMonth} className="mb-6">
+              {/* Month heading */}
+              <h3 className="text-[11px] font-semibold uppercase tracking-[0.06em] text-text3 mb-2.5">
+                {label}
+              </h3>
+
+              {/* Photo grid — 4 columns */}
+              <div className="grid grid-cols-4 gap-1.5">
+                {photos.map((photo, idx) => (
+                  <button
+                    key={photo.id ?? idx}
+                    type="button"
+                    onClick={() => openLightbox(photos, idx)}
+                    aria-label={
+                      photo.description ||
+                      t('imageLightbox.open')
+                    }
+                    className="group relative aspect-square overflow-hidden rounded-md bg-bg3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                  >
+                    {photo.blobUrl ? (
+                      <img
+                        src={photo.blobUrl}
+                        alt={photo.description ?? ''}
+                        className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                        loading="lazy"
+                      />
+                    ) : (
+                      /* Placeholder for photos without a URL */
+                      <span
+                        className="flex h-full w-full items-center justify-center text-2xl"
+                        aria-hidden="true"
+                      >
+                        {photo.category === PlanPhotoCategory.Food
+                          ? '🍽'
+                          : photo.category === PlanPhotoCategory.Body
+                            ? '🏃'
+                            : '📷'}
+                      </span>
+                    )}
+
+                    {/* Category badge */}
+                    {photo.category && (
+                      <span className="absolute bottom-1 left-1 rounded px-1 py-0.5 text-[9px] font-medium bg-black/50 text-white">
+                        {t(`clientDetail.photos.category${photo.category}`)}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+
+      {/* ── Lightbox ────────────────────────────────────────────────────────── */}
+      <ImageLightbox
+        images={lightboxImages}
+        startIndex={lightboxIndex}
+        open={lightboxOpen}
+        onClose={() => setLightboxOpen(false)}
+        altPrefix={t('clientDetail.photos.photoAltPrefix')}
+      />
+    </div>
+  );
+}

--- a/web/src/components/domain/index.ts
+++ b/web/src/components/domain/index.ts
@@ -1,6 +1,7 @@
 export { ActivityTimeline } from './ActivityTimeline';
 export { MessageBubble } from './MessageBubble';
 export { FilterChips } from './FilterChips';
+export { ClientPhotosTimeline } from './ClientPhotosTimeline';
 
 export type { ActivityTimelineProps, TimelineItem } from './ActivityTimeline';
 export type { MessageBubbleProps } from './MessageBubble';

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1300,5 +1300,22 @@
     "close": "Zavřít",
     "prev": "Předchozí obrázek",
     "next": "Další obrázek"
+  },
+  "clientDetail": {
+    "tabs": {
+      "overview": "Přehled",
+      "photos": "Fotky"
+    },
+    "photos": {
+      "categoryAll": "Vše",
+      "categoryFood": "Jídlo",
+      "categoryBody": "Tělo",
+      "categoryFreeForm": "Volné",
+      "planLabel": "Plán",
+      "planAll": "Všechny plány",
+      "emptyTitle": "Zatím žádné fotky",
+      "emptyDescription": "Jakmile klient nahraje fotky pokroku, zobrazí se zde seřazené po měsících.",
+      "photoAltPrefix": "Fotka"
+    }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1300,5 +1300,22 @@
     "close": "Schließen",
     "prev": "Vorheriges Bild",
     "next": "Nächstes Bild"
+  },
+  "clientDetail": {
+    "tabs": {
+      "overview": "Übersicht",
+      "photos": "Fotos"
+    },
+    "photos": {
+      "categoryAll": "Alle",
+      "categoryFood": "Essen",
+      "categoryBody": "Körper",
+      "categoryFreeForm": "Frei",
+      "planLabel": "Plan",
+      "planAll": "Alle Pläne",
+      "emptyTitle": "Noch keine Fotos",
+      "emptyDescription": "Wenn der Klient Fortschrittsfotos hochlädt, erscheinen sie hier nach Monaten gruppiert.",
+      "photoAltPrefix": "Foto"
+    }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1301,5 +1301,22 @@
     "close": "Close",
     "prev": "Previous image",
     "next": "Next image"
+  },
+  "clientDetail": {
+    "tabs": {
+      "overview": "Overview",
+      "photos": "Photos"
+    },
+    "photos": {
+      "categoryAll": "All",
+      "categoryFood": "Food",
+      "categoryBody": "Body",
+      "categoryFreeForm": "Free",
+      "planLabel": "Plan",
+      "planAll": "All plans",
+      "emptyTitle": "No photos yet",
+      "emptyDescription": "When the client uploads progress photos they will appear here, grouped by month.",
+      "photoAltPrefix": "Photo"
+    }
   }
 }

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -23,12 +23,14 @@ export default function ClientDetailPage() {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
 
   // Active tab — resets to 'overview' on client switch.
+  // Uses the "adjust state during render" pattern (React docs) to avoid the
+  // react-hooks/set-state-in-effect lint rule that fires on useEffect resets.
+  const [prevId, setPrevId] = useState(id);
   const [activeTab, setActiveTab] = useState<'overview' | 'photos'>('overview');
-
-  // Reset tab when the route client changes.
-  useEffect(() => {
+  if (id !== prevId) {
+    setPrevId(id);
     setActiveTab('overview');
-  }, [id]);
+  }
 
 
   const { data: client, isLoading } = useQuery({

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -9,9 +9,10 @@ import { formatWeight } from '@/lib/personalRecordFormatters';
 import { PageHeader } from '@/components/layout';
 import { Button, Tag, Dialog, Input, EditableAvatar } from '@/components/ui';
 import { PropertyList, StatsGrid } from '@/components/data';
-import { ActivityTimeline } from '@/components/domain';
+import { ActivityTimeline, ClientPhotosTimeline } from '@/components/domain';
 import { QuestionnaireAnswersSection } from '@/components/questionnaire';
 import { WeeklyCheckInSection } from '@/components/weekly-checkin/WeeklyCheckInSection';
+import { cn } from '@/lib/cn';
 
 export default function ClientDetailPage() {
   const { t, i18n } = useTranslation();
@@ -20,6 +21,14 @@ export default function ClientDetailPage() {
 
   // Edit dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+
+  // Active tab — resets to 'overview' on client switch.
+  const [activeTab, setActiveTab] = useState<'overview' | 'photos'>('overview');
+
+  // Reset tab when the route client changes.
+  useEffect(() => {
+    setActiveTab('overview');
+  }, [id]);
 
 
   const { data: client, isLoading } = useQuery({
@@ -369,6 +378,39 @@ export default function ClientDetailPage() {
 
       {/* Page Content */}
       <div className="flex-1 overflow-y-auto">
+        {/* Tab bar */}
+        <div className="flex items-center gap-1 px-20 pt-4 pb-0 border-b border-border">
+          {(
+            [
+              { id: 'overview', label: t('clientDetail.tabs.overview') },
+              { id: 'photos', label: t('clientDetail.tabs.photos') },
+            ] as const
+          ).map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                'px-3 py-2 text-[13px] font-medium border-b-2 -mb-px transition-colors',
+                activeTab === tab.id
+                  ? 'border-accent text-text'
+                  : 'border-transparent text-text3 hover:text-text2',
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Photos tab */}
+        {activeTab === 'photos' && (
+          <div className="px-20">
+            <ClientPhotosTimeline clientId={id!} />
+          </div>
+        )}
+
+        {/* Overview tab */}
+        {activeTab === 'overview' && (
         <div className="px-20 py-3">
           {/* Property List */}
           <PropertyList items={propertyItems} />
@@ -436,6 +478,7 @@ export default function ClientDetailPage() {
             <p className="text-[13px] text-text3">Žádná nedávná aktivita</p>
           )}
         </div>
+        )}
       </div>
 
       {/* Edit Client Dialog */}


### PR DESCRIPTION
## Summary

- Adds a Photos tab to the client detail page, showing progress photos grouped by calendar month.
- Category filter (All / Food / Body / FreeForm) implemented via FilterChips; plan filter via a Select dropdown backed by fetched nutrition + training plans.
- Client-side plan filtering applied over the API result (backend endpoint does not expose planId filtering).
- Lightbox integration for full-screen image viewing.
- Active tab resets to Overview when the route client changes (`useEffect` on `id`); photo filter state (category, plan) resets implicitly because the Photos tab is unmounted on tab switch.

## Related issue

Fixes #86

## Scope

web

## QA verdict (from qa-tester)

OVERALL PASS — both ACs verified: filter reset on client switch confirmed, empty-state copy present in cs/en/de (all 11 keys). `npm run build` 0 errors. Three prototype-fidelity divergences noted as non-blocking (4-col vs 6-col grid; Select vs chips for plan filter; missing plan name in month heading — requires backend change).

## Test plan

- [ ] Filters reset on client switch (navigate to a different client — category + plan selection clears)
- [ ] Empty state copy present in cs, en, de (all keys: categoryAll, categoryFood, categoryBody, categoryFreeForm, planLabel, planAll, emptyTitle, emptyDescription, photoAltPrefix + tabs.overview, tabs.photos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)