### PR TITLE
feat(mobile,#98): Today screen banner for pending photo diary request

### DIFF
--- a/mobile/app/(client)/(tabs)/index.tsx
+++ b/mobile/app/(client)/(tabs)/index.tsx
@@ -21,10 +21,15 @@ import { HasTrainerState } from '@/components/today/HasTrainerState'
 import { NotificationSheet } from '@/components/notifications/NotificationSheet'
 import { InviteCard } from '@/components/notifications/InviteCard'
 import { QuestionnaireBanner } from '@/components/notifications/QuestionnaireBanner'
+import { DiaryRequestBanner } from '@/components/today/DiaryRequestBanner'
 import { WeeklyCheckInBanner } from '@/components/today/WeeklyCheckInBanner'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useClientInvite } from '@/hooks/useClientInvite'
-import { getPendingQuestionnaires, type PendingQuestionnairesResponse } from '@/api/questionnaire'
+import {
+  getPendingQuestionnaires,
+  type PendingQuestionnairesResponse,
+  type PendingDiaryRequestItem,
+} from '@/api/questionnaire'
 import { getCurrentCheckIns, type CheckInSummary } from '@/api/weeklyCheckIns'
 import { onEvent } from '@/api/signalr'
 import { Toast } from '@/lib/toast'
@@ -85,6 +90,14 @@ export default function TodayScreen() {
   const pendingQCoachNames = useMemo(
     () => pendingQItems.map((i) => i.professionalName ?? ''),
     [pendingQItems],
+  )
+
+  // Pending diary requests — only Pending status (defensive; the query already filters)
+  const pendingDiaryItems: PendingDiaryRequestItem[] = useMemo(
+    () => (pendingQQuery.data?.pendingDiaryRequests ?? []).filter(
+      (r) => r.status === 'Pending',
+    ),
+    [pendingQQuery.data?.pendingDiaryRequests],
   )
 
   const handleNotificationAction = useCallback(
@@ -201,19 +214,36 @@ export default function TodayScreen() {
         {todayState === 'has-trainer' && (
           <HasTrainerState
             topBanner={
-              pendingQCount > 0 ? (
-                <QuestionnaireBanner
-                  count={pendingQCount}
-                  coachNames={pendingQCoachNames}
-                  onFill={() => {
-                    if (pendingQCount > 1) {
-                      router.push(href('/(client)/pending-questionnaires'))
-                    } else {
-                      router.push(hrefParams('/(auth)/questionnaire', { linkPublicId: pendingQItems[0]?.linkPublicId ?? '' }))
+              <>
+                {/* Diary-request banners render above questionnaire banners (ordering per #93) */}
+                {pendingDiaryItems.map((item) => (
+                  <DiaryRequestBanner
+                    key={item.requestPublicId}
+                    item={item}
+                    onAccept={() =>
+                      router.push(href(`/(client)/diary/${item.requestPublicId}`))
                     }
-                  }}
-                />
-              ) : undefined
+                    onDismiss={() =>
+                      router.push(href(`/(client)/diary/${item.requestPublicId}/dismiss`))
+                    }
+                  />
+                ))}
+
+                {/* Questionnaire banner */}
+                {pendingQCount > 0 && (
+                  <QuestionnaireBanner
+                    count={pendingQCount}
+                    coachNames={pendingQCoachNames}
+                    onFill={() => {
+                      if (pendingQCount > 1) {
+                        router.push(href('/(client)/pending-questionnaires'))
+                      } else {
+                        router.push(hrefParams('/(auth)/questionnaire', { linkPublicId: pendingQItems[0]?.linkPublicId ?? '' }))
+                      }
+                    }}
+                  />
+                )}
+              </>
             }
           />
         )}

--- a/mobile/app/(client)/_layout.tsx
+++ b/mobile/app/(client)/_layout.tsx
@@ -37,6 +37,10 @@ export default function ClientLayout() {
         name="profile-photos"
         options={{ animation: 'slide_from_right', headerShown: false }}
       />
+      <Stack.Screen
+        name="diary"
+        options={{ animation: 'slide_from_right' }}
+      />
     </Stack>
   )
 }

--- a/mobile/app/(client)/diary/[requestId].tsx
+++ b/mobile/app/(client)/diary/[requestId].tsx
@@ -45,7 +45,7 @@ export default function DiaryRequestScreen() {
           </Text>
           <Text style={[Type.caption1, { color: colors.label3, marginTop: 24, textAlign: 'center' }]}>
             {/* This screen will be implemented in issue #99 */}
-            Accept wizard coming soon
+            {t('today.diaryBanner.acceptPlaceholder')}
           </Text>
         </View>
 

--- a/mobile/app/(client)/diary/[requestId].tsx
+++ b/mobile/app/(client)/diary/[requestId].tsx
@@ -1,0 +1,94 @@
+/**
+ * Diary request accept flow — detail screen.
+ *
+ * TODO(#99): Implement the full accept wizard (step-by-step onboarding,
+ * schedule picker, confirmation). This file is a placeholder so the
+ * DiaryRequestBanner's "Accept" CTA navigates to a real route.
+ */
+import React from 'react'
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { href } from '@/lib/navigation'
+
+export default function DiaryRequestScreen() {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { requestId } = useLocalSearchParams<{ requestId: string }>()
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+      <View style={styles.content}>
+        {/* Header */}
+        <Pressable
+          onPress={() => router.back()}
+          style={[styles.backBtn, { backgroundColor: colors.fill }]}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
+        </Pressable>
+
+        {/* Placeholder content — replaced by accept wizard in #99 */}
+        <View style={styles.placeholder}>
+          <ActivityIndicator size="large" color={colors.green} style={styles.spinner} />
+          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
+            {t('today.diaryBanner.screenTitle')}
+          </Text>
+          <Text style={[Type.footnote, { color: colors.label2, marginTop: 8, textAlign: 'center' }]}>
+            {requestId}
+          </Text>
+          <Text style={[Type.caption1, { color: colors.label3, marginTop: 24, textAlign: 'center' }]}>
+            {/* This screen will be implemented in issue #99 */}
+            Accept wizard coming soon
+          </Text>
+        </View>
+
+        {/* Dismiss link */}
+        <Pressable
+          onPress={() => router.push(href(`/(client)/diary/${requestId}/dismiss`))}
+          style={({ pressed }) => [styles.dismissLink, { opacity: pressed ? 0.6 : 1 }]}
+        >
+          <Text style={[Type.footnote, { color: colors.label2 }]}>
+            {t('today.diaryBanner.dismiss')}
+          </Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  backBtn: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: Radius.md,
+    marginBottom: 32,
+  },
+  placeholder: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  spinner: {
+    marginBottom: 24,
+  },
+  dismissLink: {
+    alignSelf: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+  },
+})

--- a/mobile/app/(client)/diary/[requestId]/_layout.tsx
+++ b/mobile/app/(client)/diary/[requestId]/_layout.tsx
@@ -1,0 +1,16 @@
+import { Stack } from 'expo-router'
+
+/**
+ * Stack navigator for screens nested under a specific diary request.
+ * Currently contains the dismiss confirmation screen (#102).
+ */
+export default function DiaryRequestNestedLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+      }}
+    />
+  )
+}

--- a/mobile/app/(client)/diary/[requestId]/dismiss.tsx
+++ b/mobile/app/(client)/diary/[requestId]/dismiss.tsx
@@ -1,0 +1,91 @@
+/**
+ * Diary request dismiss flow.
+ *
+ * TODO(#102): Implement the full dismiss confirmation UI (reason picker,
+ * confirmation message, API call to dismiss the request).
+ * This file is a placeholder so the DiaryRequestBanner's "Dismiss" CTA
+ * navigates to a real route instead of a 404.
+ */
+import React from 'react'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+
+export default function DiaryDismissScreen() {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { requestId } = useLocalSearchParams<{ requestId: string }>()
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+      <View style={styles.content}>
+        {/* Header */}
+        <Pressable
+          onPress={() => router.back()}
+          style={[styles.backBtn, { backgroundColor: colors.fill }]}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
+        </Pressable>
+
+        {/* Placeholder content — replaced by dismiss flow in #102 */}
+        <View style={styles.placeholder}>
+          <Text style={{ fontSize: 40, marginBottom: 20 }}>🙅</Text>
+          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
+            {t('today.diaryBanner.dismissScreenTitle')}
+          </Text>
+          <Text style={[Type.footnote, { color: colors.label2, marginTop: 8, textAlign: 'center' }]}>
+            {requestId}
+          </Text>
+          <Text style={[Type.caption1, { color: colors.label3, marginTop: 24, textAlign: 'center' }]}>
+            {/* This screen will be implemented in issue #102 */}
+            Dismiss flow coming soon
+          </Text>
+        </View>
+
+        {/* Go back */}
+        <Pressable
+          onPress={() => router.back()}
+          style={[styles.goBackBtn, { backgroundColor: colors.fill }]}
+        >
+          <Text style={[Type.subheadline, { color: colors.label, fontWeight: '600' }]}>
+            {t('common.back')}
+          </Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  backBtn: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: Radius.md,
+    marginBottom: 32,
+  },
+  placeholder: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  goBackBtn: {
+    paddingVertical: 14,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+  },
+})

--- a/mobile/app/(client)/diary/[requestId]/dismiss.tsx
+++ b/mobile/app/(client)/diary/[requestId]/dismiss.tsx
@@ -45,7 +45,7 @@ export default function DiaryDismissScreen() {
           </Text>
           <Text style={[Type.caption1, { color: colors.label3, marginTop: 24, textAlign: 'center' }]}>
             {/* This screen will be implemented in issue #102 */}
-            Dismiss flow coming soon
+            {t('today.diaryBanner.dismissPlaceholder')}
           </Text>
         </View>
 

--- a/mobile/app/(client)/diary/_layout.tsx
+++ b/mobile/app/(client)/diary/_layout.tsx
@@ -1,0 +1,17 @@
+import { Stack } from 'expo-router'
+
+/**
+ * Stack navigator for the photo-diary request flow.
+ * All sub-screens (accept detail, dismiss) slide in from the right.
+ * The dismiss screen is nested under `[requestId]/dismiss`.
+ */
+export default function DiaryLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+      }}
+    />
+  )
+}

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -4912,7 +4912,7 @@ export class ApiClient {
     }
 
     /**
-     * Get all pending questionnaires for the client
+     * Get pending questionnaires and diary requests for the client
      * @return Success
      */
     getClientPendingQuestionnairesEndpoint(signal?: AbortSignal): Promise<GetClientPendingQuestionnairesResponse> {
@@ -5366,6 +5366,449 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GenerateProfessionalAvatarUploadUrlResponse>(null as any);
+    }
+
+    /**
+     * Submit / finalize a photo diary
+     * @param id The photo diary request ID (from route).
+     * @return Success
+     */
+    submitRequestEndpoint(id: string, signal?: AbortSignal): Promise<SubmitRequestResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests/{id}/submit";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSubmitRequestEndpoint(_response);
+        });
+    }
+
+    protected processSubmitRequestEndpoint(response: AxiosResponse): Promise<SubmitRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<SubmitRequestResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<SubmitRequestResponse>(null as any);
+    }
+
+    /**
+     * List photo diary requests (trainer view)
+     * @param page Page number (1-based). Defaults to 1.
+     * @param pageSize Number of items per page. Defaults to 20.
+     * @param status (optional) Optional filter by status.
+     * @param linkId (optional) Optional filter by client-professional link ID.
+     * @param pendingInviteId (optional) Optional filter by pending invite ID.
+     * @param planId (optional) Optional filter by plan ID.
+     * @return Success
+     */
+    listTrainerRequestsEndpoint(page: number, pageSize: number, status?: PhotoDiaryStatus | null | undefined, linkId?: number | null | undefined, pendingInviteId?: number | null | undefined, planId?: string | null | undefined, signal?: AbortSignal): Promise<ListTrainerRequestsResponse> {
+        let url_ = this.baseUrl + "/trainer/photo-diary-requests?";
+        if (page === undefined || page === null)
+            throw new globalThis.Error("The parameter 'page' must be defined and cannot be null.");
+        else
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (status !== undefined && status !== null)
+            url_ += "status=" + encodeURIComponent("" + status) + "&";
+        if (linkId !== undefined && linkId !== null)
+            url_ += "linkId=" + encodeURIComponent("" + linkId) + "&";
+        if (pendingInviteId !== undefined && pendingInviteId !== null)
+            url_ += "pendingInviteId=" + encodeURIComponent("" + pendingInviteId) + "&";
+        if (planId !== undefined && planId !== null)
+            url_ += "planId=" + encodeURIComponent("" + planId) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processListTrainerRequestsEndpoint(_response);
+        });
+    }
+
+    protected processListTrainerRequestsEndpoint(response: AxiosResponse): Promise<ListTrainerRequestsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ListTrainerRequestsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ListTrainerRequestsResponse>(null as any);
+    }
+
+    /**
+     * Create a photo diary request
+     * @return Success
+     */
+    createRequestEndpoint(createRequestRequest: CreateRequestRequest, signal?: AbortSignal): Promise<CreateRequestResponse> {
+        let url_ = this.baseUrl + "/trainer/photo-diary-requests";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(createRequestRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processCreateRequestEndpoint(_response);
+        });
+    }
+
+    protected processCreateRequestEndpoint(response: AxiosResponse): Promise<CreateRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<CreateRequestResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<CreateRequestResponse>(null as any);
+    }
+
+    /**
+     * List photo diary requests (client view)
+     * @param page Page number (1-based). Defaults to 1.
+     * @param pageSize Number of items per page. Defaults to 20.
+     * @param status (optional) Optional filter by status.
+     * @param planId (optional) Optional filter by plan ID.
+     * @return Success
+     */
+    listClientRequestsEndpoint(page: number, pageSize: number, status?: PhotoDiaryStatus | null | undefined, planId?: string | null | undefined, signal?: AbortSignal): Promise<ListClientRequestsResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests?";
+        if (page === undefined || page === null)
+            throw new globalThis.Error("The parameter 'page' must be defined and cannot be null.");
+        else
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (status !== undefined && status !== null)
+            url_ += "status=" + encodeURIComponent("" + status) + "&";
+        if (planId !== undefined && planId !== null)
+            url_ += "planId=" + encodeURIComponent("" + planId) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processListClientRequestsEndpoint(_response);
+        });
+    }
+
+    protected processListClientRequestsEndpoint(response: AxiosResponse): Promise<ListClientRequestsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ListClientRequestsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ListClientRequestsResponse>(null as any);
+    }
+
+    /**
+     * Dismiss a photo diary request
+     * @param id The photo diary request ID (from route).
+     * @return Success
+     */
+    dismissRequestEndpoint(id: string, dismissRequestRequest: DismissRequestRequest, signal?: AbortSignal): Promise<DismissRequestResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests/{id}/dismiss";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(dismissRequestRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDismissRequestEndpoint(_response);
+        });
+    }
+
+    protected processDismissRequestEndpoint(response: AxiosResponse): Promise<DismissRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<DismissRequestResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<DismissRequestResponse>(null as any);
+    }
+
+    /**
+     * Accept a photo diary request
+     * @param id The photo diary request ID (from route).
+     * @return Success
+     */
+    acceptRequestEndpoint(id: string, acceptRequestRequest: AcceptRequestRequest, signal?: AbortSignal): Promise<AcceptRequestResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests/{id}/accept";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(acceptRequestRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAcceptRequestEndpoint(_response);
+        });
+    }
+
+    protected processAcceptRequestEndpoint(response: AxiosResponse): Promise<AcceptRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<AcceptRequestResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<AcceptRequestResponse>(null as any);
     }
 
     /**
@@ -6525,13 +6968,19 @@ export class ApiClient {
     /**
      * Generate food image upload URL
      * @param foodId The food's public identifier (from route).
+     * @param slot Image slot: main (overwrites) or gallery (appends, max 6).
+    Provided as a query parameter: ?slot=main or ?slot=gallery.
      * @return Success
      */
-    uploadFoodImageUrlEndpoint(foodId: string, uploadFoodImageUrlRequest: UploadFoodImageUrlRequest, signal?: AbortSignal): Promise<UploadFoodImageUrlResponse> {
-        let url_ = this.baseUrl + "/foods/{foodId}/image/upload-url";
+    uploadFoodImageUrlEndpoint(foodId: string, slot: string, uploadFoodImageUrlRequest: UploadFoodImageUrlRequest, signal?: AbortSignal): Promise<UploadFoodImageUrlResponse> {
+        let url_ = this.baseUrl + "/foods/{foodId}/image/upload-url?";
         if (foodId === undefined || foodId === null)
             throw new globalThis.Error("The parameter 'foodId' must be defined.");
         url_ = url_.replace("{foodId}", encodeURIComponent("" + foodId));
+        if (slot === undefined || slot === null)
+            throw new globalThis.Error("The parameter 'slot' must be defined and cannot be null.");
+        else
+            url_ += "slot=" + encodeURIComponent("" + slot) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         const content_ = JSON.stringify(uploadFoodImageUrlRequest);
@@ -7022,13 +7471,19 @@ export class ApiClient {
     /**
      * Confirm food image upload
      * @param foodId The food's public identifier (from route).
+     * @param slot Image slot: main (overwrites ImageUrl) or gallery (appends to GalleryImageUrls).
+    Provided as a query parameter: ?slot=main or ?slot=gallery.
      * @return No Content
      */
-    confirmFoodImageEndpoint(foodId: string, confirmFoodImageRequest: ConfirmFoodImageRequest, signal?: AbortSignal): Promise<void> {
-        let url_ = this.baseUrl + "/foods/{foodId}/image";
+    confirmFoodImageEndpoint(foodId: string, slot: string, confirmFoodImageRequest: ConfirmFoodImageRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/foods/{foodId}/image?";
         if (foodId === undefined || foodId === null)
             throw new globalThis.Error("The parameter 'foodId' must be defined.");
         url_ = url_.replace("{foodId}", encodeURIComponent("" + foodId));
+        if (slot === undefined || slot === null)
+            throw new globalThis.Error("The parameter 'slot' must be defined and cannot be null.");
+        else
+            url_ += "slot=" + encodeURIComponent("" + slot) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         const content_ = JSON.stringify(confirmFoodImageRequest);
@@ -8574,9 +9029,13 @@ export class ApiClient {
      * @param category (optional) Optional category filter (Food / Body / FreeForm).
      * @param from (optional) Optional inclusive lower bound on TakenAt (UTC).
      * @param to (optional) Optional inclusive upper bound on TakenAt (UTC).
+     * @param planId (optional) Optional plan filter. When provided, only photos belonging to this plan
+    (matching PlanPhoto.PlanId) are returned. Applies regardless of
+    PlanType; the caller is expected to know whether the plan is a
+    nutrition or training plan.
      * @return Success
      */
-    getTrainerClientPhotosEndpoint(clientId: string, page: number, pageSize: number, groupByMonth: boolean, category?: PlanPhotoCategory | null | undefined, from?: string | null | undefined, to?: string | null | undefined, signal?: AbortSignal): Promise<GetTrainerClientPhotosResponse> {
+    getTrainerClientPhotosEndpoint(clientId: string, page: number, pageSize: number, groupByMonth: boolean, category?: PlanPhotoCategory | null | undefined, from?: string | null | undefined, to?: string | null | undefined, planId?: string | null | undefined, signal?: AbortSignal): Promise<GetTrainerClientPhotosResponse> {
         let url_ = this.baseUrl + "/trainer/clients/{clientId}/photos?";
         if (clientId === undefined || clientId === null)
             throw new globalThis.Error("The parameter 'clientId' must be defined.");
@@ -8599,6 +9058,8 @@ export class ApiClient {
             url_ += "from=" + encodeURIComponent("" + from) + "&";
         if (to !== undefined && to !== null)
             url_ += "to=" + encodeURIComponent("" + to) + "&";
+        if (planId !== undefined && planId !== null)
+            url_ += "planId=" + encodeURIComponent("" + planId) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         let options_: AxiosRequestConfig = {
@@ -12474,6 +12935,8 @@ export interface ClientDashboardItem {
     lastName?: string;
     /** Client's email address. */
     email?: string;
+    /** Optional MinIO blob URL for the client's avatar (from the user record). Null if no avatar uploaded. */
+    avatarBlobUrl?: string | undefined;
     /** Whether the trainer-client link is active. */
     isActive?: boolean;
     /** Client's fitness goal text (from ClientProfile.Goals). */
@@ -13155,8 +13618,33 @@ export interface ClientAnswerDto {
     fileUrl?: string | undefined;
 }
 
+/** Combined banner response. Diary requests come first (ordering convention documented on the endpoint summary); questionnaires second. */
 export interface GetClientPendingQuestionnairesResponse {
+    /** Pending photo-diary requests addressed to this client.
+Always populated before Items so the mobile banner stack
+renders diary banners above questionnaire banners. */
+    pendingDiaryRequests?: PendingDiaryRequestItem[];
+    /** Pending / in-progress questionnaires for this client (one per active professional link). */
     items?: PendingQuestionnaireItem[];
+}
+
+/** Banner DTO for a single pending photo-diary request. Shape mirrors PendingQuestionnaireItem so the mobile banner component can render both types with a single rendering pattern. */
+export interface PendingDiaryRequestItem {
+    /** Public identifier of the diary request (same as PhotoDiaryRequest.Id). */
+    requestPublicId?: string;
+    /** Display name of the professional who sent the request. */
+    professionalName?: string;
+    /** Role of the professional ("Trainer" or "Nutritionist"). */
+    professionalRole?: string | undefined;
+    /** How many days the client has to upload photos (default 7). */
+    durationDays?: number;
+    /** Always "Pending" for items returned by this endpoint. */
+    status?: string;
+    /** Optional MongoDB plan ID the diary request is scoped to.
+Null when the request has no plan context. */
+    planId?: string | undefined;
+    /** When the request was created (UTC). */
+    createdAt?: string;
 }
 
 export interface PendingQuestionnaireItem {
@@ -13250,6 +13738,148 @@ export interface GenerateProfessionalAvatarUploadUrlRequest {
     contentType: string;
     /** Declared file size in bytes. Must not exceed 5 MiB. */
     sizeBytes?: number;
+}
+
+/** Response returned after a client submits / finalizes a photo diary. */
+export interface SubmitRequestResponse {
+    id?: string;
+    status?: PhotoDiaryStatus;
+    completedAt?: string | undefined;
+}
+
+/** Lifecycle status of a PhotoDiaryRequest. */
+export enum PhotoDiaryStatus {
+    Pending = "Pending",
+    Accepted = "Accepted",
+    Dismissed = "Dismissed",
+    InProgress = "InProgress",
+    Completed = "Completed",
+}
+
+/** Route parameters for submitting / finalizing a photo diary. */
+export interface SubmitRequestRequest {
+}
+
+/** Paginated list of photo diary requests for a trainer. */
+export interface ListTrainerRequestsResponse {
+    items?: PhotoDiaryRequestSummary[];
+}
+
+/** Summary DTO for a single photo diary request in a list. */
+export interface PhotoDiaryRequestSummary {
+    id?: string;
+    professionalId?: string;
+    linkId?: number | undefined;
+    pendingInviteId?: number | undefined;
+    planId?: string | undefined;
+    durationDays?: number;
+    mode?: PhotoDiaryMode | undefined;
+    status?: PhotoDiaryStatus;
+    dismissReason?: string | undefined;
+    acceptedAt?: string | undefined;
+    completedAt?: string | undefined;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+/** The mode a client chooses when accepting a photo diary request. */
+export enum PhotoDiaryMode {
+    Bulk = "Bulk",
+    Workflow = "Workflow",
+}
+
+/** Query parameters for listing trainer photo diary requests. */
+export interface ListTrainerRequestsRequest {
+}
+
+/** Paginated list of photo diary requests visible to the authenticated client. */
+export interface ListClientRequestsResponse {
+    items?: ClientPhotoDiaryRequestSummary[];
+}
+
+/** Summary DTO for a photo diary request in the client list view. */
+export interface ClientPhotoDiaryRequestSummary {
+    id?: string;
+    professionalId?: string;
+    linkId?: number | undefined;
+    pendingInviteId?: number | undefined;
+    planId?: string | undefined;
+    durationDays?: number;
+    mode?: PhotoDiaryMode | undefined;
+    status?: PhotoDiaryStatus;
+    dismissReason?: string | undefined;
+    acceptedAt?: string | undefined;
+    completedAt?: string | undefined;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+/** Query parameters for the client's photo diary request list. */
+export interface ListClientRequestsRequest {
+}
+
+/** Response returned after a client dismisses a photo diary request. */
+export interface DismissRequestResponse {
+    id?: string;
+    status?: PhotoDiaryStatus;
+    dismissReason?: string | undefined;
+}
+
+/** Route + body for dismissing a photo diary request. */
+export interface DismissRequestRequest {
+    /** Optional reason for dismissal (max 500 characters). */
+    reason?: string | undefined;
+}
+
+/** Response body returned after creating a photo diary request. */
+export interface CreateRequestResponse {
+    /** The new request's ID. */
+    id?: string;
+    /** The professional (nutritionist) who created the request. */
+    professionalId?: string;
+    /** The client-professional link this request is attached to (if link-based). */
+    linkId?: number | undefined;
+    /** The pending invite this request is bundled with (if invite-based). */
+    pendingInviteId?: number | undefined;
+    /** Optional plan scope for this request. */
+    planId?: string | undefined;
+    /** How many days the client has to upload photos. */
+    durationDays?: number;
+    /** Current lifecycle status (always Pending on creation). */
+    status?: PhotoDiaryStatus;
+    /** When the request was created. */
+    createdAt?: string;
+}
+
+/** Request body for creating a new photo diary request. Exactly one of LinkId or PendingInviteId must be set. */
+export interface CreateRequestRequest {
+    /** Internal ID of an existing client-professional link.
+Mutually exclusive with PendingInviteId. */
+    linkId?: number | undefined;
+    /** Internal ID of a pending invite.
+Mutually exclusive with LinkId. */
+    pendingInviteId?: number | undefined;
+    /** Optional MongoDB external identifier of the nutrition or training plan this request is scoped to.
+When set, must belong to the same client as the link/invite. */
+    planId?: string | undefined;
+    /** How many days the client has to upload photos (Workflow mode).
+Defaults to 7. Allowed range: 1–30. */
+    durationDays?: number;
+}
+
+/** Response returned after a client accepts a photo diary request. */
+export interface AcceptRequestResponse {
+    id?: string;
+    status?: PhotoDiaryStatus;
+    mode?: PhotoDiaryMode | undefined;
+    acceptedAt?: string | undefined;
+}
+
+/** Route + body for accepting a photo diary request. */
+export interface AcceptRequestRequest {
+    /** The upload mode chosen by the client.
+Must be a valid PhotoDiaryMode value. */
+    mode?: PhotoDiaryMode;
 }
 
 /** Detailed nutrition plan response including all weeks, days, meals, and foods. */
@@ -13713,6 +14343,9 @@ export interface FoodSummary {
     /** URL of the food image in blob storage (e.g. foods/{foodId}.jpg).
 Null when no image has been uploaded. */
     imageUrl?: string | undefined;
+    /** URLs of gallery images (up to 6 entries). Each entry points to a blob at
+foods/{foodId}/gallery-{n}.{ext}. */
+    galleryImageUrls?: string[];
     /** True when the authenticated caller is the nutritionist who created this food.
 Clients can use this flag to decide whether to show edit/delete affordances. */
     isOwnedByCurrentUser?: boolean;
@@ -14419,6 +15052,8 @@ export interface PlanPhotoResponse {
     dateCreated?: string;
     /** The ApplicationUser.Id of the uploader. */
     uploadedByUserId?: string;
+    /** The diary request this photo is associated with, or null if none. */
+    diaryRequestId?: string | undefined;
 }
 
 /** Categorises a PlanPhoto for display grouping and filtering in the app. Maps to the three chips shown in the Fotky plánu gallery (Jídlo / Tělo / Volné). */
@@ -14468,6 +15103,12 @@ export interface FinalizePlanPhotoRequest {
     /** MongoDB MealLog ObjectId string. Required when Category is
 Food, otherwise ignored. */
     mealLogId?: string | undefined;
+    /** Optional diary request ID. When set, the photo is linked to this diary request.
+The diary request must be owned by the calling client and must be in
+Accepted or
+InProgress status.
+On the first upload for an Accepted request the request is transitioned to InProgress. */
+    diaryRequestId?: string | undefined;
 }
 
 /** Request model for deleting a plan photo by its public identifier. */

--- a/mobile/src/api/questionnaire.ts
+++ b/mobile/src/api/questionnaire.ts
@@ -4,6 +4,7 @@ import type {
   SubmittedResponseItem,
   SubmittedAnswerItem,
   PendingQuestionnaireItem,
+  PendingDiaryRequestItem,
   GetClientPendingQuestionnairesResponse,
   GetClientSubmittedResponsesResponse,
 } from './generated'
@@ -14,6 +15,7 @@ export type {
   SubmittedResponseItem,
   SubmittedAnswerItem,
   PendingQuestionnaireItem,
+  PendingDiaryRequestItem,
   GetClientPendingQuestionnairesResponse,
 }
 

--- a/mobile/src/components/today/DiaryRequestBanner.tsx
+++ b/mobile/src/components/today/DiaryRequestBanner.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useRef } from 'react'
+import { View, Text, StyleSheet, Pressable, Animated } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import type { PendingDiaryRequestItem } from '@/api/questionnaire'
+
+// ─── Stable green alpha values matching the prototype style ───────────────────
+// We derive these from the theme's green color at render-time. The theme
+// does not expose pre-computed green alphas, so we compute them once from
+// the rgba values rather than hardcoding hex.
+const greenAlpha = {
+  bg: 'rgba(52,199,89,0.07)',
+  border: 'rgba(52,199,89,0.22)',
+  iconBg: 'rgba(52,199,89,0.15)',
+  eyebrow: '#1f8a3e',
+} as const
+
+interface DiaryRequestBannerProps {
+  /** The pending diary request item from the API response. */
+  item: PendingDiaryRequestItem
+  /** Called when the user taps "Accept" — routes to the accept wizard. */
+  onAccept: () => void
+  /** Called when the user taps "Dismiss" — routes to the dismiss flow. */
+  onDismiss: () => void
+}
+
+export function DiaryRequestBanner({ item, onAccept, onDismiss }: DiaryRequestBannerProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const opacity = useRef(new Animated.Value(0)).current
+  const translateY = useRef(new Animated.Value(-40)).current
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.spring(translateY, {
+        toValue: 0,
+        damping: 16,
+        stiffness: 100,
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 500,
+        useNativeDriver: true,
+      }),
+    ]).start()
+  }, [])
+
+  // Only render when the status is Pending (defensive — the query already filters to Pending).
+  if (item.status !== 'Pending') return null
+
+  const roleKey =
+    item.professionalRole === 'Trainer'
+      ? 'today.diaryBanner.roleTrainer'
+      : 'today.diaryBanner.roleNutritionist'
+
+  return (
+    <Animated.View style={[styles.wrapper, { opacity, transform: [{ translateY }] }]}>
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: greenAlpha.bg,
+            borderColor: greenAlpha.border,
+          },
+        ]}
+      >
+        {/* Icon + text row */}
+        <View style={styles.row}>
+          <View style={[styles.iconBox, { backgroundColor: greenAlpha.iconBg }]}>
+            <Text style={styles.icon}>📸</Text>
+          </View>
+          <View style={styles.textBlock}>
+            <Text style={[styles.eyebrow, { color: greenAlpha.eyebrow }]}>
+              {t('today.diaryBanner.from', { name: item.professionalName })}
+            </Text>
+            <Text style={[Type.subheadline, styles.title, { color: colors.label }]} numberOfLines={2}>
+              {t('today.diaryBanner.title')}
+            </Text>
+            <Text style={[Type.caption1, { color: colors.label2, marginTop: 2 }]}>
+              {t('today.diaryBanner.subtitle', {
+                role: t(roleKey),
+                days: item.durationDays,
+              })}
+            </Text>
+          </View>
+          <Text style={[styles.chevron, { color: colors.label3 }]}>›</Text>
+        </View>
+
+        {/* CTAs */}
+        <View style={styles.ctaRow}>
+          <Pressable
+            onPress={onAccept}
+            style={({ pressed }) => [
+              styles.ctaAccept,
+              { backgroundColor: colors.green, opacity: pressed ? 0.8 : 1 },
+            ]}
+          >
+            <Text style={[styles.ctaText, { color: colors.onAccent }]}>
+              {t('today.diaryBanner.accept')}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={onDismiss}
+            style={({ pressed }) => [
+              styles.ctaDismiss,
+              {
+                borderColor: colors.sep,
+                backgroundColor: colors.bg2,
+                opacity: pressed ? 0.7 : 1,
+              },
+            ]}
+          >
+            <Text style={[styles.ctaText, { color: colors.label }]}>
+              {t('today.diaryBanner.dismiss')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Animated.View>
+  )
+}
+
+export default DiaryRequestBanner
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginHorizontal: 16,
+    marginTop: 16,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: Radius.lg,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+  },
+  iconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  icon: {
+    fontSize: 20,
+  },
+  textBlock: {
+    flex: 1,
+    minWidth: 0,
+  },
+  eyebrow: {
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.05,
+    marginBottom: 2,
+  },
+  title: {
+    fontWeight: '600',
+  },
+  chevron: {
+    fontSize: 18,
+    fontWeight: '600',
+    flexShrink: 0,
+  },
+  ctaRow: {
+    marginTop: 14,
+    flexDirection: 'row',
+    gap: 10,
+  },
+  ctaAccept: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+  },
+  ctaDismiss: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    borderWidth: 1,
+  },
+  ctaText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+})

--- a/mobile/src/components/today/DiaryRequestBanner.tsx
+++ b/mobile/src/components/today/DiaryRequestBanner.tsx
@@ -1,21 +1,12 @@
 import React, { useEffect, useRef } from 'react'
-import { View, Text, StyleSheet, Pressable, Animated } from 'react-native'
+import { View, Text, StyleSheet, Pressable, Animated, useColorScheme } from 'react-native'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
+import { useThemeStore } from '@/stores/themeStore'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
+import { greenAlpha } from '@/constants/colors'
 import type { PendingDiaryRequestItem } from '@/api/questionnaire'
-
-// ─── Stable green alpha values matching the prototype style ───────────────────
-// We derive these from the theme's green color at render-time. The theme
-// does not expose pre-computed green alphas, so we compute them once from
-// the rgba values rather than hardcoding hex.
-const greenAlpha = {
-  bg: 'rgba(52,199,89,0.07)',
-  border: 'rgba(52,199,89,0.22)',
-  iconBg: 'rgba(52,199,89,0.15)',
-  eyebrow: '#1f8a3e',
-} as const
 
 interface DiaryRequestBannerProps {
   /** The pending diary request item from the API response. */
@@ -29,6 +20,10 @@ interface DiaryRequestBannerProps {
 export function DiaryRequestBanner({ item, onAccept, onDismiss }: DiaryRequestBannerProps) {
   const colors = useTheme()
   const { t } = useTranslation()
+  const systemScheme = useColorScheme()
+  const preference = useThemeStore((s) => s.preference)
+  const effectiveScheme = preference === 'system' ? (systemScheme ?? 'light') : preference
+  const ga = effectiveScheme === 'dark' ? greenAlpha.dark : greenAlpha.light
   const opacity = useRef(new Animated.Value(0)).current
   const translateY = useRef(new Animated.Value(-40)).current
 
@@ -62,18 +57,18 @@ export function DiaryRequestBanner({ item, onAccept, onDismiss }: DiaryRequestBa
         style={[
           styles.card,
           {
-            backgroundColor: greenAlpha.bg,
-            borderColor: greenAlpha.border,
+            backgroundColor: ga.bg,
+            borderColor: ga.border,
           },
         ]}
       >
         {/* Icon + text row */}
         <View style={styles.row}>
-          <View style={[styles.iconBox, { backgroundColor: greenAlpha.iconBg }]}>
+          <View style={[styles.iconBox, { backgroundColor: ga.iconBg }]}>
             <Text style={styles.icon}>📸</Text>
           </View>
           <View style={styles.textBlock}>
-            <Text style={[styles.eyebrow, { color: greenAlpha.eyebrow }]}>
+            <Text style={[styles.eyebrow, { color: ga.eyebrow }]}>
               {t('today.diaryBanner.from', { name: item.professionalName })}
             </Text>
             <Text style={[Type.subheadline, styles.title, { color: colors.label }]} numberOfLines={2}>
@@ -143,20 +138,20 @@ const styles = StyleSheet.create({
   iconBox: {
     width: 44,
     height: 44,
-    borderRadius: 14,
+    borderRadius: Radius.iconBox,
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
   },
   icon: {
-    fontSize: 20,
+    fontSize: Type.title3.fontSize,
   },
   textBlock: {
     flex: 1,
     minWidth: 0,
   },
   eyebrow: {
-    fontSize: 11,
+    fontSize: Type.caption2.fontSize,
     fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 0.05,
@@ -166,7 +161,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   chevron: {
-    fontSize: 18,
+    fontSize: Type.headline.fontSize,
     fontWeight: '600',
     flexShrink: 0,
   },
@@ -189,7 +184,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   ctaText: {
-    fontSize: 15,
+    fontSize: Type.subheadline.fontSize,
     fontWeight: '600',
   },
 })

--- a/mobile/src/constants/colors.ts
+++ b/mobile/src/constants/colors.ts
@@ -23,6 +23,28 @@ export const goldAlpha = {
   solid: 'rgba(201,168,76,1)',
 } as const
 
+/**
+ * Scheme-aware green alpha values for diary-request and other green-tinted
+ * surfaces. Light uses iOS system green (#34c759); dark uses the dark-mode
+ * system green (#30d158).
+ */
+export const greenAlpha = {
+  light: {
+    bg: 'rgba(52,199,89,0.07)',
+    border: 'rgba(52,199,89,0.22)',
+    iconBg: 'rgba(52,199,89,0.15)',
+    /** Dark legible green for eyebrow text on a light-tinted background. */
+    eyebrow: '#1f8a3e',
+  },
+  dark: {
+    bg: 'rgba(48,209,88,0.10)',
+    border: 'rgba(48,209,88,0.28)',
+    iconBg: 'rgba(48,209,88,0.18)',
+    /** Bright readable green for eyebrow text on a dark-tinted background. */
+    eyebrow: '#30d158',
+  },
+} as const
+
 const light = {
   // Backgrounds
   bg: '#f2f2f7',

--- a/mobile/src/constants/radius.ts
+++ b/mobile/src/constants/radius.ts
@@ -1,6 +1,8 @@
 export const Radius = {
   sm: 10,
   md: 13,
+  /** Icon-box corner radius — matches the diary-request banner's icon container. */
+  iconBox: 14,
   lg: 20,
   xl: 28,
   full: 999,

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -258,7 +258,9 @@
       "accept": "Přijmout",
       "dismiss": "Odmítnout",
       "screenTitle": "Fotografický deník jídel",
-      "dismissScreenTitle": "Odmítnout žádost o deník"
+      "dismissScreenTitle": "Odmítnout žádost o deník",
+      "acceptPlaceholder": "Přijímací průvodce bude brzy k dispozici",
+      "dismissPlaceholder": "Funkce odmítnutí bude brzy k dispozici"
     },
     "trainingPlanType": "Tréninkový plán",
     "nutritionPlanType": "Výživový plán",

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -249,6 +249,17 @@
     "questionnaireTitle": "Nový dotazník k vyplnění",
     "questionnaireDesc": "Váš trenér vám odeslal dotazník. Vyplňte ho pro nastavení vašeho plánu.",
     "questionnaireFill": "Vyplnit",
+    "diaryBanner": {
+      "from": "Od {{name}}",
+      "title": "Sdílejte fotky svých jídel",
+      "subtitle": "Váš {{role}} chce, abyste sdíleli fotky jídel po dobu {{days}} dní",
+      "roleTrainer": "trenér",
+      "roleNutritionist": "výživový poradce",
+      "accept": "Přijmout",
+      "dismiss": "Odmítnout",
+      "screenTitle": "Fotografický deník jídel",
+      "dismissScreenTitle": "Odmítnout žádost o deník"
+    },
     "trainingPlanType": "Tréninkový plán",
     "nutritionPlanType": "Výživový plán",
     "startsOn": "Začíná {{date}}",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -258,7 +258,9 @@
       "accept": "Annehmen",
       "dismiss": "Ablehnen",
       "screenTitle": "Foto-Ernährungstagebuch",
-      "dismissScreenTitle": "Tagebuch-Anfrage ablehnen"
+      "dismissScreenTitle": "Tagebuch-Anfrage ablehnen",
+      "acceptPlaceholder": "Akzeptieren-Assistent kommt bald",
+      "dismissPlaceholder": "Ablehnungsablauf kommt bald"
     },
     "trainingPlanType": "Trainingsplan",
     "nutritionPlanType": "Ernährungsplan",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -249,6 +249,17 @@
     "questionnaireTitle": "Neuer Fragebogen zum Ausfüllen",
     "questionnaireDesc": "Dein Trainer hat dir einen Fragebogen gesendet. Fülle ihn aus, um deinen Plan einzurichten.",
     "questionnaireFill": "Ausfüllen",
+    "diaryBanner": {
+      "from": "Von {{name}}",
+      "title": "Teile Fotos deiner Mahlzeiten",
+      "subtitle": "Dein(e) {{role}} möchte, dass du {{days}} Tage lang Essensfotos teilst",
+      "roleTrainer": "Trainer",
+      "roleNutritionist": "Ernährungsberater",
+      "accept": "Annehmen",
+      "dismiss": "Ablehnen",
+      "screenTitle": "Foto-Ernährungstagebuch",
+      "dismissScreenTitle": "Tagebuch-Anfrage ablehnen"
+    },
     "trainingPlanType": "Trainingsplan",
     "nutritionPlanType": "Ernährungsplan",
     "startsOn": "Startet {{date}}",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -258,7 +258,9 @@
       "accept": "Accept",
       "dismiss": "Dismiss",
       "screenTitle": "Food Photo Diary",
-      "dismissScreenTitle": "Dismiss Diary Request"
+      "dismissScreenTitle": "Dismiss Diary Request",
+      "acceptPlaceholder": "Accept wizard coming soon",
+      "dismissPlaceholder": "Dismiss flow coming soon"
     },
     "trainingPlanType": "Training plan",
     "nutritionPlanType": "Nutrition plan",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -249,6 +249,17 @@
     "questionnaireTitle": "New questionnaire to fill",
     "questionnaireDesc": "Your trainer sent you a questionnaire. Fill it in to set up your plan.",
     "questionnaireFill": "Fill in",
+    "diaryBanner": {
+      "from": "From {{name}}",
+      "title": "Share photos of your meals",
+      "subtitle": "Your {{role}} wants you to share food photos for {{days}} days",
+      "roleTrainer": "trainer",
+      "roleNutritionist": "nutritionist",
+      "accept": "Accept",
+      "dismiss": "Dismiss",
+      "screenTitle": "Food Photo Diary",
+      "dismissScreenTitle": "Dismiss Diary Request"
+    },
     "trainingPlanType": "Training plan",
     "nutritionPlanType": "Nutrition plan",
     "startsOn": "Starts {{date}}",


### PR DESCRIPTION
## Summary

- Adds `DiaryRequestBanner` component wired into the Today screen above the existing `QuestionnaireBanner` (ordering per #93 AC).
- Diary request data derived via `useMemo` from the existing `useQuery(['pending-questionnaires'])` response's new `pendingDiaryRequests` array — no new network round-trip.
- Adds two placeholder route screens (`(client)/diary/[requestId].tsx` for #99, `(client)/diary/[requestId]/dismiss.tsx` for #102) so the banner CTAs navigate to real routes instead of 404s.
- `mobile/src/api/generated.ts` regenerated via NSwag (NOT hand-edited) — auto-gen header intact.
- Banner uses green accent (`rgba(52,199,89,...)`) per the prototype design-of-record, NOT gold — intentional by design. Brand gold `#c9a84c` is not inlined anywhere.
- i18n complete in cs/en/de for all banner strings and screen titles.

## Related issue

Fixes #98

## Parent epic (sub-issue PR)

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL PASS — Sim smoke deferred to user (fixture doesn't seed a pending diary request yet; environmental limitation, not a code defect).

## Test plan

- [ ] Banner only shows for Pending status (status gate present in component).
- [ ] Accept CTA routes to wizard screen (`(client)/diary/[requestId]`).
- [ ] Dismiss CTA routes to dismiss screen (`(client)/diary/[requestId]/dismiss`).
- [ ] Diary banners render above questionnaire banners in the Today screen stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)