### PR TITLE
chore: clean up review NITs from Epic #66 photo timeline

### DIFF
--- a/mobile/app/(client)/plan-photos.tsx
+++ b/mobile/app/(client)/plan-photos.tsx
@@ -63,13 +63,6 @@ import { Toast } from '@/lib/toast'
 type UiCategory = 'Food' | 'Progress' | 'Free'
 type FilterCategory = 'All' | UiCategory
 
-/** Map from UI category to the wire-level PlanPhotoCategory value. */
-const UI_TO_WIRE: Record<UiCategory, PlanPhotoCategory> = {
-  Food: PlanPhotoCategory.Food,
-  Progress: PlanPhotoCategory.Body,
-  Free: PlanPhotoCategory.FreeForm,
-}
-
 /** Map from PlanPhotoCategory wire value back to UI category for display. */
 const WIRE_TO_UI: Record<PlanPhotoCategory, UiCategory> = {
   [PlanPhotoCategory.Food]: 'Food',
@@ -215,11 +208,18 @@ export default function PlanPhotosScreen() {
 
   // ── Grid item renderer ──
   const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<PhotoItem>) => (
+    ({ item, index }: ListRenderItemInfo<PhotoItem>) => {
+      const labelKey =
+        item.uiCategory === 'Food'
+          ? 'planPhotos.categoryFood'
+          : item.uiCategory === 'Progress'
+            ? 'planPhotos.categoryProgress'
+            : 'planPhotos.categoryFree'
+      return (
       <Pressable
         onPress={() => handleTilePress(index)}
         accessibilityRole="button"
-        accessibilityLabel={`${t('planPhotos.categoryFood')} ${index + 1}`}
+        accessibilityLabel={`${t(labelKey)} ${index + 1}`}
         style={[
           styles.tile,
           {
@@ -235,7 +235,8 @@ export default function PlanPhotosScreen() {
           resizeMode="cover"
         />
       </Pressable>
-    ),
+      )
+    },
     [handleTilePress, tileSize, colors.fill2, t],
   )
 

--- a/mobile/app/(client)/profile-photos.tsx
+++ b/mobile/app/(client)/profile-photos.tsx
@@ -49,6 +49,7 @@ import {
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const PAGE_SIZE = 6 // month groups per page
+const OUTER_MARGIN = 20 // horizontal margin each side of the photo grid
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -147,7 +148,6 @@ export default function ProfilePhotosScreen() {
   const [lightboxIndex, setLightboxIndex] = useState(0)
 
   // ── Tile dimensions: 3 columns, 4px gap, 20px outer margin each side ──
-  const OUTER_MARGIN = 20
   const tileSize = (width - OUTER_MARGIN * 2 - GRID_GAP * 2) / 3
 
   // ── API category for current filter ──
@@ -252,7 +252,7 @@ export default function ProfilePhotosScreen() {
         />
       </View>
     ),
-    [tileSize, handleTilePress, OUTER_MARGIN],
+    [tileSize, handleTilePress],
   )
 
   const keyExtractor = useCallback(
@@ -434,7 +434,7 @@ const styles = StyleSheet.create({
   chip: {
     paddingHorizontal: 14,
     paddingVertical: 8,
-    borderRadius: 99,
+    borderRadius: Radius.full,
     alignItems: 'center',
   },
   chipLabel: {

--- a/web/src/api/photos.ts
+++ b/web/src/api/photos.ts
@@ -13,7 +13,3 @@ export async function getPlanPhotos(
   return apiClient.getPlanPhotosEndpoint(planId, page, pageSize, category);
 }
 
-/** Delete a single plan photo by its ID. */
-export async function deletePlanPhoto(photoId: string): Promise<void> {
-  return apiClient.deletePlanPhotoEndpoint(photoId);
-}

--- a/web/src/components/domain/ClientPhotosTimeline.tsx
+++ b/web/src/components/domain/ClientPhotosTimeline.tsx
@@ -28,6 +28,20 @@ interface ClientPhotosTimelineProps {
   clientId: string;
 }
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Static map from PlanPhotoCategory to i18n key.
+ * Dynamic key construction (`t(\`…${category}\`)`) is intentionally avoided so
+ * i18next-parser can extract all keys statically, and a future enum rename
+ * won't silently break translations.
+ */
+const CATEGORY_LABEL_KEY: Record<PlanPhotoCategory, string> = {
+  [PlanPhotoCategory.Food]: 'clientDetail.photos.categoryFood',
+  [PlanPhotoCategory.Body]: 'clientDetail.photos.categoryBody',
+  [PlanPhotoCategory.FreeForm]: 'clientDetail.photos.categoryFreeForm',
+};
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /** Format a YYYY-MM key as a localised month+year label. */
@@ -46,9 +60,9 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
   const locale = i18n.language === 'de' ? 'de-DE' : i18n.language === 'en' ? 'en-GB' : 'cs-CZ';
 
   // ── Filter state ────────────────────────────────────────────────────────────
-  // Both reset when clientId changes via `key` prop on the parent or here via
-  // explicit reset in an effect — but the simplest approach is to store filters
-  // in a sub-object keyed to clientId so stale state is never visible.
+  // Filters are local state. The component unmounts when the user switches away
+  // from the Photos tab on ClientDetailPage, so a different client mounts a
+  // fresh instance with cleared filters — no explicit reset is required.
   const [selectedCategory, setSelectedCategory] = useState<PlanPhotoCategory | ''>('');
   const [selectedPlanId, setSelectedPlanId] = useState<string>('');
 
@@ -64,12 +78,14 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
   );
 
   // ── Fetch photos ─────────────────────────────────────────────────────────────
+  // selectedPlanId is intentionally absent from queryKey — plan filtering is
+  // applied client-side (see groups memo below); the fetch only depends on
+  // clientId and category.
   const { data: photosData, isLoading: photosLoading } = useQuery({
     queryKey: [
       'client-photos',
       clientId,
       selectedCategory || null,
-      selectedPlanId || null,
     ],
     queryFn: () =>
       getClientPhotoGroups({
@@ -225,7 +241,7 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
                       {/* Category badge */}
                       {photo.category && (
                         <span className="absolute bottom-1 left-1 rounded px-1 py-0.5 text-[9px] font-medium bg-black/50 text-white">
-                          {t(`clientDetail.photos.category${photo.category}`)}
+                          {t(CATEGORY_LABEL_KEY[photo.category])}
                         </span>
                       )}
                     </button>
@@ -248,7 +264,7 @@ export function ClientPhotosTimeline({ clientId }: ClientPhotosTimelineProps) {
                       {/* Category badge */}
                       {photo.category && (
                         <span className="absolute bottom-1 left-1 rounded px-1 py-0.5 text-[9px] font-medium bg-black/50 text-white">
-                          {t(`clientDetail.photos.category${photo.category}`)}
+                          {t(CATEGORY_LABEL_KEY[photo.category])}
                         </span>
                       )}
                     </div>

--- a/web/src/components/photos/PlanPhotosTab.tsx
+++ b/web/src/components/photos/PlanPhotosTab.tsx
@@ -1,5 +1,5 @@
 /**
- * PlanPhotosTab — Photos tab for the NutritionPlanPage.
+ * PlanPhotosTab — Photos tab shared by NutritionPlanPage and TrainingPlanPage.
  *
  * Shows a category chip row (Food / Body / FreeForm) and a 3-column thumbnail
  * grid loaded via TanStack Query. Clicking a thumbnail opens the ImageLightbox.

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/lib/cn';
 import { type MealKind } from '@/components/nutrition/meal-kind';
 import { DayNoteInput } from '@/components/common/DayNoteInput';
 import { CheckInBanner } from '@/components/weekly-checkin/CheckInBanner';
-import { PlanPhotosTab } from '@/components/nutrition/PlanPhotosTab';
+import { PlanPhotosTab } from '@/components/photos/PlanPhotosTab';
 
 export default function NutritionPlanPage() {
   const { t, i18n } = useTranslation();

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -19,7 +19,7 @@ import { TrainingSidebar } from '@/components/training/TrainingSidebar';
 import { cn } from '@/lib/cn';
 import { DayNoteInput } from '@/components/common/DayNoteInput';
 import { CheckInBanner } from '@/components/weekly-checkin/CheckInBanner';
-import { PlanPhotosTab } from '@/components/nutrition/PlanPhotosTab';
+import { PlanPhotosTab } from '@/components/photos/PlanPhotosTab';
 import { DAY_KEYS, MUSCLE_ICONS, MUSCLE_COLORS } from '@/constants/training';
 import { SessionDragWrapper } from '@/components/training/SessionDragWrapper';
 import { ExerciseDropZone } from '@/components/training/ExerciseDropZone';


### PR DESCRIPTION
## Summary
- Cleans up review NITs flagged during the Epic #66 (Plan-scoped photo timeline) merge cycle. No behaviour changes — all polish.

## Scope

### Web (#85, #86 follow-ups)
- Remove unused `deletePlanPhoto` export from `web/src/api/photos.ts`.
- Move `PlanPhotosTab` from `components/nutrition/` to `components/photos/` (it's consumed by both `NutritionPlanPage` and `TrainingPlanPage`).
- `ClientPhotosTimeline`: rewrite the misleading filter-reset comment, drop the client-side `selectedPlanId` from the TanStack `queryKey`, and replace the dynamic `t(`clientDetail.photos.category${enum}`)` call with a static `CATEGORY_LABEL_KEY` map (i18next-parser–visible, future-rename-safe).

### Mobile (#87, #89 follow-ups)
- Remove dead `UI_TO_WIRE` constant from `plan-photos.tsx` (filtering is client-side via `WIRE_TO_UI` only).
- Fix per-tile `accessibilityLabel` on `plan-photos.tsx` so screen readers announce the actual category instead of always saying "Food".
- Move `OUTER_MARGIN` to module scope on `profile-photos.tsx` and drop it from the `renderItem` `useCallback` deps array.
- Replace `borderRadius: 99` on the profile-photos chip with `Radius.full`.

## Test plan
- [x] web: `npm run build` 0 errors
- [x] web: `npm run lint` 0 errors (14 pre-existing warnings on untouched files)
- [x] mobile: `npx tsc --noEmit` 0 errors
- [x] i18n keys (`planPhotos.categoryFood/Progress/Free`) verified present in cs/en/de
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)