### PR TITLE
feat(backend,#94): SignalR events for diary lifecycle

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientPlans/FinalizePlanPhoto/FinalizePlanPhotoEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientPlans/FinalizePlanPhoto/FinalizePlanPhotoEndpoint.cs
@@ -6,6 +6,7 @@ using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -21,12 +22,18 @@ namespace FitnessPlatform.Application.Features.ClientPlans.FinalizePlanPhoto;
 ///
 /// Ownership: looks up the plan in NutritionPlans first; falls back to TrainingPlans.
 /// Returns 404 if neither exists for the given client.
-/// After a successful insert, emits a <c>planPhotoUploaded</c> SignalR event to the owning
-/// professional (best-effort: a broadcast failure does not fail the HTTP response).
+/// After a successful insert:
+/// <list type="bullet">
+///   <item>Emits a <c>planPhotoUploaded</c> SignalR event to the owning professional.</item>
+///   <item>When <see cref="FinalizePlanPhotoRequest.DiaryRequestId"/> is set, additionally emits
+///     a <c>photoDiaryPhotoUploaded</c> event to the same professional group so the trainer/
+///     nutritionist can track diary progress in real time.</item>
+/// </list>
+/// Both broadcasts are best-effort: a failure does not fail the HTTP response.
 /// </summary>
 /// <param name="mongo">MongoDB context for plan lookup.</param>
 /// <param name="db">Relational database context for profile lookup and photo insert.</param>
-/// <param name="notifier">Realtime notifier for pushing the <c>planPhotoUploaded</c> event.</param>
+/// <param name="notifier">Realtime notifier for pushing the SignalR events.</param>
 /// <param name="logger">Logger.</param>
 public class FinalizePlanPhotoEndpoint(
     IMongoContext mongo,
@@ -96,6 +103,7 @@ public class FinalizePlanPhotoEndpoint(
             diaryRequest = await db.PhotoDiaryRequests
                 .Include(r => r.Link)
                     .ThenInclude(l => l!.ClientProfile)
+                        .ThenInclude(cp => cp.User)
                 .Include(r => r.PendingInvite)
                 .FirstOrDefaultAsync(r => r.Id == req.DiaryRequestId.Value, ct);
 
@@ -177,6 +185,39 @@ public class FinalizePlanPhotoEndpoint(
                 req.PlanId);
         }
 
+        // Emit photoDiaryPhotoUploaded when this photo is linked to a diary request (best-effort).
+        // Recipient: request.ProfessionalId  →  nutritionist/trainer group.
+        if (diaryRequest is not null && professionalUserId.HasValue)
+        {
+            try
+            {
+                var clientName = ResolveClientNameFromDiaryRequest(diaryRequest, callerUserId, emailClaim);
+                var dayIndex = diaryRequest.AcceptedAt.HasValue
+                    ? Math.Max(1, (DateTimeOffset.UtcNow - diaryRequest.AcceptedAt.Value).Days + 1)
+                    : 1;
+
+                await notifier.NotifyAsync(
+                    diaryRequest.ProfessionalId,  // → professional group
+                    "photoDiaryPhotoUploaded",
+                    new PhotoDiaryPhotoUploadedEvent
+                    {
+                        RequestId = diaryRequest.Id,
+                        PhotoId = photo.PublicId,
+                        ClientName = clientName,
+                        DayIndex = dayIndex,
+                        Caption = photo.Description,
+                        UploadedAt = DateTimeOffset.UtcNow,
+                    },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to emit photoDiaryPhotoUploaded for request {RequestId} to professional {ProfessionalId}",
+                    diaryRequest.Id, diaryRequest.ProfessionalId);
+            }
+        }
+
         var response = MapToResponse(photo);
         HttpContext.Response.Headers.Location =
             $"/client/plans/{req.PlanId}/photos/{photo.PublicId}";
@@ -246,5 +287,22 @@ public class FinalizePlanPhotoEndpoint(
                 StringComparison.OrdinalIgnoreCase);
 
         return false;
+    }
+
+    /// <summary>
+    /// Resolves a display name for the client from the diary request's navigation properties.
+    /// </summary>
+    private static string ResolveClientNameFromDiaryRequest(
+        PhotoDiaryRequest request,
+        Guid callerUserId,
+        string? clientEmail)
+    {
+        if (request.Link?.ClientProfile?.User is { } user)
+            return $"{user.FirstName} {user.LastName}".Trim();
+
+        if (request.PendingInvite is { } invite)
+            return $"{invite.FirstName} {invite.LastName}".Trim();
+
+        return clientEmail ?? string.Empty;
     }
 }

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestEndpoint.cs
@@ -169,7 +169,8 @@ public class CreateRequestEndpoint(
                     $"{professionalProfile.User.FirstName} {professionalProfile.User.LastName}".Trim();
 
                 // Resolve the professional's role from the claims (Trainer or Nutritionist).
-                var professionalRole = User.FindFirstValue(System.Security.Claims.ClaimTypes.Role)
+                // FastEndpoints encodes roles under the short "role" claim type, not ClaimTypes.Role.
+                var professionalRole = User.FindFirstValue("role")
                     ?? string.Empty;
 
                 await notifier.NotifyAsync(

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/CreateRequest/CreateRequestEndpoint.cs
@@ -4,9 +4,12 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
@@ -14,8 +17,22 @@ namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
 /// <summary>
 /// POST /trainer/photo-diary-requests
 /// Creates a new photo diary request attached to an existing client link or pending invite.
+/// After a successful save, emits a <c>photoDiaryRequested</c> SignalR event to the
+/// <b>client</b> group so the client sees the new banner in real time:
+/// <list type="bullet">
+///   <item>Link-based: notified via <c>link.ClientProfile.UserId</c> (client group).</item>
+///   <item>Invite-based + existing user: notified via the user found by the invite e-mail.</item>
+///   <item>Invite-based + no registered user yet: no notification — the banner surfaces naturally
+///     on next sign-in via the pending-banner query (#93).</item>
+/// </list>
+/// Broadcast failures are best-effort and never fail the HTTP response.
 /// </summary>
-public class CreateRequestEndpoint(IApplicationDbContext db, IMongoContext mongo)
+public class CreateRequestEndpoint(
+    IApplicationDbContext db,
+    IMongoContext mongo,
+    IRealtimeNotifier notifier,
+    UserManager<ApplicationUser> userManager,
+    ILogger<CreateRequestEndpoint> logger)
     : Endpoint<CreateRequestRequest, CreateRequestResponse>
 {
     public override void Configure()
@@ -37,7 +54,7 @@ public class CreateRequestEndpoint(IApplicationDbContext db, IMongoContext mongo
 
         // Resolve the professional's profile (needed for ownership checks on link/invite)
         var professionalProfile = await db.ProfessionalProfiles
-            .AsNoTracking()
+            .Include(p => p.User)
             .FirstOrDefaultAsync(p => p.UserId == professionalId, ct);
 
         if (professionalProfile is null)
@@ -47,6 +64,7 @@ public class CreateRequestEndpoint(IApplicationDbContext db, IMongoContext mongo
         }
 
         Guid? clientUserId = null;
+        string? inviteEmail = null;
 
         if (req.LinkId.HasValue)
         {
@@ -79,7 +97,8 @@ public class CreateRequestEndpoint(IApplicationDbContext db, IMongoContext mongo
                 return;
             }
 
-            // clientUserId remains null for invite-based requests until the invite is accepted
+            inviteEmail = invite.Email;
+            // clientUserId resolved below after save (only if user is already registered)
         }
 
         // Validate planId ownership if provided (check both nutrition and training plans)
@@ -132,6 +151,55 @@ public class CreateRequestEndpoint(IApplicationDbContext db, IMongoContext mongo
 
         db.PhotoDiaryRequests.Add(request);
         await db.SaveChangesAsync(ct);
+
+        // ── Emit photoDiaryRequested to the client group (best-effort) ───────────
+        // Link-based: client is already known.
+        // Invite-based: resolve the registered user by e-mail; skip if not yet registered.
+        if (clientUserId is null && inviteEmail is not null)
+        {
+            var invitedUser = await userManager.FindByEmailAsync(inviteEmail);
+            clientUserId = invitedUser?.Id;
+        }
+
+        if (clientUserId.HasValue)
+        {
+            try
+            {
+                var professionalName =
+                    $"{professionalProfile.User.FirstName} {professionalProfile.User.LastName}".Trim();
+
+                // Resolve the professional's role from the claims (Trainer or Nutritionist).
+                var professionalRole = User.FindFirstValue(System.Security.Claims.ClaimTypes.Role)
+                    ?? string.Empty;
+
+                await notifier.NotifyAsync(
+                    clientUserId.Value,   // → client group
+                    "photoDiaryRequested",
+                    new PhotoDiaryRequestedEvent
+                    {
+                        RequestId = request.Id,
+                        ProfessionalName = professionalName,
+                        ProfessionalRole = professionalRole,
+                        DurationDays = request.DurationDays,
+                        PlanId = request.PlanId,
+                        CreatedAt = request.CreatedAt,
+                    },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to emit photoDiaryRequested for request {RequestId} to client {ClientId}",
+                    request.Id, clientUserId.Value);
+            }
+        }
+        else if (inviteEmail is not null)
+        {
+            // No registered user for the invite e-mail yet — notification skipped intentionally.
+            logger.LogDebug(
+                "Skipping photoDiaryRequested for request {RequestId}: invite e-mail {Email} has no registered user yet",
+                request.Id, inviteEmail);
+        }
 
         await Send.CreatedAtAsync<CreateRequestEndpoint>(null, new CreateRequestResponse
         {

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/DismissRequest/DismissRequestEndpoint.cs
@@ -3,8 +3,10 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
 
@@ -12,8 +14,15 @@ namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest
 /// POST /client/photo-diary-requests/{id}/dismiss
 /// Transitions a Pending request to Dismissed, optionally recording a reason.
 /// Mutually exclusive with accept: once accepted the request is no longer Pending.
+/// After a successful transition emits a <c>photoDiaryDismissed</c> SignalR event to the
+/// <b>professional</b> group (<see cref="Domain.Entities.PhotoDiaryRequest.ProfessionalId"/>)
+/// so the trainer/nutritionist sees the update in real time.
+/// Broadcast failures are best-effort and never fail the HTTP response.
 /// </summary>
-public class DismissRequestEndpoint(IApplicationDbContext db)
+public class DismissRequestEndpoint(
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    ILogger<DismissRequestEndpoint> logger)
     : Endpoint<DismissRequestRequest, DismissRequestResponse>
 {
     public override void Configure()
@@ -37,6 +46,7 @@ public class DismissRequestEndpoint(IApplicationDbContext db)
         var request = await db.PhotoDiaryRequests
             .Include(r => r.Link)
                 .ThenInclude(l => l!.ClientProfile)
+                    .ThenInclude(cp => cp.User)
             .Include(r => r.PendingInvite)
             .FirstOrDefaultAsync(r => r.Id == req.Id, ct);
 
@@ -61,6 +71,30 @@ public class DismissRequestEndpoint(IApplicationDbContext db)
 
         await db.SaveChangesAsync(ct);
 
+        // ── Emit photoDiaryDismissed to the professional group (best-effort) ─────
+        // Recipient: request.ProfessionalId  →  nutritionist/trainer group.
+        try
+        {
+            var clientName = ResolveClientName(request, emailClaim);
+            await notifier.NotifyAsync(
+                request.ProfessionalId,   // → professional group
+                "photoDiaryDismissed",
+                new PhotoDiaryDismissedEvent
+                {
+                    RequestId = request.Id,
+                    ClientName = clientName,
+                    DismissReason = request.DismissReason,
+                    DismissedAt = request.UpdatedAt,
+                },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to emit photoDiaryDismissed for request {RequestId} to professional {ProfessionalId}",
+                request.Id, request.ProfessionalId);
+        }
+
         await Send.OkAsync(new DismissRequestResponse
         {
             Id = request.Id,
@@ -82,5 +116,23 @@ public class DismissRequestEndpoint(IApplicationDbContext db)
                 StringComparison.OrdinalIgnoreCase);
 
         return false;
+    }
+
+    /// <summary>
+    /// Resolves a display name for the client:
+    /// link-based → from the ClientProfile.User navigation; invite-based → from PendingInvite names.
+    /// Falls back to the email claim if nothing else is available.
+    /// </summary>
+    private static string ResolveClientName(
+        Domain.Entities.PhotoDiaryRequest request,
+        string? clientEmail)
+    {
+        if (request.Link?.ClientProfile?.User is { } user)
+            return $"{user.FirstName} {user.LastName}".Trim();
+
+        if (request.PendingInvite is { } invite)
+            return $"{invite.FirstName} {invite.LastName}".Trim();
+
+        return clientEmail ?? string.Empty;
     }
 }

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/PhotoDiaryEvents.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/PhotoDiaryEvents.cs
@@ -1,0 +1,103 @@
+namespace FitnessPlatform.Application.Features.PhotoDiaryRequests;
+
+// ── Payload classes for diary-lifecycle SignalR events ──────────────────────
+//
+// Routing summary:
+//   photoDiaryRequested    → client group  (identified by clientUserId)
+//   photoDiaryDismissed    → trainer/nutritionist group (request.ProfessionalId)
+//   photoDiaryPhotoUploaded → trainer/nutritionist group (request.ProfessionalId)
+//   photoDiarySubmitted    → trainer/nutritionist group (request.ProfessionalId)
+//
+// Groups are per-user: each user has their own SignalR group named by userId.ToString().
+// This gives a natural "client group" vs "nutritionist group" without extra hub machinery.
+
+/// <summary>
+/// Payload for the <c>photoDiaryRequested</c> SignalR event.
+/// Emitted to the <b>client</b> when a nutritionist/trainer creates a new photo diary request.
+/// </summary>
+public class PhotoDiaryRequestedEvent
+{
+    /// <summary>Public identifier of the newly-created diary request.</summary>
+    public Guid RequestId { get; init; }
+
+    /// <summary>Display name of the requesting professional.</summary>
+    public string ProfessionalName { get; init; } = string.Empty;
+
+    /// <summary>Role of the requesting professional (e.g. "Nutritionist", "Trainer").</summary>
+    public string ProfessionalRole { get; init; } = string.Empty;
+
+    /// <summary>Number of days the client has to complete the diary.</summary>
+    public int DurationDays { get; init; }
+
+    /// <summary>Optional MongoDB plan the request is scoped to.</summary>
+    public Guid? PlanId { get; init; }
+
+    /// <summary>When the request was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>
+/// Payload for the <c>photoDiaryDismissed</c> SignalR event.
+/// Emitted to the <b>professional</b> when the client dismisses a diary request.
+/// </summary>
+public class PhotoDiaryDismissedEvent
+{
+    /// <summary>Public identifier of the diary request.</summary>
+    public Guid RequestId { get; init; }
+
+    /// <summary>Display name of the client who dismissed.</summary>
+    public string ClientName { get; init; } = string.Empty;
+
+    /// <summary>Optional reason the client provided for dismissing.</summary>
+    public string? DismissReason { get; init; }
+
+    /// <summary>When the request was dismissed (UpdatedAt after the status transition).</summary>
+    public DateTimeOffset DismissedAt { get; init; }
+}
+
+/// <summary>
+/// Payload for the <c>photoDiaryPhotoUploaded</c> SignalR event.
+/// Emitted to the <b>professional</b> when the client uploads a photo against an active diary request.
+/// </summary>
+public class PhotoDiaryPhotoUploadedEvent
+{
+    /// <summary>Public identifier of the diary request the photo belongs to.</summary>
+    public Guid RequestId { get; init; }
+
+    /// <summary>Public identifier of the newly-created PlanPhoto row.</summary>
+    public Guid PhotoId { get; init; }
+
+    /// <summary>Display name of the uploading client.</summary>
+    public string ClientName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Day number within the diary (1-based). Computed as (UtcNow − request.AcceptedAt).Days + 1
+    /// when AcceptedAt is set; falls back to 1 otherwise.
+    /// </summary>
+    public int DayIndex { get; init; }
+
+    /// <summary>Optional description/caption the client attached to the photo.</summary>
+    public string? Caption { get; init; }
+
+    /// <summary>When the photo was finalized.</summary>
+    public DateTimeOffset UploadedAt { get; init; }
+}
+
+/// <summary>
+/// Payload for the <c>photoDiarySubmitted</c> SignalR event.
+/// Emitted to the <b>professional</b> when the client submits (completes) a diary.
+/// </summary>
+public class PhotoDiarySubmittedEvent
+{
+    /// <summary>Public identifier of the diary request.</summary>
+    public Guid RequestId { get; init; }
+
+    /// <summary>Display name of the client who submitted.</summary>
+    public string ClientName { get; init; } = string.Empty;
+
+    /// <summary>Total number of PlanPhoto rows linked to this diary request at submission time.</summary>
+    public int PhotoCount { get; init; }
+
+    /// <summary>When the diary was submitted (CompletedAt after the status transition).</summary>
+    public DateTimeOffset SubmittedAt { get; init; }
+}

--- a/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/PhotoDiaryRequests/SubmitRequest/SubmitRequestEndpoint.cs
@@ -3,16 +3,25 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace FitnessPlatform.Application.Features.PhotoDiaryRequests.SubmitRequest;
 
 /// <summary>
 /// POST /client/photo-diary-requests/{id}/submit
 /// Transitions an Accepted or InProgress request to Completed, recording CompletedAt.
+/// After a successful transition emits a <c>photoDiarySubmitted</c> SignalR event to the
+/// <b>professional</b> group (<see cref="Domain.Entities.PhotoDiaryRequest.ProfessionalId"/>)
+/// so the trainer/nutritionist sees the completed diary in real time.
+/// Broadcast failures are best-effort and never fail the HTTP response.
 /// </summary>
-public class SubmitRequestEndpoint(IApplicationDbContext db)
+public class SubmitRequestEndpoint(
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    ILogger<SubmitRequestEndpoint> logger)
     : Endpoint<SubmitRequestRequest, SubmitRequestResponse>
 {
     public override void Configure()
@@ -36,6 +45,7 @@ public class SubmitRequestEndpoint(IApplicationDbContext db)
         var request = await db.PhotoDiaryRequests
             .Include(r => r.Link)
                 .ThenInclude(l => l!.ClientProfile)
+                    .ThenInclude(cp => cp.User)
             .Include(r => r.PendingInvite)
             .FirstOrDefaultAsync(r => r.Id == req.Id, ct);
 
@@ -60,6 +70,33 @@ public class SubmitRequestEndpoint(IApplicationDbContext db)
 
         await db.SaveChangesAsync(ct);
 
+        // ── Emit photoDiarySubmitted to the professional group (best-effort) ─────
+        // Recipient: request.ProfessionalId  →  nutritionist/trainer group.
+        try
+        {
+            var clientName = ResolveClientName(request, emailClaim);
+            var photoCount = await db.PlanPhotos
+                .CountAsync(p => p.DiaryRequestId == request.Id, ct);
+
+            await notifier.NotifyAsync(
+                request.ProfessionalId,   // → professional group
+                "photoDiarySubmitted",
+                new PhotoDiarySubmittedEvent
+                {
+                    RequestId = request.Id,
+                    ClientName = clientName,
+                    PhotoCount = photoCount,
+                    SubmittedAt = request.CompletedAt!.Value,
+                },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to emit photoDiarySubmitted for request {RequestId} to professional {ProfessionalId}",
+                request.Id, request.ProfessionalId);
+        }
+
         await Send.OkAsync(new SubmitRequestResponse
         {
             Id = request.Id,
@@ -81,5 +118,23 @@ public class SubmitRequestEndpoint(IApplicationDbContext db)
                 StringComparison.OrdinalIgnoreCase);
 
         return false;
+    }
+
+    /// <summary>
+    /// Resolves a display name for the client:
+    /// link-based → from the ClientProfile.User navigation; invite-based → from PendingInvite names.
+    /// Falls back to the email claim if nothing else is available.
+    /// </summary>
+    private static string ResolveClientName(
+        Domain.Entities.PhotoDiaryRequest request,
+        string? clientEmail)
+    {
+        if (request.Link?.ClientProfile?.User is { } user)
+            return $"{user.FirstName} {user.LastName}".Trim();
+
+        if (request.PendingInvite is { } invite)
+            return $"{invite.FirstName} {invite.LastName}".Trim();
+
+        return clientEmail ?? string.Empty;
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/CreateRequestSignalRTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/CreateRequestSignalRTests.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Integration tests verifying that POST /trainer/photo-diary-requests emits
+/// the <c>photoDiaryRequested</c> SignalR event to the correct client and that
+/// broadcast failures do not roll back the mutation.
+///
+/// Uses <see cref="FitnessApiFactory"/> (Testcontainers-backed PostgreSQL + MongoDB)
+/// and the shared <see cref="FakeRealtimeNotifier"/> singleton so that
+/// <c>Send.CreatedAtAsync</c> (which requires a real <c>LinkGenerator</c>) works
+/// without any stub wiring.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class CreateRequestSignalRTests(FitnessApiFactory factory)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static string UniqueEmail(string tag = "signalr") =>
+        $"{Guid.NewGuid():N}@{tag}-diary-signalr.com";
+
+    // ── Setup helpers ──────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, Guid UserId, string FirstName, string LastName)>
+        SetupProfessionalAsync(string firstName = "Jana", string lastName = "Novakova")
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("prof");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", firstName, lastName, "Nutritionist");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id, firstName, lastName);
+    }
+
+    private async Task<(HttpClient Http, Guid UserId)> SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Petr", "Novak", "Client");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var user = await db.Users.FirstAsync(u => u.Email == email, TestContext.Current.CancellationToken);
+        return (http, user.Id);
+    }
+
+    private async Task<long> InsertLinkAsync(Guid clientUserId, Guid professionalUserId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return link.Id;
+    }
+
+    private async Task<long> InsertPendingInviteAsync(Guid professionalUserId, string inviteeEmail)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == professionalUserId, TestContext.Current.CancellationToken);
+
+        var invite = new PendingInvite
+        {
+            ProfessionalProfileId = profProfile.Id,
+            FirstName = "Petr",
+            LastName = "Novak",
+            Email = inviteeEmail,
+            SentAt = DateTime.UtcNow,
+            IsAccepted = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.PendingInvites.Add(invite);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return invite.Id;
+    }
+
+    private FakeRealtimeNotifier GetNotifier() =>
+        factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+
+    // ── Tests ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateRequest_LinkBased_EmitsPhotoDiaryRequested_ToClient()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (profHttp, profId, firstName, lastName) = await SetupProfessionalAsync();
+        var (_, clientId) = await SetupClientAsync();
+        var linkId = await InsertLinkAsync(clientId, profId);
+
+        var response = await profHttp.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = linkId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "photoDiaryRequested")
+            .ToList();
+
+        calls.Should().HaveCount(1, "exactly one photoDiaryRequested event must be emitted");
+        calls[0].UserId.Should().Be(clientId, "the event must be addressed to the client");
+
+        var evt = calls[0].Payload.Should().BeOfType<PhotoDiaryRequestedEvent>().Subject;
+        evt.DurationDays.Should().Be(7);
+        evt.ProfessionalName.Should().Be($"{firstName} {lastName}");
+        evt.ProfessionalRole.Should().Be("Nutritionist");
+    }
+
+    [Fact]
+    public async Task CreateRequest_LinkBased_EventContainsCorrectRequestId()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (profHttp, profId, _, _) = await SetupProfessionalAsync();
+        var (_, clientId) = await SetupClientAsync();
+        var linkId = await InsertLinkAsync(clientId, profId);
+
+        var response = await profHttp.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = linkId, DurationDays = 14 },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<CreateResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "photoDiaryRequested")
+            .ToList();
+
+        calls.Should().HaveCount(1);
+        var evt = calls[0].Payload.Should().BeOfType<PhotoDiaryRequestedEvent>().Subject;
+        evt.RequestId.Should().Be(body!.Id, "the RequestId in the event must match the response body Id");
+    }
+
+    [Fact]
+    public async Task CreateRequest_InviteBased_ExistingUser_EmitsPhotoDiaryRequested_ToClient()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (profHttp, profId, _, _) = await SetupProfessionalAsync();
+        var (_, clientId) = await SetupClientAsync();
+
+        // Get the client's email so we can create an invite for it
+        string clientEmail;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Id == clientId, TestContext.Current.CancellationToken);
+            clientEmail = user.Email!;
+        }
+
+        var inviteId = await InsertPendingInviteAsync(profId, clientEmail);
+
+        var response = await profHttp.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { PendingInviteId = inviteId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "photoDiaryRequested")
+            .ToList();
+
+        calls.Should().HaveCount(1, "the registered client must receive exactly one photoDiaryRequested event");
+        calls[0].UserId.Should().Be(clientId, "the event must be addressed to the registered client's userId");
+    }
+
+    [Fact]
+    public async Task CreateRequest_InviteBased_NoExistingUser_NoNotification()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+
+        var (profHttp, profId, _, _) = await SetupProfessionalAsync();
+
+        // Use an e-mail address that has no registered account
+        var unregisteredEmail = $"unregistered-{Guid.NewGuid():N}@example.com";
+        var inviteId = await InsertPendingInviteAsync(profId, unregisteredEmail);
+
+        var response = await profHttp.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { PendingInviteId = inviteId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var calls = notifier.Calls
+            .Where(c => c.EventType == "photoDiaryRequested")
+            .ToList();
+
+        calls.Should().BeEmpty(
+            "no notification should be sent when the invitee has not registered yet");
+    }
+
+    [Fact]
+    public async Task CreateRequest_BroadcastThrows_MutationStillSucceeds()
+    {
+        var notifier = GetNotifier();
+        notifier.Reset();
+        notifier.SimulateThrowOnNextCall();
+
+        var (profHttp, profId, _, _) = await SetupProfessionalAsync();
+        var (_, clientId) = await SetupClientAsync();
+        var linkId = await InsertLinkAsync(clientId, profId);
+
+        var response = await profHttp.PostAsJsonAsync(
+            "/trainer/photo-diary-requests",
+            new { LinkId = linkId, DurationDays = 7 },
+            TestContext.Current.CancellationToken);
+
+        // The HTTP response must still be 201 even though the notifier threw
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<CreateResponseBody>(
+            JsonOptions, TestContext.Current.CancellationToken);
+        body.Should().NotBeNull();
+
+        // The entity must have been persisted despite the broadcast failure
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await db.PhotoDiaryRequests
+            .FirstOrDefaultAsync(r => r.Id == body!.Id, TestContext.Current.CancellationToken);
+        persisted.Should().NotBeNull("the mutation must persist even when the broadcast throws");
+    }
+
+    // ── Response shape helper ──────────────────────────────────────────────────
+
+    private record CreateResponseBody(
+        Guid Id,
+        Guid ProfessionalId,
+        long? LinkId,
+        long? PendingInviteId,
+        Guid? PlanId,
+        int DurationDays,
+        PhotoDiaryStatus Status,
+        DateTimeOffset CreatedAt);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/DiaryLifecycleSignalRTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/DiaryLifecycleSignalRTests.cs
@@ -6,31 +6,29 @@ using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.PhotoDiaryRequests;
-using FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
 using FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
 using FitnessPlatform.Application.Features.PhotoDiaryRequests.SubmitRequest;
 using FitnessPlatform.Application.Infrastructure.Data;
-using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Builders;
-using FitnessPlatform.Tests.Endpoints.NutritionPlans;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
-using MongoDB.Driver;
 using NSubstitute;
 using ApplicationPhotoRequest = FitnessPlatform.Application.Domain.Entities.PhotoDiaryRequest;
 
 namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
 
 /// <summary>
-/// Verifies SignalR broadcast behaviour for the four diary lifecycle events:
+/// Verifies SignalR broadcast behaviour for the diary lifecycle events
+/// that do NOT require a full integration test host:
 /// <list type="bullet">
-///   <item><c>photoDiaryRequested</c>   — emitted to the <b>client</b> after CreateRequest.</item>
 ///   <item><c>photoDiaryDismissed</c>   — emitted to the <b>professional</b> after DismissRequest.</item>
-///   <item><c>photoDiaryPhotoUploaded</c> — emitted to the <b>professional</b> after FinalizePlanPhoto
-///     when a DiaryRequestId is set (covered in PhotoDiaryPhotoUploadedSignalRTests).</item>
 ///   <item><c>photoDiarySubmitted</c>   — emitted to the <b>professional</b> after SubmitRequest.</item>
 /// </list>
-/// Uses mock-based unit tests (Factory.Create + NSubstitute) so tests run without Docker.
+/// Uses mock-based unit tests (Factory.Create + NSubstitute) so these tests run without Docker.
+///
+/// The <c>photoDiaryRequested</c> event (emitted by CreateRequest) is covered by
+/// <see cref="CreateRequestSignalRTests"/>, which uses <see cref="FitnessPlatform.Tests.Infrastructure.FitnessApiFactory"/>
+/// because <c>CreateRequestEndpoint</c> calls <c>Send.CreatedAtAsync</c> which requires
+/// a real <c>LinkGenerator</c> not available in unit-test mode.
 /// </summary>
 public class DiaryLifecycleSignalRTests
 {
@@ -45,38 +43,10 @@ public class DiaryLifecycleSignalRTests
 
     // ── Loggers ──────────────────────────────────────────────────────────────────
 
-    private readonly ILogger<CreateRequestEndpoint> _createLogger =
-        Substitute.For<ILogger<CreateRequestEndpoint>>();
     private readonly ILogger<DismissRequestEndpoint> _dismissLogger =
         Substitute.For<ILogger<DismissRequestEndpoint>>();
     private readonly ILogger<SubmitRequestEndpoint> _submitLogger =
         Substitute.For<ILogger<SubmitRequestEndpoint>>();
-
-    // ── Mongo stub for CreateRequest (plan ownership check uses Mongo) ───────────
-
-    private static IMongoContext CreateEmptyMongo()
-    {
-        var mongo = Substitute.For<IMongoContext>();
-
-        var nutritionCollection = PlanTestHelpers.CreateMockMongo().NutritionPlans;
-        mongo.NutritionPlans.Returns(nutritionCollection);
-
-        var trainingCollection = Substitute.For<IMongoCollection<Application.Domain.Documents.TrainingPlan>>();
-        trainingCollection.FindAsync(
-                Arg.Any<FilterDefinition<Application.Domain.Documents.TrainingPlan>>(),
-                Arg.Any<FindOptions<Application.Domain.Documents.TrainingPlan, Application.Domain.Documents.TrainingPlan>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                var cursor = Substitute.For<IAsyncCursor<Application.Domain.Documents.TrainingPlan>>();
-                cursor.Current.Returns([]);
-                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(false);
-                return cursor;
-            });
-        mongo.TrainingPlans.Returns(trainingCollection);
-
-        return mongo;
-    }
 
     // ── Shared entity builders ───────────────────────────────────────────────────
 
@@ -146,239 +116,6 @@ public class DiaryLifecycleSignalRTests
         CreatedAt = DateTimeOffset.UtcNow,
         UpdatedAt = DateTimeOffset.UtcNow,
     };
-
-    // ── CreateRequest ────────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task CreateRequest_LinkBased_EmitsPhotoDiaryRequested_ToClient()
-    {
-        var profUser = MakeProfessionalUser();
-        var clientUser = MakeClientUser();
-        var profProfile = MakeProfessionalProfile(profUser);
-        var clientProfile = MakeClientProfile(clientUser);
-        var link = MakeLink(profProfile, clientProfile);
-
-        var db = new MockDbBuilder()
-            .With(profUser)
-            .With(profProfile)
-            .With(clientUser)
-            .With(clientProfile)
-            .With(link)
-            .Build();
-
-        var userManager = EndpointTestHelpers.CreateFakeUserManager();
-        var mongo = CreateEmptyMongo();
-
-        var ep = Factory.Create<CreateRequestEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
-            db, mongo, _notifier, userManager, _createLogger);
-
-        await ep.HandleAsync(new CreateRequestRequest
-        {
-            LinkId = link.Id,
-            DurationDays = 7,
-        }, TestContext.Current.CancellationToken);
-
-        ep.HttpContext.Response.StatusCode.Should().Be(201);
-
-        // The client must receive exactly one photoDiaryRequested event
-        await _notifier.Received(1).NotifyAsync(
-            _clientId,             // recipient = client group
-            "photoDiaryRequested",
-            Arg.Is<PhotoDiaryRequestedEvent>(e =>
-                e.DurationDays == 7 &&
-                e.ProfessionalName == "Jana Novakova" &&
-                e.ProfessionalRole == AppRoles.Nutritionist),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CreateRequest_LinkBased_EventContainsCorrectRequestId()
-    {
-        var profUser = MakeProfessionalUser();
-        var clientUser = MakeClientUser();
-        var profProfile = MakeProfessionalProfile(profUser);
-        var clientProfile = MakeClientProfile(clientUser);
-        var link = MakeLink(profProfile, clientProfile);
-
-        var db = new MockDbBuilder()
-            .With(profUser)
-            .With(profProfile)
-            .With(clientUser)
-            .With(clientProfile)
-            .With(link)
-            .Build();
-
-        var userManager = EndpointTestHelpers.CreateFakeUserManager();
-        var mongo = CreateEmptyMongo();
-
-        var ep = Factory.Create<CreateRequestEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
-            db, mongo, _notifier, userManager, _createLogger);
-
-        await ep.HandleAsync(new CreateRequestRequest
-        {
-            LinkId = link.Id,
-            DurationDays = 14,
-        }, TestContext.Current.CancellationToken);
-
-        ep.HttpContext.Response.StatusCode.Should().Be(201);
-
-        // RequestId in the event must match the id returned in the response
-        await _notifier.Received(1).NotifyAsync(
-            _clientId,
-            "photoDiaryRequested",
-            Arg.Is<PhotoDiaryRequestedEvent>(e => e.RequestId == ep.Response.Id),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CreateRequest_InviteBased_ExistingUser_EmitsPhotoDiaryRequested_ToClient()
-    {
-        const string inviteEmail = "petr@example.com";
-
-        var profUser = MakeProfessionalUser();
-        var profProfile = MakeProfessionalProfile(profUser);
-        var invite = new PendingInvite
-        {
-            Id = 10,
-            ProfessionalProfileId = profProfile.Id,
-            Email = inviteEmail,
-            FirstName = "Petr",
-            LastName = "Novak",
-            SentAt = DateTime.UtcNow,
-            IsAccepted = false,
-            PublicId = Guid.NewGuid(),
-            DateCreated = DateTime.UtcNow,
-        };
-
-        var db = new MockDbBuilder()
-            .With(profUser)
-            .With(profProfile)
-            .With(invite)
-            .Build();
-
-        // UserManager returns an existing user for the invite e-mail
-        var userManager = EndpointTestHelpers.CreateFakeUserManager();
-        var existingClientUser = MakeClientUser(); // Id = _clientId
-        userManager.FindByEmailAsync(inviteEmail).Returns(existingClientUser);
-
-        var mongo = CreateEmptyMongo();
-
-        var ep = Factory.Create<CreateRequestEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
-            db, mongo, _notifier, userManager, _createLogger);
-
-        await ep.HandleAsync(new CreateRequestRequest
-        {
-            PendingInviteId = invite.Id,
-            DurationDays = 7,
-        }, TestContext.Current.CancellationToken);
-
-        ep.HttpContext.Response.StatusCode.Should().Be(201);
-
-        // The registered client must receive the event
-        await _notifier.Received(1).NotifyAsync(
-            _clientId,             // recipient = existing user's client group
-            "photoDiaryRequested",
-            Arg.Any<object>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CreateRequest_InviteBased_NoExistingUser_NoNotification()
-    {
-        const string inviteEmail = "unregistered@example.com";
-
-        var profUser = MakeProfessionalUser();
-        var profProfile = MakeProfessionalProfile(profUser);
-        var invite = new PendingInvite
-        {
-            Id = 11,
-            ProfessionalProfileId = profProfile.Id,
-            Email = inviteEmail,
-            FirstName = "Unknown",
-            LastName = "User",
-            SentAt = DateTime.UtcNow,
-            IsAccepted = false,
-            PublicId = Guid.NewGuid(),
-            DateCreated = DateTime.UtcNow,
-        };
-
-        var db = new MockDbBuilder()
-            .With(profUser)
-            .With(profProfile)
-            .With(invite)
-            .Build();
-
-        // UserManager returns null — no registered user for this e-mail
-        var userManager = EndpointTestHelpers.CreateFakeUserManager();
-        userManager.FindByEmailAsync(inviteEmail).Returns((ApplicationUser?)null);
-
-        var mongo = CreateEmptyMongo();
-
-        var ep = Factory.Create<CreateRequestEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
-            db, mongo, _notifier, userManager, _createLogger);
-
-        await ep.HandleAsync(new CreateRequestRequest
-        {
-            PendingInviteId = invite.Id,
-            DurationDays = 7,
-        }, TestContext.Current.CancellationToken);
-
-        ep.HttpContext.Response.StatusCode.Should().Be(201);
-
-        // No notification should be sent — user hasn't registered yet
-        await _notifier.DidNotReceive().NotifyAsync(
-            Arg.Any<Guid>(),
-            "photoDiaryRequested",
-            Arg.Any<object>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CreateRequest_BroadcastThrows_MutationStillSucceeds()
-    {
-        _notifier
-            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new InvalidOperationException("hub unavailable")));
-
-        var profUser = MakeProfessionalUser();
-        var clientUser = MakeClientUser();
-        var profProfile = MakeProfessionalProfile(profUser);
-        var clientProfile = MakeClientProfile(clientUser);
-        var link = MakeLink(profProfile, clientProfile);
-
-        var db = new MockDbBuilder()
-            .With(profUser)
-            .With(profProfile)
-            .With(clientUser)
-            .With(clientProfile)
-            .With(link)
-            .Build();
-
-        var userManager = EndpointTestHelpers.CreateFakeUserManager();
-        var mongo = CreateEmptyMongo();
-
-        var ep = Factory.Create<CreateRequestEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
-            db, mongo, _notifier, userManager, _createLogger);
-
-        var act = () => ep.HandleAsync(new CreateRequestRequest
-        {
-            LinkId = link.Id,
-            DurationDays = 7,
-        }, TestContext.Current.CancellationToken);
-
-        await act.Should().NotThrowAsync();
-        ep.HttpContext.Response.StatusCode.Should().Be(201);
-    }
 
     // ── DismissRequest ────────────────────────────────────────────────────────────
 

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/DiaryLifecycleSignalRTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/DiaryLifecycleSignalRTests.cs
@@ -1,0 +1,696 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests.CreateRequest;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests.DismissRequest;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests.SubmitRequest;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using NSubstitute;
+using ApplicationPhotoRequest = FitnessPlatform.Application.Domain.Entities.PhotoDiaryRequest;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Verifies SignalR broadcast behaviour for the four diary lifecycle events:
+/// <list type="bullet">
+///   <item><c>photoDiaryRequested</c>   — emitted to the <b>client</b> after CreateRequest.</item>
+///   <item><c>photoDiaryDismissed</c>   — emitted to the <b>professional</b> after DismissRequest.</item>
+///   <item><c>photoDiaryPhotoUploaded</c> — emitted to the <b>professional</b> after FinalizePlanPhoto
+///     when a DiaryRequestId is set (covered in PhotoDiaryPhotoUploadedSignalRTests).</item>
+///   <item><c>photoDiarySubmitted</c>   — emitted to the <b>professional</b> after SubmitRequest.</item>
+/// </list>
+/// Uses mock-based unit tests (Factory.Create + NSubstitute) so tests run without Docker.
+/// </summary>
+public class DiaryLifecycleSignalRTests
+{
+    // ── Shared identities ────────────────────────────────────────────────────────
+
+    private readonly Guid _professionalId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    // ── Notifier ─────────────────────────────────────────────────────────────────
+
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+
+    // ── Loggers ──────────────────────────────────────────────────────────────────
+
+    private readonly ILogger<CreateRequestEndpoint> _createLogger =
+        Substitute.For<ILogger<CreateRequestEndpoint>>();
+    private readonly ILogger<DismissRequestEndpoint> _dismissLogger =
+        Substitute.For<ILogger<DismissRequestEndpoint>>();
+    private readonly ILogger<SubmitRequestEndpoint> _submitLogger =
+        Substitute.For<ILogger<SubmitRequestEndpoint>>();
+
+    // ── Mongo stub for CreateRequest (plan ownership check uses Mongo) ───────────
+
+    private static IMongoContext CreateEmptyMongo()
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        var nutritionCollection = PlanTestHelpers.CreateMockMongo().NutritionPlans;
+        mongo.NutritionPlans.Returns(nutritionCollection);
+
+        var trainingCollection = Substitute.For<IMongoCollection<Application.Domain.Documents.TrainingPlan>>();
+        trainingCollection.FindAsync(
+                Arg.Any<FilterDefinition<Application.Domain.Documents.TrainingPlan>>(),
+                Arg.Any<FindOptions<Application.Domain.Documents.TrainingPlan, Application.Domain.Documents.TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<Application.Domain.Documents.TrainingPlan>>();
+                cursor.Current.Returns([]);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(false);
+                return cursor;
+            });
+        mongo.TrainingPlans.Returns(trainingCollection);
+
+        return mongo;
+    }
+
+    // ── Shared entity builders ───────────────────────────────────────────────────
+
+    private ApplicationUser MakeProfessionalUser() => new()
+    {
+        Id = _professionalId,
+        FirstName = "Jana",
+        LastName = "Novakova",
+        Email = "jana@example.com",
+        UserName = "jana@example.com",
+    };
+
+    private ApplicationUser MakeClientUser() => new()
+    {
+        Id = _clientId,
+        FirstName = "Petr",
+        LastName = "Novak",
+        Email = "petr@example.com",
+        UserName = "petr@example.com",
+    };
+
+    private ProfessionalProfile MakeProfessionalProfile(ApplicationUser user) => new()
+    {
+        Id = 1,
+        UserId = _professionalId,
+        User = user,
+    };
+
+    private ClientProfile MakeClientProfile(ApplicationUser user) => new()
+    {
+        Id = 2,
+        UserId = _clientId,
+        PublicId = _clientId,
+        User = user,
+    };
+
+    private ClientProfessionalLink MakeLink(ProfessionalProfile prof, ClientProfile client) => new()
+    {
+        Id = 1,
+        ProfessionalProfileId = prof.Id,
+        ClientProfileId = client.Id,
+        ClientProfile = client,
+        IsActive = true,
+        ProfessionalRole = UserRole.Nutritionist,
+        PublicId = Guid.NewGuid(),
+        DateCreated = DateTime.UtcNow,
+    };
+
+    /// <summary>Builds a pending diary request attached to a link.</summary>
+    private ApplicationPhotoRequest MakeDiaryRequest(
+        ClientProfessionalLink link,
+        PhotoDiaryStatus status = PhotoDiaryStatus.Pending,
+        DateTimeOffset? acceptedAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        ProfessionalId = _professionalId,
+        LinkId = link.Id,
+        Link = link,
+        DurationDays = 7,
+        Status = status,
+        Mode = status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+            ? PhotoDiaryMode.Bulk : null,
+        AcceptedAt = acceptedAt ?? (status is PhotoDiaryStatus.Accepted or PhotoDiaryStatus.InProgress or PhotoDiaryStatus.Completed
+            ? DateTimeOffset.UtcNow : null),
+        CompletedAt = status == PhotoDiaryStatus.Completed ? DateTimeOffset.UtcNow : null,
+        DismissReason = status == PhotoDiaryStatus.Dismissed ? "pre-dismissed" : null,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+    };
+
+    // ── CreateRequest ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateRequest_LinkBased_EmitsPhotoDiaryRequested_ToClient()
+    {
+        var profUser = MakeProfessionalUser();
+        var clientUser = MakeClientUser();
+        var profProfile = MakeProfessionalProfile(profUser);
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = MakeLink(profProfile, clientProfile);
+
+        var db = new MockDbBuilder()
+            .With(profUser)
+            .With(profProfile)
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var mongo = CreateEmptyMongo();
+
+        var ep = Factory.Create<CreateRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
+            db, mongo, _notifier, userManager, _createLogger);
+
+        await ep.HandleAsync(new CreateRequestRequest
+        {
+            LinkId = link.Id,
+            DurationDays = 7,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // The client must receive exactly one photoDiaryRequested event
+        await _notifier.Received(1).NotifyAsync(
+            _clientId,             // recipient = client group
+            "photoDiaryRequested",
+            Arg.Is<PhotoDiaryRequestedEvent>(e =>
+                e.DurationDays == 7 &&
+                e.ProfessionalName == "Jana Novakova" &&
+                e.ProfessionalRole == AppRoles.Nutritionist),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateRequest_LinkBased_EventContainsCorrectRequestId()
+    {
+        var profUser = MakeProfessionalUser();
+        var clientUser = MakeClientUser();
+        var profProfile = MakeProfessionalProfile(profUser);
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = MakeLink(profProfile, clientProfile);
+
+        var db = new MockDbBuilder()
+            .With(profUser)
+            .With(profProfile)
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var mongo = CreateEmptyMongo();
+
+        var ep = Factory.Create<CreateRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
+            db, mongo, _notifier, userManager, _createLogger);
+
+        await ep.HandleAsync(new CreateRequestRequest
+        {
+            LinkId = link.Id,
+            DurationDays = 14,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // RequestId in the event must match the id returned in the response
+        await _notifier.Received(1).NotifyAsync(
+            _clientId,
+            "photoDiaryRequested",
+            Arg.Is<PhotoDiaryRequestedEvent>(e => e.RequestId == ep.Response.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateRequest_InviteBased_ExistingUser_EmitsPhotoDiaryRequested_ToClient()
+    {
+        const string inviteEmail = "petr@example.com";
+
+        var profUser = MakeProfessionalUser();
+        var profProfile = MakeProfessionalProfile(profUser);
+        var invite = new PendingInvite
+        {
+            Id = 10,
+            ProfessionalProfileId = profProfile.Id,
+            Email = inviteEmail,
+            FirstName = "Petr",
+            LastName = "Novak",
+            SentAt = DateTime.UtcNow,
+            IsAccepted = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+
+        var db = new MockDbBuilder()
+            .With(profUser)
+            .With(profProfile)
+            .With(invite)
+            .Build();
+
+        // UserManager returns an existing user for the invite e-mail
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var existingClientUser = MakeClientUser(); // Id = _clientId
+        userManager.FindByEmailAsync(inviteEmail).Returns(existingClientUser);
+
+        var mongo = CreateEmptyMongo();
+
+        var ep = Factory.Create<CreateRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
+            db, mongo, _notifier, userManager, _createLogger);
+
+        await ep.HandleAsync(new CreateRequestRequest
+        {
+            PendingInviteId = invite.Id,
+            DurationDays = 7,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // The registered client must receive the event
+        await _notifier.Received(1).NotifyAsync(
+            _clientId,             // recipient = existing user's client group
+            "photoDiaryRequested",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateRequest_InviteBased_NoExistingUser_NoNotification()
+    {
+        const string inviteEmail = "unregistered@example.com";
+
+        var profUser = MakeProfessionalUser();
+        var profProfile = MakeProfessionalProfile(profUser);
+        var invite = new PendingInvite
+        {
+            Id = 11,
+            ProfessionalProfileId = profProfile.Id,
+            Email = inviteEmail,
+            FirstName = "Unknown",
+            LastName = "User",
+            SentAt = DateTime.UtcNow,
+            IsAccepted = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+
+        var db = new MockDbBuilder()
+            .With(profUser)
+            .With(profProfile)
+            .With(invite)
+            .Build();
+
+        // UserManager returns null — no registered user for this e-mail
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByEmailAsync(inviteEmail).Returns((ApplicationUser?)null);
+
+        var mongo = CreateEmptyMongo();
+
+        var ep = Factory.Create<CreateRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
+            db, mongo, _notifier, userManager, _createLogger);
+
+        await ep.HandleAsync(new CreateRequestRequest
+        {
+            PendingInviteId = invite.Id,
+            DurationDays = 7,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // No notification should be sent — user hasn't registered yet
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "photoDiaryRequested",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateRequest_BroadcastThrows_MutationStillSucceeds()
+    {
+        _notifier
+            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("hub unavailable")));
+
+        var profUser = MakeProfessionalUser();
+        var clientUser = MakeClientUser();
+        var profProfile = MakeProfessionalProfile(profUser);
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = MakeLink(profProfile, clientProfile);
+
+        var db = new MockDbBuilder()
+            .With(profUser)
+            .With(profProfile)
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var mongo = CreateEmptyMongo();
+
+        var ep = Factory.Create<CreateRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_professionalId, AppRoles.Nutritionist))),
+            db, mongo, _notifier, userManager, _createLogger);
+
+        var act = () => ep.HandleAsync(new CreateRequestRequest
+        {
+            LinkId = link.Id,
+            DurationDays = 7,
+        }, TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+    }
+
+    // ── DismissRequest ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dismiss_EmitsPhotoDiaryDismissed_ToProfessional()
+    {
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.Pending);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var ep = Factory.Create<DismissRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _dismissLogger);
+
+        await ep.HandleAsync(new DismissRequestRequest
+        {
+            Id = diaryReq.Id,
+            Reason = null,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The professional must receive exactly one photoDiaryDismissed event
+        await _notifier.Received(1).NotifyAsync(
+            _professionalId,        // recipient = professional group
+            "photoDiaryDismissed",
+            Arg.Is<PhotoDiaryDismissedEvent>(e =>
+                e.RequestId == diaryReq.Id &&
+                e.ClientName == "Petr Novak" &&
+                e.DismissReason == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Dismiss_WithReason_EventContainsReason()
+    {
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.Pending);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        const string reason = "I prefer not to share photos.";
+
+        var ep = Factory.Create<DismissRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _dismissLogger);
+
+        await ep.HandleAsync(new DismissRequestRequest
+        {
+            Id = diaryReq.Id,
+            Reason = reason,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await _notifier.Received(1).NotifyAsync(
+            _professionalId,
+            "photoDiaryDismissed",
+            Arg.Is<PhotoDiaryDismissedEvent>(e =>
+                e.RequestId == diaryReq.Id &&
+                e.DismissReason == reason),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Dismiss_NotifiesProfessional_NotClient()
+    {
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.Pending);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var ep = Factory.Create<DismissRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _dismissLogger);
+
+        await ep.HandleAsync(new DismissRequestRequest
+        {
+            Id = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        // Client must NOT receive the event
+        await _notifier.DidNotReceive().NotifyAsync(
+            _clientId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Dismiss_BroadcastThrows_MutationStillSucceeds()
+    {
+        _notifier
+            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("hub unavailable")));
+
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.Pending);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var ep = Factory.Create<DismissRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _dismissLogger);
+
+        var act = () => ep.HandleAsync(new DismissRequestRequest
+        {
+            Id = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    // ── SubmitRequest ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submit_EmitsPhotoDiarySubmitted_ToProfessional()
+    {
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.InProgress);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var ep = Factory.Create<SubmitRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _submitLogger);
+
+        await ep.HandleAsync(new SubmitRequestRequest
+        {
+            Id = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The professional must receive exactly one photoDiarySubmitted event
+        await _notifier.Received(1).NotifyAsync(
+            _professionalId,       // recipient = professional group
+            "photoDiarySubmitted",
+            Arg.Is<PhotoDiarySubmittedEvent>(e =>
+                e.RequestId == diaryReq.Id &&
+                e.ClientName == "Petr Novak"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Submit_EventContainsPhotoCount()
+    {
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.Accepted);
+
+        // Pre-seed 3 plan photos linked to this diary request
+        var photos = Enumerable.Range(0, 3).Select(_ => new PlanPhoto
+        {
+            PublicId = Guid.NewGuid(),
+            ClientProfileId = clientProfile.Id,
+            PlanId = Guid.NewGuid(),
+            PlanType = PlanPhotoType.Nutrition,
+            Category = PlanPhotoCategory.Body,
+            BlobUrl = $"plan-photos/{Guid.NewGuid()}.jpg",
+            TakenAt = DateTime.UtcNow,
+            UploadedByUserId = _clientId,
+            DiaryRequestId = diaryReq.Id,
+            DateCreated = DateTime.UtcNow,
+            DateUpdated = DateTime.UtcNow,
+        }).ToList();
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .With(photos[0])
+            .With(photos[1])
+            .With(photos[2])
+            .Build();
+
+        var ep = Factory.Create<SubmitRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _submitLogger);
+
+        await ep.HandleAsync(new SubmitRequestRequest
+        {
+            Id = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await _notifier.Received(1).NotifyAsync(
+            _professionalId,
+            "photoDiarySubmitted",
+            Arg.Is<PhotoDiarySubmittedEvent>(e =>
+                e.RequestId == diaryReq.Id &&
+                e.PhotoCount == 3),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Submit_NotifiesProfessional_NotClient()
+    {
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.Accepted);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var ep = Factory.Create<SubmitRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _submitLogger);
+
+        await ep.HandleAsync(new SubmitRequestRequest
+        {
+            Id = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        // Client must NOT receive the event
+        await _notifier.DidNotReceive().NotifyAsync(
+            _clientId,
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Submit_BroadcastThrows_MutationStillSucceeds()
+    {
+        _notifier
+            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("hub unavailable")));
+
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var profProfile = MakeProfessionalProfile(MakeProfessionalUser());
+        var link = MakeLink(profProfile, clientProfile);
+        var diaryReq = MakeDiaryRequest(link, PhotoDiaryStatus.InProgress);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var ep = Factory.Create<SubmitRequestEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, _notifier, _submitLogger);
+
+        var act = () => ep.HandleAsync(new SubmitRequestRequest
+        {
+            Id = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/PhotoDiaryPhotoUploadedSignalRTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/PhotoDiaryRequests/PhotoDiaryPhotoUploadedSignalRTests.cs
@@ -1,0 +1,324 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests;
+using FitnessPlatform.Application.Features.ClientPlans;
+using FitnessPlatform.Application.Features.ClientPlans.FinalizePlanPhoto;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using ApplicationPhotoRequest = FitnessPlatform.Application.Domain.Entities.PhotoDiaryRequest;
+
+namespace FitnessPlatform.Tests.Endpoints.PhotoDiaryRequests;
+
+/// <summary>
+/// Verifies the <c>photoDiaryPhotoUploaded</c> SignalR broadcast emitted by
+/// <see cref="FinalizePlanPhotoEndpoint"/> when a photo is linked to an active diary request.
+///
+/// Covers:
+/// <list type="bullet">
+///   <item>Upload with diary request → professional receives <c>photoDiaryPhotoUploaded</c>.</item>
+///   <item>Upload without diary request → <c>photoDiaryPhotoUploaded</c> is NOT emitted.</item>
+///   <item>DayIndex computation: AcceptedAt set → computed; AcceptedAt null → 1.</item>
+///   <item>Best-effort: broadcast failure does not fail the HTTP response.</item>
+/// </list>
+/// </summary>
+public class PhotoDiaryPhotoUploadedSignalRTests
+{
+    // ── Shared identities ────────────────────────────────────────────────────────
+
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _nutritionistId = Guid.NewGuid();
+
+    // ── Dependencies ─────────────────────────────────────────────────────────────
+
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly ILogger<FinalizePlanPhotoEndpoint> _logger =
+        Substitute.For<ILogger<FinalizePlanPhotoEndpoint>>();
+
+    // ── DB builder helpers ────────────────────────────────────────────────────────
+
+    private ApplicationUser MakeClientUser() => new()
+    {
+        Id = _clientId,
+        FirstName = "Petr",
+        LastName = "Novak",
+        Email = "petr@example.com",
+        UserName = "petr@example.com",
+    };
+
+    private ClientProfile MakeClientProfile(ApplicationUser user) => new()
+    {
+        Id = 1,
+        UserId = _clientId,
+        PublicId = _clientId,
+        User = user,
+    };
+
+    private ApplicationPhotoRequest MakeDiaryRequest(
+        long linkId,
+        ClientProfessionalLink link,
+        PhotoDiaryStatus status = PhotoDiaryStatus.Accepted,
+        DateTimeOffset? acceptedAt = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        ProfessionalId = _nutritionistId,
+        LinkId = linkId,
+        Link = link,
+        DurationDays = 7,
+        Status = status,
+        Mode = PhotoDiaryMode.Workflow,
+        AcceptedAt = acceptedAt ?? DateTimeOffset.UtcNow.AddDays(-2),
+        CreatedAt = DateTimeOffset.UtcNow.AddDays(-3),
+        UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2),
+    };
+
+    // ── Mongo helper ──────────────────────────────────────────────────────────────
+
+    private IMongoContext CreateMongoWithNutritionPlan(Guid planId) =>
+        PlanTestHelpers.CreateMockMongo([PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            clientId: _clientId,
+            nutritionistId: _nutritionistId,
+            status: NutritionPlanStatus.Active)]);
+
+    // ── Endpoint factory ──────────────────────────────────────────────────────────
+
+    private FinalizePlanPhotoEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
+        Factory.Create<FinalizePlanPhotoEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _logger);
+
+    // ── Tests ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Upload_WithDiaryRequest_EmitsPhotoDiaryPhotoUploaded_ToProfessional()
+    {
+        var planId = Guid.NewGuid();
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = new ClientProfessionalLink
+        {
+            Id = 1,
+            ProfessionalProfileId = 2,
+            ClientProfileId = clientProfile.Id,
+            ClientProfile = clientProfile,
+            IsActive = true,
+            ProfessionalRole = UserRole.Nutritionist,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        var diaryReq = MakeDiaryRequest(link.Id, link);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var mongo = CreateMongoWithNutritionPlan(planId);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body,
+            DiaryRequestId = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // Professional must receive photoDiaryPhotoUploaded
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,          // recipient = professional group
+            "photoDiaryPhotoUploaded",
+            Arg.Is<PhotoDiaryPhotoUploadedEvent>(e =>
+                e.RequestId == diaryReq.Id &&
+                e.ClientName == "Petr Novak"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Upload_WithDiaryRequest_EventContainsCorrectPhotoId()
+    {
+        var planId = Guid.NewGuid();
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = new ClientProfessionalLink
+        {
+            Id = 1,
+            ProfessionalProfileId = 2,
+            ClientProfileId = clientProfile.Id,
+            ClientProfile = clientProfile,
+            IsActive = true,
+            ProfessionalRole = UserRole.Nutritionist,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        var diaryReq = MakeDiaryRequest(link.Id, link);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var mongo = CreateMongoWithNutritionPlan(planId);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body,
+            DiaryRequestId = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // PhotoId in the diary event must match the photo returned by the endpoint
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,
+            "photoDiaryPhotoUploaded",
+            Arg.Is<PhotoDiaryPhotoUploadedEvent>(e => e.PhotoId == ep.Response.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Upload_WithDiaryRequest_DayIndex_ComputedFromAcceptedAt()
+    {
+        var planId = Guid.NewGuid();
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = new ClientProfessionalLink
+        {
+            Id = 1,
+            ProfessionalProfileId = 2,
+            ClientProfileId = clientProfile.Id,
+            ClientProfile = clientProfile,
+            IsActive = true,
+            ProfessionalRole = UserRole.Nutritionist,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+
+        // AcceptedAt 3 days ago → DayIndex should be 4
+        var acceptedAt = DateTimeOffset.UtcNow.AddDays(-3);
+        var diaryReq = MakeDiaryRequest(link.Id, link, PhotoDiaryStatus.InProgress, acceptedAt);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var mongo = CreateMongoWithNutritionPlan(planId);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body,
+            DiaryRequestId = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await _notifier.Received(1).NotifyAsync(
+            _nutritionistId,
+            "photoDiaryPhotoUploaded",
+            Arg.Is<PhotoDiaryPhotoUploadedEvent>(e => e.DayIndex == 4),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Upload_WithoutDiaryRequest_DoesNotEmitPhotoDiaryPhotoUploaded()
+    {
+        var planId = Guid.NewGuid();
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .Build();
+
+        var mongo = CreateMongoWithNutritionPlan(planId);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body,
+            // No DiaryRequestId — plain upload
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // photoDiaryPhotoUploaded must NOT be emitted for a plain upload
+        await _notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "photoDiaryPhotoUploaded",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Upload_WithDiaryRequest_BroadcastThrows_MutationStillSucceeds()
+    {
+        _notifier
+            .NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("hub unavailable")));
+
+        var planId = Guid.NewGuid();
+        var clientUser = MakeClientUser();
+        var clientProfile = MakeClientProfile(clientUser);
+        var link = new ClientProfessionalLink
+        {
+            Id = 1,
+            ProfessionalProfileId = 2,
+            ClientProfileId = clientProfile.Id,
+            ClientProfile = clientProfile,
+            IsActive = true,
+            ProfessionalRole = UserRole.Nutritionist,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        var diaryReq = MakeDiaryRequest(link.Id, link);
+
+        var db = new MockDbBuilder()
+            .With(clientUser)
+            .With(clientProfile)
+            .With(link)
+            .With(diaryReq)
+            .Build();
+
+        var mongo = CreateMongoWithNutritionPlan(planId);
+        var ep = CreateEndpoint(mongo, db);
+
+        var act = () => ep.HandleAsync(new FinalizePlanPhotoRequest
+        {
+            PlanId = planId,
+            BlobUrl = $"plan-photos/{planId}/{Guid.NewGuid()}.jpg",
+            Category = PlanPhotoCategory.Body,
+            DiaryRequestId = diaryReq.Id,
+        }, TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Infrastructure/FakeRealtimeNotifier.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FakeRealtimeNotifier.cs
@@ -10,6 +10,7 @@ public class FakeRealtimeNotifier : IRealtimeNotifier
 {
     private readonly List<NotifyCall> _calls = [];
     private readonly Lock _lock = new();
+    private bool _throwOnNextCall;
 
     /// <summary>
     /// Returns a snapshot of all recorded <c>NotifyAsync</c> invocations.
@@ -27,6 +28,12 @@ public class FakeRealtimeNotifier : IRealtimeNotifier
     {
         lock (_lock)
         {
+            if (_throwOnNextCall)
+            {
+                _throwOnNextCall = false;
+                throw new InvalidOperationException("hub unavailable (simulated)");
+            }
+
             _calls.Add(new NotifyCall(userId, eventType, payload));
         }
 
@@ -38,7 +45,21 @@ public class FakeRealtimeNotifier : IRealtimeNotifier
     /// </summary>
     public void Reset()
     {
-        lock (_lock) _calls.Clear();
+        lock (_lock)
+        {
+            _calls.Clear();
+            _throwOnNextCall = false;
+        }
+    }
+
+    /// <summary>
+    /// Configures the notifier to throw <see cref="InvalidOperationException"/> on the next
+    /// <c>NotifyAsync</c> call. Use in tests that verify broadcast failures are non-fatal.
+    /// After the single throw the notifier returns to normal recording behaviour.
+    /// </summary>
+    public void SimulateThrowOnNextCall()
+    {
+        lock (_lock) _throwOnNextCall = true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Wires four SignalR events into existing photo-diary endpoints so trainers/nutritionists and clients receive real-time updates during the diary lifecycle.
- `photoDiaryRequested` → emitted by `CreateRequestEndpoint` to the **client** group (link-based: `link.ClientProfile.UserId`; invite-based + registered user: resolved via `UserManager.FindByEmailAsync`; invite-based + no registered user: notification silently skipped, banner surfaces on next sign-in).
- `photoDiaryDismissed` → emitted by `DismissRequestEndpoint` to the **professional** group (`request.ProfessionalId`).
- `photoDiaryPhotoUploaded` → emitted by `FinalizePlanPhotoEndpoint` (when `DiaryRequestId` is set) to the **professional** group.
- `photoDiarySubmitted` → emitted by `SubmitRequestEndpoint` to the **professional** group.
- All four broadcasts are best-effort: a `try/catch` around each `NotifyAsync` call ensures SignalR faults never roll back the DB write.
- Fixes a latent JWT-claim bug in `CreateRequestEndpoint`: `ProfessionalRole` payload now reads from the short `"role"` claim type (FastEndpoints encoding) instead of `ClaimTypes.Role`, which always returned an empty string.
- 18 new tests across three files (`CreateRequestSignalRTests`, `DiaryLifecycleSignalRTests`, `PhotoDiaryPhotoUploadedSignalRTests`). New `SimulateThrowOnNextCall()` helper on `FakeRealtimeNotifier` supports broadcast-fault tests. Total suite: **974/974** passing.

## Related issue

Fixes #94

## Parent epic

Part of epic #67 — base branch: `feature/67-diary-request`.

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all ACs covered; 974/974 tests pass.

## Test plan

- [ ] Named groups for each role (photoDiaryRequested → client; photoDiaryDismissed / photoDiaryPhotoUploaded / photoDiarySubmitted → professional).
- [ ] Test coverage per event (CreateRequestSignalRTests, DiaryLifecycleSignalRTests, PhotoDiaryPhotoUploadedSignalRTests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)