### PR TITLE
fix: forward planId when opening photo gallery from Today screen

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -821,8 +821,9 @@ export function HasTrainerState() {
 
   /** Navigate to the plan-photos gallery screen. */
   const handlePhotoGridPress = useCallback(() => {
-    router.push(href('/(client)/plan-photos'))
-  }, [router])
+    if (!plan?.planId) return
+    router.push(hrefParams('/(client)/plan-photos', { planId: plan.planId }))
+  }, [router, plan?.planId])
 
   /** Navigate to the meal-log-photo modal screen for the tapped meal. */
   const handlePhotoPress = useCallback(


### PR DESCRIPTION
## Summary
- Today-screen photo-grid CTA navigated to `/(client)/plan-photos` without forwarding `planId`, causing the destination screen to render with 0 photos and a permanently-disabled FAB.
- Root cause: `handlePhotoGridPress` in `HasTrainerState.tsx` called `href('/(client)/plan-photos')` instead of `hrefParams('/(client)/plan-photos', { planId: plan.planId })`.
- Fix adds a `plan?.planId` guard (early return if missing) and passes the param via `hrefParams`, which was already imported and used for adjacent meal-log-photo navigation.
- Brings the Today-screen CTA into parity with the plan-detail entry point at `app/(client)/(tabs)/plans/[planId].tsx:758`, which already passed `planId` correctly.

## Related issue
Fixes #145

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS. ACs #1, #4, #5 confirmed via static + git-diff inspection. AC #2 confirmed via live API probe — `GET /client/plans/<id>/photos` returned 3 photo records (Body / Food / FreeForm split), with `Access-Control-Allow-Origin: http://localhost:8081` proving the dev CORS fix is loaded. AC #3 confirmed via static analysis — FAB `disabled` expression is `isUploading || !planId`, both false post-fix, so the FAB is enabled; expo-image-picker integration unchanged from already-shipped code. Playwright browser backend was unavailable for click-through, but the data and code paths are mechanically proven.

## Test plan
- [ ] Tapping the Today-screen photo-grid CTA opens `/(client)/plan-photos` with the active nutrition plan's `planId` (read from `planQuery.data.planId`, the same source used elsewhere in `HasTrainerState`).
- [ ] The plan-photos screen renders existing photos for that plan (counts in the chips reflect reality, the 3-column grid loads).
- [ ] The "+" FAB launches the multi-photo picker, uploads work, and the grid refreshes after upload (SignalR `planphotouploaded` event already wired).
- [ ] If `plan.planId` is somehow missing (no active plan), the CTA either is hidden or no-ops cleanly — no navigation to a broken state.
- [ ] No TypeScript regressions: `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)