### PR TITLE
feat(backend,#90): PhotoDiaryRequest entity + migration

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Entities/PhotoDiaryRequest.cs
+++ b/backend/FitnessPlatform.Application/Domain/Entities/PhotoDiaryRequest.cs
@@ -1,0 +1,122 @@
+using System.ComponentModel.DataAnnotations;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Entities;
+
+/// <summary>
+/// Tracks the lifecycle of a nutritionist's request for a client to submit food-diary photos.
+/// A request is either attached to an existing client-professional link (<see cref="LinkId"/>)
+/// or bundled with a pending invite (<see cref="PendingInviteId"/>); exactly one must be set.
+/// </summary>
+/// <remarks>
+/// Invariants enforced via PostgreSQL CHECK constraints (see <c>PhotoDiaryRequestConfiguration</c>):
+/// <list type="bullet">
+///   <item>Exactly one of <see cref="LinkId"/> / <see cref="PendingInviteId"/> is non-null (XOR).</item>
+///   <item><see cref="Mode"/> is non-null if and only if <see cref="Status"/> is
+///     <see cref="PhotoDiaryStatus.Accepted"/>, <see cref="PhotoDiaryStatus.InProgress"/>,
+///     or <see cref="PhotoDiaryStatus.Completed"/>.</item>
+///   <item><see cref="DismissReason"/> is non-null only when <see cref="Status"/> is
+///     <see cref="PhotoDiaryStatus.Dismissed"/>.</item>
+///   <item><see cref="AcceptedAt"/> is non-null if and only if <see cref="Status"/> is
+///     <see cref="PhotoDiaryStatus.Accepted"/>, <see cref="PhotoDiaryStatus.InProgress"/>,
+///     or <see cref="PhotoDiaryStatus.Completed"/>.</item>
+///   <item><see cref="CompletedAt"/> is non-null if and only if <see cref="Status"/> is
+///     <see cref="PhotoDiaryStatus.Completed"/>.</item>
+///   <item><see cref="DurationDays"/> is between 1 and 30.</item>
+/// </list>
+/// </remarks>
+public class PhotoDiaryRequest
+{
+    /// <summary>
+    /// Primary key — a client-generated or server-generated GUID.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Foreign key to the <see cref="ApplicationUser"/> (nutritionist) who created the request.
+    /// </summary>
+    public Guid ProfessionalId { get; set; }
+
+    /// <summary>
+    /// Foreign key to the <see cref="ClientProfessionalLink"/> this request is attached to.
+    /// Mutually exclusive with <see cref="PendingInviteId"/>; exactly one must be set.
+    /// </summary>
+    public long? LinkId { get; set; }
+
+    /// <summary>
+    /// Foreign key to the <see cref="PendingInvite"/> this request is bundled with.
+    /// Mutually exclusive with <see cref="LinkId"/>; exactly one must be set.
+    /// </summary>
+    public long? PendingInviteId { get; set; }
+
+    /// <summary>
+    /// The MongoDB external identifier of the nutrition plan this request is scoped to.
+    /// Nullable — a request may exist without a specific plan context.
+    /// No FK constraint because the plan lives in MongoDB.
+    /// </summary>
+    public Guid? PlanId { get; set; }
+
+    /// <summary>
+    /// How many days the client has to upload photos in Workflow mode (default 7).
+    /// Must be between 1 and 30 (enforced by CHECK constraint).
+    /// </summary>
+    public int DurationDays { get; set; } = 7;
+
+    /// <summary>
+    /// The upload mode chosen by the client on accept.
+    /// Null until the request is accepted (i.e. while <see cref="Status"/> is
+    /// <see cref="PhotoDiaryStatus.Pending"/> or <see cref="PhotoDiaryStatus.Dismissed"/>).
+    /// </summary>
+    public PhotoDiaryMode? Mode { get; set; }
+
+    /// <summary>
+    /// Current lifecycle status of the request.
+    /// </summary>
+    public PhotoDiaryStatus Status { get; set; } = PhotoDiaryStatus.Pending;
+
+    /// <summary>
+    /// Optional reason provided by the client when dismissing the request (max 500 chars).
+    /// Non-null only when <see cref="Status"/> is <see cref="PhotoDiaryStatus.Dismissed"/>.
+    /// </summary>
+    [MaxLength(500)]
+    public string? DismissReason { get; set; }
+
+    /// <summary>
+    /// Timestamp when the client accepted the request.
+    /// Non-null iff <see cref="Status"/> ∈ {Accepted, InProgress, Completed}.
+    /// </summary>
+    public DateTimeOffset? AcceptedAt { get; set; }
+
+    /// <summary>
+    /// Timestamp when the client submitted / finalized the diary.
+    /// Non-null iff <see cref="Status"/> is <see cref="PhotoDiaryStatus.Completed"/>.
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    /// <summary>
+    /// Audit timestamp — when the request record was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Audit timestamp — when the request record was last updated.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    // ── Navigation properties ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Navigation property to the nutritionist user.
+    /// </summary>
+    public ApplicationUser Professional { get; set; } = null!;
+
+    /// <summary>
+    /// Navigation property to the client-professional link (when <see cref="LinkId"/> is set).
+    /// </summary>
+    public ClientProfessionalLink? Link { get; set; }
+
+    /// <summary>
+    /// Navigation property to the pending invite (when <see cref="PendingInviteId"/> is set).
+    /// </summary>
+    public PendingInvite? PendingInvite { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/PhotoDiaryMode.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/PhotoDiaryMode.cs
@@ -1,0 +1,18 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// The mode a client chooses when accepting a photo diary request.
+/// </summary>
+public enum PhotoDiaryMode
+{
+    /// <summary>
+    /// Client uploads all photos at once and submits as a batch.
+    /// </summary>
+    Bulk = 1,
+
+    /// <summary>
+    /// Client uploads photos day-by-day over a defined window; the nutritionist
+    /// sees photos as they arrive and the client finalises on day N.
+    /// </summary>
+    Workflow = 2,
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/PhotoDiaryStatus.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/PhotoDiaryStatus.cs
@@ -1,0 +1,32 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Lifecycle status of a <see cref="FitnessPlatform.Application.Domain.Entities.PhotoDiaryRequest"/>.
+/// </summary>
+public enum PhotoDiaryStatus
+{
+    /// <summary>
+    /// The request has been sent by the nutritionist and is awaiting client action.
+    /// </summary>
+    Pending = 1,
+
+    /// <summary>
+    /// The client has accepted the request and chosen a mode (Bulk or Workflow).
+    /// </summary>
+    Accepted = 2,
+
+    /// <summary>
+    /// The client dismissed the request (optionally with a reason).
+    /// </summary>
+    Dismissed = 3,
+
+    /// <summary>
+    /// The client is actively uploading photos (Workflow mode only; set after first upload).
+    /// </summary>
+    InProgress = 4,
+
+    /// <summary>
+    /// The client has submitted / finalized the diary.
+    /// </summary>
+    Completed = 5,
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
@@ -125,6 +125,11 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     /// </summary>
     public virtual DbSet<WeeklyCheckIn> WeeklyCheckIns { get; set; } = null!;
 
+    /// <summary>
+    /// Photo diary requests sent by nutritionists to clients.
+    /// </summary>
+    public virtual DbSet<PhotoDiaryRequest> PhotoDiaryRequests { get; set; } = null!;
+
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Configurations/PhotoDiaryRequestConfiguration.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Configurations/PhotoDiaryRequestConfiguration.cs
@@ -1,0 +1,111 @@
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitnessPlatform.Application.Infrastructure.Data.Configurations;
+
+/// <summary>
+/// EF Core configuration for <see cref="PhotoDiaryRequest"/>.
+/// Defines the table mapping, FK relationships, indexes, and CHECK constraints
+/// that enforce the entity's invariants at the database level.
+/// </summary>
+public class PhotoDiaryRequestConfiguration : IEntityTypeConfiguration<PhotoDiaryRequest>
+{
+    // Numeric values of the status enum used in the SQL CHECK expressions.
+    // Keep in sync with PhotoDiaryStatus.
+    private const int StatusAccepted = (int)PhotoDiaryStatus.Accepted;
+    private const int StatusDismissed = (int)PhotoDiaryStatus.Dismissed;
+    private const int StatusInProgress = (int)PhotoDiaryStatus.InProgress;
+    private const int StatusCompleted = (int)PhotoDiaryStatus.Completed;
+
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<PhotoDiaryRequest> builder)
+    {
+        builder.ToTable("photo_diary_requests");
+
+        builder.HasKey(r => r.Id);
+        builder.Property(r => r.Id).ValueGeneratedNever();
+
+        // ── enum columns stored as integers ──────────────────────────────────
+        builder.Property(r => r.Status)
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(r => r.Mode)
+            .HasConversion<int?>();
+
+        // ── DismissReason max-length (also enforced via data annotation) ─────
+        builder.Property(r => r.DismissReason)
+            .HasMaxLength(500);
+
+        // ── FK: ProfessionalId → users.id ────────────────────────────────────
+        builder.HasOne(r => r.Professional)
+            .WithMany()
+            .HasForeignKey(r => r.ProfessionalId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // ── FK: LinkId → client_professional_links.id (nullable) ────────────
+        builder.HasOne(r => r.Link)
+            .WithMany()
+            .HasForeignKey(r => r.LinkId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(false);
+
+        // ── FK: PendingInviteId → pending_invites.id (nullable) ─────────────
+        builder.HasOne(r => r.PendingInvite)
+            .WithMany()
+            .HasForeignKey(r => r.PendingInviteId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(false);
+
+        // ── Indexes ───────────────────────────────────────────────────────────
+        // Trainer's "my pending diary requests" list
+        builder.HasIndex(r => new { r.ProfessionalId, r.Status })
+            .HasDatabaseName("ix_photo_diary_requests_professional_status");
+
+        // Client's pending diary requests via link
+        builder.HasIndex(r => r.LinkId)
+            .HasDatabaseName("ix_photo_diary_requests_link_id");
+
+        // Client's pending diary requests via invite
+        builder.HasIndex(r => r.PendingInviteId)
+            .HasDatabaseName("ix_photo_diary_requests_pending_invite_id");
+
+        // ── CHECK constraints (invariants) ────────────────────────────────────
+
+        // 1. Exactly one of LinkId / PendingInviteId is set (XOR).
+        builder.ToTable(t => t.HasCheckConstraint(
+            "ck_photo_diary_requests_link_xor_invite",
+            "(link_id IS NOT NULL AND pending_invite_id IS NULL) OR " +
+            "(link_id IS NULL AND pending_invite_id IS NOT NULL)"));
+
+        // 2. Mode is non-null iff Status ∈ {Accepted, InProgress, Completed}.
+        builder.ToTable(t => t.HasCheckConstraint(
+            "ck_photo_diary_requests_mode_with_accepted_status",
+            $"(status IN ({StatusAccepted},{StatusInProgress},{StatusCompleted}) AND mode IS NOT NULL) OR " +
+            $"(status NOT IN ({StatusAccepted},{StatusInProgress},{StatusCompleted}) AND mode IS NULL)"));
+
+        // 3. DismissReason is non-null only when Status = Dismissed.
+        builder.ToTable(t => t.HasCheckConstraint(
+            "ck_photo_diary_requests_dismiss_reason_only_when_dismissed",
+            $"(status = {StatusDismissed} OR dismiss_reason IS NULL)"));
+
+        // 4. AcceptedAt is non-null iff Status ∈ {Accepted, InProgress, Completed}.
+        builder.ToTable(t => t.HasCheckConstraint(
+            "ck_photo_diary_requests_accepted_at_with_accepted_status",
+            $"(status IN ({StatusAccepted},{StatusInProgress},{StatusCompleted}) AND accepted_at IS NOT NULL) OR " +
+            $"(status NOT IN ({StatusAccepted},{StatusInProgress},{StatusCompleted}) AND accepted_at IS NULL)"));
+
+        // 5. CompletedAt is non-null iff Status = Completed.
+        builder.ToTable(t => t.HasCheckConstraint(
+            "ck_photo_diary_requests_completed_at_only_when_completed",
+            $"(status = {StatusCompleted} AND completed_at IS NOT NULL) OR " +
+            $"(status != {StatusCompleted} AND completed_at IS NULL)"));
+
+        // 6. DurationDays between 1 and 30.
+        builder.ToTable(t => t.HasCheckConstraint(
+            "ck_photo_diary_requests_duration_days_range",
+            "duration_days >= 1 AND duration_days <= 30"));
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
@@ -130,6 +130,11 @@ public interface IApplicationDbContext
     DbSet<WeeklyCheckIn> WeeklyCheckIns { get; set; }
 
     /// <summary>
+    /// Photo diary requests sent by nutritionists to clients.
+    /// </summary>
+    DbSet<PhotoDiaryRequest> PhotoDiaryRequests { get; set; }
+
+    /// <summary>
     /// Saves all changes made in this context to the database.
     /// </summary>
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428171601_AddPhotoDiaryRequest.Designer.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428171601_AddPhotoDiaryRequest.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428171601_AddPhotoDiaryRequest")]
+    partial class AddPhotoDiaryRequest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428171601_AddPhotoDiaryRequest.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428171601_AddPhotoDiaryRequest.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhotoDiaryRequest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "photo_diary_requests",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    professional_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    link_id = table.Column<long>(type: "bigint", nullable: true),
+                    pending_invite_id = table.Column<long>(type: "bigint", nullable: true),
+                    plan_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    duration_days = table.Column<int>(type: "integer", nullable: false),
+                    mode = table.Column<int>(type: "integer", nullable: true),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    dismiss_reason = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    accepted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    completed_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_photo_diary_requests", x => x.id);
+                    table.CheckConstraint("ck_photo_diary_requests_accepted_at_with_accepted_status", "(status IN (2,4,5) AND accepted_at IS NOT NULL) OR (status NOT IN (2,4,5) AND accepted_at IS NULL)");
+                    table.CheckConstraint("ck_photo_diary_requests_completed_at_only_when_completed", "(status = 5 AND completed_at IS NOT NULL) OR (status != 5 AND completed_at IS NULL)");
+                    table.CheckConstraint("ck_photo_diary_requests_dismiss_reason_only_when_dismissed", "(status = 3 OR dismiss_reason IS NULL)");
+                    table.CheckConstraint("ck_photo_diary_requests_duration_days_range", "duration_days >= 1 AND duration_days <= 30");
+                    table.CheckConstraint("ck_photo_diary_requests_link_xor_invite", "(link_id IS NOT NULL AND pending_invite_id IS NULL) OR (link_id IS NULL AND pending_invite_id IS NOT NULL)");
+                    table.CheckConstraint("ck_photo_diary_requests_mode_with_accepted_status", "(status IN (2,4,5) AND mode IS NOT NULL) OR (status NOT IN (2,4,5) AND mode IS NULL)");
+                    table.ForeignKey(
+                        name: "fk_photo_diary_requests_client_professional_links_link_id",
+                        column: x => x.link_id,
+                        principalTable: "client_professional_links",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_photo_diary_requests_pending_invites_pending_invite_id",
+                        column: x => x.pending_invite_id,
+                        principalTable: "pending_invites",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_photo_diary_requests_users_professional_id",
+                        column: x => x.professional_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_photo_diary_requests_link_id",
+                table: "photo_diary_requests",
+                column: "link_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_photo_diary_requests_pending_invite_id",
+                table: "photo_diary_requests",
+                column: "pending_invite_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_photo_diary_requests_professional_status",
+                table: "photo_diary_requests",
+                columns: new[] { "professional_id", "status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "photo_diary_requests");
+        }
+    }
+}

--- a/backend/FitnessPlatform.Tests/Domain/PhotoDiaryRequestTests.cs
+++ b/backend/FitnessPlatform.Tests/Domain/PhotoDiaryRequestTests.cs
@@ -1,0 +1,581 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace FitnessPlatform.Tests.Domain;
+
+/// <summary>
+/// Testcontainers integration tests for the <see cref="PhotoDiaryRequest"/> entity.
+/// Covers:
+/// <list type="bullet">
+///   <item>Insert with correct defaults and round-trip read-back.</item>
+///   <item>CHECK constraint violations rejected by Postgres.</item>
+///   <item>Status transition roundtrip: Pending → Accepted → InProgress → Completed.</item>
+///   <item>Dismissed path with reason.</item>
+/// </list>
+/// </summary>
+public class PhotoDiaryRequestTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16")
+        .Build();
+
+    private ApplicationDbContext _db = null!;
+
+    // ── Lifecycle ────────────────────────────────────────────────────────────
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.StartAsync();
+        _db = BuildContext(_postgres.GetConnectionString());
+        await _db.Database.MigrateAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await _postgres.DisposeAsync();
+    }
+
+    // ── Context factory ──────────────────────────────────────────────────────
+
+    private static ApplicationDbContext BuildContext(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(connectionString)
+            .UseSnakeCaseNamingConvention()
+            .ConfigureWarnings(w =>
+                w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private async Task RebuildContextAsync()
+    {
+        await _db.DisposeAsync();
+        _db = BuildContext(_postgres.GetConnectionString());
+    }
+
+    // ── Seed helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>Creates a minimal ApplicationUser row directly via SQL (bypasses Identity).</summary>
+    private async Task<Guid> CreateUserAsync()
+    {
+        var userId = Guid.NewGuid();
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO users (
+                id, user_name, normalized_user_name,
+                email, normalized_email, email_confirmed,
+                password_hash, security_stamp, concurrency_stamp,
+                phone_number_confirmed, two_factor_enabled,
+                lockout_enabled, access_failed_count,
+                first_name, last_name, is_active, date_created,
+                gdpr_consent, verification_emails_sent, time_zone
+            ) VALUES (
+                @id, @email, @emailUpper,
+                @email, @emailUpper, true,
+                '', gen_random_uuid()::text, gen_random_uuid()::text,
+                false, false,
+                true, 0,
+                'Test', 'User', true, now(),
+                true, 0, 'Europe/Prague'
+            )";
+        cmd.Parameters.AddWithValue("id", userId);
+        cmd.Parameters.AddWithValue("email", $"{userId:N}@diary-test.com");
+        cmd.Parameters.AddWithValue("emailUpper", $"{userId:N}@DIARY-TEST.COM");
+        await cmd.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        return userId;
+    }
+
+    /// <summary>Creates a ProfessionalProfile row and returns its internal id.</summary>
+    private async Task<long> CreateProfessionalProfileAsync(Guid userId)
+    {
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO professional_profiles
+                (user_id, public_id, date_created)
+            VALUES
+                (@userId, @publicId, now())
+            RETURNING id";
+        cmd.Parameters.AddWithValue("userId", userId);
+        cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+        return (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    /// <summary>Creates a ClientProfile row and returns its internal id.</summary>
+    private async Task<long> CreateClientProfileAsync(Guid userId)
+    {
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO client_profiles
+                (user_id, public_id, date_created, is_onboarding_complete)
+            VALUES
+                (@userId, @publicId, now(), false)
+            RETURNING id";
+        cmd.Parameters.AddWithValue("userId", userId);
+        cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+        return (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    /// <summary>Creates a ClientProfessionalLink and returns its internal id.</summary>
+    private async Task<long> CreateLinkAsync(long clientProfileId, long professionalProfileId)
+    {
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        // professional_role is stored as integer: Nutritionist = 2
+        cmd.CommandText = @"
+            INSERT INTO client_professional_links
+                (client_profile_id, professional_profile_id, professional_role,
+                 is_active, can_view_nutrition_plans, can_view_training_plans,
+                 public_id, date_created)
+            VALUES
+                (@clientProfileId, @professionalProfileId, 2,
+                 true, true, false,
+                 @publicId, now())
+            RETURNING id";
+        cmd.Parameters.AddWithValue("clientProfileId", clientProfileId);
+        cmd.Parameters.AddWithValue("professionalProfileId", professionalProfileId);
+        cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+        return (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    /// <summary>Creates a PendingInvite row and returns its internal id.</summary>
+    private async Task<long> CreatePendingInviteAsync(long professionalProfileId)
+    {
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(TestContext.Current.CancellationToken);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO pending_invites
+                (professional_profile_id, first_name, last_name, email,
+                 sent_at, is_accepted, public_id, date_created)
+            VALUES
+                (@professionalProfileId, 'Jane', 'Doe', @email,
+                 now(), false, @publicId, now())
+            RETURNING id";
+        cmd.Parameters.AddWithValue("professionalProfileId", professionalProfileId);
+        cmd.Parameters.AddWithValue("email", $"{Guid.NewGuid():N}@invite-test.com");
+        cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+        return (long)(await cmd.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    // ── Helper: insert a valid pending request directly via EF ───────────────
+
+    private async Task<(Guid requestId, Guid professionalUserId, long linkId)>
+        CreatePendingRequestViaLinkAsync()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var requestId = Guid.NewGuid();
+        var request = new PhotoDiaryRequest
+        {
+            Id = requestId,
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            PendingInviteId = null,
+            DurationDays = 7,
+            Status = PhotoDiaryStatus.Pending,
+            Mode = null,
+            DismissReason = null,
+            AcceptedAt = null,
+            CompletedAt = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+        await _db.SaveChangesAsync(ct);
+
+        return (requestId, profUserId, linkId);
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Insert_PendingRequest_ReadsBackWithCorrectDefaults()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (requestId, _, _) = await CreatePendingRequestViaLinkAsync();
+
+        await RebuildContextAsync();
+
+        var loaded = await _db.PhotoDiaryRequests
+            .AsNoTracking()
+            .SingleAsync(r => r.Id == requestId, ct);
+
+        loaded.Status.Should().Be(PhotoDiaryStatus.Pending);
+        loaded.DurationDays.Should().Be(7);
+        loaded.Mode.Should().BeNull("mode is not set on a pending request");
+        loaded.DismissReason.Should().BeNull();
+        loaded.AcceptedAt.Should().BeNull();
+        loaded.CompletedAt.Should().BeNull();
+        loaded.PendingInviteId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckConstraint_BothLinkAndInvite_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+        var inviteId = await CreatePendingInviteAsync(profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            PendingInviteId = inviteId, // Both set — violates XOR constraint
+            Status = PhotoDiaryStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "setting both LinkId and PendingInviteId violates ck_photo_diary_requests_link_xor_invite");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_NeitherLinkNorInvite_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        await CreateProfessionalProfileAsync(profUserId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = null,
+            PendingInviteId = null, // Neither set — violates XOR constraint
+            Status = PhotoDiaryStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "setting neither LinkId nor PendingInviteId violates ck_photo_diary_requests_link_xor_invite");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_AcceptedStatus_RequiresMode()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            Status = PhotoDiaryStatus.Accepted,
+            Mode = null, // Accepted without Mode — violates constraint
+            AcceptedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "Accepted status without Mode violates ck_photo_diary_requests_mode_with_accepted_status");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_PendingStatus_WithMode_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            Status = PhotoDiaryStatus.Pending,
+            Mode = PhotoDiaryMode.Bulk, // Mode set on Pending — violates constraint
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "Mode set while Status=Pending violates ck_photo_diary_requests_mode_with_accepted_status");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_DismissReason_WithoutDismissedStatus_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            Status = PhotoDiaryStatus.Pending,
+            Mode = null,
+            DismissReason = "Not interested", // DismissReason on Pending — violates constraint
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "DismissReason on Pending status violates ck_photo_diary_requests_dismiss_reason_only_when_dismissed");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_AcceptedAtWithoutAcceptedStatus_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            Status = PhotoDiaryStatus.Pending,
+            Mode = null,
+            AcceptedAt = DateTimeOffset.UtcNow, // AcceptedAt set on Pending — violates constraint
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "AcceptedAt set on Pending status violates ck_photo_diary_requests_accepted_at_with_accepted_status");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_CompletedAtWithoutCompletedStatus_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            Status = PhotoDiaryStatus.Accepted,
+            Mode = PhotoDiaryMode.Workflow,
+            AcceptedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow, // CompletedAt on Accepted — violates constraint
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "CompletedAt set on Accepted status violates ck_photo_diary_requests_completed_at_only_when_completed");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_DurationDays_OutOfRange_Rejected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var clientUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var clientProfileId = await CreateClientProfileAsync(clientUserId);
+        var linkId = await CreateLinkAsync(clientProfileId, profProfileId);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            Status = PhotoDiaryStatus.Pending,
+            DurationDays = 31, // Out of range — violates ck_photo_diary_requests_duration_days_range
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+
+        var act = async () => await _db.SaveChangesAsync(ct);
+        await act.Should().ThrowAsync<Exception>(
+            "DurationDays=31 violates ck_photo_diary_requests_duration_days_range");
+    }
+
+    [Fact]
+    public async Task StatusTransition_Pending_Accepted_InProgress_Completed_RoundTrip()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (requestId, _, _) = await CreatePendingRequestViaLinkAsync();
+
+        // ── Accept ────────────────────────────────────────────────────────────
+        var acceptedAt = DateTimeOffset.UtcNow;
+        var request = await _db.PhotoDiaryRequests.SingleAsync(r => r.Id == requestId, ct);
+        request.Status = PhotoDiaryStatus.Accepted;
+        request.Mode = PhotoDiaryMode.Workflow;
+        request.AcceptedAt = acceptedAt;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+        await _db.SaveChangesAsync(ct);
+
+        await RebuildContextAsync();
+        var accepted = await _db.PhotoDiaryRequests.AsNoTracking()
+            .SingleAsync(r => r.Id == requestId, ct);
+        accepted.Status.Should().Be(PhotoDiaryStatus.Accepted);
+        accepted.Mode.Should().Be(PhotoDiaryMode.Workflow);
+        accepted.AcceptedAt.Should().BeCloseTo(acceptedAt, TimeSpan.FromSeconds(1));
+        accepted.CompletedAt.Should().BeNull();
+
+        // ── Transition to InProgress ──────────────────────────────────────────
+        request = await _db.PhotoDiaryRequests.SingleAsync(r => r.Id == requestId, ct);
+        request.Status = PhotoDiaryStatus.InProgress;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+        await _db.SaveChangesAsync(ct);
+
+        await RebuildContextAsync();
+        var inProgress = await _db.PhotoDiaryRequests.AsNoTracking()
+            .SingleAsync(r => r.Id == requestId, ct);
+        inProgress.Status.Should().Be(PhotoDiaryStatus.InProgress);
+        inProgress.Mode.Should().Be(PhotoDiaryMode.Workflow, "mode must persist across status transitions");
+        inProgress.AcceptedAt.Should().NotBeNull();
+        inProgress.CompletedAt.Should().BeNull();
+
+        // ── Complete ──────────────────────────────────────────────────────────
+        var completedAt = DateTimeOffset.UtcNow;
+        request = await _db.PhotoDiaryRequests.SingleAsync(r => r.Id == requestId, ct);
+        request.Status = PhotoDiaryStatus.Completed;
+        request.CompletedAt = completedAt;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+        await _db.SaveChangesAsync(ct);
+
+        await RebuildContextAsync();
+        var completed = await _db.PhotoDiaryRequests.AsNoTracking()
+            .SingleAsync(r => r.Id == requestId, ct);
+        completed.Status.Should().Be(PhotoDiaryStatus.Completed);
+        completed.Mode.Should().Be(PhotoDiaryMode.Workflow);
+        completed.AcceptedAt.Should().NotBeNull();
+        completed.CompletedAt.Should().BeCloseTo(completedAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task StatusTransition_Pending_Dismissed_WithReason_Persists()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (requestId, _, _) = await CreatePendingRequestViaLinkAsync();
+
+        const string reason = "I prefer not to share photos right now.";
+
+        var request = await _db.PhotoDiaryRequests.SingleAsync(r => r.Id == requestId, ct);
+        request.Status = PhotoDiaryStatus.Dismissed;
+        request.DismissReason = reason;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+        await _db.SaveChangesAsync(ct);
+
+        await RebuildContextAsync();
+        var dismissed = await _db.PhotoDiaryRequests.AsNoTracking()
+            .SingleAsync(r => r.Id == requestId, ct);
+        dismissed.Status.Should().Be(PhotoDiaryStatus.Dismissed);
+        dismissed.DismissReason.Should().Be(reason);
+        dismissed.Mode.Should().BeNull("mode is not set when dismissed");
+        dismissed.AcceptedAt.Should().BeNull();
+        dismissed.CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Insert_ViaInvite_ReadsBackWithCorrectLinkFields()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var profUserId = await CreateUserAsync();
+        var profProfileId = await CreateProfessionalProfileAsync(profUserId);
+        var inviteId = await CreatePendingInviteAsync(profProfileId);
+
+        var requestId = Guid.NewGuid();
+        var request = new PhotoDiaryRequest
+        {
+            Id = requestId,
+            ProfessionalId = profUserId,
+            LinkId = null,
+            PendingInviteId = inviteId,
+            DurationDays = 14,
+            Status = PhotoDiaryStatus.Pending,
+            Mode = null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.PhotoDiaryRequests.Add(request);
+        await _db.SaveChangesAsync(ct);
+
+        await RebuildContextAsync();
+
+        var loaded = await _db.PhotoDiaryRequests.AsNoTracking()
+            .SingleAsync(r => r.Id == requestId, ct);
+
+        loaded.PendingInviteId.Should().Be(inviteId);
+        loaded.LinkId.Should().BeNull();
+        loaded.DurationDays.Should().Be(14);
+        loaded.Status.Should().Be(PhotoDiaryStatus.Pending);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces the `PhotoDiaryRequest` EF Core entity that tracks the full lifecycle of a nutritionist's request for a client to submit food-diary photos.
- Adds two supporting enums: `PhotoDiaryStatus` (Pending/Accepted/Dismissed/InProgress/Completed) and `PhotoDiaryMode` (Bulk/Workflow), both stored as integers.
- Wires `PhotoDiaryRequestConfiguration` (IEntityTypeConfiguration) with 6 CHECK constraints enforcing all domain invariants at the database level (XOR link/invite, mode-with-accepted-status, dismiss-reason-when-dismissed, accepted-at-with-accepted-status, completed-at-when-completed, duration-days 1–30).
- EF Core migration `20260428171601_AddPhotoDiaryRequest.cs` creates the `photo_diary_requests` table with all FKs, indexes, and CHECK constraints.

## Related issue

Fixes #90

## Parent epic (sub-issue PR)

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — 12 Testcontainers tests green; CHECK constraint violations confirmed rejected by Postgres; full status transition roundtrip (Pending → Accepted → InProgress → Completed) verified.

## Test plan

- [x] Invariants enforced via Postgres CHECK constraints (no Value Object).
- [x] Testcontainers coverage: insert roundtrip, all 6 CHECK constraint violation cases, status transition cycle (Pending → Accepted → InProgress → Completed), dismissed path with reason, via-invite variant.

## Migration

`20260428171601_AddPhotoDiaryRequest.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)