### PR TITLE
feat(backend,#93): extend pending-asks query with diary requests

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Questionnaires/GetClientPendingQuestionnaires/GetClientPendingQuestionnairesEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Questionnaires/GetClientPendingQuestionnaires/GetClientPendingQuestionnairesEndpoint.cs
@@ -1,18 +1,29 @@
 using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace FitnessPlatform.Application.Features.Questionnaires.GetClientPendingQuestionnaires;
 
 /// <summary>
-/// Returns all pending/in-progress questionnaires for the client — one per active
-/// professional link. Allows the mobile app to show a list when the client has
-/// multiple coaches.
+/// Returns pending questionnaires AND pending photo-diary requests so the mobile
+/// Today screen can render its top banner stack from one query.
+///
+/// Ordering convention (intentional):
+///   1. <see cref="GetClientPendingQuestionnairesResponse.PendingDiaryRequests"/> — diary first,
+///      sorted by <c>CreatedAt DESC</c> within the list.
+///   2. <see cref="GetClientPendingQuestionnairesResponse.Items"/> — questionnaires second,
+///      one per active professional link.
+///
+/// The mobile client renders the two arrays in order, producing: diary banner(s) → questionnaire banner(s).
 /// </summary>
-public class GetClientPendingQuestionnairesEndpoint(IApplicationDbContext db)
+public class GetClientPendingQuestionnairesEndpoint(
+    IApplicationDbContext db,
+    UserManager<ApplicationUser> userManager)
     : EndpointWithoutRequest<GetClientPendingQuestionnairesResponse>
 {
     public override void Configure()
@@ -21,14 +32,17 @@ public class GetClientPendingQuestionnairesEndpoint(IApplicationDbContext db)
         Roles(AppRoles.Client);
         Summary(s =>
         {
-            s.Summary = "Get all pending questionnaires for the client";
-            s.Description = "Returns pending/in-progress questionnaires across all active professional links.";
+            s.Summary = "Get pending questionnaires and diary requests for the client";
+            s.Description =
+                "Returns pending photo-diary requests (diary first) and pending/in-progress questionnaires " +
+                "across all active professional links. Single query — no additional round-trip required.";
         });
     }
 
     public override async Task HandleAsync(CancellationToken ct)
     {
         var userId = User.FindFirstValue(AppClaims.UserId);
+        var emailClaim = User.FindFirstValue(AppClaims.Email);
         if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
         var userGuid = Guid.Parse(userId);
 
@@ -42,19 +56,82 @@ public class GetClientPendingQuestionnairesEndpoint(IApplicationDbContext db)
             return;
         }
 
-        // Get all active professional links
+        // ── 1. Pending diary requests ─────────────────────────────────────────
+
+        // Collect link IDs and invite IDs for this client (same dual-source pattern as ListClientRequests)
+        var clientLinkIds = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .Where(l => l.ClientProfileId == clientProfile.Id)
+            .Select(l => (long?)l.Id)
+            .ToListAsync(ct);
+
+        var clientInviteIds = emailClaim is not null
+            ? await db.PendingInvites
+                .AsNoTracking()
+                .Where(i => i.Email == emailClaim)
+                .Select(i => (long?)i.Id)
+                .ToListAsync(ct)
+            : [];
+
+        var pendingDiaryEntities = await db.PhotoDiaryRequests
+            .AsNoTracking()
+            .Include(r => r.Professional)
+            .Include(r => r.Link)
+            .Where(r =>
+                r.Status == PhotoDiaryStatus.Pending &&
+                (
+                    (r.LinkId != null && clientLinkIds.Contains(r.LinkId)) ||
+                    (r.PendingInviteId != null && clientInviteIds.Contains(r.PendingInviteId))
+                ))
+            .OrderByDescending(r => r.CreatedAt)
+            .ToListAsync(ct);
+
+        var pendingDiaryItems = new List<PendingDiaryRequestItem>(pendingDiaryEntities.Count);
+
+        foreach (var req in pendingDiaryEntities)
+        {
+            // Resolve professional role:
+            //   - Link-based: use the link's stored ProfessionalRole (no extra DB hit).
+            //   - Invite-based: look up Identity roles (UserManager is already injected).
+            string? professionalRole = null;
+
+            if (req.Link is not null)
+            {
+                professionalRole = req.Link.ProfessionalRole.ToString();
+            }
+            else
+            {
+                var roles = await userManager.GetRolesAsync(req.Professional);
+                professionalRole = roles.Contains(AppRoles.Nutritionist)
+                    ? AppRoles.Nutritionist
+                    : roles.Contains(AppRoles.Trainer) ? AppRoles.Trainer : null;
+            }
+
+            pendingDiaryItems.Add(new PendingDiaryRequestItem
+            {
+                RequestPublicId = req.Id,
+                ProfessionalName = $"{req.Professional.FirstName} {req.Professional.LastName}",
+                ProfessionalRole = professionalRole,
+                DurationDays = req.DurationDays,
+                Status = "Pending",
+                PlanId = req.PlanId,
+                CreatedAt = req.CreatedAt,
+            });
+        }
+
+        // ── 2. Pending questionnaires (existing logic, unchanged) ─────────────
+
+        // Get all active professional links (with profile/user navigation)
         var links = await db.ClientProfessionalLinks
             .Include(l => l.ProfessionalProfile).ThenInclude(pp => pp.User)
             .Where(l => l.ClientProfileId == clientProfile.Id && l.IsActive)
             .ToListAsync(ct);
 
-        var items = new List<PendingQuestionnaireItem>();
+        var questionnaireItems = new List<PendingQuestionnaireItem>();
 
         foreach (var link in links)
         {
             // Skip links where the client already submitted a questionnaire response.
-            // Check both by LinkId and by ProfessionalId (for legacy responses
-            // created before LinkId was tracked, which have LinkId == 0).
             var hasSubmitted = await db.QuestionnaireResponses
                 .AsNoTracking()
                 .AnyAsync(r =>
@@ -88,7 +165,7 @@ public class GetClientPendingQuestionnairesEndpoint(IApplicationDbContext db)
 
             if (questionnaire is null && existingResponse is null) continue;
 
-            items.Add(new PendingQuestionnaireItem
+            questionnaireItems.Add(new PendingQuestionnaireItem
             {
                 LinkPublicId = link.PublicId,
                 ProfessionalName = $"{link.ProfessionalProfile.User.FirstName} {link.ProfessionalProfile.User.LastName}",
@@ -101,6 +178,12 @@ public class GetClientPendingQuestionnairesEndpoint(IApplicationDbContext db)
             });
         }
 
-        await Send.OkAsync(new GetClientPendingQuestionnairesResponse { Items = items }, ct);
+        // ── 3. Return: diary first, questionnaires second ─────────────────────
+
+        await Send.OkAsync(new GetClientPendingQuestionnairesResponse
+        {
+            PendingDiaryRequests = pendingDiaryItems,
+            Items = questionnaireItems,
+        }, ct);
     }
 }

--- a/backend/FitnessPlatform.Application/Features/Questionnaires/GetClientPendingQuestionnaires/GetClientPendingQuestionnairesResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Questionnaires/GetClientPendingQuestionnaires/GetClientPendingQuestionnairesResponse.cs
@@ -1,8 +1,54 @@
 namespace FitnessPlatform.Application.Features.Questionnaires.GetClientPendingQuestionnaires;
 
+/// <summary>
+/// Combined banner response. Diary requests come first (ordering convention documented
+/// on the endpoint summary); questionnaires second.
+/// </summary>
 public class GetClientPendingQuestionnairesResponse
 {
+    /// <summary>
+    /// Pending photo-diary requests addressed to this client.
+    /// Always populated before <see cref="Items"/> so the mobile banner stack
+    /// renders diary banners above questionnaire banners.
+    /// </summary>
+    public List<PendingDiaryRequestItem> PendingDiaryRequests { get; set; } = [];
+
+    /// <summary>
+    /// Pending / in-progress questionnaires for this client (one per active professional link).
+    /// </summary>
     public List<PendingQuestionnaireItem> Items { get; set; } = [];
+}
+
+/// <summary>
+/// Banner DTO for a single pending photo-diary request.
+/// Shape mirrors <see cref="PendingQuestionnaireItem"/> so the mobile banner component
+/// can render both types with a single rendering pattern.
+/// </summary>
+public class PendingDiaryRequestItem
+{
+    /// <summary>Public identifier of the diary request (same as <c>PhotoDiaryRequest.Id</c>).</summary>
+    public Guid RequestPublicId { get; set; }
+
+    /// <summary>Display name of the professional who sent the request.</summary>
+    public string ProfessionalName { get; set; } = string.Empty;
+
+    /// <summary>Role of the professional ("Trainer" or "Nutritionist").</summary>
+    public string? ProfessionalRole { get; set; }
+
+    /// <summary>How many days the client has to upload photos (default 7).</summary>
+    public int DurationDays { get; set; }
+
+    /// <summary>Always "Pending" for items returned by this endpoint.</summary>
+    public string Status { get; set; } = "Pending";
+
+    /// <summary>
+    /// Optional MongoDB plan ID the diary request is scoped to.
+    /// Null when the request has no plan context.
+    /// </summary>
+    public Guid? PlanId { get; set; }
+
+    /// <summary>When the request was created (UTC).</summary>
+    public DateTimeOffset CreatedAt { get; set; }
 }
 
 public class PendingQuestionnaireItem

--- a/backend/FitnessPlatform.Tests/Endpoints/Questionnaires/GetClientPendingQuestionnairesEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Questionnaires/GetClientPendingQuestionnairesEndpointTests.cs
@@ -1,0 +1,367 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.Questionnaires;
+
+/// <summary>
+/// Integration tests for GET /client/questionnaires/pending —
+/// verifies that both PendingDiaryRequests and Items are correctly populated,
+/// and that ordering (diary first, questionnaire second) is respected.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class GetClientPendingQuestionnairesEndpointTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail(string tag = "pq") =>
+        $"{Guid.NewGuid():N}@{tag}-pending.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId, string Email)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Client", "BannerTest", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id, email);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupNutritionistAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("nutr");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Nutr", "BannerTest", "Nutritionist");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId,
+        UserRole role = UserRole.Nutritionist)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = role,
+            IsActive = true,
+            CanViewNutritionPlans = role == UserRole.Nutritionist,
+            CanViewTrainingPlans = role == UserRole.Trainer,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<long> InsertPendingInviteAsync(Guid professionalUserId, string inviteeEmail)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+
+        var invite = new PendingInvite
+        {
+            ProfessionalProfileId = profProfile.Id,
+            FirstName = "Test",
+            LastName = "Client",
+            Email = inviteeEmail,
+            SentAt = DateTime.UtcNow,
+            IsAccepted = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.PendingInvites.Add(invite);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return invite.Id;
+    }
+
+    private async Task<Guid> InsertDiaryRequestAsync(
+        Guid profUserId,
+        long? linkId = null,
+        long? inviteId = null,
+        PhotoDiaryStatus status = PhotoDiaryStatus.Pending,
+        DateTimeOffset? createdAt = null)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUserId,
+            LinkId = linkId,
+            PendingInviteId = inviteId,
+            DurationDays = 7,
+            Status = status,
+            Mode = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? PhotoDiaryMode.Bulk : null,
+            AcceptedAt = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+                ? DateTimeOffset.UtcNow : null,
+            CompletedAt = status == PhotoDiaryStatus.Completed ? DateTimeOffset.UtcNow : null,
+            CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return request.Id;
+    }
+
+    // ── Diary request via active link → returned in PendingDiaryRequests ──────
+
+    [Fact]
+    public async Task DiaryRequest_ViaActiveLink_AppearsInPendingDiaryRequests()
+    {
+        var (_, profId) = await SetupNutritionistAsync();
+        var (clientHttp, clientUserId, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+        var requestId = await InsertDiaryRequestAsync(profId, linkId: linkId);
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        var diaryItem = body!.PendingDiaryRequests.Should()
+            .ContainSingle(i => i.RequestPublicId == requestId).Which;
+        diaryItem.DurationDays.Should().Be(7);
+        diaryItem.Status.Should().Be("Pending");
+        diaryItem.ProfessionalRole.Should().Be("Nutritionist");
+        diaryItem.ProfessionalName.Should().NotBeNullOrEmpty();
+    }
+
+    // ── Diary request via pending invite → returned (email-matched) ───────────
+
+    [Fact]
+    public async Task DiaryRequest_ViaPendingInvite_AppearsInPendingDiaryRequests()
+    {
+        var (_, profId) = await SetupNutritionistAsync();
+        var (clientHttp, _, clientEmail) = await SetupClientAsync();
+
+        var inviteId = await InsertPendingInviteAsync(profId, clientEmail);
+        var requestId = await InsertDiaryRequestAsync(profId, inviteId: inviteId);
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        body!.PendingDiaryRequests.Should().Contain(i => i.RequestPublicId == requestId);
+    }
+
+    // ── Non-pending statuses are excluded ─────────────────────────────────────
+
+    [Fact]
+    public async Task DiaryRequest_NonPendingStatus_NotReturned()
+    {
+        var (_, profId) = await SetupNutritionistAsync();
+        var (clientHttp, clientUserId, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+
+        var acceptedId = await InsertDiaryRequestAsync(profId, linkId: linkId, status: PhotoDiaryStatus.Accepted);
+        var dismissedId = await InsertDiaryRequestAsync(profId, linkId: linkId, status: PhotoDiaryStatus.Dismissed);
+        var inProgressId = await InsertDiaryRequestAsync(profId, linkId: linkId, status: PhotoDiaryStatus.InProgress);
+        var completedId = await InsertDiaryRequestAsync(profId, linkId: linkId, status: PhotoDiaryStatus.Completed);
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        var ids = body!.PendingDiaryRequests.Select(i => i.RequestPublicId).ToList();
+        ids.Should().NotContain(acceptedId);
+        ids.Should().NotContain(dismissedId);
+        ids.Should().NotContain(inProgressId);
+        ids.Should().NotContain(completedId);
+    }
+
+    // ── IDOR: diary request for another client is not returned ────────────────
+
+    [Fact]
+    public async Task DiaryRequest_BelongingToAnotherClient_NotReturned()
+    {
+        var (_, profId) = await SetupNutritionistAsync();
+        var (clientHttp, _, _) = await SetupClientAsync();
+        var (_, otherClientId, _) = await SetupClientAsync();
+
+        var otherLinkId = await InsertLinkAsync(otherClientId, profId);
+        var otherRequestId = await InsertDiaryRequestAsync(profId, linkId: otherLinkId);
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        body!.PendingDiaryRequests.Should().NotContain(i => i.RequestPublicId == otherRequestId);
+    }
+
+    // ── Mixed: both a diary request and a questionnaire → both returned ───────
+
+    [Fact]
+    public async Task Mixed_PendingDiaryAndQuestionnaire_BothReturned()
+    {
+        var (_, profId) = await SetupNutritionistAsync();
+        var (clientHttp, clientUserId, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+        var diaryRequestId = await InsertDiaryRequestAsync(profId, linkId: linkId);
+
+        // Seed a questionnaire for this professional so the pending questionnaire list is non-empty
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var questionnaire = new Questionnaire
+            {
+                PublicId = Guid.NewGuid(),
+                ProfessionalId = profId,
+                Title = "Onboarding",
+                IsDefault = true,
+                IsActive = true,
+                DateCreated = DateTime.UtcNow,
+            };
+            db.Questionnaires.Add(questionnaire);
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        body!.PendingDiaryRequests.Should().Contain(i => i.RequestPublicId == diaryRequestId);
+        body.Items.Should().NotBeEmpty("the questionnaire seeded for this professional should appear");
+    }
+
+    // ── Empty: no pending of either type → both arrays are empty ─────────────
+
+    [Fact]
+    public async Task EmptyClient_NoPendingOfEitherType_BothArraysEmpty()
+    {
+        var (clientHttp, _, _) = await SetupClientAsync();
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        body!.PendingDiaryRequests.Should().BeEmpty();
+        body.Items.Should().BeEmpty();
+    }
+
+    // ── Ordering: diary CreatedAt DESC ────────────────────────────────────────
+
+    [Fact]
+    public async Task DiaryRequests_OrderedByCreatedAtDescending()
+    {
+        var (_, profId) = await SetupNutritionistAsync();
+        var (clientHttp, clientUserId, _) = await SetupClientAsync();
+
+        var linkId = await InsertLinkAsync(clientUserId, profId);
+
+        var olderTime = DateTimeOffset.UtcNow.AddDays(-2);
+        var newerTime = DateTimeOffset.UtcNow.AddDays(-1);
+
+        var olderRequestId = await InsertDiaryRequestAsync(profId, linkId: linkId, createdAt: olderTime);
+        var newerRequestId = await InsertDiaryRequestAsync(profId, linkId: linkId, createdAt: newerTime);
+
+        var response = await clientHttp.GetAsync(
+            "/client/questionnaires/pending",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<BannerResponse>(
+            JsonOptions, TestContext.Current.CancellationToken);
+
+        var diaryIds = body!.PendingDiaryRequests
+            .Select(i => i.RequestPublicId)
+            .ToList();
+
+        // newerRequestId should appear before olderRequestId
+        diaryIds.Should().Contain(newerRequestId);
+        diaryIds.Should().Contain(olderRequestId);
+        diaryIds.IndexOf(newerRequestId).Should().BeLessThan(diaryIds.IndexOf(olderRequestId));
+    }
+
+    // ── Response shape helpers ─────────────────────────────────────────────────
+
+    private record DiaryItem(
+        Guid RequestPublicId,
+        string ProfessionalName,
+        string? ProfessionalRole,
+        int DurationDays,
+        string Status,
+        Guid? PlanId,
+        DateTimeOffset CreatedAt);
+
+    private record QuestionnaireItem(
+        Guid LinkPublicId,
+        string ProfessionalName,
+        string? ProfessionalRole);
+
+    private record BannerResponse(
+        List<DiaryItem> PendingDiaryRequests,
+        List<QuestionnaireItem> Items);
+}


### PR DESCRIPTION
## Summary

- Extends the existing `GET /client/questionnaires/pending` endpoint (no new route) to return pending photo-diary requests alongside pending questionnaires in a single response.
- Response DTO gains `PendingDiaryRequests: List<PendingDiaryRequestItem>` prepended before the existing `Items` field — fully backward-compatible.
- Diary requests are sourced via both ownership paths: active `ClientProfessionalLink` and `PendingInvite` (email-matched), mirroring the pattern from `ListClientRequestsEndpoint`.
- 7 new Testcontainers integration tests cover: link-based, invite-based, status filtering, IDOR isolation, mixed (both types), empty client, and `CreatedAt DESC` ordering. Suite at 956/956 green.

## Related issue

Fixes #93

## Parent epic (sub-issue PR)

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all ACs verified: no new round-trip (route unchanged), ordering (diary first, `CreatedAt DESC` within), both ownership branches (link + invite), status filter (Pending only), DTO shape complete.

## Test plan

- [ ] No new network round-trip — route `GET /client/questionnaires/pending` unchanged.
- [ ] Ordering — diary requests first; questionnaire items second.
- [ ] Both ownership branches: active link and pending invite.
- [ ] Status filter: only `Pending` diary requests returned.
- [ ] DTO shape: `RequestPublicId`, `ProfessionalName`, `ProfessionalRole`, `DurationDays`, `Status`, `PlanId?`, `CreatedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)