### PR TITLE
feat(web,backend,#96): photo diary request dialog + invite checkbox

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
@@ -190,6 +190,7 @@ public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService 
 
         await Send.OkAsync(new GetClientDashboardResponse
         {
+            LinkId = link.Id,
             ClientPublicId = clientProfile.PublicId,
             Email = clientProfile.User.Email!,
             FirstName = clientProfile.User.FirstName,

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardResponse.cs
@@ -6,6 +6,12 @@ namespace FitnessPlatform.Application.Features.Trainers.GetClientDashboard;
 public class GetClientDashboardResponse
 {
     /// <summary>
+    /// Internal integer primary key of the ClientProfessionalLink row.
+    /// Used to populate <c>linkId</c> on the photo-diary-request create form.
+    /// </summary>
+    public long LinkId { get; set; }
+
+    /// <summary>
     /// The client profile's public ID.
     /// </summary>
     public Guid ClientPublicId { get; set; }

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClients/GetClientsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClients/GetClientsEndpoint.cs
@@ -70,6 +70,7 @@ public class GetClientsEndpoint(IApplicationDbContext db) : Endpoint<GetClientsR
             .Take(req.PageSize)
             .Select(ctl => new ClientSummary
             {
+                LinkId = ctl.Id,
                 PublicId = ctl.ClientProfile.PublicId,
                 Email = ctl.ClientProfile.User.Email!,
                 FirstName = ctl.ClientProfile.User.FirstName,

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClients/GetClientsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClients/GetClientsResponse.cs
@@ -32,6 +32,12 @@ public class GetClientsResponse
 public class ClientSummary
 {
     /// <summary>
+    /// Internal integer primary key of the ClientProfessionalLink row.
+    /// Used to populate <c>linkId</c> on the photo-diary-request create form.
+    /// </summary>
+    public long LinkId { get; set; }
+
+    /// <summary>
     /// Client profile's public ID.
     /// </summary>
     public Guid PublicId { get; set; }

--- a/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/Create/CreatePendingInviteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/Create/CreatePendingInviteEndpoint.cs
@@ -196,6 +196,7 @@ public class CreatePendingInviteEndpoint(
 
         await Send.ResponseAsync(new CreatePendingInviteResponse
         {
+            Id = pendingInvite.Id,
             PublicId = pendingInvite.PublicId,
             FirstName = pendingInvite.FirstName,
             LastName = pendingInvite.LastName,

--- a/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/Create/CreatePendingInviteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/Create/CreatePendingInviteResponse.cs
@@ -6,6 +6,12 @@ namespace FitnessPlatform.Application.Features.Trainers.PendingInvites.Create;
 public class CreatePendingInviteResponse
 {
     /// <summary>
+    /// Internal integer primary key of the PendingInvite row.
+    /// Used to populate <c>pendingInviteId</c> on the photo-diary-request create form.
+    /// </summary>
+    public long Id { get; set; }
+
+    /// <summary>
     /// Public identifier of the created pending invite.
     /// </summary>
     public Guid PublicId { get; set; }

--- a/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/GetAll/GetPendingInvitesEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/GetAll/GetPendingInvitesEndpoint.cs
@@ -52,6 +52,7 @@ public class GetPendingInvitesEndpoint(IApplicationDbContext db) : EndpointWitho
             .OrderByDescending(pi => pi.SentAt)
             .Select(pi => new PendingInviteDto
             {
+                Id = pi.Id,
                 PublicId = pi.PublicId,
                 FirstName = pi.FirstName,
                 LastName = pi.LastName,

--- a/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/GetAll/GetPendingInvitesResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/PendingInvites/GetAll/GetPendingInvitesResponse.cs
@@ -17,6 +17,12 @@ public class GetPendingInvitesResponse
 public class PendingInviteDto
 {
     /// <summary>
+    /// Internal integer primary key of the PendingInvite row.
+    /// Used to populate <c>pendingInviteId</c> on the photo-diary-request create form.
+    /// </summary>
+    public long Id { get; set; }
+
+    /// <summary>
     /// Public identifier of the pending invite.
     /// </summary>
     public Guid PublicId { get; set; }

--- a/backend/FitnessPlatform.Tests/Builders/EntityBuilders.cs
+++ b/backend/FitnessPlatform.Tests/Builders/EntityBuilders.cs
@@ -42,6 +42,11 @@ public static class EntityBuilder
     /// Creates a new <see cref="ClientOnboardingDataBuilder"/>.
     /// </summary>
     public static ClientOnboardingDataBuilder ClientOnboardingData => new();
+
+    /// <summary>
+    /// Creates a new <see cref="PendingInviteBuilder"/>.
+    /// </summary>
+    public static PendingInviteBuilder PendingInvite => new();
 }
 
 /// <summary>
@@ -189,6 +194,7 @@ public class ClientProfileBuilder
 /// </summary>
 public class ClientProfessionalLinkBuilder
 {
+    private long _id;
     private long _clientProfileId;
     private long _professionalProfileId;
     private UserRole _professionalRole = UserRole.Trainer;
@@ -196,6 +202,11 @@ public class ClientProfessionalLinkBuilder
     private ClientProfile? _clientProfile;
     private ProfessionalProfile? _professionalProfile;
     private DateTime _dateCreated = DateTime.UtcNow;
+
+    /// <summary>
+    /// Sets the internal ID.
+    /// </summary>
+    public ClientProfessionalLinkBuilder WithId(long id) { _id = id; return this; }
 
     /// <summary>
     /// Sets the client profile ID.
@@ -237,6 +248,7 @@ public class ClientProfessionalLinkBuilder
     /// </summary>
     public ClientProfessionalLink Build() => new()
     {
+        Id = _id,
         ClientProfileId = _clientProfileId, ProfessionalProfileId = _professionalProfileId,
         ProfessionalRole = _professionalRole, IsActive = _isActive,
         ClientProfile = _clientProfile!, ProfessionalProfile = _professionalProfile!,
@@ -356,6 +368,71 @@ public class InvitationTokenBuilder
     {
         ProfessionalProfileId = _professionalProfileId, Email = _email, Token = _token,
         ExpiresAt = _expiresAt, IsUsed = _isUsed, ProfessionalProfile = _professionalProfile!
+    };
+}
+
+/// <summary>
+/// Builder for <see cref="Application.Domain.Entities.PendingInvite"/> test entities.
+/// </summary>
+public class PendingInviteBuilder
+{
+    private long _id;
+    private long _professionalProfileId = 1;
+    private string _firstName = "Invited";
+    private string _lastName = "Client";
+    private string _email = "invited@test.com";
+    private DateTime _sentAt = DateTime.UtcNow;
+    private bool _isAccepted;
+    private ProfessionalProfile? _professionalProfile;
+
+    /// <summary>
+    /// Sets the internal ID.
+    /// </summary>
+    public PendingInviteBuilder WithId(long id) { _id = id; return this; }
+
+    /// <summary>
+    /// Sets the professional profile ID.
+    /// </summary>
+    public PendingInviteBuilder WithProfessionalProfileId(long id) { _professionalProfileId = id; return this; }
+
+    /// <summary>
+    /// Sets the first name.
+    /// </summary>
+    public PendingInviteBuilder WithFirstName(string fn) { _firstName = fn; return this; }
+
+    /// <summary>
+    /// Sets the last name.
+    /// </summary>
+    public PendingInviteBuilder WithLastName(string ln) { _lastName = ln; return this; }
+
+    /// <summary>
+    /// Sets the email.
+    /// </summary>
+    public PendingInviteBuilder WithEmail(string email) { _email = email; return this; }
+
+    /// <summary>
+    /// Marks the invite as accepted.
+    /// </summary>
+    public PendingInviteBuilder Accepted() { _isAccepted = true; return this; }
+
+    /// <summary>
+    /// Sets the ProfessionalProfile navigation property.
+    /// </summary>
+    public PendingInviteBuilder WithProfessionalProfile(ProfessionalProfile pp) { _professionalProfile = pp; _professionalProfileId = pp.Id; return this; }
+
+    /// <summary>
+    /// Builds the <see cref="Application.Domain.Entities.PendingInvite"/> instance.
+    /// </summary>
+    public Application.Domain.Entities.PendingInvite Build() => new()
+    {
+        Id = _id,
+        ProfessionalProfileId = _professionalProfileId,
+        FirstName = _firstName,
+        LastName = _lastName,
+        Email = _email,
+        SentAt = _sentAt,
+        IsAccepted = _isAccepted,
+        ProfessionalProfile = _professionalProfile!
     };
 }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/CreatePendingInviteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/CreatePendingInviteEndpointTests.cs
@@ -1,0 +1,86 @@
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Trainers.PendingInvites.Create;
+using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+public class CreatePendingInviteEndpointTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    [Fact]
+    public async Task HandleAsync_ValidRequest_ReturnsResponseWithId()
+    {
+        var trainerUser = EntityBuilder.User.WithId(_trainerId).WithEmail("trainer@test.com")
+            .WithFirstName("Train").WithLastName("Er").Build();
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUser(trainerUser).Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerUser)
+            .With(trainerProfile)
+            .Build();
+
+        // Capture the PendingInvite added to the DbSet so we can compare its Id with the response.
+        PendingInvite? captured = null;
+        db.PendingInvites.When(x => x.Add(Arg.Any<PendingInvite>()))
+            .Do(ci => captured = ci.Arg<PendingInvite>());
+
+        var emailService = Substitute.For<IEmailService>();
+        var notificationService = Substitute.For<INotificationService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+        var logger = Substitute.For<ILogger<CreatePendingInviteEndpoint>>();
+
+        var ep = Factory.Create<CreatePendingInviteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db, emailService, notificationService, notifier, logger);
+
+        await ep.HandleAsync(new CreatePendingInviteRequest
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@test.com"
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        captured.Should().NotBeNull();
+        // In unit tests the mock DB does not auto-assign the PK, so the captured object's Id
+        // matches what the response returns (both will be 0 here). The important contract is
+        // that the response field is wired to pendingInvite.Id.
+        ep.Response.Id.Should().Be(captured!.Id);
+        ep.Response.PublicId.Should().Be(captured.PublicId);
+        ep.Response.Email.Should().Be("jane@test.com");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoProfessionalProfile_ThrowsError()
+    {
+        var db = new MockDbBuilder().Build();
+        var emailService = Substitute.For<IEmailService>();
+        var notificationService = Substitute.For<INotificationService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+        var logger = Substitute.For<ILogger<CreatePendingInviteEndpoint>>();
+
+        var ep = Factory.Create<CreatePendingInviteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db, emailService, notificationService, notifier, logger);
+
+        var act = () => ep.HandleAsync(new CreatePendingInviteRequest
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@test.com"
+        }, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ValidationFailureException>();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardEndpointTests.cs
@@ -23,6 +23,7 @@ public class GetClientDashboardEndpointTests
         var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
         var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
         var link = EntityBuilder.ClientProfessionalLink
+            .WithId(99)
             .WithClientProfile(clientProfile)
             .WithProfessionalProfile(trainerProfile)
             .Build();
@@ -50,6 +51,7 @@ public class GetClientDashboardEndpointTests
         ep.Response.IsActive.Should().BeTrue();
         ep.Response.TotalMeasurements.Should().Be(0);
         ep.Response.TotalProgressPhotos.Should().Be(0);
+        ep.Response.LinkId.Should().Be(99);
     }
 
     [Fact]

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientsEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientsEndpointTests.cs
@@ -18,6 +18,7 @@ public class GetClientsEndpointTests
         var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
         var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
         var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
             .WithClientProfile(clientProfile)
             .WithProfessionalProfile(trainerProfile)
             .Build();
@@ -38,6 +39,7 @@ public class GetClientsEndpointTests
 
         ep.Response.TotalCount.Should().Be(1);
         ep.Response.Clients.Should().ContainSingle(c => c.Email == "linked-client@test.com");
+        ep.Response.Clients[0].LinkId.Should().Be(42);
     }
 
     [Fact]

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetPendingInvitesEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetPendingInvitesEndpointTests.cs
@@ -1,0 +1,67 @@
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Features.Trainers.PendingInvites.GetAll;
+using FitnessPlatform.Tests.Builders;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+public class GetPendingInvitesEndpointTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    [Fact]
+    public async Task HandleAsync_WithPendingInvites_ReturnsIdInEachItem()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var invite = EntityBuilder.PendingInvite
+            .WithId(77)
+            .WithProfessionalProfile(trainerProfile)
+            .WithEmail("invited@test.com")
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(invite)
+            .Build();
+
+        var ep = Factory.Create<GetPendingInvitesEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.Invites.Should().ContainSingle();
+        ep.Response.Invites[0].Id.Should().Be(77);
+        ep.Response.Invites[0].Email.Should().Be("invited@test.com");
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoProfessionalProfile_Returns404()
+    {
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<GetPendingInvitesEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoClaims_Returns401()
+    {
+        var db = new MockDbBuilder().Build();
+        var ep = Factory.Create<GetPendingInvitesEndpoint>(db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+}

--- a/web/src/api/diary-requests.ts
+++ b/web/src/api/diary-requests.ts
@@ -2,15 +2,6 @@
  * Diary requests API module.
  *
  * Wraps the NSwag-generated createRequestEndpoint.
- *
- * NOTE — backend contract gap:
- *   CreateRequestRequest requires `linkId` (int64) or `pendingInviteId` (int64).
- *   Neither is exposed in any client-list or invite-list response today.
- *   - GetClientDashboardResponse does not include linkId.
- *   - CreatePendingInviteResponse only contains publicId (GUID), not the internal integer.
- *   Callers must supply the integer ID when available; otherwise pass undefined and the
- *   dialog will disable submission (linkId-based flow) or skip the diary POST
- *   (invite-bundled flow). Both IDs need to be surfaced by the backend in a follow-up.
  */
 import { apiClient } from '@/api/client';
 import type { CreateRequestResponse } from '@/api/generated';

--- a/web/src/api/diary-requests.ts
+++ b/web/src/api/diary-requests.ts
@@ -1,0 +1,43 @@
+/**
+ * Diary requests API module.
+ *
+ * Wraps the NSwag-generated createRequestEndpoint.
+ *
+ * NOTE — backend contract gap:
+ *   CreateRequestRequest requires `linkId` (int64) or `pendingInviteId` (int64).
+ *   Neither is exposed in any client-list or invite-list response today.
+ *   - GetClientDashboardResponse does not include linkId.
+ *   - CreatePendingInviteResponse only contains publicId (GUID), not the internal integer.
+ *   Callers must supply the integer ID when available; otherwise pass undefined and the
+ *   dialog will disable submission (linkId-based flow) or skip the diary POST
+ *   (invite-bundled flow). Both IDs need to be surfaced by the backend in a follow-up.
+ */
+import { apiClient } from '@/api/client';
+import type { CreateRequestResponse } from '@/api/generated';
+
+export type { CreateRequestResponse };
+
+export interface CreateDiaryRequestParams {
+  /** Internal integer ID of the client-professional link. XOR with pendingInviteId. */
+  linkId?: number;
+  /** Internal integer ID of the pending invite. XOR with linkId. */
+  pendingInviteId?: number;
+  /** Optional plan scope (MongoDB external ID). */
+  planId?: string;
+  /** Duration in days (1–30). Defaults to 7. */
+  durationDays?: number;
+}
+
+/**
+ * Create a photo diary request via POST /trainer/photo-diary-requests.
+ */
+export async function createDiaryRequest(
+  params: CreateDiaryRequestParams,
+): Promise<CreateRequestResponse> {
+  return apiClient.createRequestEndpoint({
+    linkId: params.linkId ?? undefined,
+    pendingInviteId: params.pendingInviteId ?? undefined,
+    planId: params.planId ?? undefined,
+    durationDays: params.durationDays ?? 7,
+  });
+}

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -12819,6 +12819,9 @@ export interface GetPendingInvitesResponse {
 
 /** DTO representing a single pending invitation. */
 export interface PendingInviteDto {
+    /** Internal integer primary key of the PendingInvite row.
+Used to populate pendingInviteId on the photo-diary-request create form. */
+    id?: number;
     /** Public identifier of the pending invite. */
     publicId?: string;
     /** First name of the invited client. */
@@ -12845,6 +12848,9 @@ export interface DeletePendingInviteRequest {
 
 /** Response model returned after creating a pending invitation. */
 export interface CreatePendingInviteResponse {
+    /** Internal integer primary key of the PendingInvite row.
+Used to populate pendingInviteId on the photo-diary-request create form. */
+    id?: number;
     /** Public identifier of the created pending invite. */
     publicId?: string;
     /** First name of the invited client. */
@@ -13027,6 +13033,9 @@ export interface GetClientsResponse {
 
 /** Summary of a client in the trainer's client list. */
 export interface ClientSummary {
+    /** Internal integer primary key of the ClientProfessionalLink row.
+Used to populate linkId on the photo-diary-request create form. */
+    linkId?: number;
     /** Client profile's public ID. */
     publicId?: string;
     /** Client's email address. */
@@ -13083,6 +13092,9 @@ export interface GetClientProgressRequest {
 
 /** Response model containing a client's dashboard summary for a trainer. */
 export interface GetClientDashboardResponse {
+    /** Internal integer primary key of the ClientProfessionalLink row.
+Used to populate linkId on the photo-diary-request create form. */
+    linkId?: number;
     /** The client profile's public ID. */
     clientPublicId?: string;
     /** The client's email address. */

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -4912,7 +4912,7 @@ export class ApiClient {
     }
 
     /**
-     * Get all pending questionnaires for the client
+     * Get pending questionnaires and diary requests for the client
      * @return Success
      */
     getClientPendingQuestionnairesEndpoint(signal?: AbortSignal): Promise<GetClientPendingQuestionnairesResponse> {
@@ -5366,6 +5366,449 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GenerateProfessionalAvatarUploadUrlResponse>(null as any);
+    }
+
+    /**
+     * Submit / finalize a photo diary
+     * @param id The photo diary request ID (from route).
+     * @return Success
+     */
+    submitRequestEndpoint(id: string, signal?: AbortSignal): Promise<SubmitRequestResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests/{id}/submit";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSubmitRequestEndpoint(_response);
+        });
+    }
+
+    protected processSubmitRequestEndpoint(response: AxiosResponse): Promise<SubmitRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<SubmitRequestResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<SubmitRequestResponse>(null as any);
+    }
+
+    /**
+     * List photo diary requests (trainer view)
+     * @param page Page number (1-based). Defaults to 1.
+     * @param pageSize Number of items per page. Defaults to 20.
+     * @param status (optional) Optional filter by status.
+     * @param linkId (optional) Optional filter by client-professional link ID.
+     * @param pendingInviteId (optional) Optional filter by pending invite ID.
+     * @param planId (optional) Optional filter by plan ID.
+     * @return Success
+     */
+    listTrainerRequestsEndpoint(page: number, pageSize: number, status?: PhotoDiaryStatus | null | undefined, linkId?: number | null | undefined, pendingInviteId?: number | null | undefined, planId?: string | null | undefined, signal?: AbortSignal): Promise<ListTrainerRequestsResponse> {
+        let url_ = this.baseUrl + "/trainer/photo-diary-requests?";
+        if (page === undefined || page === null)
+            throw new globalThis.Error("The parameter 'page' must be defined and cannot be null.");
+        else
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (status !== undefined && status !== null)
+            url_ += "status=" + encodeURIComponent("" + status) + "&";
+        if (linkId !== undefined && linkId !== null)
+            url_ += "linkId=" + encodeURIComponent("" + linkId) + "&";
+        if (pendingInviteId !== undefined && pendingInviteId !== null)
+            url_ += "pendingInviteId=" + encodeURIComponent("" + pendingInviteId) + "&";
+        if (planId !== undefined && planId !== null)
+            url_ += "planId=" + encodeURIComponent("" + planId) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processListTrainerRequestsEndpoint(_response);
+        });
+    }
+
+    protected processListTrainerRequestsEndpoint(response: AxiosResponse): Promise<ListTrainerRequestsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ListTrainerRequestsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ListTrainerRequestsResponse>(null as any);
+    }
+
+    /**
+     * Create a photo diary request
+     * @return Success
+     */
+    createRequestEndpoint(createRequestRequest: CreateRequestRequest, signal?: AbortSignal): Promise<CreateRequestResponse> {
+        let url_ = this.baseUrl + "/trainer/photo-diary-requests";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(createRequestRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processCreateRequestEndpoint(_response);
+        });
+    }
+
+    protected processCreateRequestEndpoint(response: AxiosResponse): Promise<CreateRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<CreateRequestResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<CreateRequestResponse>(null as any);
+    }
+
+    /**
+     * List photo diary requests (client view)
+     * @param page Page number (1-based). Defaults to 1.
+     * @param pageSize Number of items per page. Defaults to 20.
+     * @param status (optional) Optional filter by status.
+     * @param planId (optional) Optional filter by plan ID.
+     * @return Success
+     */
+    listClientRequestsEndpoint(page: number, pageSize: number, status?: PhotoDiaryStatus | null | undefined, planId?: string | null | undefined, signal?: AbortSignal): Promise<ListClientRequestsResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests?";
+        if (page === undefined || page === null)
+            throw new globalThis.Error("The parameter 'page' must be defined and cannot be null.");
+        else
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        if (status !== undefined && status !== null)
+            url_ += "status=" + encodeURIComponent("" + status) + "&";
+        if (planId !== undefined && planId !== null)
+            url_ += "planId=" + encodeURIComponent("" + planId) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processListClientRequestsEndpoint(_response);
+        });
+    }
+
+    protected processListClientRequestsEndpoint(response: AxiosResponse): Promise<ListClientRequestsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ListClientRequestsResponse>(result200);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ListClientRequestsResponse>(null as any);
+    }
+
+    /**
+     * Dismiss a photo diary request
+     * @param id The photo diary request ID (from route).
+     * @return Success
+     */
+    dismissRequestEndpoint(id: string, dismissRequestRequest: DismissRequestRequest, signal?: AbortSignal): Promise<DismissRequestResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests/{id}/dismiss";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(dismissRequestRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDismissRequestEndpoint(_response);
+        });
+    }
+
+    protected processDismissRequestEndpoint(response: AxiosResponse): Promise<DismissRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<DismissRequestResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<DismissRequestResponse>(null as any);
+    }
+
+    /**
+     * Accept a photo diary request
+     * @param id The photo diary request ID (from route).
+     * @return Success
+     */
+    acceptRequestEndpoint(id: string, acceptRequestRequest: AcceptRequestRequest, signal?: AbortSignal): Promise<AcceptRequestResponse> {
+        let url_ = this.baseUrl + "/client/photo-diary-requests/{id}/accept";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(acceptRequestRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAcceptRequestEndpoint(_response);
+        });
+    }
+
+    protected processAcceptRequestEndpoint(response: AxiosResponse): Promise<AcceptRequestResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<AcceptRequestResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<AcceptRequestResponse>(null as any);
     }
 
     /**
@@ -13175,8 +13618,33 @@ export interface ClientAnswerDto {
     fileUrl?: string | undefined;
 }
 
+/** Combined banner response. Diary requests come first (ordering convention documented on the endpoint summary); questionnaires second. */
 export interface GetClientPendingQuestionnairesResponse {
+    /** Pending photo-diary requests addressed to this client.
+Always populated before Items so the mobile banner stack
+renders diary banners above questionnaire banners. */
+    pendingDiaryRequests?: PendingDiaryRequestItem[];
+    /** Pending / in-progress questionnaires for this client (one per active professional link). */
     items?: PendingQuestionnaireItem[];
+}
+
+/** Banner DTO for a single pending photo-diary request. Shape mirrors PendingQuestionnaireItem so the mobile banner component can render both types with a single rendering pattern. */
+export interface PendingDiaryRequestItem {
+    /** Public identifier of the diary request (same as PhotoDiaryRequest.Id). */
+    requestPublicId?: string;
+    /** Display name of the professional who sent the request. */
+    professionalName?: string;
+    /** Role of the professional ("Trainer" or "Nutritionist"). */
+    professionalRole?: string | undefined;
+    /** How many days the client has to upload photos (default 7). */
+    durationDays?: number;
+    /** Always "Pending" for items returned by this endpoint. */
+    status?: string;
+    /** Optional MongoDB plan ID the diary request is scoped to.
+Null when the request has no plan context. */
+    planId?: string | undefined;
+    /** When the request was created (UTC). */
+    createdAt?: string;
 }
 
 export interface PendingQuestionnaireItem {
@@ -13270,6 +13738,148 @@ export interface GenerateProfessionalAvatarUploadUrlRequest {
     contentType: string;
     /** Declared file size in bytes. Must not exceed 5 MiB. */
     sizeBytes?: number;
+}
+
+/** Response returned after a client submits / finalizes a photo diary. */
+export interface SubmitRequestResponse {
+    id?: string;
+    status?: PhotoDiaryStatus;
+    completedAt?: string | undefined;
+}
+
+/** Lifecycle status of a PhotoDiaryRequest. */
+export enum PhotoDiaryStatus {
+    Pending = "Pending",
+    Accepted = "Accepted",
+    Dismissed = "Dismissed",
+    InProgress = "InProgress",
+    Completed = "Completed",
+}
+
+/** Route parameters for submitting / finalizing a photo diary. */
+export interface SubmitRequestRequest {
+}
+
+/** Paginated list of photo diary requests for a trainer. */
+export interface ListTrainerRequestsResponse {
+    items?: PhotoDiaryRequestSummary[];
+}
+
+/** Summary DTO for a single photo diary request in a list. */
+export interface PhotoDiaryRequestSummary {
+    id?: string;
+    professionalId?: string;
+    linkId?: number | undefined;
+    pendingInviteId?: number | undefined;
+    planId?: string | undefined;
+    durationDays?: number;
+    mode?: PhotoDiaryMode | undefined;
+    status?: PhotoDiaryStatus;
+    dismissReason?: string | undefined;
+    acceptedAt?: string | undefined;
+    completedAt?: string | undefined;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+/** The mode a client chooses when accepting a photo diary request. */
+export enum PhotoDiaryMode {
+    Bulk = "Bulk",
+    Workflow = "Workflow",
+}
+
+/** Query parameters for listing trainer photo diary requests. */
+export interface ListTrainerRequestsRequest {
+}
+
+/** Paginated list of photo diary requests visible to the authenticated client. */
+export interface ListClientRequestsResponse {
+    items?: ClientPhotoDiaryRequestSummary[];
+}
+
+/** Summary DTO for a photo diary request in the client list view. */
+export interface ClientPhotoDiaryRequestSummary {
+    id?: string;
+    professionalId?: string;
+    linkId?: number | undefined;
+    pendingInviteId?: number | undefined;
+    planId?: string | undefined;
+    durationDays?: number;
+    mode?: PhotoDiaryMode | undefined;
+    status?: PhotoDiaryStatus;
+    dismissReason?: string | undefined;
+    acceptedAt?: string | undefined;
+    completedAt?: string | undefined;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+/** Query parameters for the client's photo diary request list. */
+export interface ListClientRequestsRequest {
+}
+
+/** Response returned after a client dismisses a photo diary request. */
+export interface DismissRequestResponse {
+    id?: string;
+    status?: PhotoDiaryStatus;
+    dismissReason?: string | undefined;
+}
+
+/** Route + body for dismissing a photo diary request. */
+export interface DismissRequestRequest {
+    /** Optional reason for dismissal (max 500 characters). */
+    reason?: string | undefined;
+}
+
+/** Response body returned after creating a photo diary request. */
+export interface CreateRequestResponse {
+    /** The new request's ID. */
+    id?: string;
+    /** The professional (nutritionist) who created the request. */
+    professionalId?: string;
+    /** The client-professional link this request is attached to (if link-based). */
+    linkId?: number | undefined;
+    /** The pending invite this request is bundled with (if invite-based). */
+    pendingInviteId?: number | undefined;
+    /** Optional plan scope for this request. */
+    planId?: string | undefined;
+    /** How many days the client has to upload photos. */
+    durationDays?: number;
+    /** Current lifecycle status (always Pending on creation). */
+    status?: PhotoDiaryStatus;
+    /** When the request was created. */
+    createdAt?: string;
+}
+
+/** Request body for creating a new photo diary request. Exactly one of LinkId or PendingInviteId must be set. */
+export interface CreateRequestRequest {
+    /** Internal ID of an existing client-professional link.
+Mutually exclusive with PendingInviteId. */
+    linkId?: number | undefined;
+    /** Internal ID of a pending invite.
+Mutually exclusive with LinkId. */
+    pendingInviteId?: number | undefined;
+    /** Optional MongoDB external identifier of the nutrition or training plan this request is scoped to.
+When set, must belong to the same client as the link/invite. */
+    planId?: string | undefined;
+    /** How many days the client has to upload photos (Workflow mode).
+Defaults to 7. Allowed range: 1–30. */
+    durationDays?: number;
+}
+
+/** Response returned after a client accepts a photo diary request. */
+export interface AcceptRequestResponse {
+    id?: string;
+    status?: PhotoDiaryStatus;
+    mode?: PhotoDiaryMode | undefined;
+    acceptedAt?: string | undefined;
+}
+
+/** Route + body for accepting a photo diary request. */
+export interface AcceptRequestRequest {
+    /** The upload mode chosen by the client.
+Must be a valid PhotoDiaryMode value. */
+    mode?: PhotoDiaryMode;
 }
 
 /** Detailed nutrition plan response including all weeks, days, meals, and foods. */
@@ -14442,6 +15052,8 @@ export interface PlanPhotoResponse {
     dateCreated?: string;
     /** The ApplicationUser.Id of the uploader. */
     uploadedByUserId?: string;
+    /** The diary request this photo is associated with, or null if none. */
+    diaryRequestId?: string | undefined;
 }
 
 /** Categorises a PlanPhoto for display grouping and filtering in the app. Maps to the three chips shown in the Fotky plánu gallery (Jídlo / Tělo / Volné). */
@@ -14491,6 +15103,12 @@ export interface FinalizePlanPhotoRequest {
     /** MongoDB MealLog ObjectId string. Required when Category is
 Food, otherwise ignored. */
     mealLogId?: string | undefined;
+    /** Optional diary request ID. When set, the photo is linked to this diary request.
+The diary request must be owned by the calling client and must be in
+Accepted or
+InProgress status.
+On the first upload for an Accepted request the request is transitioned to InProgress. */
+    diaryRequestId?: string | undefined;
 }
 
 /** Request model for deleting a plan photo by its public identifier. */

--- a/web/src/api/nutrition-goals.ts
+++ b/web/src/api/nutrition-goals.ts
@@ -66,6 +66,8 @@ export interface OnboardingData {
 
 export interface ClientDashboard {
   clientPublicId: string;
+  /** Internal integer PK of the ClientProfessionalLink row. Used for diary requests. */
+  linkId?: number | null;
   email: string;
   firstName: string;
   lastName: string;

--- a/web/src/api/pending-invites.ts
+++ b/web/src/api/pending-invites.ts
@@ -1,6 +1,8 @@
 import api from '@/lib/api';
 
 export interface PendingInviteDto {
+  /** Internal integer PK of the PendingInvite row. Used for diary requests. */
+  id?: number;
   publicId: string;
   firstName: string;
   lastName: string;
@@ -21,6 +23,8 @@ export interface CreatePendingInviteRequest {
 }
 
 export interface CreatePendingInviteResponse {
+  /** Internal integer PK of the PendingInvite row. Used for diary requests. */
+  id?: number;
   publicId: string;
   firstName: string;
   lastName: string;

--- a/web/src/components/NewClientDialog.tsx
+++ b/web/src/components/NewClientDialog.tsx
@@ -2,21 +2,16 @@
  * NewClientDialog — invite a new client via email.
  *
  * The "Bundle photo diary" toggle (per invite-new.html prototype) is included.
- * When checked, the component attempts to POST a diary request after the invite
- * is created.
- *
- * NOTE — backend contract gap:
- *   CreateRequestRequest.pendingInviteId expects the internal integer PK of
- *   PendingInvite. CreatePendingInviteResponse only returns publicId (GUID).
- *   Until the backend exposes `id` (int64) in the create-invite response the
- *   diary POST is skipped after invite creation — the user sees a non-blocking
- *   warning toast ("Invite sent, diary request failed..."). The invite is still
- *   created successfully. See diary-requests.ts for full contract-gap note.
+ * When checked, the component fires POST /trainer/photo-diary-requests
+ * (with pendingInviteId) immediately after the invite is created.
+ * On diary failure the invite is already sent — a non-blocking warning toast
+ * tells the user they can retry from the client detail page.
  */
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { createPendingInvite } from '@/api/pending-invites';
+import { createDiaryRequest } from '@/api/diary-requests';
 import { getTrainerQuestionnaires } from '@/api/questionnaires';
 import { CANCEL_BUTTON_CLASS } from '@/lib/styles';
 import { showApiError } from '@/lib/api-errors';
@@ -79,17 +74,19 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
         message: message.trim() || null,
         questionnairePublicId: selectedQuestionnaireId || null,
       }),
-    onSuccess: (_inviteResponse) => {
+    onSuccess: async (inviteResponse) => {
       queryClient.invalidateQueries({ queryKey: ['pending-invites'] });
       queryClient.invalidateQueries({ queryKey: ['sidebar-clients'] });
 
-      if (bundleDiary) {
-        // NOTE — backend contract gap: CreatePendingInviteResponse does not expose
-        // the internal integer `id` required by CreateRequestRequest.pendingInviteId.
-        // The diary POST is intentionally skipped here until the backend exposes
-        // `id` (int64) in the invite creation response.
-        // When that field is added: call createDiaryRequest({ pendingInviteId: inviteResponse.id, durationDays: diaryDurationDays })
-        addToast(i18n.t('diary.request.inviteDiaryFailed'), 'error');
+      if (bundleDiary && inviteResponse.id != null) {
+        try {
+          await createDiaryRequest({
+            pendingInviteId: inviteResponse.id,
+            durationDays: diaryDurationDays,
+          });
+        } catch {
+          addToast(i18n.t('diary.request.inviteDiaryFailed'), 'error');
+        }
       }
 
       onClose();
@@ -372,13 +369,6 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
                       </div>
                     </div>
 
-                    {/* Warning about the contract gap */}
-                    <div
-                      className="rounded-md px-3 py-2 text-[11px] leading-relaxed"
-                      style={{ background: 'var(--bg)', color: 'var(--text3)', border: '1px solid var(--border)' }}
-                    >
-                      {t('diary.request.inviteCheckboxWarning')}
-                    </div>
                   </div>
                 )}
               </div>

--- a/web/src/components/NewClientDialog.tsx
+++ b/web/src/components/NewClientDialog.tsx
@@ -1,9 +1,30 @@
+/**
+ * NewClientDialog — invite a new client via email.
+ *
+ * The "Bundle photo diary" toggle (per invite-new.html prototype) is included.
+ * When checked, the component attempts to POST a diary request after the invite
+ * is created.
+ *
+ * NOTE — backend contract gap:
+ *   CreateRequestRequest.pendingInviteId expects the internal integer PK of
+ *   PendingInvite. CreatePendingInviteResponse only returns publicId (GUID).
+ *   Until the backend exposes `id` (int64) in the create-invite response the
+ *   diary POST is skipped after invite creation — the user sees a non-blocking
+ *   warning toast ("Invite sent, diary request failed..."). The invite is still
+ *   created successfully. See diary-requests.ts for full contract-gap note.
+ */
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { createPendingInvite } from '@/api/pending-invites';
 import { getTrainerQuestionnaires } from '@/api/questionnaires';
 import { CANCEL_BUTTON_CLASS } from '@/lib/styles';
+import { showApiError } from '@/lib/api-errors';
+import { useToastStore } from '@/stores/toast';
+import i18n from '@/i18n';
+
+const DURATION_OPTIONS = [3, 7, 14] as const;
+type DurationDays = (typeof DURATION_OPTIONS)[number];
 
 interface NewClientDialogProps {
   open: boolean;
@@ -13,11 +34,19 @@ interface NewClientDialogProps {
 export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+
   const [email, setEmail] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [message, setMessage] = useState('');
   const [selectedQuestionnaireId, setSelectedQuestionnaireId] = useState<string>('');
+
+  // Photo diary bundle state
+  const [bundleDiary, setBundleDiary] = useState(false);
+  const [diaryDurationDays, setDiaryDurationDays] = useState<DurationDays>(7);
+  const [diaryMessage, setDiaryMessage] = useState('');
+
   const [trackedOpen, setTrackedOpen] = useState(false);
 
   const { data: questionnaires = [] } = useQuery({
@@ -33,6 +62,9 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
       setFirstName('');
       setLastName('');
       setMessage('');
+      setBundleDiary(false);
+      setDiaryDurationDays(7);
+      setDiaryMessage(t('diary.request.defaultMessage'));
       const defaultQ = questionnaires.find((q) => q.isDefault && q.isActive);
       setSelectedQuestionnaireId(defaultQ?.publicId ?? '');
     }
@@ -47,10 +79,23 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
         message: message.trim() || null,
         questionnairePublicId: selectedQuestionnaireId || null,
       }),
-    onSuccess: () => {
+    onSuccess: (_inviteResponse) => {
       queryClient.invalidateQueries({ queryKey: ['pending-invites'] });
       queryClient.invalidateQueries({ queryKey: ['sidebar-clients'] });
+
+      if (bundleDiary) {
+        // NOTE — backend contract gap: CreatePendingInviteResponse does not expose
+        // the internal integer `id` required by CreateRequestRequest.pendingInviteId.
+        // The diary POST is intentionally skipped here until the backend exposes
+        // `id` (int64) in the invite creation response.
+        // When that field is added: call createDiaryRequest({ pendingInviteId: inviteResponse.id, durationDays: diaryDurationDays })
+        addToast(i18n.t('diary.request.inviteDiaryFailed'), 'error');
+      }
+
       onClose();
+    },
+    onError: (err) => {
+      showApiError(err, 'invite.error');
     },
   });
 
@@ -59,28 +104,66 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
 
   if (!open) return null;
 
-  const inp = 'rounded-md border border-border-md bg-bg px-3 py-2 text-[13px] text-text outline-none transition-colors placeholder:text-text3 focus:border-border-hv w-full';
+  const inp =
+    'rounded-md border border-border-md bg-bg px-3 py-2 text-[13px] text-text outline-none transition-colors placeholder:text-text3 focus:border-border-hv w-full';
 
   return (
     <>
-      <div className="fixed inset-0 z-[60] bg-black/50" onClick={onClose} style={{ animation: 'dlg-fade-in .4s ease-out' }} />
+      <div
+        className="fixed inset-0 z-[60] bg-black/50"
+        onClick={onClose}
+        style={{ animation: 'dlg-fade-in .4s ease-out' }}
+      />
       <div className="fixed inset-0 z-[61] flex items-start justify-center pt-[5vh] pointer-events-none">
         <div
           className="pointer-events-auto flex flex-col border border-border shadow-2xl overflow-hidden"
-          style={{ width: 480, maxWidth: '95vw', maxHeight: '90vh', background: 'var(--bg)', borderRadius: 10, animation: 'dlg-slide-up .4s ease-out' }}
+          style={{
+            width: 480,
+            maxWidth: '95vw',
+            maxHeight: '90vh',
+            background: 'var(--bg)',
+            borderRadius: 10,
+            animation: 'dlg-slide-up .4s ease-out',
+          }}
         >
           {/* Hero */}
-          <div className="flex items-center justify-center" style={{ height: 90, background: 'var(--accent-bg)', borderRadius: '10px 10px 0 0' }}>
+          <div
+            className="flex items-center justify-center"
+            style={{
+              height: 90,
+              background: 'var(--accent-bg)',
+              borderRadius: '10px 10px 0 0',
+            }}
+          >
             <span style={{ fontSize: 36, opacity: 0.6 }}>✉️</span>
           </div>
 
           {/* Header */}
-          <div className="flex items-center gap-3 px-5 py-3 border-b border-border" style={{ flexShrink: 0 }}>
+          <div
+            className="flex items-center gap-3 px-5 py-3 border-b border-border"
+            style={{ flexShrink: 0 }}
+          >
             <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text)' }}>{t('invite.title')}</div>
-              <div style={{ fontSize: 12, color: 'var(--text3)', marginTop: 2 }}>{t('invite.description')}</div>
+              <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text)' }}>
+                {t('invite.title')}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text3)', marginTop: 2 }}>
+                {t('invite.description')}
+              </div>
             </div>
-            <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 18, color: 'var(--text3)', padding: 4 }}>✕</button>
+            <button
+              onClick={onClose}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 18,
+                color: 'var(--text3)',
+                padding: 4,
+              }}
+            >
+              ✕
+            </button>
           </div>
 
           {/* Body */}
@@ -89,25 +172,48 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
               {/* Name row */}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
                 <div>
-                  <label className="mb-1 block text-xs font-medium text-text3">{t('profile.firstName')}</label>
-                  <input value={firstName} onChange={(e) => setFirstName(e.target.value)} placeholder="Jan" className={inp} />
+                  <label className="mb-1 block text-xs font-medium text-text3">
+                    {t('profile.firstName')}
+                  </label>
+                  <input
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    placeholder="Jan"
+                    className={inp}
+                  />
                 </div>
                 <div>
-                  <label className="mb-1 block text-xs font-medium text-text3">{t('profile.lastName')}</label>
-                  <input value={lastName} onChange={(e) => setLastName(e.target.value)} placeholder="Novák" className={inp} />
+                  <label className="mb-1 block text-xs font-medium text-text3">
+                    {t('profile.lastName')}
+                  </label>
+                  <input
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    placeholder="Novák"
+                    className={inp}
+                  />
                 </div>
               </div>
 
               {/* Email */}
               <div>
                 <label className="mb-1 block text-xs font-medium text-text3">Email</label>
-                <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="jan@example.cz" className={inp} />
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="jan@example.cz"
+                  className={inp}
+                />
               </div>
 
               {/* Introduction message */}
               <div>
                 <label className="mb-1 block text-xs font-medium text-text3">
-                  {t('invite.message')} <span className="font-normal" style={{ color: 'var(--text4)' }}>({t('common.optional')})</span>
+                  {t('invite.message')}{' '}
+                  <span className="font-normal" style={{ color: 'var(--text4)' }}>
+                    ({t('common.optional')})
+                  </span>
                 </label>
                 <textarea
                   value={message}
@@ -117,12 +223,16 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
                   maxLength={500}
                   className={`${inp} resize-vertical`}
                 />
-                <div className="text-[10px] text-text4 text-right mt-0.5">{message.length}/500</div>
+                <div className="text-[10px] text-text4 text-right mt-0.5">
+                  {message.length}/500
+                </div>
               </div>
 
               {/* Questionnaire selector */}
               <div>
-                <label className="mb-1 block text-xs font-medium text-text3">{t('invite.questionnaire')}</label>
+                <label className="mb-1 block text-xs font-medium text-text3">
+                  {t('invite.questionnaire')}
+                </label>
                 <select
                   value={selectedQuestionnaireId}
                   onChange={(e) => setSelectedQuestionnaireId(e.target.value)}
@@ -132,26 +242,167 @@ export function NewClientDialog({ open, onClose }: NewClientDialogProps) {
                   <option value="">{t('invite.noQuestionnaire')}</option>
                   {activeQuestionnaires.map((q) => (
                     <option key={q.publicId} value={q.publicId}>
-                      {q.title}{q.isDefault ? ` (${t('questionnaire.default')})` : ''}
+                      {q.title}
+                      {q.isDefault ? ` (${t('questionnaire.default')})` : ''}
                     </option>
                   ))}
                 </select>
-                <div className="text-[11px] text-text3 mt-1">{t('invite.questionnaireHint')}</div>
+                <div className="text-[11px] text-text3 mt-1">
+                  {t('invite.questionnaireHint')}
+                </div>
+              </div>
+
+              {/* ── Photo diary bundle (per invite-new.html prototype) ── */}
+              <div
+                className="rounded-md border overflow-hidden"
+                style={{
+                  borderColor: bundleDiary ? 'var(--accent-br)' : 'var(--border)',
+                  transition: 'border-color 0.2s',
+                }}
+              >
+                {/* Toggle row */}
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div
+                      className="flex items-center justify-center shrink-0 text-base"
+                      style={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: 10,
+                        background: bundleDiary
+                          ? 'rgba(201,168,76,.15)'
+                          : 'var(--bg3)',
+                      }}
+                    >
+                      📸
+                    </div>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text)' }}>
+                        {t('diary.request.inviteCheckboxLabel')}
+                      </div>
+                      <div style={{ fontSize: 12, color: 'var(--text3)', marginTop: 1 }}>
+                        {t('diary.request.inviteCheckboxHint')}
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Toggle switch */}
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={bundleDiary}
+                    onClick={() => setBundleDiary((v) => !v)}
+                    className="shrink-0 ml-3"
+                    style={{
+                      width: 44,
+                      height: 26,
+                      borderRadius: 13,
+                      background: bundleDiary ? 'var(--accent)' : 'var(--bg3)',
+                      border: 'none',
+                      cursor: 'pointer',
+                      position: 'relative',
+                      transition: 'background 0.2s',
+                    }}
+                  >
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: 3,
+                        left: bundleDiary ? 21 : 3,
+                        width: 20,
+                        height: 20,
+                        borderRadius: '50%',
+                        background: '#fff',
+                        boxShadow: '0 1px 3px rgba(0,0,0,.2)',
+                        transition: 'left 0.2s',
+                      }}
+                    />
+                  </button>
+                </div>
+
+                {/* Expanded fields — shown when bundleDiary is on */}
+                {bundleDiary && (
+                  <div
+                    className="border-t px-4 pb-4 pt-3 flex flex-col gap-3"
+                    style={{ borderColor: 'var(--accent-br)', background: 'var(--accent-bg)' }}
+                  >
+                    {/* Duration */}
+                    <div>
+                      <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.04em] text-text3">
+                        {t('diary.request.durationLabel')}
+                      </label>
+                      <div className="flex gap-1.5">
+                        {DURATION_OPTIONS.map((d) => (
+                          <button
+                            key={d}
+                            type="button"
+                            onClick={() => setDiaryDurationDays(d)}
+                            className="flex-1 px-3 py-1.5 rounded-md text-[12px] font-medium border transition-colors"
+                            style={{
+                              background:
+                                diaryDurationDays === d ? 'var(--accent)' : 'var(--bg)',
+                              color:
+                                diaryDurationDays === d ? '#fff' : 'var(--text3)',
+                              borderColor:
+                                diaryDurationDays === d ? 'var(--accent)' : 'var(--border)',
+                            }}
+                          >
+                            {t('diary.request.durationDays', { count: d })}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {/* Diary intro message */}
+                    <div>
+                      <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.04em] text-text3">
+                        {t('diary.request.messageLabel')}
+                      </label>
+                      <textarea
+                        value={diaryMessage}
+                        onChange={(e) => setDiaryMessage(e.target.value)}
+                        placeholder={t('diary.request.messagePlaceholder')}
+                        rows={3}
+                        maxLength={500}
+                        className={`${inp} resize-none`}
+                        style={{ background: 'var(--bg)' }}
+                      />
+                      <div className="text-[10px] text-text4 text-right mt-0.5">
+                        {diaryMessage.length} / 500
+                      </div>
+                    </div>
+
+                    {/* Warning about the contract gap */}
+                    <div
+                      className="rounded-md px-3 py-2 text-[11px] leading-relaxed"
+                      style={{ background: 'var(--bg)', color: 'var(--text3)', border: '1px solid var(--border)' }}
+                    >
+                      {t('diary.request.inviteCheckboxWarning')}
+                    </div>
+                  </div>
+                )}
               </div>
 
               {mutation.isError && (
-                <p style={{ fontSize: 12, color: 'var(--red)', margin: 0 }}>{t('invite.error')}</p>
+                <p style={{ fontSize: 12, color: 'var(--red)', margin: 0 }}>
+                  {t('invite.error')}
+                </p>
               )}
             </div>
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-end gap-2 px-5 py-3 border-t border-border" style={{ flexShrink: 0 }}>
+          <div
+            className="flex items-center justify-end gap-2 px-5 py-3 border-t border-border"
+            style={{ flexShrink: 0 }}
+          >
             <button onClick={onClose} className={CANCEL_BUTTON_CLASS}>
               {t('common.cancel')}
             </button>
             <button
-              onClick={() => { if (canSend) mutation.mutate(); }}
+              onClick={() => {
+                if (canSend) mutation.mutate();
+              }}
               disabled={mutation.isPending || !canSend}
               className="px-5 py-2 rounded-md text-[13px] font-medium transition-colors disabled:opacity-50"
               style={{ background: 'var(--accent)', color: '#fff' }}

--- a/web/src/components/diary/RequestDiaryDialog.tsx
+++ b/web/src/components/diary/RequestDiaryDialog.tsx
@@ -1,0 +1,331 @@
+/**
+ * RequestDiaryDialog — standalone modal for sending a photo diary request.
+ *
+ * Design-of-record: docs/prototypes/trainer/scenes/diary-request-dialog.html
+ *
+ * Entry points:
+ *   - NutritionPlanPage (Photos tab CTA) → passes linkId + planId
+ *   - ClientDetailPage (photos tab CTA)  → passes linkId only
+ *   - DashboardPage                      → passes linkId only
+ *
+ * NOTE — backend contract gap:
+ *   `linkId` is the internal integer PK of ClientProfessionalLink.
+ *   It is NOT exposed in GetClientDashboardResponse or any client-list API today.
+ *   Until the backend adds `linkId` to those responses the prop will be undefined
+ *   and the submit button stays disabled. Track as a backend follow-up.
+ */
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { createDiaryRequest } from '@/api/diary-requests';
+import { showSuccess, showApiError } from '@/lib/api-errors';
+import { CANCEL_BUTTON_CLASS } from '@/lib/styles';
+
+const DURATION_OPTIONS = [3, 7, 14] as const;
+type DurationDays = (typeof DURATION_OPTIONS)[number];
+
+export interface RequestDiaryDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Internal integer PK of the ClientProfessionalLink. Required for submission. */
+  linkId: number | undefined;
+  /** Optional plan scope — passed from plan detail pages. */
+  planId?: string;
+  /** Display name shown in the client strip. */
+  clientName: string;
+  /** Client initials for the avatar. */
+  clientInitials: string;
+  /** Subtitle shown below the client name (e.g. "Výživa · Týden 4 / 12 · …"). */
+  clientSubtitle?: string;
+}
+
+export function RequestDiaryDialog({
+  open,
+  onClose,
+  linkId,
+  planId,
+  clientName,
+  clientInitials,
+  clientSubtitle,
+}: RequestDiaryDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const [message, setMessage] = useState('');
+  const [durationDays, setDurationDays] = useState<DurationDays>(7);
+
+  // Reset on open
+  const [trackedOpen, setTrackedOpen] = useState(false);
+  if (open !== trackedOpen) {
+    setTrackedOpen(open);
+    if (open) {
+      setMessage(t('diary.request.defaultMessage'));
+      setDurationDays(7);
+    }
+  }
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createDiaryRequest({
+        linkId,
+        planId,
+        durationDays,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['diary-requests'] });
+      showSuccess(t('diary.request.successToast'));
+      onClose();
+    },
+    onError: (err) => {
+      showApiError(err, 'diary.request.errorToast');
+    },
+  });
+
+  if (!open) return null;
+
+  const canSubmit = linkId != null && !mutation.isPending;
+  const charCount = message.length;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-[60] bg-black/50"
+        onClick={onClose}
+        style={{ animation: 'dlg-fade-in .4s ease-out' }}
+      />
+
+      {/* Dialog */}
+      <div className="fixed inset-0 z-[61] flex items-start justify-center pt-[5vh] pointer-events-none">
+        <div
+          className="pointer-events-auto flex flex-col border border-border shadow-2xl overflow-hidden"
+          style={{
+            width: 480,
+            maxWidth: '95vw',
+            maxHeight: '90vh',
+            background: 'var(--bg)',
+            borderRadius: 10,
+            animation: 'dlg-slide-up .4s ease-out',
+          }}
+        >
+          {/* Hero */}
+          <div
+            className="flex items-center justify-center shrink-0"
+            style={{
+              height: 72,
+              background: 'var(--accent-bg)',
+              borderRadius: '10px 10px 0 0',
+              borderBottom: '1px solid var(--accent-br)',
+            }}
+          >
+            <span style={{ fontSize: 28, opacity: 0.7 }}>📸</span>
+          </div>
+
+          {/* Header */}
+          <div className="flex items-center gap-3 px-5 py-3 border-b border-border shrink-0">
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text)' }}>
+                {t('diary.request.dialogTitle')}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text3)', marginTop: 2 }}>
+                {t('diary.request.dialogSubtitle')}
+              </div>
+            </div>
+            <button
+              onClick={onClose}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 18,
+                color: 'var(--text3)',
+                padding: 4,
+              }}
+              aria-label={t('common.close')}
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto" style={{ minHeight: 0 }}>
+            {/* Client strip */}
+            <div
+              className="flex items-center gap-3 px-5 py-3 border-b border-border"
+              style={{ background: 'var(--bg2)' }}
+            >
+              <div
+                className="flex items-center justify-center shrink-0 text-white text-base font-bold"
+                style={{
+                  width: 44,
+                  height: 44,
+                  borderRadius: 12,
+                  background: 'linear-gradient(135deg, var(--blue), #0056b3)',
+                  fontSize: 16,
+                }}
+              >
+                {clientInitials}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text)' }}>
+                  {clientName}
+                </div>
+                {clientSubtitle && (
+                  <div
+                    className="truncate"
+                    style={{ fontSize: 12, color: 'var(--text3)', marginTop: 1 }}
+                  >
+                    {clientSubtitle}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Info banner */}
+            <div
+              className="mx-5 mt-4 mb-3 rounded-md px-3.5 py-2.5 text-[12px] leading-relaxed"
+              style={{
+                background: 'var(--accent-bg)',
+                border: '1px solid var(--accent-br)',
+                color: 'var(--text3)',
+              }}
+            >
+              {t('diary.request.infoBanner')}
+            </div>
+
+            <div className="px-5 pb-5 flex flex-col gap-4">
+              {/* Message field */}
+              <div>
+                <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.04em] text-text3">
+                  {t('diary.request.messageLabel')}
+                </label>
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder={t('diary.request.messagePlaceholder')}
+                  rows={4}
+                  maxLength={500}
+                  className="rounded-md border border-border-md bg-bg px-3 py-2 text-[13px] text-text outline-none transition-colors placeholder:text-text3 focus:border-border-hv w-full resize-none"
+                />
+                <div className="text-[10px] text-text4 text-right mt-0.5">
+                  {charCount} / 500
+                </div>
+              </div>
+
+              {/* Duration selector */}
+              <div>
+                <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.04em] text-text3">
+                  {t('diary.request.durationLabel')}
+                </label>
+                <div className="flex gap-1.5">
+                  {DURATION_OPTIONS.map((d) => (
+                    <button
+                      key={d}
+                      type="button"
+                      onClick={() => setDurationDays(d)}
+                      className="flex-1 px-3 py-1.5 rounded-md text-[12px] font-medium border transition-colors"
+                      style={{
+                        background: durationDays === d ? 'var(--accent)' : 'var(--bg2)',
+                        color: durationDays === d ? '#fff' : 'var(--text3)',
+                        borderColor: durationDays === d ? 'var(--accent)' : 'var(--border)',
+                      }}
+                    >
+                      {t('diary.request.durationDays', { count: d })}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Upload mode info */}
+              <div>
+                <label className="mb-1.5 block text-[11px] font-semibold uppercase tracking-[0.04em] text-text3">
+                  {t('diary.request.uploadModeLabel')}
+                </label>
+                <div
+                  className="rounded-md px-3.5 py-2.5 text-[12px] leading-relaxed"
+                  style={{
+                    background: 'var(--bg2)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--text3)',
+                  }}
+                >
+                  <div>
+                    <span style={{ fontWeight: 600, color: 'var(--text)' }}>
+                      {t('diary.request.modeAllAtOnce')}
+                    </span>{' '}
+                    — {t('diary.request.modeAllAtOnceDesc')}
+                  </div>
+                  <div className="mt-1">
+                    <span style={{ fontWeight: 600, color: 'var(--text)' }}>
+                      {t('diary.request.modeWorkflow')}
+                    </span>{' '}
+                    — {t('diary.request.modeWorkflowDesc', { days: durationDays })}
+                  </div>
+                </div>
+                <div
+                  className="mt-1.5 text-[11px]"
+                  style={{ color: 'var(--text4)' }}
+                >
+                  {t('diary.request.modeHint')}
+                </div>
+              </div>
+
+              {/* Sender info strip */}
+              <div
+                className="rounded-md px-3.5 py-2.5 text-[12px] leading-relaxed"
+                style={{
+                  background: 'rgba(52,199,89,0.07)',
+                  border: '1px solid rgba(52,199,89,0.2)',
+                  color: 'var(--text3)',
+                }}
+              >
+                {t('diary.request.senderInfo')}
+              </div>
+
+              {/* linkId gap warning */}
+              {linkId == null && (
+                <div
+                  className="rounded-md px-3.5 py-2.5 text-[12px]"
+                  style={{
+                    background: 'var(--bg3)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--text3)',
+                  }}
+                >
+                  {t('diary.request.linkIdMissing')}
+                </div>
+              )}
+
+              {mutation.isError && (
+                <p style={{ fontSize: 12, color: 'var(--red)', margin: 0 }}>
+                  {t('diary.request.errorToast')}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div
+            className="flex items-center justify-end gap-2 px-5 py-3 border-t border-border shrink-0"
+          >
+            <button onClick={onClose} className={CANCEL_BUTTON_CLASS}>
+              {t('common.cancel')}
+            </button>
+            <button
+              onClick={() => {
+                if (canSubmit) mutation.mutate();
+              }}
+              disabled={!canSubmit}
+              className="px-5 py-2 rounded-md text-[13px] font-medium transition-colors disabled:opacity-50"
+              style={{ background: 'var(--accent)', color: '#fff' }}
+            >
+              {mutation.isPending
+                ? t('diary.request.sending')
+                : t('diary.request.send')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/diary/RequestDiaryDialog.tsx
+++ b/web/src/components/diary/RequestDiaryDialog.tsx
@@ -7,12 +7,6 @@
  *   - NutritionPlanPage (Photos tab CTA) → passes linkId + planId
  *   - ClientDetailPage (photos tab CTA)  → passes linkId only
  *   - DashboardPage                      → passes linkId only
- *
- * NOTE — backend contract gap:
- *   `linkId` is the internal integer PK of ClientProfessionalLink.
- *   It is NOT exposed in GetClientDashboardResponse or any client-list API today.
- *   Until the backend adds `linkId` to those responses the prop will be undefined
- *   and the submit button stays disabled. Track as a backend follow-up.
  */
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -28,7 +22,7 @@ export interface RequestDiaryDialogProps {
   open: boolean;
   onClose: () => void;
   /** Internal integer PK of the ClientProfessionalLink. Required for submission. */
-  linkId: number | undefined;
+  linkId?: number | null;
   /** Optional plan scope — passed from plan detail pages. */
   planId?: string;
   /** Display name shown in the client strip. */
@@ -67,7 +61,7 @@ export function RequestDiaryDialog({
   const mutation = useMutation({
     mutationFn: () =>
       createDiaryRequest({
-        linkId,
+        linkId: linkId ?? undefined,
         planId,
         durationDays,
       }),
@@ -83,7 +77,7 @@ export function RequestDiaryDialog({
 
   if (!open) return null;
 
-  const canSubmit = linkId != null && !mutation.isPending;
+  const canSubmit = !mutation.isPending;
   const charCount = message.length;
 
   return (
@@ -281,20 +275,6 @@ export function RequestDiaryDialog({
               >
                 {t('diary.request.senderInfo')}
               </div>
-
-              {/* linkId gap warning */}
-              {linkId == null && (
-                <div
-                  className="rounded-md px-3.5 py-2.5 text-[12px]"
-                  style={{
-                    background: 'var(--bg3)',
-                    border: '1px solid var(--border)',
-                    color: 'var(--text3)',
-                  }}
-                >
-                  {t('diary.request.linkIdMissing')}
-                </div>
-              )}
 
               {mutation.isError && (
                 <p style={{ fontSize: 12, color: 'var(--red)', margin: 0 }}>

--- a/web/src/components/diary/RequestDiaryDialog.tsx
+++ b/web/src/components/diary/RequestDiaryDialog.tsx
@@ -154,7 +154,7 @@ export function RequestDiaryDialog({
                   width: 44,
                   height: 44,
                   borderRadius: 12,
-                  background: 'linear-gradient(135deg, var(--blue), #0056b3)',
+                  background: 'linear-gradient(135deg, var(--blue), var(--blue-dark))',
                   fontSize: 16,
                 }}
               >

--- a/web/src/components/photos/PlanPhotosTab.tsx
+++ b/web/src/components/photos/PlanPhotosTab.tsx
@@ -6,9 +6,8 @@
  * SignalR invalidation is handled at the AppShell level.
  *
  * The "Request photo diary" CTA button at the top-right opens RequestDiaryDialog.
- * `linkId` is the internal integer PK of ClientProfessionalLink — not exposed by
- * any current API response; the button is present but submission is disabled until
- * the backend exposes that field (known contract gap, see diary-requests.ts).
+ * `linkId` is the internal integer PK of ClientProfessionalLink, passed in by the
+ * parent page from the client-list or client-dashboard API response.
  */
 
 import { useState, useMemo } from 'react';
@@ -30,10 +29,9 @@ interface PlanPhotosTabProps {
   clientName?: string;
   /**
    * Internal integer PK of ClientProfessionalLink.
-   * Not yet exposed by any trainer API response — submission is disabled until
-   * the backend surfaces this field. See known gap note in diary-requests.ts.
+   * Sourced from the client-list or client-dashboard API response.
    */
-  linkId?: number;
+  linkId?: number | null;
 }
 
 const CATEGORIES: Array<{ key: PlanPhotoCategory | null; labelKey: string }> = [

--- a/web/src/components/photos/PlanPhotosTab.tsx
+++ b/web/src/components/photos/PlanPhotosTab.tsx
@@ -4,6 +4,11 @@
  * Shows a category chip row (Food / Body / FreeForm) and a 3-column thumbnail
  * grid loaded via TanStack Query. Clicking a thumbnail opens the ImageLightbox.
  * SignalR invalidation is handled at the AppShell level.
+ *
+ * The "Request photo diary" CTA button at the top-right opens RequestDiaryDialog.
+ * `linkId` is the internal integer PK of ClientProfessionalLink — not exposed by
+ * any current API response; the button is present but submission is disabled until
+ * the backend exposes that field (known contract gap, see diary-requests.ts).
  */
 
 import { useState, useMemo } from 'react';
@@ -14,12 +19,21 @@ import { ImageLightbox } from '@/components/ui/ImageLightbox';
 import { getPlanPhotos } from '@/api/photos';
 import { PlanPhotoCategory } from '@/api/generated';
 import { CardGrid, Card, CardBody } from '@/components/data';
+import { RequestDiaryDialog } from '@/components/diary/RequestDiaryDialog';
 
 interface PlanPhotosTabProps {
   planId: string;
   /** Client (profile) public id. Required because the web portal hits the
    *  trainer endpoint (`/trainer/clients/{clientId}/photos`). */
   clientId: string;
+  /** Display name of the client — shown in the diary request dialog's client strip. */
+  clientName?: string;
+  /**
+   * Internal integer PK of ClientProfessionalLink.
+   * Not yet exposed by any trainer API response — submission is disabled until
+   * the backend surfaces this field. See known gap note in diary-requests.ts.
+   */
+  linkId?: number;
 }
 
 const CATEGORIES: Array<{ key: PlanPhotoCategory | null; labelKey: string }> = [
@@ -31,11 +45,20 @@ const CATEGORIES: Array<{ key: PlanPhotoCategory | null; labelKey: string }> = [
 
 const PAGE_SIZE = 60;
 
-export function PlanPhotosTab({ planId, clientId }: PlanPhotosTabProps) {
+export function PlanPhotosTab({ planId, clientId, clientName, linkId }: PlanPhotosTabProps) {
   const { t } = useTranslation();
   const [activeCategory, setActiveCategory] = useState<PlanPhotoCategory | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
+  const [diaryDialogOpen, setDiaryDialogOpen] = useState(false);
+
+  const resolvedClientName = clientName ?? '';
+  const clientInitials = resolvedClientName
+    .split(' ')
+    .map((n) => n[0] ?? '')
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
 
   // Fetch the full (unfiltered) photo list once. Filtering by category
   // happens client-side so all per-category counts stay visible regardless
@@ -73,7 +96,7 @@ export function PlanPhotosTab({ planId, clientId }: PlanPhotosTabProps) {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Category chips — sized to match the page-level tabs (Jídelníček / Fotky) */}
+      {/* Category chips + diary CTA */}
       <div className="shrink-0 flex items-center gap-1 px-4 py-2 border-b border-border">
         {CATEGORIES.map(({ key, labelKey }) => {
           const isActive = activeCategory === key;
@@ -97,6 +120,22 @@ export function PlanPhotosTab({ planId, clientId }: PlanPhotosTabProps) {
             </button>
           );
         })}
+
+        {/* Request photo diary CTA — right-aligned */}
+        <button
+          type="button"
+          onClick={() => setDiaryDialogOpen(true)}
+          className="ml-auto inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[12px] font-medium border transition-colors"
+          style={{
+            background: 'var(--accent-bg)',
+            borderColor: 'var(--accent-br)',
+            color: 'var(--accent)',
+          }}
+          title={t('diary.request.photosTabCta')}
+        >
+          <span>📸</span>
+          <span>{t('diary.request.ctaButton')}</span>
+        </button>
       </div>
 
       {/* Photo grid */}
@@ -179,6 +218,16 @@ export function PlanPhotosTab({ planId, clientId }: PlanPhotosTabProps) {
         open={lightboxOpen}
         onClose={() => setLightboxOpen(false)}
         altPrefix={t('nutrition.photos.photoAlt')}
+      />
+
+      {/* Request photo diary dialog */}
+      <RequestDiaryDialog
+        open={diaryDialogOpen}
+        onClose={() => setDiaryDialogOpen(false)}
+        linkId={linkId}
+        planId={planId}
+        clientName={resolvedClientName}
+        clientInitials={clientInitials}
       />
     </div>
   );

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1353,5 +1353,36 @@
       "emptyDescription": "Jakmile klient nahraje fotky pokroku, zobrazí se zde seřazené po měsících.",
       "photoAltPrefix": "Fotka"
     }
+  },
+  "diary": {
+    "request": {
+      "dialogTitle": "Požádat o foto-deník",
+      "dialogSubtitle": "Klient uvidí žádost jako banner a může ji přijmout nebo odmítnout.",
+      "infoBanner": "Klient uvidí žádost jako banner na úvodní obrazovce. Může ji přijmout nebo odmítnout (s volitelným důvodem).",
+      "messageLabel": "Úvodní zpráva pro klienta",
+      "messagePlaceholder": "Napište osobní zprávu...",
+      "defaultMessage": "Abych si udělala co nejlepší obrázek o tvých stravovacích návycích, než ti sestavím plán, ráda bych od tebe dostala fotky všech jídel, které běžně jíš.",
+      "durationLabel": "Délka deníku",
+      "durationDays_one": "{{count}} den",
+      "durationDays_other": "{{count}} dní",
+      "uploadModeLabel": "Způsob nahrání",
+      "modeAllAtOnce": "Vše najednou",
+      "modeAllAtOnceDesc": "Fotí, potom odešle.",
+      "modeWorkflow": "Workflow",
+      "modeWorkflowDesc": "{{days}} dní postupně, nutricionista vidí fotky živě.",
+      "modeHint": "Klient si vybere způsob při akceptaci žádosti.",
+      "senderInfo": "Klient uvidí tvé jméno jako odesilatele a tvůj avatar. Po odevzdání fotek budeš dostávat notifikace v reálném čase.",
+      "linkIdMissing": "Nelze odeslat: ID propojení klienta zatím není k dispozici. Toto je známý problém backendu — kontaktujte podporu.",
+      "send": "Odeslat žádost",
+      "sending": "Odesílání...",
+      "successToast": "Žádost o foto-deník odeslána",
+      "errorToast": "Nepodařilo se odeslat žádost o foto-deník. Zkuste to znovu.",
+      "ctaButton": "Požádat o foto-deník",
+      "photosTabCta": "Požádat klienta o foto-deník",
+      "inviteCheckboxLabel": "Přiložit foto-deník k pozvánce",
+      "inviteCheckboxHint": "Po akceptaci bude klient vyzván k nasdílení fotografií jídel.",
+      "inviteCheckboxWarning": "Žádost o foto-deník bude odeslána po úspěšném vytvoření pozvánky.",
+      "inviteDiaryFailed": "Pozvánka odeslána, ale žádost o foto-deník se nepodařila. Můžete ji odeslat později z detailu klienta."
+    }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1353,5 +1353,36 @@
       "emptyDescription": "Wenn der Klient Fortschrittsfotos hochlädt, erscheinen sie hier nach Monaten gruppiert.",
       "photoAltPrefix": "Foto"
     }
+  },
+  "diary": {
+    "request": {
+      "dialogTitle": "Fototagebuch anfordern",
+      "dialogSubtitle": "Der Klient sieht die Anfrage als Banner und kann sie annehmen oder ablehnen.",
+      "infoBanner": "Der Klient sieht die Anfrage als Banner auf dem Startbildschirm. Er kann sie annehmen oder ablehnen (mit optionalem Grund).",
+      "messageLabel": "Einleitungsnachricht für den Klienten",
+      "messagePlaceholder": "Schreiben Sie eine persönliche Nachricht...",
+      "defaultMessage": "Um mir vor der Planerstellung ein möglichst genaues Bild Ihrer Ernährungsgewohnheiten zu machen, würde ich gerne Fotos aller Mahlzeiten erhalten, die Sie normalerweise essen.",
+      "durationLabel": "Tagebuchdauer",
+      "durationDays_one": "{{count}} Tag",
+      "durationDays_other": "{{count}} Tage",
+      "uploadModeLabel": "Upload-Modus",
+      "modeAllAtOnce": "Alles auf einmal",
+      "modeAllAtOnceDesc": "Klient fotografiert, dann sendet er alles.",
+      "modeWorkflow": "Workflow",
+      "modeWorkflowDesc": "{{days}} Tage schrittweise, Ernährungsberater sieht Fotos live.",
+      "modeHint": "Der Klient wählt den Modus bei der Annahme der Anfrage.",
+      "senderInfo": "Der Klient sieht Ihren Namen als Absender und Ihren Avatar. Nach dem Einreichen der Fotos erhalten Sie Echtzeit-Benachrichtigungen.",
+      "linkIdMissing": "Senden nicht möglich: Die Client-Link-ID ist noch nicht verfügbar. Dies ist eine bekannte Backend-Lücke — bitte kontaktieren Sie den Support.",
+      "send": "Anfrage senden",
+      "sending": "Wird gesendet...",
+      "successToast": "Fototagebuch-Anfrage gesendet",
+      "errorToast": "Fehler beim Senden der Fototagebuch-Anfrage. Bitte versuchen Sie es erneut.",
+      "ctaButton": "Fototagebuch anfordern",
+      "photosTabCta": "Fototagebuch vom Klienten anfordern",
+      "inviteCheckboxLabel": "Fototagebuch-Anfrage zur Einladung hinzufügen",
+      "inviteCheckboxHint": "Nach der Annahme wird der Klient aufgefordert, Fotos seiner Mahlzeiten zu teilen.",
+      "inviteCheckboxWarning": "Die Fototagebuch-Anfrage wird nach erfolgreicher Erstellung der Einladung gesendet.",
+      "inviteDiaryFailed": "Einladung gesendet, aber Fototagebuch-Anfrage fehlgeschlagen. Sie können sie später über das Klientendetail senden."
+    }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1354,5 +1354,36 @@
       "emptyDescription": "When the client uploads progress photos they will appear here, grouped by month.",
       "photoAltPrefix": "Photo"
     }
+  },
+  "diary": {
+    "request": {
+      "dialogTitle": "Request photo diary",
+      "dialogSubtitle": "Client will see a banner and can accept or decline.",
+      "infoBanner": "The client will see this request as a banner on the home screen. They can accept or decline (with an optional reason).",
+      "messageLabel": "Opening message for the client",
+      "messagePlaceholder": "Write a personal message...",
+      "defaultMessage": "To get the best picture of your eating habits before I build your plan, I'd love to receive photos of all the meals you normally eat.",
+      "durationLabel": "Diary duration",
+      "durationDays_one": "{{count}} day",
+      "durationDays_other": "{{count}} days",
+      "uploadModeLabel": "Upload mode",
+      "modeAllAtOnce": "All at once",
+      "modeAllAtOnceDesc": "Client photographs, then submits.",
+      "modeWorkflow": "Workflow",
+      "modeWorkflowDesc": "{{days}} days gradually, nutritionist sees photos live.",
+      "modeHint": "Client selects the mode when they accept the request.",
+      "senderInfo": "The client will see your name as the sender and your avatar. You will receive real-time notifications after photos are submitted.",
+      "linkIdMissing": "Unable to send: the client link ID is not yet available. This is a known backend gap — please contact support.",
+      "send": "Send request",
+      "sending": "Sending...",
+      "successToast": "Photo diary request sent",
+      "errorToast": "Failed to send diary request. Please try again.",
+      "ctaButton": "Request photo diary",
+      "photosTabCta": "Request photo diary from client",
+      "inviteCheckboxLabel": "Bundle photo diary request with this invite",
+      "inviteCheckboxHint": "After the client accepts, they will be prompted to share food photos.",
+      "inviteCheckboxWarning": "Diary request will be sent after the invite is successfully created.",
+      "inviteDiaryFailed": "Invite sent, but diary request failed. You can send it later from the client detail."
+    }
   }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -39,6 +39,7 @@
   --green-bg:  rgba(15, 123, 108, 0.08);
   --green-br:  rgba(15, 123, 108, 0.2);
   --blue:      #0b6e99;
+  --blue-dark: #0056b3;
   --blue-bg:   rgba(11, 110, 153, 0.08);
   --blue-br:   rgba(11, 110, 153, 0.2);
   --purple:    #6940a5;

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -12,6 +12,7 @@ import { PropertyList, StatsGrid } from '@/components/data';
 import { ActivityTimeline, ClientPhotosTimeline } from '@/components/domain';
 import { QuestionnaireAnswersSection } from '@/components/questionnaire';
 import { WeeklyCheckInSection } from '@/components/weekly-checkin/WeeklyCheckInSection';
+import { RequestDiaryDialog } from '@/components/diary/RequestDiaryDialog';
 import { cn } from '@/lib/cn';
 
 export default function ClientDetailPage() {
@@ -21,6 +22,8 @@ export default function ClientDetailPage() {
 
   // Edit dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  // Diary request dialog state
+  const [diaryDialogOpen, setDiaryDialogOpen] = useState(false);
 
   // Active tab — resets to 'overview' on client switch.
   // Uses the "adjust state during render" pattern (React docs) to avoid the
@@ -407,6 +410,23 @@ export default function ClientDetailPage() {
         {/* Photos tab */}
         {activeTab === 'photos' && (
           <div className="px-20">
+            {/* Request diary CTA — top of tab, right-aligned */}
+            {/* linkId not yet available from API response — see diary-requests.ts */}
+            <div className="flex justify-end pt-3 pb-1">
+              <button
+                type="button"
+                onClick={() => setDiaryDialogOpen(true)}
+                className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[12px] font-medium border transition-colors"
+                style={{
+                  background: 'var(--accent-bg)',
+                  borderColor: 'var(--accent-br)',
+                  color: 'var(--accent)',
+                }}
+              >
+                <span>📸</span>
+                <span>{t('diary.request.ctaButton')}</span>
+              </button>
+            </div>
             <ClientPhotosTimeline clientId={id!} />
           </div>
         )}
@@ -530,6 +550,16 @@ export default function ClientDetailPage() {
           />
         </div>
       </Dialog>
+
+      {/* Request Diary Dialog */}
+      {/* linkId not yet available from API response — see diary-requests.ts */}
+      <RequestDiaryDialog
+        open={diaryDialogOpen}
+        onClose={() => setDiaryDialogOpen(false)}
+        linkId={undefined}
+        clientName={clientName}
+        clientInitials={clientInitials}
+      />
     </div>
   );
 }

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -411,7 +411,6 @@ export default function ClientDetailPage() {
         {activeTab === 'photos' && (
           <div className="px-20">
             {/* Request diary CTA — top of tab, right-aligned */}
-            {/* linkId not yet available from API response — see diary-requests.ts */}
             <div className="flex justify-end pt-3 pb-1">
               <button
                 type="button"
@@ -552,11 +551,10 @@ export default function ClientDetailPage() {
       </Dialog>
 
       {/* Request Diary Dialog */}
-      {/* linkId not yet available from API response — see diary-requests.ts */}
       <RequestDiaryDialog
         open={diaryDialogOpen}
         onClose={() => setDiaryDialogOpen(false)}
-        linkId={undefined}
+        linkId={client?.linkId}
         clientName={clientName}
         clientInitials={clientInitials}
       />

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -430,7 +430,16 @@ export default function NutritionPlanPage() {
       {/* ── Photos tab content ── */}
       {pageTab === 'photos' && planId && (
         <div className="flex-1 overflow-hidden">
-          <PlanPhotosTab planId={planId} clientId={plan.clientId} />
+          {/* linkId is not passed: not yet available from any API response — see diary-requests.ts */}
+          <PlanPhotosTab
+            planId={planId}
+            clientId={plan.clientId}
+            clientName={
+              clientDashboard
+                ? `${clientDashboard.firstName} ${clientDashboard.lastName}`
+                : undefined
+            }
+          />
         </div>
       )}
 

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -430,7 +430,6 @@ export default function NutritionPlanPage() {
       {/* ── Photos tab content ── */}
       {pageTab === 'photos' && planId && (
         <div className="flex-1 overflow-hidden">
-          {/* linkId is not passed: not yet available from any API response — see diary-requests.ts */}
           <PlanPhotosTab
             planId={planId}
             clientId={plan.clientId}
@@ -439,6 +438,7 @@ export default function NutritionPlanPage() {
                 ? `${clientDashboard.firstName} ${clientDashboard.lastName}`
                 : undefined
             }
+            linkId={clientDashboard?.linkId}
           />
         </div>
       )}

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -85,11 +85,15 @@ export default function TrainingPlanPage() {
     enabled: !!plan?.clientId,
   });
 
-  const clientName = useMemo(() => {
+  const clientEntry = useMemo(() => {
     if (!plan?.clientId || !clientsData?.clients) return null;
-    const client = clientsData.clients.find((c) => c.publicId === plan.clientId);
-    return client ? `${client.firstName ?? ''} ${client.lastName ?? ''}`.trim() : null;
+    return clientsData.clients.find((c) => c.publicId === plan.clientId) ?? null;
   }, [plan?.clientId, clientsData]);
+
+  const clientName = useMemo(() => {
+    if (!clientEntry) return null;
+    return `${clientEntry.firstName ?? ''} ${clientEntry.lastName ?? ''}`.trim();
+  }, [clientEntry]);
 
   // ── Fetch muscle groups for exercises ──
   const allExerciseIds = useMemo(() => {
@@ -425,13 +429,13 @@ export default function TrainingPlanPage() {
       </div>
 
       {/* ── Photos tab content ── */}
-      {/* linkId is not passed: not yet available from any API response — see diary-requests.ts */}
       {pageTab === 'photos' && planId && (
         <div className="flex-1 overflow-hidden">
           <PlanPhotosTab
             planId={planId}
             clientId={plan.clientId}
             clientName={clientName ?? undefined}
+            linkId={clientEntry?.linkId}
           />
         </div>
       )}

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -425,9 +425,14 @@ export default function TrainingPlanPage() {
       </div>
 
       {/* ── Photos tab content ── */}
+      {/* linkId is not passed: not yet available from any API response — see diary-requests.ts */}
       {pageTab === 'photos' && planId && (
         <div className="flex-1 overflow-hidden">
-          <PlanPhotosTab planId={planId} clientId={plan.clientId} />
+          <PlanPhotosTab
+            planId={planId}
+            clientId={plan.clientId}
+            clientName={clientName ?? undefined}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Backend exposes `linkId` (long) on `ClientSummary` / `GetClientDashboardResponse` and `id` (long) on `CreatePendingInviteResponse` / `PendingInviteDto` — required so the web dialog can post real integer IDs to the C2 endpoint.
- New `RequestDiaryDialog` component (standalone modal) wired to the Photos tab CTA on `NutritionPlanPage`, `TrainingPlanPage`, and `ClientDetailPage`.
- `NewClientDialog` gains a "Bundle photo diary" toggle that fires `POST /trainer/photo-diary-requests` (with `pendingInviteId`) immediately after the invite is created; on diary failure the invite is already sent — a non-blocking warning toast surfaces to the user.
- `web/src/api/generated.ts` regenerated via `npm run generate-api` (not hand-edited).

## Related issue

Fixes #96

## Parent epic (sub-issue PRs only)

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

cross-cut (backend + web) — sequential dispatches on the same branch per project convention.

## QA verdict (from qa-tester)

OVERALL PASS — all 3 ACs pass after `#0056b3` → `var(--blue-dark)` token fix in `5f6ddf1`.

## Test plan

- [ ] Client strip on dialog renders correct client.
- [ ] Default-copy pre-fill (cs/en/de).
- [ ] Invite + plan both create the request via C2 endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)