### PR TITLE
feat(backend,#91): photo diary REST endpoints

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -190,6 +190,25 @@ public static class ErrorCodes
     /// </summary>
     public const string InvalidImageSubPath = "INVALID_IMAGE_SUB_PATH";
 
+    // ── Photo Diary Requests ─────────────────────────────────────────
+    /// <summary>Photo diary request not found or does not belong to the caller.</summary>
+    public const string PhotoDiaryRequestNotFound = "PHOTO_DIARY_REQUEST_NOT_FOUND";
+
+    /// <summary>The photo diary request is not in the expected status for this operation.</summary>
+    public const string PhotoDiaryRequestInvalidStatus = "PHOTO_DIARY_REQUEST_INVALID_STATUS";
+
+    /// <summary>Exactly one of linkId or pendingInviteId must be set.</summary>
+    public const string PhotoDiaryRequestLinkXorInvite = "PHOTO_DIARY_REQUEST_LINK_XOR_INVITE";
+
+    /// <summary>The referenced client-professional link does not belong to the calling professional.</summary>
+    public const string PhotoDiaryRequestLinkNotOwned = "PHOTO_DIARY_REQUEST_LINK_NOT_OWNED";
+
+    /// <summary>The referenced pending invite does not belong to the calling professional.</summary>
+    public const string PhotoDiaryRequestInviteNotOwned = "PHOTO_DIARY_REQUEST_INVITE_NOT_OWNED";
+
+    /// <summary>The referenced plan does not belong to the client associated with this link/invite.</summary>
+    public const string PhotoDiaryRequestPlanNotOwned = "PHOTO_DIARY_REQUEST_PLAN_NOT_OWNED";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestEndpoint.cs
@@ -1,0 +1,88 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.AcceptRequest;
+
+/// <summary>
+/// POST /client/photo-diary-requests/{id}/accept
+/// Transitions a Pending request to Accepted, records the chosen Mode and AcceptedAt timestamp.
+/// </summary>
+public class AcceptRequestEndpoint(IApplicationDbContext db)
+    : Endpoint<AcceptRequestRequest, AcceptRequestResponse>
+{
+    public override void Configure()
+    {
+        Post("/client/photo-diary-requests/{id}/accept");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Accept a photo diary request";
+            s.Description = "Transitions a Pending photo diary request to Accepted, recording the chosen mode.";
+        });
+    }
+
+    public override async Task HandleAsync(AcceptRequestRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        var emailClaim = User.FindFirstValue(AppClaims.Email);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+        var clientUserId = Guid.Parse(userId);
+
+        // Load the request with the link/invite for ownership check
+        var request = await db.PhotoDiaryRequests
+            .Include(r => r.Link)
+                .ThenInclude(l => l!.ClientProfile)
+            .Include(r => r.PendingInvite)
+            .FirstOrDefaultAsync(r => r.Id == req.Id, ct);
+
+        // 404 if not found — do not leak existence for IDOR
+        if (request is null || !IsOwnedByClient(request, clientUserId, emailClaim))
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // 409 if not in Pending status
+        if (request.Status != PhotoDiaryStatus.Pending)
+        {
+            await this.SendProblemAsync(409, ErrorCodes.PhotoDiaryRequestInvalidStatus,
+                "This request is not in Pending status and cannot be accepted.", ct);
+            return;
+        }
+
+        request.Status = PhotoDiaryStatus.Accepted;
+        request.Mode = req.Mode;
+        request.AcceptedAt = DateTimeOffset.UtcNow;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        await Send.OkAsync(new AcceptRequestResponse
+        {
+            Id = request.Id,
+            Status = request.Status,
+            Mode = request.Mode,
+            AcceptedAt = request.AcceptedAt,
+        }, ct);
+    }
+
+    private static bool IsOwnedByClient(
+        Domain.Entities.PhotoDiaryRequest request,
+        Guid clientUserId,
+        string? clientEmail)
+    {
+        if (request.Link is not null)
+            return request.Link.ClientProfile.UserId == clientUserId;
+
+        if (request.PendingInvite is not null && clientEmail is not null)
+            return string.Equals(request.PendingInvite.Email, clientEmail,
+                StringComparison.OrdinalIgnoreCase);
+
+        return false;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestRequest.cs
@@ -1,0 +1,18 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.AcceptRequest;
+
+/// <summary>
+/// Route + body for accepting a photo diary request.
+/// </summary>
+public class AcceptRequestRequest
+{
+    /// <summary>The photo diary request ID (from route).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// The upload mode chosen by the client.
+    /// Must be a valid <see cref="PhotoDiaryMode"/> value.
+    /// </summary>
+    public PhotoDiaryMode Mode { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestResponse.cs
@@ -1,0 +1,14 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.AcceptRequest;
+
+/// <summary>
+/// Response returned after a client accepts a photo diary request.
+/// </summary>
+public class AcceptRequestResponse
+{
+    public Guid Id { get; set; }
+    public PhotoDiaryStatus Status { get; set; }
+    public PhotoDiaryMode? Mode { get; set; }
+    public DateTimeOffset? AcceptedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/AcceptRequest/AcceptRequestValidator.cs
@@ -1,0 +1,20 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.AcceptRequest;
+
+/// <summary>
+/// Validates <see cref="AcceptRequestRequest"/> before the endpoint handler executes.
+/// </summary>
+public class AcceptRequestValidator : Validator<AcceptRequestRequest>
+{
+    public AcceptRequestValidator()
+    {
+        RuleFor(x => x.Mode)
+            .IsInEnum()
+            .WithErrorCode(ErrorCodes.OutOfRange)
+            .WithMessage($"Mode must be a valid {nameof(PhotoDiaryMode)} value.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestEndpoint.cs
@@ -1,0 +1,153 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
+
+/// <summary>
+/// POST /trainer/photo-diary-requests
+/// Creates a new photo diary request attached to an existing client link or pending invite.
+/// </summary>
+public class CreateRequestEndpoint(IApplicationDbContext db, IMongoContext mongo)
+    : Endpoint<CreateRequestRequest, CreateRequestResponse>
+{
+    public override void Configure()
+    {
+        Post("/trainer/photo-diary-requests");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Create a photo diary request";
+            s.Description = "Sends a photo diary request to a client via an existing link or a pending invite.";
+        });
+    }
+
+    public override async Task HandleAsync(CreateRequestRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+        var professionalId = Guid.Parse(userId);
+
+        // Resolve the professional's profile (needed for ownership checks on link/invite)
+        var professionalProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == professionalId, ct);
+
+        if (professionalProfile is null)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.TrainerProfileMissing, "Professional profile not found.");
+            return;
+        }
+
+        Guid? clientUserId = null;
+
+        if (req.LinkId.HasValue)
+        {
+            // Verify the link is owned by this professional and is active
+            var link = await db.ClientProfessionalLinks
+                .AsNoTracking()
+                .Include(l => l.ClientProfile)
+                .FirstOrDefaultAsync(l => l.Id == req.LinkId.Value, ct);
+
+            if (link is null || link.ProfessionalProfileId != professionalProfile.Id || !link.IsActive)
+            {
+                await SendProblemDetailsAsync(404, ErrorCodes.PhotoDiaryRequestLinkNotOwned,
+                    "Link not found or does not belong to you.", ct);
+                return;
+            }
+
+            clientUserId = link.ClientProfile.UserId;
+        }
+        else if (req.PendingInviteId.HasValue)
+        {
+            // Verify the invite is owned by this professional
+            var invite = await db.PendingInvites
+                .AsNoTracking()
+                .FirstOrDefaultAsync(i => i.Id == req.PendingInviteId.Value, ct);
+
+            if (invite is null || invite.ProfessionalProfileId != professionalProfile.Id)
+            {
+                await SendProblemDetailsAsync(404, ErrorCodes.PhotoDiaryRequestInviteNotOwned,
+                    "Pending invite not found or does not belong to you.", ct);
+                return;
+            }
+
+            // clientUserId remains null for invite-based requests until the invite is accepted
+        }
+
+        // Validate planId ownership if provided (check both nutrition and training plans)
+        if (req.PlanId.HasValue && clientUserId.HasValue)
+        {
+            var planId = req.PlanId.Value;
+
+            var nutritionFilter = Builders<Domain.Documents.NutritionPlan>.Filter
+                .Eq(p => p.ExternalId, planId);
+            var nutritionPlan = await (await mongo.NutritionPlans
+                .FindAsync(nutritionFilter, cancellationToken: ct))
+                .FirstOrDefaultAsync(ct);
+
+            bool planBelongsToClient;
+            if (nutritionPlan is not null)
+            {
+                planBelongsToClient = nutritionPlan.ClientId == clientUserId.Value;
+            }
+            else
+            {
+                var trainingFilter = Builders<Domain.Documents.TrainingPlan>.Filter
+                    .Eq(p => p.ExternalId, planId);
+                var trainingPlan = await (await mongo.TrainingPlans
+                    .FindAsync(trainingFilter, cancellationToken: ct))
+                    .FirstOrDefaultAsync(ct);
+
+                planBelongsToClient = trainingPlan is not null && trainingPlan.ClientId == clientUserId.Value;
+            }
+
+            if (!planBelongsToClient)
+            {
+                await SendProblemDetailsAsync(404, ErrorCodes.PhotoDiaryRequestPlanNotOwned,
+                    "The specified plan was not found or does not belong to this client.", ct);
+                return;
+            }
+        }
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = professionalId,
+            LinkId = req.LinkId,
+            PendingInviteId = req.PendingInviteId,
+            PlanId = req.PlanId,
+            DurationDays = req.DurationDays,
+            Status = PhotoDiaryStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(ct);
+
+        await Send.CreatedAtAsync<CreateRequestEndpoint>(null, new CreateRequestResponse
+        {
+            Id = request.Id,
+            ProfessionalId = request.ProfessionalId,
+            LinkId = request.LinkId,
+            PendingInviteId = request.PendingInviteId,
+            PlanId = request.PlanId,
+            DurationDays = request.DurationDays,
+            Status = request.Status,
+            CreatedAt = request.CreatedAt,
+        }, cancellation: ct);
+    }
+
+    private async Task SendProblemDetailsAsync(int statusCode, string errorCode, string detail, CancellationToken ct)
+    {
+        await this.SendProblemAsync(statusCode, errorCode, detail, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestRequest.cs
@@ -1,0 +1,32 @@
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
+
+/// <summary>
+/// Request body for creating a new photo diary request.
+/// Exactly one of <see cref="LinkId"/> or <see cref="PendingInviteId"/> must be set.
+/// </summary>
+public class CreateRequestRequest
+{
+    /// <summary>
+    /// Internal ID of an existing client-professional link.
+    /// Mutually exclusive with <see cref="PendingInviteId"/>.
+    /// </summary>
+    public long? LinkId { get; set; }
+
+    /// <summary>
+    /// Internal ID of a pending invite.
+    /// Mutually exclusive with <see cref="LinkId"/>.
+    /// </summary>
+    public long? PendingInviteId { get; set; }
+
+    /// <summary>
+    /// Optional MongoDB external identifier of the nutrition or training plan this request is scoped to.
+    /// When set, must belong to the same client as the link/invite.
+    /// </summary>
+    public Guid? PlanId { get; set; }
+
+    /// <summary>
+    /// How many days the client has to upload photos (Workflow mode).
+    /// Defaults to 7. Allowed range: 1–30.
+    /// </summary>
+    public int DurationDays { get; set; } = 7;
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestResponse.cs
@@ -1,0 +1,33 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
+
+/// <summary>
+/// Response body returned after creating a photo diary request.
+/// </summary>
+public class CreateRequestResponse
+{
+    /// <summary>The new request's ID.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The professional (nutritionist) who created the request.</summary>
+    public Guid ProfessionalId { get; set; }
+
+    /// <summary>The client-professional link this request is attached to (if link-based).</summary>
+    public long? LinkId { get; set; }
+
+    /// <summary>The pending invite this request is bundled with (if invite-based).</summary>
+    public long? PendingInviteId { get; set; }
+
+    /// <summary>Optional plan scope for this request.</summary>
+    public Guid? PlanId { get; set; }
+
+    /// <summary>How many days the client has to upload photos.</summary>
+    public int DurationDays { get; set; }
+
+    /// <summary>Current lifecycle status (always <c>Pending</c> on creation).</summary>
+    public PhotoDiaryStatus Status { get; set; }
+
+    /// <summary>When the request was created.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestValidator.cs
@@ -1,0 +1,24 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
+
+/// <summary>
+/// Validates <see cref="CreateRequestRequest"/> before the endpoint handler executes.
+/// </summary>
+public class CreateRequestValidator : Validator<CreateRequestRequest>
+{
+    public CreateRequestValidator()
+    {
+        RuleFor(x => x)
+            .Must(x => (x.LinkId.HasValue) != (x.PendingInviteId.HasValue))
+            .WithErrorCode(ErrorCodes.PhotoDiaryRequestLinkXorInvite)
+            .WithMessage("Exactly one of linkId or pendingInviteId must be provided.");
+
+        RuleFor(x => x.DurationDays)
+            .InclusiveBetween(1, 30)
+            .WithErrorCode(ErrorCodes.OutOfRange)
+            .WithMessage("DurationDays must be between 1 and 30.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestEndpoint.cs
@@ -1,0 +1,86 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
+
+/// <summary>
+/// POST /client/photo-diary-requests/{id}/dismiss
+/// Transitions a Pending request to Dismissed, optionally recording a reason.
+/// Mutually exclusive with accept: once accepted the request is no longer Pending.
+/// </summary>
+public class DismissRequestEndpoint(IApplicationDbContext db)
+    : Endpoint<DismissRequestRequest, DismissRequestResponse>
+{
+    public override void Configure()
+    {
+        Post("/client/photo-diary-requests/{id}/dismiss");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Dismiss a photo diary request";
+            s.Description = "Transitions a Pending photo diary request to Dismissed, optionally recording a reason.";
+        });
+    }
+
+    public override async Task HandleAsync(DismissRequestRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        var emailClaim = User.FindFirstValue(AppClaims.Email);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+        var clientUserId = Guid.Parse(userId);
+
+        var request = await db.PhotoDiaryRequests
+            .Include(r => r.Link)
+                .ThenInclude(l => l!.ClientProfile)
+            .Include(r => r.PendingInvite)
+            .FirstOrDefaultAsync(r => r.Id == req.Id, ct);
+
+        // 404 if not found — do not leak existence for IDOR
+        if (request is null || !IsOwnedByClient(request, clientUserId, emailClaim))
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // 409 if not in Pending status (also covers the mutually-exclusive accept case)
+        if (request.Status != PhotoDiaryStatus.Pending)
+        {
+            await this.SendProblemAsync(409, ErrorCodes.PhotoDiaryRequestInvalidStatus,
+                "This request is not in Pending status and cannot be dismissed.", ct);
+            return;
+        }
+
+        request.Status = PhotoDiaryStatus.Dismissed;
+        request.DismissReason = req.Reason;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        await Send.OkAsync(new DismissRequestResponse
+        {
+            Id = request.Id,
+            Status = request.Status,
+            DismissReason = request.DismissReason,
+        }, ct);
+    }
+
+    private static bool IsOwnedByClient(
+        Domain.Entities.PhotoDiaryRequest request,
+        Guid clientUserId,
+        string? clientEmail)
+    {
+        if (request.Link is not null)
+            return request.Link.ClientProfile.UserId == clientUserId;
+
+        if (request.PendingInvite is not null && clientEmail is not null)
+            return string.Equals(request.PendingInvite.Email, clientEmail,
+                StringComparison.OrdinalIgnoreCase);
+
+        return false;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
+
+/// <summary>
+/// Route + body for dismissing a photo diary request.
+/// </summary>
+public class DismissRequestRequest
+{
+    /// <summary>The photo diary request ID (from route).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Optional reason for dismissal (max 500 characters).</summary>
+    public string? Reason { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestResponse.cs
@@ -1,0 +1,13 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
+
+/// <summary>
+/// Response returned after a client dismisses a photo diary request.
+/// </summary>
+public class DismissRequestResponse
+{
+    public Guid Id { get; set; }
+    public PhotoDiaryStatus Status { get; set; }
+    public string? DismissReason { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestValidator.cs
@@ -1,0 +1,20 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
+
+/// <summary>
+/// Validates <see cref="DismissRequestRequest"/> before the endpoint handler executes.
+/// </summary>
+public class DismissRequestValidator : Validator<DismissRequestRequest>
+{
+    public DismissRequestValidator()
+    {
+        RuleFor(x => x.Reason)
+            .MaximumLength(500)
+            .WithErrorCode(ErrorCodes.OutOfRange)
+            .WithMessage("Reason must not exceed 500 characters.")
+            .When(x => x.Reason is not null);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListClientRequests/ListClientRequestsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListClientRequests/ListClientRequestsEndpoint.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.ListClientRequests;
+
+/// <summary>
+/// GET /client/photo-diary-requests
+/// Returns a paginated list of photo diary requests addressed to the authenticated client.
+/// Requests are resolved via client-professional links (where ClientProfile.UserId matches)
+/// and via pending invites (where PendingInvite.Email matches the caller's email claim).
+/// </summary>
+public class ListClientRequestsEndpoint(IApplicationDbContext db)
+    : Endpoint<ListClientRequestsRequest, ListClientRequestsResponse>
+{
+    public override void Configure()
+    {
+        Get("/client/photo-diary-requests");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "List photo diary requests (client view)";
+            s.Description = "Returns a paginated list of photo diary requests addressed to the authenticated client.";
+        });
+    }
+
+    public override async Task HandleAsync(ListClientRequestsRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        var emailClaim = User.FindFirstValue(AppClaims.Email);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+        var clientUserId = Guid.Parse(userId);
+
+        // Collect link IDs where this client is the client profile
+        var clientLinkIds = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .Where(l => l.ClientProfile.UserId == clientUserId)
+            .Select(l => (long?)l.Id)
+            .ToListAsync(ct);
+
+        // Collect invite IDs addressed to this client's email
+        var clientInviteIds = emailClaim is not null
+            ? await db.PendingInvites
+                .AsNoTracking()
+                .Where(i => i.Email == emailClaim)
+                .Select(i => (long?)i.Id)
+                .ToListAsync(ct)
+            : [];
+
+        var query = db.PhotoDiaryRequests
+            .AsNoTracking()
+            .Where(r =>
+                (r.LinkId != null && clientLinkIds.Contains(r.LinkId)) ||
+                (r.PendingInviteId != null && clientInviteIds.Contains(r.PendingInviteId)));
+
+        if (req.Status.HasValue)
+            query = query.Where(r => r.Status == req.Status.Value);
+
+        if (req.PlanId.HasValue)
+            query = query.Where(r => r.PlanId == req.PlanId.Value);
+
+        var totalCount = await query.CountAsync(ct);
+
+        HttpContext.Response.Headers["X-Total-Count"] = totalCount.ToString();
+
+        var items = await query
+            .OrderByDescending(r => r.CreatedAt)
+            .Skip((req.Page - 1) * req.PageSize)
+            .Take(req.PageSize)
+            .Select(r => new ClientPhotoDiaryRequestSummary
+            {
+                Id = r.Id,
+                ProfessionalId = r.ProfessionalId,
+                LinkId = r.LinkId,
+                PendingInviteId = r.PendingInviteId,
+                PlanId = r.PlanId,
+                DurationDays = r.DurationDays,
+                Mode = r.Mode,
+                Status = r.Status,
+                DismissReason = r.DismissReason,
+                AcceptedAt = r.AcceptedAt,
+                CompletedAt = r.CompletedAt,
+                CreatedAt = r.CreatedAt,
+                UpdatedAt = r.UpdatedAt,
+            })
+            .ToListAsync(ct);
+
+        await Send.OkAsync(new ListClientRequestsResponse { Items = items }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListClientRequests/ListClientRequestsRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListClientRequests/ListClientRequestsRequest.cs
@@ -1,0 +1,21 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.ListClientRequests;
+
+/// <summary>
+/// Query parameters for the client's photo diary request list.
+/// </summary>
+public class ListClientRequestsRequest
+{
+    /// <summary>Page number (1-based). Defaults to 1.</summary>
+    public int Page { get; set; } = 1;
+
+    /// <summary>Number of items per page. Defaults to 20.</summary>
+    public int PageSize { get; set; } = 20;
+
+    /// <summary>Optional filter by status.</summary>
+    public PhotoDiaryStatus? Status { get; set; }
+
+    /// <summary>Optional filter by plan ID.</summary>
+    public Guid? PlanId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListClientRequests/ListClientRequestsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListClientRequests/ListClientRequestsResponse.cs
@@ -1,0 +1,31 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.ListClientRequests;
+
+/// <summary>
+/// Summary DTO for a photo diary request in the client list view.
+/// </summary>
+public class ClientPhotoDiaryRequestSummary
+{
+    public Guid Id { get; set; }
+    public Guid ProfessionalId { get; set; }
+    public long? LinkId { get; set; }
+    public long? PendingInviteId { get; set; }
+    public Guid? PlanId { get; set; }
+    public int DurationDays { get; set; }
+    public PhotoDiaryMode? Mode { get; set; }
+    public PhotoDiaryStatus Status { get; set; }
+    public string? DismissReason { get; set; }
+    public DateTimeOffset? AcceptedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Paginated list of photo diary requests visible to the authenticated client.
+/// </summary>
+public class ListClientRequestsResponse
+{
+    public List<ClientPhotoDiaryRequestSummary> Items { get; set; } = [];
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListTrainerRequests/ListTrainerRequestsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListTrainerRequests/ListTrainerRequestsEndpoint.cs
@@ -1,0 +1,77 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.ListTrainerRequests;
+
+/// <summary>
+/// GET /trainer/photo-diary-requests
+/// Returns a paginated list of photo diary requests created by the authenticated professional.
+/// </summary>
+public class ListTrainerRequestsEndpoint(IApplicationDbContext db)
+    : Endpoint<ListTrainerRequestsRequest, ListTrainerRequestsResponse>
+{
+    public override void Configure()
+    {
+        Get("/trainer/photo-diary-requests");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "List photo diary requests (trainer view)";
+            s.Description = "Returns a paginated list of photo diary requests created by the authenticated professional.";
+        });
+    }
+
+    public override async Task HandleAsync(ListTrainerRequestsRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+        var professionalId = Guid.Parse(userId);
+
+        var query = db.PhotoDiaryRequests
+            .AsNoTracking()
+            .Where(r => r.ProfessionalId == professionalId);
+
+        if (req.Status.HasValue)
+            query = query.Where(r => r.Status == req.Status.Value);
+
+        if (req.LinkId.HasValue)
+            query = query.Where(r => r.LinkId == req.LinkId.Value);
+
+        if (req.PendingInviteId.HasValue)
+            query = query.Where(r => r.PendingInviteId == req.PendingInviteId.Value);
+
+        if (req.PlanId.HasValue)
+            query = query.Where(r => r.PlanId == req.PlanId.Value);
+
+        var totalCount = await query.CountAsync(ct);
+
+        HttpContext.Response.Headers["X-Total-Count"] = totalCount.ToString();
+
+        var items = await query
+            .OrderByDescending(r => r.CreatedAt)
+            .Skip((req.Page - 1) * req.PageSize)
+            .Take(req.PageSize)
+            .Select(r => new PhotoDiaryRequestSummary
+            {
+                Id = r.Id,
+                ProfessionalId = r.ProfessionalId,
+                LinkId = r.LinkId,
+                PendingInviteId = r.PendingInviteId,
+                PlanId = r.PlanId,
+                DurationDays = r.DurationDays,
+                Mode = r.Mode,
+                Status = r.Status,
+                DismissReason = r.DismissReason,
+                AcceptedAt = r.AcceptedAt,
+                CompletedAt = r.CompletedAt,
+                CreatedAt = r.CreatedAt,
+                UpdatedAt = r.UpdatedAt,
+            })
+            .ToListAsync(ct);
+
+        await Send.OkAsync(new ListTrainerRequestsResponse { Items = items }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListTrainerRequests/ListTrainerRequestsRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListTrainerRequests/ListTrainerRequestsRequest.cs
@@ -1,0 +1,27 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.ListTrainerRequests;
+
+/// <summary>
+/// Query parameters for listing trainer photo diary requests.
+/// </summary>
+public class ListTrainerRequestsRequest
+{
+    /// <summary>Page number (1-based). Defaults to 1.</summary>
+    public int Page { get; set; } = 1;
+
+    /// <summary>Number of items per page. Defaults to 20.</summary>
+    public int PageSize { get; set; } = 20;
+
+    /// <summary>Optional filter by status.</summary>
+    public PhotoDiaryStatus? Status { get; set; }
+
+    /// <summary>Optional filter by client-professional link ID.</summary>
+    public long? LinkId { get; set; }
+
+    /// <summary>Optional filter by pending invite ID.</summary>
+    public long? PendingInviteId { get; set; }
+
+    /// <summary>Optional filter by plan ID.</summary>
+    public Guid? PlanId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListTrainerRequests/ListTrainerRequestsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/ListTrainerRequests/ListTrainerRequestsResponse.cs
@@ -1,0 +1,31 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.ListTrainerRequests;
+
+/// <summary>
+/// Summary DTO for a single photo diary request in a list.
+/// </summary>
+public class PhotoDiaryRequestSummary
+{
+    public Guid Id { get; set; }
+    public Guid ProfessionalId { get; set; }
+    public long? LinkId { get; set; }
+    public long? PendingInviteId { get; set; }
+    public Guid? PlanId { get; set; }
+    public int DurationDays { get; set; }
+    public PhotoDiaryMode? Mode { get; set; }
+    public PhotoDiaryStatus Status { get; set; }
+    public string? DismissReason { get; set; }
+    public DateTimeOffset? AcceptedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Paginated list of photo diary requests for a trainer.
+/// </summary>
+public class ListTrainerRequestsResponse
+{
+    public List<PhotoDiaryRequestSummary> Items { get; set; } = [];
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestEndpoint.cs
@@ -1,0 +1,85 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.SubmitRequest;
+
+/// <summary>
+/// POST /client/photo-diary-requests/{id}/submit
+/// Transitions an Accepted or InProgress request to Completed, recording CompletedAt.
+/// </summary>
+public class SubmitRequestEndpoint(IApplicationDbContext db)
+    : Endpoint<SubmitRequestRequest, SubmitRequestResponse>
+{
+    public override void Configure()
+    {
+        Post("/client/photo-diary-requests/{id}/submit");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Submit / finalize a photo diary";
+            s.Description = "Transitions an Accepted or InProgress photo diary request to Completed.";
+        });
+    }
+
+    public override async Task HandleAsync(SubmitRequestRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        var emailClaim = User.FindFirstValue(AppClaims.Email);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+        var clientUserId = Guid.Parse(userId);
+
+        var request = await db.PhotoDiaryRequests
+            .Include(r => r.Link)
+                .ThenInclude(l => l!.ClientProfile)
+            .Include(r => r.PendingInvite)
+            .FirstOrDefaultAsync(r => r.Id == req.Id, ct);
+
+        // 404 if not found — do not leak existence for IDOR
+        if (request is null || !IsOwnedByClient(request, clientUserId, emailClaim))
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // 409 if not in a submittable status
+        if (request.Status is not (PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress))
+        {
+            await this.SendProblemAsync(409, ErrorCodes.PhotoDiaryRequestInvalidStatus,
+                "This request must be in Accepted or InProgress status to be submitted.", ct);
+            return;
+        }
+
+        request.Status = PhotoDiaryStatus.Completed;
+        request.CompletedAt = DateTimeOffset.UtcNow;
+        request.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+
+        await Send.OkAsync(new SubmitRequestResponse
+        {
+            Id = request.Id,
+            Status = request.Status,
+            CompletedAt = request.CompletedAt,
+        }, ct);
+    }
+
+    private static bool IsOwnedByClient(
+        Domain.Entities.PhotoDiaryRequest request,
+        Guid clientUserId,
+        string? clientEmail)
+    {
+        if (request.Link is not null)
+            return request.Link.ClientProfile.UserId == clientUserId;
+
+        if (request.PendingInvite is not null && clientEmail is not null)
+            return string.Equals(request.PendingInvite.Email, clientEmail,
+                StringComparison.OrdinalIgnoreCase);
+
+        return false;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestRequest.cs
@@ -1,0 +1,10 @@
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.SubmitRequest;
+
+/// <summary>
+/// Route parameters for submitting / finalizing a photo diary.
+/// </summary>
+public class SubmitRequestRequest
+{
+    /// <summary>The photo diary request ID (from route).</summary>
+    public Guid Id { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestResponse.cs
@@ -1,0 +1,13 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.SubmitRequest;
+
+/// <summary>
+/// Response returned after a client submits / finalizes a photo diary.
+/// </summary>
+public class SubmitRequestResponse
+{
+    public Guid Id { get; set; }
+    public PhotoDiaryStatus Status { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Tests/Builders/MockDbBuilder.cs
+++ b/backend/FitnessPlatform.Tests/Builders/MockDbBuilder.cs
@@ -26,6 +26,7 @@ public class MockDbBuilder
     private readonly List<DevicePushToken> _devicePushTokens = [];
     private readonly List<WeeklyCheckInSetting> _weeklyCheckInSettings = [];
     private readonly List<WeeklyCheckInClientOverride> _weeklyCheckInClientOverrides = [];
+    private readonly List<PhotoDiaryRequest> _photoDiaryRequests = [];
 
     /// <summary>
     /// Adds an <see cref="ApplicationUser"/> to the mock context.
@@ -98,6 +99,11 @@ public class MockDbBuilder
     public MockDbBuilder With(WeeklyCheckInClientOverride o) { _weeklyCheckInClientOverrides.Add(o); return this; }
 
     /// <summary>
+    /// Adds a <see cref="PhotoDiaryRequest"/> to the mock context.
+    /// </summary>
+    public MockDbBuilder With(PhotoDiaryRequest request) { _photoDiaryRequests.Add(request); return this; }
+
+    /// <summary>
     /// Builds a mocked <see cref="IApplicationDbContext"/> with all registered entities as queryable DbSets.
     /// </summary>
     public IApplicationDbContext Build()
@@ -120,6 +126,7 @@ public class MockDbBuilder
         var devicePushTokensSet = _devicePushTokens.BuildMockDbSet();
         var weeklyCheckInSettingsSet = _weeklyCheckInSettings.BuildMockDbSet();
         var weeklyCheckInClientOverridesSet = _weeklyCheckInClientOverrides.BuildMockDbSet();
+        var photoDiaryRequestsSet = _photoDiaryRequests.BuildMockDbSet();
 
         var db = Substitute.For<IApplicationDbContext>();
 
@@ -139,6 +146,7 @@ public class MockDbBuilder
         db.DevicePushTokens.Returns(devicePushTokensSet);
         db.WeeklyCheckInSettings.Returns(weeklyCheckInSettingsSet);
         db.WeeklyCheckInClientOverrides.Returns(weeklyCheckInClientOverridesSet);
+        db.PhotoDiaryRequests.Returns(photoDiaryRequestsSet);
 
         db.SaveChangesAsync(Arg.Any<CancellationToken>()).Returns(1);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/AcceptRequestEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/AcceptRequestEndpointTests.cs
@@ -1,0 +1,263 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Integration tests for POST /client/photo-diary-requests/{id}/accept.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class AcceptRequestEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "accept") =>
+        $"{Guid.NewGuid():N}@{tag}-diary.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupProfessionalAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("prof");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Prof", "Accept", "Nutritionist");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Client", "Accept", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<Guid> InsertPendingDiaryRequestViaLinkAsync(
+        Guid profUserId, long linkId,
+        PhotoDiaryStatus status = PhotoDiaryStatus.Pending)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            DurationDays = 7,
+            Status = status,
+            Mode = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? PhotoDiaryMode.Workflow : null,
+            AcceptedAt = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? DateTimeOffset.UtcNow : null,
+            CompletedAt = status == PhotoDiaryStatus.Completed ? DateTimeOffset.UtcNow : null,
+            DismissReason = status == PhotoDiaryStatus.Dismissed ? "Not interested" : null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return request.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Accept_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/accept",
+            new { Mode = 1 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Accept_TrainerRole_Returns403()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/accept",
+            new { Mode = 1 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Not found / IDOR ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Accept_UnknownId_Returns404()
+    {
+        var (http, _) = await SetupClientAsync();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/accept",
+            new { Mode = PhotoDiaryMode.Bulk },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Accept_OtherClientsRequest_Returns404()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (_, client1Id) = await SetupClientAsync();
+        var (http, _) = await SetupClientAsync(); // client 2
+
+        var linkId = await InsertLinkAsync(client1Id, profId);
+        var requestId = await InsertPendingDiaryRequestViaLinkAsync(profId, linkId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/accept",
+            new { Mode = PhotoDiaryMode.Bulk },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Accept_Pending_Returns200_AndTransitions()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertPendingDiaryRequestViaLinkAsync(profId, linkId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/accept",
+            new { Mode = PhotoDiaryMode.Workflow },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<AcceptResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body!.Status.Should().Be(PhotoDiaryStatus.Accepted);
+        body.Mode.Should().Be(PhotoDiaryMode.Workflow);
+        body.AcceptedAt.Should().NotBeNull();
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+        persisted.Status.Should().Be(PhotoDiaryStatus.Accepted);
+        persisted.Mode.Should().Be(PhotoDiaryMode.Workflow);
+        persisted.AcceptedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Accept_WithBulkMode_Returns200_AndModeIsPersisted()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertPendingDiaryRequestViaLinkAsync(profId, linkId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/accept",
+            new { Mode = PhotoDiaryMode.Bulk },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+        persisted.Mode.Should().Be(PhotoDiaryMode.Bulk);
+    }
+
+    // ── Conflict — wrong status ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Accept_AlreadyAccepted_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertPendingDiaryRequestViaLinkAsync(profId, linkId, PhotoDiaryStatus.Accepted);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/accept",
+            new { Mode = PhotoDiaryMode.Bulk },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Accept_Dismissed_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertPendingDiaryRequestViaLinkAsync(profId, linkId, PhotoDiaryStatus.Dismissed);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/accept",
+            new { Mode = PhotoDiaryMode.Bulk },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ── Response shape helpers ─────────────────────────────────────────────────
+
+    private record AcceptResponseBody(
+        Guid Id,
+        PhotoDiaryStatus Status,
+        PhotoDiaryMode? Mode,
+        DateTimeOffset? AcceptedAt);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/CreateRequestEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/CreateRequestEndpointTests.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Integration tests for POST /trainer/photo-diary-requests.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class CreateRequestEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "trainer") =>
+        $"{Guid.NewGuid():N}@{tag}-create-diary.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupProfessionalAsync(string role = "Nutritionist")
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail(role.ToLower());
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Prof", "Test", role);
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId, string Email)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Client", "Test", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id, email);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<long> InsertPendingInviteAsync(Guid professionalUserId, string inviteeEmail)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+
+        var invite = new PendingInvite
+        {
+            ProfessionalProfileId = profProfile.Id,
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = inviteeEmail,
+            SentAt = DateTime.UtcNow,
+            IsAccepted = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.PendingInvites.Add(invite);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return invite.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = 1L },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Create_ClientRole_Returns403()
+    {
+        var (http, _, _) = await SetupClientAsync();
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = 1L },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_BothLinkAndInvite_Returns400()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = 1L, PendingInviteId = 2L, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_NeitherLinkNorInvite_Returns400()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_DurationDaysZero_Returns400()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = 1L, DurationDays = 0 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Create_DurationDays31_Returns400()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = 1L, DurationDays = 31 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── Ownership ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_LinkOwnedByAnotherProfessional_Returns404()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var (_, otherProfId) = await SetupProfessionalAsync();
+        var (_, clientUserId, _) = await SetupClientAsync();
+
+        // Link belongs to otherProf, not http's user
+        var linkId = await InsertLinkAsync(clientUserId, otherProfId);
+
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = linkId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Create_InviteOwnedByAnotherProfessional_Returns404()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var (_, otherProfId) = await SetupProfessionalAsync();
+
+        var inviteId = await InsertPendingInviteAsync(otherProfId, "someone@example.com");
+
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { PendingInviteId = inviteId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Happy path — link-based ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_WithValidLink_Returns201_AndPersists()
+    {
+        var (http, profId) = await SetupProfessionalAsync();
+        var (_, clientUserId, _) = await SetupClientAsync();
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = linkId, DurationDays = 14 },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<CreateResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        body!.Status.Should().Be(PhotoDiaryStatus.Pending);
+        body.DurationDays.Should().Be(14);
+        body.LinkId.Should().Be(linkId);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstOrDefaultAsync(r => r.Id == body.Id, TestContext.Current.CancellationToken);
+        persisted.Should().NotBeNull();
+        persisted!.ProfessionalId.Should().Be(profId);
+        persisted.Status.Should().Be(PhotoDiaryStatus.Pending);
+    }
+
+    // ── Happy path — invite-based ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_WithValidInvite_Returns201_AndPersists()
+    {
+        var (http, profId) = await SetupProfessionalAsync();
+        var inviteId = await InsertPendingInviteAsync(profId, "invite-test@example.com");
+
+        var response = await http.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { PendingInviteId = inviteId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<CreateResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        body!.PendingInviteId.Should().Be(inviteId);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstOrDefaultAsync(r => r.Id == body.Id, TestContext.Current.CancellationToken);
+        persisted.Should().NotBeNull();
+        persisted!.LinkId.Should().BeNull();
+        persisted.PendingInviteId.Should().Be(inviteId);
+    }
+
+    // ── Response shape helper ──────────────────────────────────────────────────
+
+    private record CreateResponseBody(
+        Guid Id,
+        Guid ProfessionalId,
+        long? LinkId,
+        long? PendingInviteId,
+        Guid? PlanId,
+        int DurationDays,
+        PhotoDiaryStatus Status,
+        DateTimeOffset CreatedAt);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/DismissRequestEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/DismissRequestEndpointTests.cs
@@ -1,0 +1,285 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Integration tests for POST /client/photo-diary-requests/{id}/dismiss.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class DismissRequestEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "dismiss") =>
+        $"{Guid.NewGuid():N}@{tag}-diary.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupProfessionalAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("prof");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Prof", "Dismiss", "Nutritionist");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Client", "Dismiss", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<Guid> InsertDiaryRequestAsync(
+        Guid profUserId, long linkId,
+        PhotoDiaryStatus status = PhotoDiaryStatus.Pending)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            DurationDays = 7,
+            Status = status,
+            Mode = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? PhotoDiaryMode.Bulk : null,
+            AcceptedAt = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? DateTimeOffset.UtcNow : null,
+            CompletedAt = status == PhotoDiaryStatus.Completed ? DateTimeOffset.UtcNow : null,
+            DismissReason = status == PhotoDiaryStatus.Dismissed ? "pre-dismissed" : null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return request.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Dismiss_TrainerRole_Returns403()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Not found / IDOR ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_UnknownId_Returns404()
+    {
+        var (http, _) = await SetupClientAsync();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Dismiss_OtherClientsRequest_Returns404()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (_, client1Id) = await SetupClientAsync();
+        var (http, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(client1Id, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_Pending_Returns200_AndTransitions()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<DismissResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body!.Status.Should().Be(PhotoDiaryStatus.Dismissed);
+        body.DismissReason.Should().BeNull();
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+        persisted.Status.Should().Be(PhotoDiaryStatus.Dismissed);
+        persisted.DismissReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Dismiss_WithReason_ReasonIsPersisted()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId);
+
+        const string reason = "I prefer not to share photos.";
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/dismiss",
+            new { Reason = reason },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+        persisted.DismissReason.Should().Be(reason);
+    }
+
+    // ── Conflict — wrong status ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_AlreadyAccepted_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Accepted);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Dismiss_AlreadyDismissed_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Dismissed);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/dismiss",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ── Mutually-exclusive guard: dismiss then accept → 409 ──────────────────
+
+    [Fact]
+    public async Task DismissThenAccept_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId);
+
+        // Dismiss first
+        var dismissResponse = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/dismiss",
+            new { Reason = "Changed my mind" },
+            TestContext.Current.CancellationToken);
+        dismissResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Now try to accept — must be 409 because it's no longer Pending
+        var acceptResponse = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/accept",
+            new { Mode = PhotoDiaryMode.Bulk },
+            TestContext.Current.CancellationToken);
+        acceptResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ── Response shape helpers ─────────────────────────────────────────────────
+
+    private record DismissResponseBody(Guid Id, PhotoDiaryStatus Status, string? DismissReason);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/ListRequestsEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/ListRequestsEndpointTests.cs
@@ -1,0 +1,299 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Integration tests for GET /trainer/photo-diary-requests and GET /client/photo-diary-requests.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class ListRequestsEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "list") =>
+        $"{Guid.NewGuid():N}@{tag}-diary.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupProfessionalAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("prof");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Prof", "List", "Nutritionist");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId, string Email)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Client", "List", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id, email);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<long> InsertPendingInviteAsync(Guid professionalUserId, string inviteeEmail)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+
+        var invite = new PendingInvite
+        {
+            ProfessionalProfileId = profProfile.Id,
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = inviteeEmail,
+            SentAt = DateTime.UtcNow,
+            IsAccepted = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.PendingInvites.Add(invite);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return invite.Id;
+    }
+
+    private async Task<Guid> InsertDiaryRequestAsync(
+        Guid profUserId, long? linkId = null, long? inviteId = null,
+        PhotoDiaryStatus status = PhotoDiaryStatus.Pending)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            PendingInviteId = inviteId,
+            DurationDays = 7,
+            Status = status,
+            Mode = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? PhotoDiaryMode.Bulk : null,
+            AcceptedAt = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? DateTimeOffset.UtcNow : null,
+            CompletedAt = status == PhotoDiaryStatus.Completed ? DateTimeOffset.UtcNow : null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return request.Id;
+    }
+
+    // ── Trainer list ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListTrainer_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.GetAsync(
+            "/trainer/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ListTrainer_ClientRole_Returns403()
+    {
+        var (http, _, _) = await SetupClientAsync();
+        var response = await http.GetAsync(
+            "/trainer/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListTrainer_ReturnsOnlyOwnRequests()
+    {
+        var (http, profId) = await SetupProfessionalAsync();
+        var (_, otherProfId) = await SetupProfessionalAsync();
+        var (_, clientUserId, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+        var otherLinkId = await InsertLinkAsync(clientUserId, otherProfId);
+
+        var myRequestId = await InsertDiaryRequestAsync(profId, linkId: linkId);
+        await InsertDiaryRequestAsync(otherProfId, linkId: otherLinkId);
+
+        var response = await http.GetAsync(
+            "/trainer/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+        body!.Items.Should().Contain(i => i.Id == myRequestId);
+        body.Items.Should().NotContain(i => i.ProfessionalId == otherProfId);
+    }
+
+    [Fact]
+    public async Task ListTrainer_StatusFilter_Works()
+    {
+        var (http, profId) = await SetupProfessionalAsync();
+        var (_, clientUserId, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+
+        await InsertDiaryRequestAsync(profId, linkId: linkId, status: PhotoDiaryStatus.Pending);
+        await InsertDiaryRequestAsync(profId, linkId: linkId, status: PhotoDiaryStatus.Accepted);
+
+        var response = await http.GetAsync(
+            "/trainer/photo-diary-requests?status=1", // Pending = 1
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body!.Items.Should().OnlyContain(i => i.Status == PhotoDiaryStatus.Pending);
+    }
+
+    [Fact]
+    public async Task ListTrainer_XTotalCountHeader_IsSet()
+    {
+        var (http, profId) = await SetupProfessionalAsync();
+        var (_, clientUserId, _) = await SetupClientAsync();
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+
+        await InsertDiaryRequestAsync(profId, linkId: linkId);
+        await InsertDiaryRequestAsync(profId, linkId: linkId);
+
+        var response = await http.GetAsync(
+            "/trainer/photo-diary-requests?pageSize=1",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Contains("X-Total-Count").Should().BeTrue();
+        var total = int.Parse(response.Headers.GetValues("X-Total-Count").First());
+        total.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    // ── Client list ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListClient_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.GetAsync(
+            "/client/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ListClient_TrainerRole_Returns403()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.GetAsync(
+            "/client/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListClient_ReturnsOwnRequestsViaLink()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientUserId, _) = await SetupClientAsync();
+        var (_, otherClientId, _) = await SetupClientAsync();
+
+        var myLinkId = await InsertLinkAsync(clientUserId, profId);
+        var otherLinkId = await InsertLinkAsync(otherClientId, profId);
+
+        var myRequestId = await InsertDiaryRequestAsync(profId, linkId: myLinkId);
+        var otherRequestId = await InsertDiaryRequestAsync(profId, linkId: otherLinkId);
+
+        var response = await http.GetAsync(
+            "/client/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body!.Items.Should().Contain(i => i.Id == myRequestId);
+        body.Items.Should().NotContain(i => i.Id == otherRequestId);
+    }
+
+    [Fact]
+    public async Task ListClient_ReturnsOwnRequestsViaInvite()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, _, clientEmail) = await SetupClientAsync();
+        var otherEmail = UniqueEmail("other-invite");
+
+        var myInviteId = await InsertPendingInviteAsync(profId, clientEmail);
+        var otherInviteId = await InsertPendingInviteAsync(profId, otherEmail);
+
+        var myRequestId = await InsertDiaryRequestAsync(profId, inviteId: myInviteId);
+        var otherRequestId = await InsertDiaryRequestAsync(profId, inviteId: otherInviteId);
+
+        var response = await http.GetAsync(
+            "/client/photo-diary-requests",
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ListResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body!.Items.Should().Contain(i => i.Id == myRequestId);
+        body.Items.Should().NotContain(i => i.Id == otherRequestId);
+    }
+
+    // ── Response shape helpers ─────────────────────────────────────────────────
+
+    private record ListItem(Guid Id, Guid ProfessionalId, PhotoDiaryStatus Status);
+    private record ListResponseBody(List<ListItem> Items);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/SubmitRequestEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/SubmitRequestEndpointTests.cs
@@ -1,0 +1,275 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Integration tests for POST /client/photo-diary-requests/{id}/submit.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class SubmitRequestEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "submit") =>
+        $"{Guid.NewGuid():N}@{tag}-diary.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupProfessionalAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("prof");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Prof", "Submit", "Nutritionist");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Client", "Submit", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<Guid> InsertDiaryRequestAsync(
+        Guid profUserId, long linkId,
+        PhotoDiaryStatus status)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            DurationDays = 7,
+            Status = status,
+            Mode = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? PhotoDiaryMode.Workflow : null,
+            AcceptedAt = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? DateTimeOffset.UtcNow : null,
+            CompletedAt = status == PhotoDiaryStatus.Completed ? DateTimeOffset.UtcNow : null,
+            DismissReason = status == PhotoDiaryStatus.Dismissed ? "Not interested" : null,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return request.Id;
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submit_Unauthenticated_Returns401()
+    {
+        var http = factory.CreateClient();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Submit_TrainerRole_Returns403()
+    {
+        var (http, _) = await SetupProfessionalAsync();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Not found / IDOR ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submit_UnknownId_Returns404()
+    {
+        var (http, _) = await SetupClientAsync();
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{Guid.NewGuid()}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Submit_OtherClientsRequest_Returns404()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (_, client1Id) = await SetupClientAsync();
+        var (http, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(client1Id, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Accepted);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Happy path — Accepted → Completed ─────────────────────────────────────
+
+    [Fact]
+    public async Task Submit_FromAccepted_Returns200_AndCompletedAtPersisted()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Accepted);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<SubmitResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body!.Status.Should().Be(PhotoDiaryStatus.Completed);
+        body.CompletedAt.Should().NotBeNull();
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+        persisted.Status.Should().Be(PhotoDiaryStatus.Completed);
+        persisted.CompletedAt.Should().NotBeNull();
+    }
+
+    // ── Happy path — InProgress → Completed ──────────────────────────────────
+
+    [Fact]
+    public async Task Submit_FromInProgress_Returns200_AndCompletes()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.InProgress);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+        persisted.Status.Should().Be(PhotoDiaryStatus.Completed);
+    }
+
+    // ── Conflict — wrong status ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submit_FromPending_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Pending);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Submit_AlreadyCompleted_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Completed);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Submit_Dismissed_Returns409()
+    {
+        var (_, profId) = await SetupProfessionalAsync();
+        var (http, clientId) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId, PhotoDiaryStatus.Dismissed);
+
+        var response = await http.PostAsJsonAsync(
+            $"/client/photo-diary-requests/{requestId}/submit",
+            new { },
+            TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ── Response shape helpers ─────────────────────────────────────────────────
+
+    private record SubmitResponseBody(Guid Id, PhotoDiaryStatus Status, DateTimeOffset? CompletedAt);
+}


### PR DESCRIPTION
## Summary

- Adds 6 FastEndpoints under `Features/PhotoDiaryRequests/` for the full photo diary lifecycle.
- `POST /trainer/photo-diary-requests` — create request, attached to either a plan or a pending invite (XOR validated).
- `GET /trainer/photo-diary-requests` — trainer list with pagination.
- `GET /client/photo-diary-requests` — client list with pagination.
- `POST /client/photo-diary-requests/{id}/accept` — client accepts with a chosen Mode; transitions `Pending → Accepted`.
- `POST /client/photo-diary-requests/{id}/dismiss` — client dismisses with optional reason; transitions `Pending → Dismissed`; mutually exclusive with accept (409 if already Accepted/Dismissed).
- `POST /client/photo-diary-requests/{id}/submit` — client submits; transitions `Accepted → Completed` or `InProgress → Completed`.

## Related issue

Fixes #91

## Parent epic (sub-issue PRs only)

Part of epic #67 — base branch: `feature/67-diary-request`.

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all 51 new Testcontainers tests pass (941/941 suite-wide); every AC has explicit test coverage.

## Test plan

- [ ] Role-gated (401/403 for each endpoint)
- [ ] Status transitions validated (409 from wrong state)
- [ ] Dismiss + accept mutually exclusive (`DismissThenAccept_Returns409`)
- [ ] Testcontainers coverage on every transition (Pending→Accepted/Dismissed, Accepted→Completed, InProgress→Completed)
- [ ] IDOR ownership checks return 404 (not 403) to avoid leaking existence
- [ ] 400 validation: XOR linkId/pendingInviteId, DurationDays ∈ [1,30]

🤖 Generated with [Claude Code](https://claude.com/claude-code)