### PR TITLE
feat(backend,#95): photo diary reminder scheduler + auto-finalize

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Entities/PhotoDiaryReminderLog.cs
+++ b/backend/FitnessPlatform.Application/Domain/Entities/PhotoDiaryReminderLog.cs
@@ -1,0 +1,32 @@
+namespace FitnessPlatform.Application.Domain.Entities;
+
+/// <summary>
+/// Idempotency log for the <c>PhotoDiaryReminderScheduler</c>.
+/// One row per (DiaryRequestId, ClientLocalDate) — enforced by a unique index.
+/// The scheduler inserts this row before emitting any side-effects; a duplicate
+/// <c>INSERT</c> (Postgres error 23505) means the reminder was already sent for
+/// that calendar day, so the tick is silently skipped.
+/// </summary>
+public class PhotoDiaryReminderLog
+{
+    /// <summary>Primary key.</summary>
+    public long Id { get; set; }
+
+    /// <summary>FK to <see cref="PhotoDiaryRequest"/>.</summary>
+    public Guid DiaryRequestId { get; set; }
+
+    /// <summary>
+    /// The client-local calendar date for which the reminder was emitted.
+    /// Formatted as a <see cref="DateOnly"/> so TZ conversions are done in
+    /// application code before insertion.
+    /// </summary>
+    public DateOnly ClientLocalDate { get; set; }
+
+    /// <summary>UTC timestamp of row insertion.</summary>
+    public DateTime SentAt { get; set; }
+
+    // ── Navigation ────────────────────────────────────────────────────────────
+
+    /// <summary>Navigation to the diary request.</summary>
+    public PhotoDiaryRequest DiaryRequest { get; set; } = null!;
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/NotificationType.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/NotificationType.cs
@@ -45,5 +45,11 @@ public enum NotificationType
     WeeklyCheckInRequested,
 
     /// <summary>A client responded to a weekly check-in reminder; delivered to the professional.</summary>
-    WeeklyCheckInResponded
+    WeeklyCheckInResponded,
+
+    /// <summary>
+    /// A daily reminder sent to a client in an active photo diary workflow
+    /// when no photo has been uploaded for the current day yet.
+    /// </summary>
+    PhotoDiaryReminder
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
@@ -130,6 +130,11 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     /// </summary>
     public virtual DbSet<PhotoDiaryRequest> PhotoDiaryRequests { get; set; } = null!;
 
+    /// <summary>
+    /// Idempotency log for the daily photo-diary reminder scheduler.
+    /// </summary>
+    public virtual DbSet<PhotoDiaryReminderLog> PhotoDiaryReminderLogs { get; set; } = null!;
+
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -250,6 +255,22 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
             e.HasIndex(p => p.PlanId);
             e.HasIndex(p => p.DiaryRequestId)
                 .HasDatabaseName("ix_plan_photos_diary_request_id");
+        });
+
+        builder.Entity<PhotoDiaryReminderLog>(e =>
+        {
+            e.HasKey(l => l.Id);
+            e.Property(l => l.ClientLocalDate).HasColumnType("date");
+
+            e.HasOne(l => l.DiaryRequest)
+                .WithMany()
+                .HasForeignKey(l => l.DiaryRequestId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Uniqueness constraint: at most one reminder log per (request, calendar day).
+            e.HasIndex(l => new { l.DiaryRequestId, l.ClientLocalDate })
+                .IsUnique()
+                .HasDatabaseName("ix_photo_diary_reminder_logs_request_date");
         });
 
         builder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
@@ -135,6 +135,12 @@ public interface IApplicationDbContext
     DbSet<PhotoDiaryRequest> PhotoDiaryRequests { get; set; }
 
     /// <summary>
+    /// Idempotency log for the daily photo-diary reminder scheduler.
+    /// One row per (DiaryRequestId, ClientLocalDate).
+    /// </summary>
+    DbSet<PhotoDiaryReminderLog> PhotoDiaryReminderLogs { get; set; }
+
+    /// <summary>
     /// Saves all changes made in this context to the database.
     /// </summary>
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428195348_AddPhotoDiaryReminderLog.Designer.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428195348_AddPhotoDiaryReminderLog.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428195348_AddPhotoDiaryReminderLog")]
+    partial class AddPhotoDiaryReminderLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428195348_AddPhotoDiaryReminderLog.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260428195348_AddPhotoDiaryReminderLog.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhotoDiaryReminderLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "photo_diary_reminder_logs",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    diary_request_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    client_local_date = table.Column<DateOnly>(type: "date", nullable: false),
+                    sent_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_photo_diary_reminder_logs", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_photo_diary_reminder_logs_photo_diary_requests_diary_reques",
+                        column: x => x.diary_request_id,
+                        principalTable: "photo_diary_requests",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_photo_diary_reminder_logs_request_date",
+                table: "photo_diary_reminder_logs",
+                columns: new[] { "diary_request_id", "client_local_date" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "photo_diary_reminder_logs");
+        }
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PhotoDiaryReminderScheduler.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PhotoDiaryReminderScheduler.cs
@@ -301,8 +301,19 @@ public class PhotoDiaryReminderScheduler(
                 Data = notificationData
             };
 
-            db.Notifications.Add(notification);
-            await db.SaveChangesAsync(ct);
+            // ── Persist in-app notification (best-effort) ────────────────────
+            try
+            {
+                db.Notifications.Add(notification);
+                await db.SaveChangesAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "PhotoDiaryReminderScheduler: failed to persist notification for client {ClientUserId} " +
+                    "on request {RequestId}.", clientUserId, request.Id);
+                continue;
+            }
 
             // ── Push notification (best-effort) ───────────────────────────────
             try
@@ -447,7 +458,7 @@ public class PhotoDiaryReminderScheduler(
         {
             return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
         }
-        catch
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
         {
             logger.LogWarning(
                 "PhotoDiaryReminderScheduler: unknown time zone '{IanaId}'; falling back to UTC.", ianaId);

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PhotoDiaryReminderScheduler.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PhotoDiaryReminderScheduler.cs
@@ -1,0 +1,460 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.PhotoDiaryRequests;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+[assembly: InternalsVisibleTo("FitnessPlatform.Tests")]
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Background service that fires a daily reminder to clients in an active photo-diary
+/// workflow when the client has not yet uploaded any photo for the current day.
+/// The scheduler ticks once per hour (aligned to :00) and checks each active
+/// workflow-mode diary request to see whether the client's local-time noon falls
+/// within the last tick window.
+///
+/// <para><b>Idempotency:</b> a <see cref="PhotoDiaryReminderLog"/> row is inserted
+/// per (DiaryRequestId, ClientLocalDate) under a unique constraint.  A duplicate
+/// insert (Postgres error 23505) means the reminder already fired — skip silently.</para>
+///
+/// <para><b>Auto-finalize:</b> requests that have exceeded their window
+/// (<c>now &gt; AcceptedAt + (DurationDays + 1) days</c>) are automatically
+/// transitioned to <see cref="PhotoDiaryStatus.Completed"/> and the
+/// <c>photoDiarySubmitted</c> event is emitted to the professional.</para>
+/// </summary>
+public class PhotoDiaryReminderScheduler(
+    IServiceScopeFactory scopeFactory,
+    ILogger<PhotoDiaryReminderScheduler> logger) : BackgroundService
+{
+    // Exposed for unit/integration tests — drive the scheduler with a virtual clock.
+    internal DateTime? OverrideNow { get; set; }
+
+    private DateTime _lastTickAt;
+    private bool _cursorInitialized;
+
+    /// <summary>
+    /// Resets the scheduler's cursor state so the next <see cref="TickAsync"/> call
+    /// re-seeds from the DB. Use between tests that share the same singleton instance.
+    /// </summary>
+    internal void ResetCursor()
+    {
+        _cursorInitialized = false;
+        _lastTickAt = default;
+    }
+
+    /// <summary>
+    /// Force-sets the last-tick cursor to a specific point in time WITHOUT re-seeding from DB.
+    /// Use in tests that need to position the window precisely without resetting
+    /// <see cref="_cursorInitialized"/>.
+    /// </summary>
+    internal void SetLastTickAt(DateTime lastTickAt)
+    {
+        _cursorInitialized = true;
+        _lastTickAt = lastTickAt;
+    }
+
+    /// <summary>
+    /// Entry point used by tests: execute one scheduler cycle treating <paramref name="now"/>
+    /// as the current UTC time.  The internal cursor is seeded on first call.
+    /// </summary>
+    internal async Task TickAsync(DateTime now, CancellationToken ct = default)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+
+        if (!_cursorInitialized)
+        {
+            _lastTickAt = await SeedCursorAsync(db, now, ct);
+            _cursorInitialized = true;
+        }
+
+        await ProcessTickAsync(db, scope.ServiceProvider, now, ct);
+        _lastTickAt = now;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Align first tick to the next :00 boundary.
+        var now = UtcNow();
+        var delay = TimeSpan.FromMinutes(60 - now.Minute)
+                            .Subtract(TimeSpan.FromSeconds(now.Second))
+                            .Subtract(TimeSpan.FromMilliseconds(now.Millisecond));
+
+        if (delay.TotalMilliseconds > 0)
+        {
+            logger.LogInformation(
+                "PhotoDiaryReminderScheduler: first tick in {Delay:mm\\:ss} (aligning to :00).", delay);
+            await Task.Delay(delay, stoppingToken);
+        }
+
+        // Seed cursor from DB so a cold start doesn't re-fire the last hour.
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+            _lastTickAt = await SeedCursorAsync(db, UtcNow(), stoppingToken);
+        }
+
+        _cursorInitialized = true;
+
+        using var timer = new PeriodicTimer(TimeSpan.FromHours(1));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var tickNow = UtcNow();
+            logger.LogDebug("PhotoDiaryReminderScheduler: tick at {TickNow:u}.", tickNow);
+
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+                await ProcessTickAsync(db, scope.ServiceProvider, tickNow, stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogError(ex,
+                    "PhotoDiaryReminderScheduler: unhandled error on tick at {TickNow:u}.", tickNow);
+            }
+
+            _lastTickAt = tickNow;
+
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
+    private async Task<DateTime> SeedCursorAsync(
+        IApplicationDbContext db, DateTime now, CancellationToken ct)
+    {
+        var maxSentAt = await db.PhotoDiaryReminderLogs
+            .AsNoTracking()
+            .MaxAsync(l => (DateTime?)l.SentAt, ct);
+
+        var oneHourAgo = now.AddHours(-1);
+
+        if (maxSentAt.HasValue)
+        {
+            var seedFrom = maxSentAt.Value.AddMinutes(-1);
+            var cursor = seedFrom < oneHourAgo ? oneHourAgo : seedFrom;
+            logger.LogInformation(
+                "PhotoDiaryReminderScheduler: seeding cursor to {Cursor:u} (maxSentAt={MaxSentAt:u}).",
+                cursor, maxSentAt.Value);
+            return cursor;
+        }
+
+        logger.LogInformation(
+            "PhotoDiaryReminderScheduler: no previous reminders; seeding cursor to {Cursor:u}.", oneHourAgo);
+        return oneHourAgo;
+    }
+
+    private async Task ProcessTickAsync(
+        IApplicationDbContext db,
+        IServiceProvider services,
+        DateTime now,
+        CancellationToken ct)
+    {
+        // Load all active workflow-mode diary requests in the acceptance/in-progress window,
+        // joined with the client user so we can read their time zone.
+        var candidates = await db.PhotoDiaryRequests
+            .AsNoTracking()
+            .Where(r => r.Mode == PhotoDiaryMode.Workflow
+                        && (r.Status == PhotoDiaryStatus.Accepted || r.Status == PhotoDiaryStatus.InProgress))
+            .Include(r => r.Link)
+                .ThenInclude(l => l!.ClientProfile)
+                    .ThenInclude(cp => cp.User)
+            .Include(r => r.PendingInvite)
+            .ToListAsync(ct);
+
+        if (candidates.Count == 0) return;
+
+        var notifier = services.GetRequiredService<IRealtimeNotifier>();
+        var push = services.GetRequiredService<IPushNotificationService>();
+
+        foreach (var request in candidates)
+        {
+            // ── Resolve client user (needed for TZ and UserId) ────────────────
+            var (clientUserId, clientUserTz) = ResolveClientInfo(request);
+            if (clientUserId == Guid.Empty)
+            {
+                // Invite-based request with no registered user yet — skip.
+                continue;
+            }
+
+            // ── Auto-finalize check: window expired ───────────────────────────
+            // If now > AcceptedAt + (DurationDays + 1) days, auto-complete.
+            if (request.AcceptedAt.HasValue
+                && now > request.AcceptedAt.Value.UtcDateTime.AddDays(request.DurationDays + 1))
+            {
+                await AutoFinalizeAsync(db, services, request, clientUserId, now, ct);
+                continue;  // request is now Completed — no reminder needed
+            }
+
+            // ── Skip if past the valid window but not yet day N+1 ────────────
+            // If now >= AcceptedAt + DurationDays we're inside the finalize-grace day — still remind.
+            if (!request.AcceptedAt.HasValue) continue;
+
+            // ── TZ & noon computation ─────────────────────────────────────────
+            var tz = GetTimeZoneInfo(clientUserTz);
+            var localNow = TimeZoneInfo.ConvertTimeFromUtc(now, tz);
+            var noonLocal = localNow.Date.Add(TimeSpan.FromHours(12));
+            var noonUtc = TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(noonLocal, DateTimeKind.Unspecified), tz);
+
+            // Fire only if noon crossed within the half-open window (_lastTickAt, now].
+            if (noonUtc <= _lastTickAt || noonUtc > now)
+                continue;
+
+            // ── Check if client already uploaded a photo today ────────────────
+            // "today" = [start-of-local-day, end-of-local-day) in UTC.
+            var localDayStart = localNow.Date;
+            var localDayEnd   = localDayStart.AddDays(1);
+
+            var dayStartUtc = TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(localDayStart, DateTimeKind.Unspecified), tz);
+            var dayEndUtc = TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(localDayEnd, DateTimeKind.Unspecified), tz);
+
+            var alreadyUploaded = await db.PlanPhotos
+                .AsNoTracking()
+                .AnyAsync(p => p.DiaryRequestId == request.Id
+                               && p.DateCreated >= dayStartUtc
+                               && p.DateCreated < dayEndUtc,
+                          ct);
+
+            if (alreadyUploaded)
+            {
+                logger.LogDebug(
+                    "PhotoDiaryReminderScheduler: client {ClientUserId} already uploaded " +
+                    "today for request {RequestId} — skip.",
+                    clientUserId, request.Id);
+                continue;
+            }
+
+            // ── Day index (1-based) ───────────────────────────────────────────
+            var acceptedAtLocal = TimeZoneInfo.ConvertTimeFromUtc(
+                request.AcceptedAt.Value.UtcDateTime, tz);
+            var dayIndex = (localNow.Date - acceptedAtLocal.Date).Days + 1;
+            if (dayIndex < 1) dayIndex = 1;
+
+            var clientLocalDate = DateOnly.FromDateTime(localNow.Date);
+
+            // ── Idempotency: insert log row ────────────────────────────────────
+            // NB: we need a tracking context for this insert so re-query with tracking.
+            var logEntry = new PhotoDiaryReminderLog
+            {
+                DiaryRequestId = request.Id,
+                ClientLocalDate = clientLocalDate,
+                SentAt = now
+            };
+
+            db.PhotoDiaryReminderLogs.Add(logEntry);
+
+            try
+            {
+                await db.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+            {
+                logger.LogWarning(
+                    "PhotoDiaryReminderScheduler: duplicate reminder skipped for " +
+                    "request={RequestId} date={Date}.",
+                    request.Id, clientLocalDate);
+
+                db.PhotoDiaryReminderLogs.Remove(logEntry);
+                continue;
+            }
+
+            // ── Persist in-app notification ───────────────────────────────────
+            var title = "Don't forget your diary photo";
+            var body  = $"Today is day {dayIndex} of {request.DurationDays}. " +
+                        "Take a photo of what you eat — your nutritionist will see it live.";
+
+            var notificationData = JsonSerializer.Serialize(new
+            {
+                requestId = request.Id,
+                dayIndex
+            });
+
+            var notification = new Notification
+            {
+                RecipientUserId = clientUserId,
+                Type = NotificationType.PhotoDiaryReminder,
+                Title = title,
+                Body = body,
+                Data = notificationData
+            };
+
+            db.Notifications.Add(notification);
+            await db.SaveChangesAsync(ct);
+
+            // ── Push notification (best-effort) ───────────────────────────────
+            try
+            {
+                await push.SendAsync(
+                    clientUserId,
+                    title,
+                    body,
+                    new { type = "PhotoDiaryReminder", requestId = request.Id, dayIndex },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "PhotoDiaryReminderScheduler: failed to send push to client {ClientUserId} " +
+                    "for request {RequestId}.", clientUserId, request.Id);
+            }
+
+            // ── SignalR broadcast (best-effort) ───────────────────────────────
+            try
+            {
+                await notifier.NotifyAsync(
+                    clientUserId,
+                    "newnotification",
+                    new
+                    {
+                        id = notification.Id,
+                        type = NotificationType.PhotoDiaryReminder.ToString(),
+                        data = notificationData
+                    },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "PhotoDiaryReminderScheduler: failed to broadcast newnotification to " +
+                    "client {ClientUserId} for request {RequestId}.", clientUserId, request.Id);
+            }
+
+            logger.LogInformation(
+                "PhotoDiaryReminderScheduler: fired reminder for request {RequestId} " +
+                "client={ClientUserId} dayIndex={DayIndex}.",
+                request.Id, clientUserId, dayIndex);
+        }
+    }
+
+    /// <summary>
+    /// Transitions a timed-out diary request to Completed, persists it, and emits
+    /// <c>photoDiarySubmitted</c> to the professional. Idempotent — once the request is
+    /// Completed the scheduler's candidate query excludes it.
+    /// </summary>
+    private async Task AutoFinalizeAsync(
+        IApplicationDbContext db,
+        IServiceProvider services,
+        PhotoDiaryRequest request,
+        Guid clientUserId,
+        DateTime now,
+        CancellationToken ct)
+    {
+        // Re-load with tracking to apply the mutation.
+        var tracked = await db.PhotoDiaryRequests
+            .Where(r => r.Id == request.Id
+                        && (r.Status == PhotoDiaryStatus.Accepted || r.Status == PhotoDiaryStatus.InProgress))
+            .FirstOrDefaultAsync(ct);
+
+        if (tracked is null)
+        {
+            // Already finalized by another path (race / concurrent tick).
+            return;
+        }
+
+        tracked.Status = PhotoDiaryStatus.Completed;
+        tracked.CompletedAt = new DateTimeOffset(now, TimeSpan.Zero);
+        tracked.UpdatedAt = new DateTimeOffset(now, TimeSpan.Zero);
+
+        await db.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "PhotoDiaryReminderScheduler: auto-finalized request {RequestId} for client {ClientUserId}.",
+            request.Id, clientUserId);
+
+        // Emit photoDiarySubmitted to the professional (best-effort).
+        var notifier = services.GetRequiredService<IRealtimeNotifier>();
+        try
+        {
+            // Resolve client display name.
+            string clientName;
+            if (request.Link?.ClientProfile?.User is { } user)
+                clientName = $"{user.FirstName} {user.LastName}".Trim();
+            else if (request.PendingInvite is { } invite)
+                clientName = $"{invite.FirstName} {invite.LastName}".Trim();
+            else
+                clientName = clientUserId.ToString();
+
+            var photoCount = await db.PlanPhotos
+                .AsNoTracking()
+                .CountAsync(p => p.DiaryRequestId == request.Id, ct);
+
+            await notifier.NotifyAsync(
+                request.ProfessionalId,
+                "photoDiarySubmitted",
+                new PhotoDiarySubmittedEvent
+                {
+                    RequestId = request.Id,
+                    ClientName = clientName,
+                    PhotoCount = photoCount,
+                    SubmittedAt = tracked.CompletedAt!.Value
+                },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "PhotoDiaryReminderScheduler: failed to emit photoDiarySubmitted for " +
+                "request {RequestId} to professional {ProfessionalId}.",
+                request.Id, request.ProfessionalId);
+        }
+    }
+
+    // ── Pure helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Resolves the client's <see cref="Guid"/> UserId and IANA time-zone string
+    /// from a <see cref="PhotoDiaryRequest"/>.
+    /// Returns (<see cref="Guid.Empty"/>, &quot;Europe/Prague&quot;) when the client
+    /// user cannot be determined (e.g. unaccepted invite with no registered user).
+    /// </summary>
+    private static (Guid UserId, string TimeZone) ResolveClientInfo(PhotoDiaryRequest request)
+    {
+        if (request.Link?.ClientProfile?.User is { } user)
+            return (user.Id, user.TimeZone);
+
+        // PendingInvite-based requests don't have a registered user yet.
+        return (Guid.Empty, "Europe/Prague");
+    }
+
+    private DateTime UtcNow() => OverrideNow ?? DateTime.UtcNow;
+
+    private TimeZoneInfo GetTimeZoneInfo(string ianaId)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+        }
+        catch
+        {
+            logger.LogWarning(
+                "PhotoDiaryReminderScheduler: unknown time zone '{IanaId}'; falling back to UTC.", ianaId);
+            return TimeZoneInfo.Utc;
+        }
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pgEx && pgEx.SqlState == "23505";
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -199,6 +199,10 @@ builder.Services.AddScoped<IRealtimeNotifier, SignalRNotifier>();
 builder.Services.AddSingleton<WeeklyCheckInScheduler>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<WeeklyCheckInScheduler>());
 
+// Photo diary reminder scheduler — registered as both singleton (for test access) and hosted service.
+builder.Services.AddSingleton<PhotoDiaryReminderScheduler>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<PhotoDiaryReminderScheduler>());
+
 // Compliance
 builder.Services.AddScoped<IComplianceService, ComplianceService>();
 

--- a/backend/FitnessPlatform.Tests/Infrastructure/FakePushNotificationService.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FakePushNotificationService.cs
@@ -1,0 +1,68 @@
+using FitnessPlatform.Application.Domain.Interfaces;
+
+namespace FitnessPlatform.Tests.Infrastructure;
+
+/// <summary>
+/// Thread-safe fake implementation of <see cref="IPushNotificationService"/> for integration tests.
+/// Records all <c>SendAsync</c> calls so tests can assert on recipients and payloads.
+/// Optionally throws on the next call to simulate push-service outages.
+/// </summary>
+public class FakePushNotificationService : IPushNotificationService
+{
+    private readonly List<PushCall> _calls = [];
+    private readonly Lock _lock = new();
+    private bool _throwOnNextCall;
+
+    /// <summary>
+    /// Returns a snapshot of all recorded <c>SendAsync</c> invocations.
+    /// </summary>
+    public IReadOnlyList<PushCall> Calls
+    {
+        get
+        {
+            lock (_lock) return _calls.ToList();
+        }
+    }
+
+    /// <inheritdoc />
+    public Task SendAsync(Guid userId, string title, string body, object? data = null, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            if (_throwOnNextCall)
+            {
+                _throwOnNextCall = false;
+                throw new InvalidOperationException("push service unavailable (simulated)");
+            }
+
+            _calls.Add(new PushCall(userId, title, body, data));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Clears all recorded calls. Call between tests if the service is shared.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _calls.Clear();
+            _throwOnNextCall = false;
+        }
+    }
+
+    /// <summary>
+    /// Configures the service to throw <see cref="InvalidOperationException"/> on the next
+    /// <c>SendAsync</c> call. Use in tests that verify push failures are non-fatal.
+    /// After the single throw the service returns to normal recording behaviour.
+    /// </summary>
+    public void SimulateThrowOnNextCall()
+    {
+        lock (_lock) _throwOnNextCall = true;
+    }
+
+    /// <summary>A single recorded invocation of <c>SendAsync</c>.</summary>
+    public record PushCall(Guid UserId, string Title, string Body, object? Data);
+}

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
@@ -98,6 +98,17 @@ public class FitnessApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
                 services.Remove(blobDescriptor);
 
             services.AddSingleton<IBlobStorageService, FakeBlobStorageService>();
+
+            // Replace push notification service with in-memory fake so integration tests
+            // can assert on sent pushes without a real Expo endpoint.
+            var pushDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(IPushNotificationService));
+            if (pushDescriptor is not null)
+                services.Remove(pushDescriptor);
+
+            services.AddSingleton<FakePushNotificationService>();
+            services.AddSingleton<IPushNotificationService>(
+                sp => sp.GetRequiredService<FakePushNotificationService>());
         });
 
         builder.UseEnvironment("Development");

--- a/backend/FitnessPlatform.Tests/Infrastructure/Services/PhotoDiaryReminderSchedulerTests.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/Services/PhotoDiaryReminderSchedulerTests.cs
@@ -1,0 +1,590 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Infrastructure.Services;
+
+/// <summary>
+/// Integration tests for <see cref="PhotoDiaryReminderScheduler"/> using a virtual clock.
+/// Uses Testcontainers PostgreSQL + MongoDB (Docker required).
+/// </summary>
+[Collection(TestCollection.Name)]
+public class PhotoDiaryReminderSchedulerTests(FitnessApiFactory factory)
+{
+    // ── Helper: unique emails ──────────────────────────────────────────────────
+
+    private static string UniqueEmail(string tag = "sched") =>
+        $"{Guid.NewGuid():N}@{tag}-reminder-test.com";
+
+    // ── Setup: register nutritionist + client, link them, insert diary request ─
+
+    /// <summary>
+    /// Creates a nutritionist and a client, links them, and inserts a workflow-mode
+    /// PhotoDiaryRequest with the given status and acceptedAt.
+    /// Returns the nutritionist UserId, client UserId, and the diary request Id.
+    /// </summary>
+    private async Task<(Guid ProfessionalId, Guid ClientUserId, Guid RequestId, long LinkId)>
+        SetupWorkflowRequestAsync(
+            PhotoDiaryStatus status = PhotoDiaryStatus.Accepted,
+            DateTimeOffset? acceptedAt = null,
+            int durationDays = 7,
+            string clientTimeZone = "Europe/Prague")
+    {
+        var profEmail = UniqueEmail("prof");
+        var clientEmail = UniqueEmail("client");
+
+        var profHttp = factory.CreateClient();
+        var clientHttp = factory.CreateClient();
+
+        await TestHelpers.RegisterAsync(profHttp, profEmail, "TestPass1!", "Nutritionist", "Reminder", "Nutritionist");
+        await TestHelpers.RegisterAsync(clientHttp, clientEmail, "TestPass1!", "Client", "Reminder", "Client");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profUser = await db.Users.FirstAsync(u => u.Email == profEmail, TestContext.Current.CancellationToken);
+        var clientUser = await db.Users.FirstAsync(u => u.Email == clientEmail, TestContext.Current.CancellationToken);
+
+        // Set client timezone
+        clientUser.TimeZone = clientTimeZone;
+
+        var profProfile = await db.ProfessionalProfiles
+            .FirstAsync(p => p.UserId == profUser.Id, TestContext.Current.CancellationToken);
+        var clientProfile = await db.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUser.Id, TestContext.Current.CancellationToken);
+
+        // Link client to nutritionist
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        db.ClientProfessionalLinks.Add(link);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Insert the diary request
+        var now = DateTimeOffset.UtcNow;
+        var resolvedAcceptedAt = acceptedAt ?? now.AddDays(-1);
+
+        var request = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUser.Id,
+            LinkId = link.Id,
+            Mode = PhotoDiaryMode.Workflow,
+            Status = status,
+            DurationDays = durationDays,
+            AcceptedAt = resolvedAcceptedAt,
+            CompletedAt = status == PhotoDiaryStatus.Completed ? now : null,
+            DismissReason = status == PhotoDiaryStatus.Dismissed ? "test" : null,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        db.PhotoDiaryRequests.Add(request);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        return (profUser.Id, clientUser.Id, request.Id, link.Id);
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Tick_BeforeNoon_DoesNotFire()
+    {
+        // Europe/Prague CEST (UTC+2): noon = 12:00 Prague = 10:00 UTC.
+        // Seed cursor at 10:30 UTC (AFTER noon) so noon is NOT in the next tick window.
+        // Use real UTC today as the virtual date and AcceptedAt = yesterday so window is valid.
+        var utcNow = DateTime.UtcNow;
+        var virtualDate = utcNow.Date;
+        var afterNoonPrague = virtualDate.AddHours(10).AddMinutes(30); // 10:30 UTC (noon Prague CEST)
+
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "Europe/Prague");
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to 10:30 UTC (after noon Prague = 10:00 UTC).
+        scheduler.SetLastTickAt(afterNoonPrague);
+
+        // Tick at 11:30 UTC: window is (10:30, 11:30]. Noon = 10:00 UTC is NOT in the window.
+        scheduler.OverrideNow = afterNoonPrague.AddHours(1);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().BeEmpty("noon already passed before the tick window — reminder must not fire");
+    }
+
+    [Fact]
+    public async Task Tick_AtNoon_Prague_Fires()
+    {
+        // Europe/Prague CEST (UTC+2): noon = 12:00 Prague = 10:00 UTC.
+        // Tick window: _lastTickAt=09:00 UTC, now=10:30 UTC → noon (10:00) is inside window → FIRES.
+        // Use real UTC today as the virtual date and AcceptedAt = yesterday.
+        var utcNow = DateTime.UtcNow;
+        var virtualDate = utcNow.Date;
+        var beforeNoonPrague = virtualDate.AddHours(9);   // 09:00 UTC
+        var afterNoonPrague  = virtualDate.AddHours(10).AddMinutes(30); // 10:30 UTC
+
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "Europe/Prague");
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to 09:00 UTC (before noon Prague = 10:00 UTC).
+        scheduler.SetLastTickAt(beforeNoonPrague);
+
+        // Tick at 10:30 UTC: window (09:00, 10:30]. Noon (10:00) IS inside → FIRES.
+        scheduler.OverrideNow = afterNoonPrague;
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().HaveCount(1, "noon crossed in this tick window → should fire once");
+
+        var notification = await db.Notifications
+            .Where(n => n.RecipientUserId == clientUserId && n.Type == NotificationType.PhotoDiaryReminder)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        notification.Should().NotBeNull("in-app notification must be created");
+
+        var signalRCalls = notifier.Calls
+            .Where(c => c.UserId == clientUserId && c.EventType == "newnotification")
+            .ToList();
+
+        signalRCalls.Should().HaveCount(1, "scheduler must broadcast exactly one newnotification to the client");
+    }
+
+    [Fact]
+    public async Task Tick_PhotoAlreadyUploadedToday_DoesNotFire()
+    {
+        // If the client already uploaded a photo for the diary request today, no reminder.
+        // Strategy: use real UTC time so ApplyTimestamps stamps the photo with DateCreated = today,
+        // then use real UTC noon as the virtual clock.  UTC timezone = no DST offset.
+        var utcNow = DateTime.UtcNow;
+
+        // AcceptedAt = yesterday so the request is inside its 7-day window.
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "UTC");
+
+        using var setupScope = factory.Services.CreateScope();
+        var setupDb = setupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var clientProfile = await setupDb.ClientProfiles
+            .FirstAsync(p => p.UserId == clientUserId, TestContext.Current.CancellationToken);
+
+        // ApplyTimestamps will set DateCreated = real UtcNow — that's "today" in UTC.
+        var photo = new PlanPhoto
+        {
+            ClientProfileId = clientProfile.Id,
+            DiaryRequestId = requestId,
+            BlobUrl = "https://example.com/photo.jpg",
+            Category = PlanPhotoCategory.Food,
+            TakenAt = utcNow,
+            UploadedByUserId = clientUserId,
+        };
+        setupDb.PlanPhotos.Add(photo);
+        await setupDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Virtual noon UTC = today's noon UTC.
+        var noonUtcToday = utcNow.Date.AddHours(12);
+        // Seed cursor to one hour before noon so noon is within the second tick window.
+        var seedTime = noonUtcToday.AddHours(-1);
+
+        scheduler.OverrideNow = seedTime;
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Tick at noon + 30 min: noon IS in window, but photo already uploaded → no reminder.
+        scheduler.OverrideNow = noonUtcToday.AddMinutes(30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().BeEmpty("client already uploaded a photo today — reminder must be skipped");
+    }
+
+    [Fact]
+    public async Task Tick_StatusNotAcceptedOrInProgress_DoesNotFire()
+    {
+        // Completed requests are excluded by the candidate query.
+        var utcNow = DateTime.UtcNow;
+        var virtualDate = utcNow.Date;
+
+        var (_, _, requestId, _) = await SetupWorkflowRequestAsync(
+            status: PhotoDiaryStatus.Completed,
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "Europe/Prague");
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Window: (09:00, 10:30] UTC → noon Prague (10:00) inside, but request is Completed → skip.
+        scheduler.SetLastTickAt(virtualDate.AddHours(9));
+        scheduler.OverrideNow = virtualDate.AddHours(10).AddMinutes(30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().BeEmpty("Completed requests must not fire reminders");
+    }
+
+    [Fact]
+    public async Task Tick_ModeBulk_DoesNotFire()
+    {
+        // Bulk-mode requests must not trigger the workflow reminder.
+        var profEmail = UniqueEmail("bulk-prof");
+        var clientEmail = UniqueEmail("bulk-client");
+
+        var profHttp = factory.CreateClient();
+        var clientHttp = factory.CreateClient();
+        await TestHelpers.RegisterAsync(profHttp, profEmail, "TestPass1!", "N", "Bulk", "Nutritionist");
+        await TestHelpers.RegisterAsync(clientHttp, clientEmail, "TestPass1!", "C", "Bulk", "Client");
+
+        using var setupScope = factory.Services.CreateScope();
+        var setupDb = setupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var profUser = await setupDb.Users.FirstAsync(u => u.Email == profEmail, TestContext.Current.CancellationToken);
+        var clientUser = await setupDb.Users.FirstAsync(u => u.Email == clientEmail, TestContext.Current.CancellationToken);
+        var profProfile = await setupDb.ProfessionalProfiles.FirstAsync(p => p.UserId == profUser.Id, TestContext.Current.CancellationToken);
+        var clientProfile = await setupDb.ClientProfiles.FirstAsync(p => p.UserId == clientUser.Id, TestContext.Current.CancellationToken);
+
+        var link = new ClientProfessionalLink
+        {
+            ClientProfileId = clientProfile.Id,
+            ProfessionalProfileId = profProfile.Id,
+            ProfessionalRole = UserRole.Nutritionist,
+            IsActive = true,
+            CanViewNutritionPlans = true,
+            CanViewTrainingPlans = false,
+            PublicId = Guid.NewGuid(),
+            DateCreated = DateTime.UtcNow,
+        };
+        setupDb.ClientProfessionalLinks.Add(link);
+        await setupDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var utcNowForBulk = DateTimeOffset.UtcNow;
+        var bulkRequest = new PhotoDiaryRequest
+        {
+            Id = Guid.NewGuid(),
+            ProfessionalId = profUser.Id,
+            LinkId = link.Id,
+            Mode = PhotoDiaryMode.Bulk,  // ← Bulk, not Workflow
+            Status = PhotoDiaryStatus.Accepted,
+            DurationDays = 7,
+            AcceptedAt = utcNowForBulk.AddDays(-1),
+            CreatedAt = utcNowForBulk,
+            UpdatedAt = utcNowForBulk,
+        };
+        setupDb.PhotoDiaryRequests.Add(bulkRequest);
+        await setupDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Window: (09:00, 10:30] UTC today → noon Prague (10:00) inside, but Bulk → no reminder.
+        var todayUtc = utcNowForBulk.UtcDateTime.Date;
+        scheduler.SetLastTickAt(todayUtc.AddHours(9));
+        scheduler.OverrideNow = todayUtc.AddHours(10).AddMinutes(30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var verifyScope = factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await verifyDb.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == bulkRequest.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().BeEmpty("Bulk-mode requests must not fire workflow reminders");
+    }
+
+    [Fact]
+    public async Task Tick_Idempotent_TwoTicksSameDay_OnlyOneReminder()
+    {
+        // Simulates a scheduler restart mid-tick: the first run inserts the log but
+        // _lastTickAt was not persisted. On restart we force the cursor back to before noon
+        // so the scheduler tries to fire again — the unique constraint must catch it.
+        var utcNow = DateTime.UtcNow;
+        var virtualDate = utcNow.Date;
+        // Noon Prague CEST (UTC+2) = 10:00 UTC.
+        var beforeNoon = virtualDate.AddHours(9);   // 09:00 UTC
+        var afterNoon  = virtualDate.AddHours(10).AddMinutes(30); // 10:30 UTC
+
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "Europe/Prague");
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // First run: seed cursor to 09:00, tick to 10:30 → fires.
+        scheduler.SetLastTickAt(beforeNoon);
+        scheduler.OverrideNow = afterNoon;
+        await scheduler.TickAsync(afterNoon, TestContext.Current.CancellationToken);
+
+        // Simulate restart: force cursor back to before noon on the same day.
+        scheduler.SetLastTickAt(beforeNoon);
+        scheduler.OverrideNow = afterNoon.AddMinutes(30);  // 11:00 UTC — noon still in (09:00, 11:00]
+        await scheduler.TickAsync(afterNoon.AddMinutes(30), TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().HaveCount(1, "unique index must prevent a second reminder on the same day");
+
+        var notifications = await db.Notifications
+            .Where(n => n.RecipientUserId == clientUserId && n.Type == NotificationType.PhotoDiaryReminder)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        notifications.Should().HaveCount(1, "only one notification must be created despite the retry");
+    }
+
+    [Fact]
+    public async Task Tick_NewYorkTimezone_FiresAtNoonEastern()
+    {
+        // America/New_York in April 2026 = EDT (UTC-4).
+        // Noon New York = 12:00 EDT = 16:00 UTC.
+        // Window: _lastTickAt=15:00 UTC, now=16:30 UTC → noon NY (16:00) inside window → FIRES.
+        //
+        // Use real UTC today as the virtual date so AcceptedAt (yesterday) is inside the
+        // 7-day window AND the auto-finalize threshold (AcceptedAt + 8 days) is in the future.
+        var utcNow = DateTime.UtcNow;
+        var virtualDate = utcNow.Date; // today UTC
+        var virtualNoonNY = virtualDate.AddHours(16);  // noon New York EDT = 16:00 UTC
+
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "America/New_York");
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to 15:00 UTC today (before noon NY).
+        var seedTime = virtualDate.AddHours(15);
+        scheduler.SetLastTickAt(seedTime);
+
+        // Tick at 16:30 UTC today = 12:30 New York EDT — noon (16:00 UTC) is inside (15:00, 16:30].
+        scheduler.OverrideNow = virtualNoonNY.AddMinutes(30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().HaveCount(1, "noon New York should trigger a reminder for EDT clients");
+    }
+
+    [Fact]
+    public async Task Tick_NewYorkTimezone_BeforeNoonEastern_DoesNotFire()
+    {
+        // America/New_York EDT (UTC-4). Noon NY = 16:00 UTC.
+        // Seed cursor at 16:30 UTC (AFTER noon) → noon is NOT in next window.
+        // Use real UTC today so the window period is safe.
+        var utcNow = DateTime.UtcNow;
+        var virtualDate = utcNow.Date;
+        var afterNoonNY = virtualDate.AddHours(16).AddMinutes(30); // 16:30 UTC = 12:30 NY
+
+        var (_, _, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "America/New_York");
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to 16:30 UTC (AFTER noon NY).
+        scheduler.SetLastTickAt(afterNoonNY);
+
+        // Tick at 17:30 UTC: window is (16:30, 17:30]. Noon (16:00) is NOT in the window.
+        scheduler.OverrideNow = afterNoonNY.AddHours(1);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var reminderLogs = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        reminderLogs.Should().BeEmpty("noon already passed before this tick window — no reminder");
+    }
+
+    [Fact]
+    public async Task Tick_AutoFinalizeAtDayNPlusOne()
+    {
+        // A request accepted 9 days ago (DurationDays=7) should be auto-finalized.
+        // AcceptedAt + (7+1) days = 8 days after acceptance. Use 9 days so we're clearly past.
+        var acceptedAt = new DateTimeOffset(DateTime.UtcNow.AddDays(-9));
+
+        var (professionalId, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: acceptedAt,
+            durationDays: 7,
+            clientTimeZone: "Europe/Prague");
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Use real-time-relative noon UTC to avoid the DateCreated photo issue.
+        var noonUtcToday = DateTime.UtcNow.Date.AddHours(12);
+        var seedTime = noonUtcToday.AddHours(-1);
+
+        scheduler.OverrideNow = seedTime;
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Tick at noon+30min: the auto-finalize condition triggers (9 days > 8 days threshold).
+        scheduler.OverrideNow = noonUtcToday.AddMinutes(30);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var request = await db.PhotoDiaryRequests
+            .FirstAsync(r => r.Id == requestId, TestContext.Current.CancellationToken);
+
+        request.Status.Should().Be(PhotoDiaryStatus.Completed, "request should be auto-finalized");
+        request.CompletedAt.Should().NotBeNull("CompletedAt must be set on auto-finalize");
+
+        // Verify photoDiarySubmitted emitted to the professional.
+        var submittedEvents = notifier.Calls
+            .Where(c => c.UserId == professionalId && c.EventType == "photoDiarySubmitted")
+            .ToList();
+
+        submittedEvents.Should().HaveCount(1, "photoDiarySubmitted must be emitted to the professional");
+    }
+
+    [Fact]
+    public async Task Tick_DayIndexInPayload_CorrectValue()
+    {
+        // AcceptedAt = 2 days ago in Prague local time → today is day 3.
+        var prague = TimeZoneInfo.FindSystemTimeZoneById("Europe/Prague");
+        var utcNow = DateTime.UtcNow;
+        var virtualNow = utcNow.Date.AddHours(10).AddMinutes(30); // 10:30 UTC (after noon Prague CEST)
+
+        var virtualNowPrague = TimeZoneInfo.ConvertTimeFromUtc(virtualNow, prague);
+
+        // AcceptedAt = 2 days ago local (at 09:00 local).
+        var acceptedAtLocal = virtualNowPrague.Date.AddDays(-2).Add(TimeSpan.FromHours(9));
+        var acceptedAtUtc = TimeZoneInfo.ConvertTimeToUtc(
+            DateTime.SpecifyKind(acceptedAtLocal, DateTimeKind.Unspecified), prague);
+
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(acceptedAtUtc),
+            clientTimeZone: "Europe/Prague");
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to before noon Prague (09:00 UTC).
+        scheduler.SetLastTickAt(utcNow.Date.AddHours(9));
+
+        // Tick at 10:30 UTC (after noon Prague = 10:00 UTC) → fires.
+        scheduler.OverrideNow = virtualNow;
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var notification = await db.Notifications
+            .Where(n => n.RecipientUserId == clientUserId && n.Type == NotificationType.PhotoDiaryReminder)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        notification.Should().NotBeNull("notification must be created");
+        notification!.Data.Should().Contain("\"dayIndex\":3",
+            "day index must be 3 when AcceptedAt was 2 local days ago");
+    }
+
+    [Fact]
+    public async Task Tick_PushFailure_DoesNotBlockNotificationPersistence()
+    {
+        // If the push service throws, the in-app notification must still be persisted
+        // and no exception should bubble out.
+        // Use UTC timezone + real-time based noon so AcceptedAt and window stay valid.
+        var utcNow = DateTime.UtcNow;
+        var noonUtcToday = utcNow.Date.AddHours(12);
+
+        var (_, clientUserId, requestId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: new DateTimeOffset(utcNow.AddDays(-1)),
+            clientTimeZone: "UTC");
+
+        var push = factory.Services.GetRequiredService<FakePushNotificationService>();
+        push.SimulateThrowOnNextCall();
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to one hour before noon.
+        scheduler.SetLastTickAt(noonUtcToday.AddHours(-1));
+
+        var act = async () =>
+        {
+            // Tick at noon + 30 min: noon (12:00 UTC) is in window.
+            scheduler.OverrideNow = noonUtcToday.AddMinutes(30);
+            await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+        };
+
+        await act.Should().NotThrowAsync("push failure must not propagate out of the scheduler");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var notification = await db.Notifications
+            .Where(n => n.RecipientUserId == clientUserId && n.Type == NotificationType.PhotoDiaryReminder)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+
+        notification.Should().NotBeNull("in-app notification must still be persisted despite push failure");
+    }
+}


### PR DESCRIPTION
## Summary

- New `PhotoDiaryReminderScheduler` BackgroundService (mirrors `WeeklyCheckInScheduler` pattern): hourly tick aligned to `:00`, virtual clock for tests, DI scope per tick.
- Fires a daily reminder push + in-app notification to workflow-mode diary clients at their local noon when no photo has been uploaded for that day; idempotency enforced by `PhotoDiaryReminderLog` with a unique index on `(diary_request_id, client_local_date)` — duplicate inserts caught by Postgres `23505` and silently skipped.
- Auto-finalize safety net: requests where `now > AcceptedAt + (DurationDays + 1) days` are transitioned to `Completed` and `photoDiarySubmitted` is emitted to the professional (reuses Epic #94's payload). This is server-side protection since the mobile client cannot be relied upon to finalize.
- New `PhotoDiaryReminderLog` entity + migration `20260428195348_AddPhotoDiaryReminderLog.cs` + 11 integration tests (985/985 pass).

## Related issue
Fixes #95

## Parent epic (sub-issue PR)
Part of #67 — base branch: `feature/67-diary-request`.

## Scope
backend

## QA verdict (from qa-tester)
OVERALL PASS — all ACs covered. 985/985 tests green.

## Test plan
- [ ] Fires once per day at the client's local noon.
- [ ] Idempotent if the job retries (unique-constraint idempotency).
- [ ] Unit-test / integration-test job handler logic (11 new tests).

## Notes
- Auto-finalize on day N+1 was originally scoped against #101; it is implemented here as a server-side safety net and does not affect the #101 scope.
- Migration file `20260428195348_AddPhotoDiaryReminderLog.cs` is included — **this PR is subject to the merge exclusion rule** and must be merged manually onto the epic branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)