### PR TITLE
feat(mobile,#99): photo diary accept wizard (Bulk / Workflow choice)

### DIFF
--- a/mobile/app/(client)/diary/[requestId].tsx
+++ b/mobile/app/(client)/diary/[requestId].tsx
@@ -1,61 +1,214 @@
 /**
- * Diary request accept flow — detail screen.
+ * Diary request accept wizard.
  *
- * TODO(#99): Implement the full accept wizard (step-by-step onboarding,
- * schedule picker, confirmation). This file is a placeholder so the
- * DiaryRequestBanner's "Accept" CTA navigates to a real route.
+ * Implements #99: intro card + two mode-selection cards (Bulk / Workflow)
+ * with gold-selected state, persistent selection, and Pokračovat CTA.
+ *
+ * Design-of-record: docs/prototypes/mobile/scenes/diary-accept-wizard.html
  */
-import React from 'react'
-import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native'
+import React, { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+  useColorScheme,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useTranslation } from 'react-i18next'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTheme } from '@/hooks/useTheme'
+import { useThemeStore } from '@/stores/themeStore'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
+import { goldAlpha, greenAlpha } from '@/constants/colors'
 import { href } from '@/lib/navigation'
+import { Toast } from '@/lib/toast'
+import { useDiaryStore, type DiaryMode } from '@/stores/diaryStore'
+import { acceptDiaryRequest, PhotoDiaryMode } from '@/api/diaryRequests'
 
-export default function DiaryRequestScreen() {
+// ─── Main screen ──────────────────────────────────────────────────────
+
+export function DiaryAcceptWizardScreen() {
   const colors = useTheme()
   const { t } = useTranslation()
   const router = useRouter()
-  const { requestId } = useLocalSearchParams<{ requestId: string }>()
+  const queryClient = useQueryClient()
+
+  // Dark-mode-aware green alpha values (same pattern as DiaryRequestBanner).
+  const systemScheme = useColorScheme()
+  const preference = useThemeStore((s) => s.preference)
+  const effectiveScheme = preference === 'system' ? (systemScheme ?? 'light') : preference
+  const ga = effectiveScheme === 'dark' ? greenAlpha.dark : greenAlpha.light
+
+  // useLocalSearchParams requires all values to be string (Expo Router constraint).
+  const { requestId, professionalName } = useLocalSearchParams<{
+    requestId: string
+    professionalName: string
+  }>()
+
+  // Persisted selection — restores the chosen card on re-entry (AC #3).
+  const { getSelection, setSelection, clearSelection } = useDiaryStore()
+  const [selected, setSelected] = useState<DiaryMode | undefined>(
+    () => getSelection(requestId),
+  )
+
+  const handleSelect = useCallback(
+    (mode: DiaryMode) => {
+      setSelected(mode)
+      setSelection(requestId, mode)
+    },
+    [requestId, setSelection],
+  )
+
+  const acceptMutation = useMutation({
+    mutationFn: () =>
+      acceptDiaryRequest(
+        requestId,
+        selected === 'Bulk' ? PhotoDiaryMode.Bulk : PhotoDiaryMode.Workflow,
+      ),
+    onSuccess: () => {
+      // Clear the persisted selection — the request is now accepted server-side.
+      clearSelection(requestId)
+      // Invalidate today / diary-related queries so banners refresh.
+      queryClient.invalidateQueries({ queryKey: ['today-questionnaires'] })
+      queryClient.invalidateQueries({ queryKey: ['diary-requests'] })
+
+      // Navigate to the picked flow (AC #2).
+      if (selected === 'Bulk') {
+        router.replace(href(`/(client)/diary/${requestId}/bulk`))
+      } else {
+        router.replace(href(`/(client)/diary/${requestId}/workflow`))
+      }
+    },
+    onError: () => {
+      Toast.show(t('diary.acceptWizard.errorAccept'))
+    },
+  })
+
+  const isLoading = acceptMutation.isPending
+  const canContinue = selected !== undefined && !isLoading
+  const displayName = professionalName ?? ''
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
-      <View style={styles.content}>
-        {/* Header */}
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      edges={['top', 'bottom']}
+    >
+      {/* ── Modal-style top bar ───────────────────────────────── */}
+      <View style={[styles.topBar, { borderBottomColor: colors.sep2 }]}>
         <Pressable
           onPress={() => router.back()}
-          style={[styles.backBtn, { backgroundColor: colors.fill }]}
+          style={({ pressed }) => [styles.topBarSide, { opacity: pressed ? 0.5 : 1 }]}
           accessibilityRole="button"
-          accessibilityLabel={t('common.back')}
+          accessibilityLabel={t('diary.acceptWizard.cancel')}
         >
-          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
+          <Text style={[Type.subheadline, styles.topBarCancel, { color: colors.label2 }]}>
+            {t('diary.acceptWizard.cancel')}
+          </Text>
         </Pressable>
 
-        {/* Placeholder content — replaced by accept wizard in #99 */}
-        <View style={styles.placeholder}>
-          <ActivityIndicator size="large" color={colors.green} style={styles.spinner} />
-          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
-            {t('today.diaryBanner.screenTitle')}
-          </Text>
-          <Text style={[Type.footnote, { color: colors.label2, marginTop: 8, textAlign: 'center' }]}>
-            {requestId}
-          </Text>
-          <Text style={[Type.caption1, { color: colors.label3, marginTop: 24, textAlign: 'center' }]}>
-            {/* This screen will be implemented in issue #99 */}
-            {t('today.diaryBanner.acceptPlaceholder')}
+        <Text
+          style={[Type.subheadline, styles.topBarTitle, { color: colors.label }]}
+          numberOfLines={1}
+        >
+          {t('diary.acceptWizard.title')}
+        </Text>
+
+        {/* Right spacer — keeps title visually centred. */}
+        <View style={styles.topBarSide} />
+      </View>
+
+      {/* ── Scrollable content ───────────────────────────────── */}
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Intro card */}
+        <View style={[styles.introCard, { backgroundColor: colors.bg2 }]}>
+          <Text style={[Type.footnote, styles.introText, { color: colors.label2 }]}>
+            {t('diary.acceptWizard.intro', {
+              name: displayName || t('common.yourCoach'),
+            })}
           </Text>
         </View>
 
-        {/* Dismiss link */}
+        {/* Mode card — Bulk (gold accent when selected) */}
+        <ModeCard
+          mode="Bulk"
+          selected={selected === 'Bulk'}
+          title={t('diary.acceptWizard.bulkTitle')}
+          description={t('diary.acceptWizard.bulkDesc')}
+          icon="📤"
+          colors={colors}
+          greenAlphaBg={ga.bg}
+          greenAlphaIconBg={ga.iconBg}
+          onPress={handleSelect}
+        />
+
+        {/* Mode card — Workflow (green accent when selected) */}
+        <ModeCard
+          mode="Workflow"
+          selected={selected === 'Workflow'}
+          title={t('diary.acceptWizard.workflowTitle')}
+          description={t('diary.acceptWizard.workflowDesc')}
+          icon="📅"
+          colors={colors}
+          greenAlphaBg={ga.bg}
+          greenAlphaIconBg={ga.iconBg}
+          onPress={handleSelect}
+        />
+      </ScrollView>
+
+      {/* ── Pinned action bar ────────────────────────────────── */}
+      <View
+        style={[
+          styles.actionBar,
+          { backgroundColor: colors.bg, borderTopColor: colors.sep2 },
+        ]}
+      >
+        {/* Pokračovat CTA — disabled until a card is selected (AC #2). */}
         <Pressable
-          onPress={() => router.push(href(`/(client)/diary/${requestId}/dismiss`))}
-          style={({ pressed }) => [styles.dismissLink, { opacity: pressed ? 0.6 : 1 }]}
+          onPress={() => acceptMutation.mutate()}
+          disabled={!canContinue}
+          style={({ pressed }) => [
+            styles.ctaContinue,
+            {
+              backgroundColor: colors.gold,
+              opacity: !canContinue ? 0.45 : pressed ? 0.8 : 1,
+            },
+          ]}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canContinue }}
         >
-          <Text style={[Type.footnote, { color: colors.label2 }]}>
-            {t('today.diaryBanner.dismiss')}
+          {isLoading ? (
+            <ActivityIndicator color={colors.onAccent} />
+          ) : (
+            <Text style={[styles.ctaContinueLabel, { color: colors.onAccent }]}>
+              {t('diary.acceptWizard.continue')}
+            </Text>
+          )}
+        </Pressable>
+
+        {/* Zrušit / Cancel */}
+        <Pressable
+          onPress={() => router.back()}
+          style={({ pressed }) => [
+            styles.ctaCancel,
+            {
+              backgroundColor: colors.bg2,
+              borderColor: colors.sep2,
+              opacity: pressed ? 0.6 : 1,
+            },
+          ]}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.ctaCancelLabel, { color: colors.label }]}>
+            {t('diary.acceptWizard.cancel')}
           </Text>
         </Pressable>
       </View>
@@ -63,32 +216,188 @@ export default function DiaryRequestScreen() {
   )
 }
 
+// ─── Mode card ────────────────────────────────────────────────────────
+
+interface ModeCardProps {
+  mode: DiaryMode
+  selected: boolean
+  title: string
+  description: string
+  icon: string
+  colors: ReturnType<typeof useTheme>
+  /** Scheme-aware green alpha background (for the Workflow card when selected). */
+  greenAlphaBg: string
+  /** Scheme-aware green alpha icon background (for the Workflow icon box). */
+  greenAlphaIconBg: string
+  onPress: (mode: DiaryMode) => void
+}
+
+function ModeCard({
+  mode,
+  selected,
+  title,
+  description,
+  icon,
+  colors,
+  greenAlphaBg,
+  greenAlphaIconBg,
+  onPress,
+}: ModeCardProps) {
+  const isWorkflow = mode === 'Workflow'
+
+  // Card background and border follow prototype:
+  // — Bulk selected:    gold tint (goldAlpha['08']) + gold border
+  // — Workflow selected: green tint + green border
+  // — Unselected:       bg2 + sep2 border
+  const cardBg = selected
+    ? isWorkflow
+      ? greenAlphaBg
+      : goldAlpha['08']
+    : colors.bg2
+
+  const cardBorderColor = selected
+    ? isWorkflow
+      ? colors.green
+      : colors.gold
+    : colors.sep2
+
+  const cardBorderWidth = selected ? 1.5 : 1
+
+  // Icon box: green-tinted for Workflow, gold-tinted for Bulk.
+  const iconBg = isWorkflow ? greenAlphaIconBg : goldAlpha['15']
+
+  return (
+    <Pressable
+      onPress={() => onPress(mode)}
+      style={({ pressed }) => [
+        styles.modeCard,
+        {
+          backgroundColor: cardBg,
+          borderColor: cardBorderColor,
+          borderWidth: cardBorderWidth,
+          opacity: pressed ? 0.85 : 1,
+        },
+      ]}
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+    >
+      <View style={[styles.modeIconBox, { backgroundColor: iconBg }]}>
+        <Text style={styles.modeIcon}>{icon}</Text>
+      </View>
+      <View style={styles.modeText}>
+        <Text style={[Type.callout, styles.modeTitle, { color: colors.label }]}>
+          {title}
+        </Text>
+        <Text style={[Type.footnote, styles.modeDesc, { color: colors.label2 }]}>
+          {description}
+        </Text>
+      </View>
+    </Pressable>
+  )
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  content: {
-    flex: 1,
-    padding: 20,
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: 14,
+    paddingBottom: 10,
+    borderBottomWidth: 0.5,
   },
-  backBtn: {
-    alignSelf: 'flex-start',
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: Radius.md,
-    marginBottom: 32,
+  topBarSide: {
+    width: 64,
   },
-  placeholder: {
+  topBarCancel: {
+    fontWeight: '600',
+  },
+  topBarTitle: {
+    fontWeight: '600',
     flex: 1,
+    textAlign: 'center',
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 20,
+  },
+  introCard: {
+    borderRadius: Radius.lg,
+    padding: 16,
+    marginBottom: 14,
+  },
+  introText: {
+    lineHeight: 20,
+  },
+  modeCard: {
+    borderRadius: Radius.lg,
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    marginBottom: 10,
+  },
+  modeIconBox: {
+    width: 40,
+    height: 40,
+    borderRadius: Radius.iconBox,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  modeIcon: {
+    fontSize: 20,
+  },
+  modeText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  modeTitle: {
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  modeDesc: {
+    lineHeight: 18,
+  },
+  actionBar: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderTopWidth: 0.5,
+    flexDirection: 'row',
+    gap: 10,
+  },
+  ctaContinue: {
+    flex: 1,
+    height: 50,
+    borderRadius: Radius.lg,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  spinner: {
-    marginBottom: 24,
+  ctaContinueLabel: {
+    ...Type.subheadline,
+    fontWeight: '600',
   },
-  dismissLink: {
-    alignSelf: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 20,
+  ctaCancel: {
+    height: 50,
+    paddingHorizontal: 18,
+    borderRadius: Radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  ctaCancelLabel: {
+    ...Type.footnote,
+    fontWeight: '600',
   },
 })
+
+export default DiaryAcceptWizardScreen

--- a/mobile/app/(client)/diary/[requestId]/bulk.tsx
+++ b/mobile/app/(client)/diary/[requestId]/bulk.tsx
@@ -1,0 +1,94 @@
+/**
+ * Bulk photo upload screen — placeholder.
+ *
+ * TODO(#100): Implement the full bulk upload flow (image picker,
+ * multi-photo queue, progress, submission to the backend).
+ * This file exists so the accept wizard's "Bulk" CTA navigates to a
+ * valid route after the request is accepted.
+ */
+import React from 'react'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+
+export function DiaryBulkScreen() {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { requestId } = useLocalSearchParams<{ requestId: string }>()
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      edges={['top', 'bottom']}
+    >
+      <View style={styles.content}>
+        {/* Header */}
+        <Pressable
+          onPress={() => router.back()}
+          style={[styles.backBtn, { backgroundColor: colors.fill }]}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
+        </Pressable>
+
+        {/* Placeholder content — replaced by bulk upload flow in #100 */}
+        <View style={styles.placeholder}>
+          <Text style={styles.icon}>📤</Text>
+          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
+            {t('diary.bulk.title')}
+          </Text>
+          <Text
+            style={[
+              Type.footnote,
+              { color: colors.label2, marginTop: 8, textAlign: 'center' },
+            ]}
+          >
+            {requestId}
+          </Text>
+          <Text
+            style={[
+              Type.caption1,
+              { color: colors.label3, marginTop: 24, textAlign: 'center' },
+            ]}
+          >
+            {t('diary.bulk.placeholder')}
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  backBtn: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: Radius.md,
+    marginBottom: 32,
+  },
+  placeholder: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: 20,
+  },
+})
+
+export default DiaryBulkScreen

--- a/mobile/app/(client)/diary/[requestId]/workflow.tsx
+++ b/mobile/app/(client)/diary/[requestId]/workflow.tsx
@@ -1,0 +1,94 @@
+/**
+ * 7-day workflow screen — placeholder.
+ *
+ * TODO(#101): Implement the full 7-day workflow (daily reminder setup,
+ * day-by-day progress view, per-day photo upload).
+ * This file exists so the accept wizard's "Workflow" CTA navigates to a
+ * valid route after the request is accepted.
+ */
+import React from 'react'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+
+export function DiaryWorkflowScreen() {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { requestId } = useLocalSearchParams<{ requestId: string }>()
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      edges={['top', 'bottom']}
+    >
+      <View style={styles.content}>
+        {/* Header */}
+        <Pressable
+          onPress={() => router.back()}
+          style={[styles.backBtn, { backgroundColor: colors.fill }]}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
+        </Pressable>
+
+        {/* Placeholder content — replaced by workflow flow in #101 */}
+        <View style={styles.placeholder}>
+          <Text style={styles.icon}>📅</Text>
+          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
+            {t('diary.workflow.title')}
+          </Text>
+          <Text
+            style={[
+              Type.footnote,
+              { color: colors.label2, marginTop: 8, textAlign: 'center' },
+            ]}
+          >
+            {requestId}
+          </Text>
+          <Text
+            style={[
+              Type.caption1,
+              { color: colors.label3, marginTop: 24, textAlign: 'center' },
+            ]}
+          >
+            {t('diary.workflow.placeholder')}
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    padding: 20,
+  },
+  backBtn: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: Radius.md,
+    marginBottom: 32,
+  },
+  placeholder: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: 20,
+  },
+})
+
+export default DiaryWorkflowScreen

--- a/mobile/src/api/diaryRequests.ts
+++ b/mobile/src/api/diaryRequests.ts
@@ -1,0 +1,36 @@
+/**
+ * Domain module for client photo-diary request actions.
+ *
+ * All endpoints under `/client/photo-diary-requests/`.
+ * Types come from `generated.ts` — do not edit that file.
+ */
+import api from './client'
+import type {
+  AcceptRequestRequest,
+  AcceptRequestResponse,
+  ClientPhotoDiaryRequestSummary,
+} from './generated'
+import { PhotoDiaryMode } from './generated'
+
+// Re-export so consumers only need one import.
+export { PhotoDiaryMode }
+export type { ClientPhotoDiaryRequestSummary }
+
+/**
+ * Accept a pending photo-diary request with the chosen upload mode.
+ *
+ * `POST /client/photo-diary-requests/{id}/accept`
+ *
+ * Transitions the request from Pending → Accepted and stores the mode.
+ */
+export async function acceptDiaryRequest(
+  requestId: string,
+  mode: PhotoDiaryMode,
+): Promise<AcceptRequestResponse> {
+  const body: AcceptRequestRequest = { mode }
+  const { data } = await api.post<AcceptRequestResponse>(
+    `/client/photo-diary-requests/${requestId}/accept`,
+    body,
+  )
+  return data
+}

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -183,7 +183,8 @@
     "back": "Zpět",
     "cancel": "Zrušit",
     "error": "Chyba",
-    "options": "Možnosti"
+    "options": "Možnosti",
+    "yourCoach": "váš kouč"
   },
   "imagePicker": {
     "sourceTitle": "Vyberte zdroj",
@@ -974,6 +975,27 @@
       "consentRequiredMessage": "Pro registraci je nutný souhlas se zpracováním zdravotních údajů.",
       "failedTitle": "Registrace selhala",
       "failedMessage": "Registrace selhala. Zkuste to prosím znovu."
+    }
+  },
+  "diary": {
+    "acceptWizard": {
+      "title": "Jak chceš sdílet fotky?",
+      "intro": "Vyber si způsob, který ti bude vyhovovat. {{name}} dostane fotky buď všechny najednou, nebo postupně během 7 dní.",
+      "cancel": "Zrušit",
+      "continue": "Pokračovat",
+      "bulkTitle": "Nahrát vše najednou",
+      "bulkDesc": "Nafoť, co obvykle jíš, a pošli všechny fotky jedním odesláním. Hotovo během pár minut.",
+      "workflowTitle": "Sedmidenní workflow",
+      "workflowDesc": "Během 7 dní postupně fotíš, co jíš. Každý den dostaneš připomenutí. Tvůj kouč uvidí fotky v reálném čase.",
+      "errorAccept": "Žádost se nepodařilo přijmout. Zkus to znovu."
+    },
+    "bulk": {
+      "title": "Nahrání fotografií",
+      "placeholder": "Tady budeš moci nahrát své fotografie jídel. (Implementováno v #100)"
+    },
+    "workflow": {
+      "title": "Sedmidenní workflow",
+      "placeholder": "Tady uvidíš každodenní průběh sdílení fotografií. (Implementováno v #101)"
     }
   }
 }

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -183,7 +183,8 @@
     "back": "Zurück",
     "cancel": "Abbrechen",
     "error": "Fehler",
-    "options": "Optionen"
+    "options": "Optionen",
+    "yourCoach": "dein Coach"
   },
   "imagePicker": {
     "sourceTitle": "Quelle auswählen",
@@ -965,6 +966,27 @@
       "consentRequiredMessage": "Zur Registrierung ist die Einwilligung in die Verarbeitung von Gesundheitsdaten erforderlich.",
       "failedTitle": "Registrierung fehlgeschlagen",
       "failedMessage": "Registrierung fehlgeschlagen. Bitte erneut versuchen."
+    }
+  },
+  "diary": {
+    "acceptWizard": {
+      "title": "Wie möchtest du Fotos teilen?",
+      "intro": "Wähle die Methode, die dir am besten passt. {{name}} erhält deine Fotos entweder alle auf einmal oder schrittweise über 7 Tage.",
+      "cancel": "Abbrechen",
+      "continue": "Weiter",
+      "bulkTitle": "Alles auf einmal hochladen",
+      "bulkDesc": "Mache Fotos von dem, was du normalerweise isst, und sende sie in einer einzigen Übertragung. In wenigen Minuten erledigt.",
+      "workflowTitle": "7-Tage-Workflow",
+      "workflowDesc": "Über 7 Tage fotografierst du schrittweise, was du isst. Du erhältst täglich eine Erinnerung. Dein Coach sieht die Fotos in Echtzeit.",
+      "errorAccept": "Anfrage konnte nicht angenommen werden. Bitte versuche es erneut."
+    },
+    "bulk": {
+      "title": "Fotos hochladen",
+      "placeholder": "Hier kannst du deine Essensfotos hochladen. (Implementiert in #100)"
+    },
+    "workflow": {
+      "title": "7-Tage-Workflow",
+      "placeholder": "Hier siehst du den täglichen Fotoablauf. (Implementiert in #101)"
     }
   }
 }

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -183,7 +183,8 @@
     "back": "Back",
     "cancel": "Cancel",
     "error": "Error",
-    "options": "Options"
+    "options": "Options",
+    "yourCoach": "your coach"
   },
   "imagePicker": {
     "sourceTitle": "Select source",
@@ -966,6 +967,27 @@
       "consentRequiredMessage": "You must consent to health data processing to register.",
       "failedTitle": "Registration Failed",
       "failedMessage": "Registration failed. Please try again."
+    }
+  },
+  "diary": {
+    "acceptWizard": {
+      "title": "How do you want to share photos?",
+      "intro": "Choose the method that suits you. {{name}} will receive your photos either all at once or gradually over 7 days.",
+      "cancel": "Cancel",
+      "continue": "Continue",
+      "bulkTitle": "Upload all at once",
+      "bulkDesc": "Take photos of what you usually eat and send them all in one submission. Done in just a few minutes.",
+      "workflowTitle": "7-day workflow",
+      "workflowDesc": "Over 7 days you gradually photograph what you eat. You will get a daily reminder. Your coach sees photos in real time.",
+      "errorAccept": "Could not accept the request. Please try again."
+    },
+    "bulk": {
+      "title": "Photo Upload",
+      "placeholder": "Here you will be able to upload your food photos. (Implemented in #100)"
+    },
+    "workflow": {
+      "title": "7-Day Workflow",
+      "placeholder": "Here you will see the daily photo-sharing flow. (Implemented in #101)"
     }
   }
 }

--- a/mobile/src/stores/diaryStore.ts
+++ b/mobile/src/stores/diaryStore.ts
@@ -1,0 +1,70 @@
+/**
+ * Persists per-request wizard state so the selected mode survives
+ * navigation away and back before the client confirms.
+ *
+ * The server transition (`POST /accept`) only fires on Pokračovat.
+ * Until that point, the selection lives here only.
+ */
+import { create } from 'zustand'
+import { createMMKV } from 'react-native-mmkv'
+
+const mmkv = createMMKV({ id: 'mmkv.diary' })
+const STORAGE_KEY = 'diaryWizardSelections'
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export type DiaryMode = 'Bulk' | 'Workflow'
+
+/** Map of requestId → chosen mode (persisted via MMKV). */
+type SelectionMap = Record<string, DiaryMode>
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function readMap(): SelectionMap {
+  // SSR guard — Metro pre-renders on Node for expo-web where MMKV throws.
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = mmkv.getString(STORAGE_KEY)
+    if (!raw) return {}
+    return JSON.parse(raw) as SelectionMap
+  } catch {
+    return {}
+  }
+}
+
+function writeMap(map: SelectionMap): void {
+  if (typeof window === 'undefined') return
+  mmkv.set(STORAGE_KEY, JSON.stringify(map))
+}
+
+// ─── Store ───────────────────────────────────────────────────────────
+
+interface DiaryStore {
+  /** Current in-memory selections (keyed by requestId). */
+  selections: SelectionMap
+  /** Set (or replace) the mode for a specific request. */
+  setSelection: (requestId: string, mode: DiaryMode) => void
+  /** Get the persisted mode for a specific request (undefined = not chosen). */
+  getSelection: (requestId: string) => DiaryMode | undefined
+  /** Clear the stored selection for a request (after accept succeeds). */
+  clearSelection: (requestId: string) => void
+}
+
+export const useDiaryStore = create<DiaryStore>((set, get) => ({
+  selections: readMap(),
+
+  setSelection: (requestId, mode) => {
+    const next = { ...get().selections, [requestId]: mode }
+    writeMap(next)
+    set({ selections: next })
+  },
+
+  getSelection: (requestId) => get().selections[requestId],
+
+  clearSelection: (requestId) => {
+    const next = { ...get().selections }
+    delete next[requestId]
+    writeMap(next)
+    set({ selections: next })
+  },
+}))


### PR DESCRIPTION
## Summary

- Replaces the placeholder screen at `mobile/app/(client)/diary/[requestId].tsx` (created in #98) with the full accept wizard: intro card + two mode-selection cards (Bulk / Workflow) with gold/green selected states.
- Pokračovat CTA fires `POST /client/photo-diary-requests/{id}/accept`, then navigates to the picked flow route.
- Adds two new placeholder routes — `[requestId]/bulk.tsx` (TODO #100) and `[requestId]/workflow.tsx` (TODO #101) — so navigation does not dead-end after accept.
- New API wrapper `mobile/src/api/diaryRequests.ts` and Zustand store `mobile/src/stores/diaryStore.ts` (MMKV-persisted, keyed by `requestId`) for persistent mode selection.

## Related issue

Fixes #99

## Parent epic

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all three acceptance criteria verified on iOS Simulator and react-native-web.

## Test plan

- [ ] Either card (Bulk / Workflow) becomes selected on tap; selected state is visually distinct (gold border + tint for Bulk, green border + tint for Workflow).
- [ ] Pokračovat button routes to the picked flow (`/(client)/diary/[requestId]/bulk` or `/(client)/diary/[requestId]/workflow`).
- [ ] Persistent state: leaving the wizard and returning restores the previously chosen card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)