### PR TITLE
feat(web,backend,#97): nutritionist diary viewer + status chip + live gallery

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientPhotos/Common/PlanPhotoResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientPhotos/Common/PlanPhotoResponse.cs
@@ -63,6 +63,11 @@ public class PlanPhotoResponse
     public DateTime UploadedAt { get; set; }
 
     /// <summary>
+    /// The diary request this photo is associated with, or null if none.
+    /// </summary>
+    public Guid? DiaryRequestId { get; set; }
+
+    /// <summary>
     /// Maps a <see cref="PlanPhoto"/> entity to a <see cref="PlanPhotoResponse"/>.
     /// </summary>
     public static PlanPhotoResponse FromEntity(PlanPhoto p) => new()
@@ -77,5 +82,6 @@ public class PlanPhotoResponse
         TakenAt = p.TakenAt,
         UploadedByUserId = p.UploadedByUserId,
         UploadedAt = p.DateCreated,
+        DiaryRequestId = p.DiaryRequestId,
     };
 }

--- a/backend/FitnessPlatform.Application/Features/ClientPhotos/GetTrainerClientPhotos/GetTrainerClientPhotosEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientPhotos/GetTrainerClientPhotos/GetTrainerClientPhotosEndpoint.cs
@@ -140,6 +140,7 @@ public class GetTrainerClientPhotosEndpoint(IApplicationDbContext db)
                     TakenAt = p.TakenAt,
                     UploadedByUserId = p.UploadedByUserId,
                     UploadedAt = p.DateCreated,
+                    DiaryRequestId = p.DiaryRequestId,
                 })
                 .ToListAsync(ct);
 
@@ -188,6 +189,7 @@ public class GetTrainerClientPhotosEndpoint(IApplicationDbContext db)
                     TakenAt = p.TakenAt,
                     UploadedByUserId = p.UploadedByUserId,
                     UploadedAt = p.DateCreated,
+                    DiaryRequestId = p.DiaryRequestId,
                 })
                 .ToListAsync(ct);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientPhotos/GetTrainerClientPhotosEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientPhotos/GetTrainerClientPhotosEndpointTests.cs
@@ -49,7 +49,8 @@ public class GetTrainerClientPhotosEndpointTests
         long clientProfileId,
         PlanPhotoCategory category = PlanPhotoCategory.Body,
         DateTime? takenAt = null,
-        Guid? planId = null)
+        Guid? planId = null,
+        Guid? diaryRequestId = null)
     {
         return new PlanPhoto
         {
@@ -62,6 +63,7 @@ public class GetTrainerClientPhotosEndpointTests
             UploadedByUserId = Guid.NewGuid(),
             DateCreated = DateTime.UtcNow,
             PlanId = planId,
+            DiaryRequestId = diaryRequestId,
         };
     }
 
@@ -428,6 +430,40 @@ public class GetTrainerClientPhotosEndpointTests
         ep.Response.Groups!.Should().HaveCount(1);
         ep.Response.Groups[0].YearMonth.Should().Be("2026-01");
         ep.HttpContext.Response.Headers["X-Total-Count"].ToString().Should().Be("3");
+    }
+
+    // ── DiaryRequestId projection ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_PhotoWithDiaryRequestId_ExposesDiaryRequestIdInResponse()
+    {
+        var diaryRequestId = Guid.NewGuid();
+        var (builder, _, _) = CreateLinkedSetup();
+        // Photo with a DiaryRequestId set
+        builder.With(MakePhoto(2, PlanPhotoCategory.Body, diaryRequestId: diaryRequestId));
+        // Photo without a DiaryRequestId (null)
+        builder.With(MakePhoto(2, PlanPhotoCategory.Food));
+        var db = builder.Build();
+
+        var ep = Factory.Create<GetTrainerClientPhotosEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerUserId, AppRoles.Trainer))),
+            db);
+
+        await ep.HandleAsync(
+            new GetTrainerClientPhotosRequest { ClientId = _clientPublicId, Page = 1, PageSize = 20 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Photos.Should().NotBeNull();
+        ep.Response.Photos!.Count.Should().Be(2);
+
+        var withDiary = ep.Response.Photos.Single(p => p.Category == PlanPhotoCategory.Body);
+        withDiary.DiaryRequestId.Should().Be(diaryRequestId);
+
+        var withoutDiary = ep.Response.Photos.Single(p => p.Category == PlanPhotoCategory.Food);
+        withoutDiary.DiaryRequestId.Should().BeNull();
     }
 
     // ── Plan filter ───────────────────────────────────────────────────────────

--- a/web/src/api/diary-requests.ts
+++ b/web/src/api/diary-requests.ts
@@ -1,12 +1,22 @@
 /**
  * Diary requests API module.
  *
- * Wraps the NSwag-generated createRequestEndpoint.
+ * Wraps the NSwag-generated diary-request endpoints.
  */
 import { apiClient } from '@/api/client';
-import type { CreateRequestResponse } from '@/api/generated';
+import type {
+  CreateRequestResponse,
+  PhotoDiaryRequestSummary,
+  PhotoDiaryStatus,
+  PhotoDiaryMode,
+} from '@/api/generated';
 
-export type { CreateRequestResponse };
+export type {
+  CreateRequestResponse,
+  PhotoDiaryRequestSummary,
+  PhotoDiaryStatus,
+  PhotoDiaryMode,
+};
 
 export interface CreateDiaryRequestParams {
   /** Internal integer ID of the client-professional link. XOR with pendingInviteId. */
@@ -31,4 +41,30 @@ export async function createDiaryRequest(
     planId: params.planId ?? undefined,
     durationDays: params.durationDays ?? 7,
   });
+}
+
+export interface ListDiaryRequestsParams {
+  page?: number;
+  pageSize?: number;
+  status?: PhotoDiaryStatus | null;
+  linkId?: number | null;
+  planId?: string | null;
+}
+
+/**
+ * List trainer's photo diary requests via GET /trainer/photo-diary-requests.
+ * Supports filtering by status, linkId, and planId.
+ */
+export async function listDiaryRequests(
+  params: ListDiaryRequestsParams = {},
+): Promise<PhotoDiaryRequestSummary[]> {
+  const response = await apiClient.listTrainerRequestsEndpoint(
+    params.page ?? 1,
+    params.pageSize ?? 50,
+    params.status ?? undefined,
+    params.linkId ?? undefined,
+    undefined, // pendingInviteId
+    params.planId ?? undefined,
+  );
+  return response.items ?? [];
 }

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -20,7 +20,7 @@ export class ApiClient {
 
         this.instance = instance || axios.create();
 
-        this.baseUrl = baseUrl ?? "https://localhost:5001";
+        this.baseUrl = baseUrl ?? "http://localhost:5000";
 
     }
 
@@ -15159,6 +15159,8 @@ Null when PlanId is null. */
     uploadedByUserId?: string;
     /** When the record was created (upload timestamp), in UTC. */
     uploadedAt?: string;
+    /** The diary request this photo is associated with, or null if none. */
+    diaryRequestId?: string | undefined;
 }
 
 /** Represents a calendar-month bucket of plan photos returned when groupByMonth=true is passed to the aggregation endpoints. */

--- a/web/src/components/diary/DiaryRequestCard.tsx
+++ b/web/src/components/diary/DiaryRequestCard.tsx
@@ -3,10 +3,8 @@
  * and (for active/completed requests) photos grouped by calendar day.
  *
  * Photos are sourced from the parent's `allPhotos` prop (already loaded
- * by PlanPhotosTab) — filtered to photos whose `takenAt` falls within
- * [acceptedAt, acceptedAt + durationDays) to associate them with this
- * request.  Because PlanPhotoResponse2 doesn't carry diaryRequestId on
- * the trainer aggregation endpoint, we rely on the date window heuristic.
+ * by PlanPhotosTab) — filtered strictly by `diaryRequestId === request.id`
+ * using the FK field now present on PlanPhotoResponse2 (ClientPhotos.Common).
  *
  * For Dismissed requests the dismiss reason is shown prominently instead.
  *
@@ -25,7 +23,7 @@ import type { PlanPhotoResponse2 } from '@/api/generated';
 
 interface Props {
   request: PhotoDiaryRequestSummary;
-  /** All plan photos already loaded — this component filters by date window. */
+  /** All plan photos already loaded — this component filters by diaryRequestId FK. */
   allPhotos: PlanPhotoResponse2[];
 }
 
@@ -44,25 +42,17 @@ interface DayGroup {
 
 function buildDayGroups(
   photos: PlanPhotoResponse2[],
+  requestId: string,
   acceptedAt: string,
   durationDays: number,
 ): DayGroup[] {
-  const acceptedDate = new Date(acceptedAt);
-  // End of diary window (exclusive)
-  const endDate = new Date(acceptedDate);
-  endDate.setDate(endDate.getDate() + durationDays);
+  // Filter strictly by the FK field — no date-window heuristic needed.
+  const diaryPhotos = photos.filter((p) => p.diaryRequestId === requestId);
 
-  // Filter photos within the window
-  const windowPhotos = photos.filter((p) => {
-    if (!p.takenAt && !p.uploadedAt) return false;
-    const ts = p.takenAt ?? p.uploadedAt ?? '';
-    const d = new Date(ts);
-    return d >= acceptedDate && d < endDate;
-  });
-
-  // Group by calendar day
+  // Group by calendar day (takenAt preferred, uploadedAt as fallback)
   const grouped = new Map<string, PlanPhotoResponse2[]>();
-  for (const photo of windowPhotos) {
+  for (const photo of diaryPhotos) {
+    if (!photo.takenAt && !photo.uploadedAt) continue;
     const ts = photo.takenAt ?? photo.uploadedAt ?? '';
     const key = toLocalDateKey(ts);
     const arr = grouped.get(key) ?? [];
@@ -106,11 +96,11 @@ export function DiaryRequestCard({ request, allPhotos }: Props) {
       status === PhotoDiaryStatus.Completed ||
       status === PhotoDiaryStatus.Accepted
     ) {
-      if (!acceptedAt) return [];
-      return buildDayGroups(allPhotos, acceptedAt, durationDays);
+      if (!acceptedAt || !request.id) return [];
+      return buildDayGroups(allPhotos, request.id, acceptedAt, durationDays);
     }
     return [];
-  }, [status, acceptedAt, durationDays, allPhotos]);
+  }, [status, acceptedAt, durationDays, allPhotos, request.id]);
 
   const totalPhotoCount = useMemo(
     () => dayGroups.reduce((sum, g) => sum + g.photos.length, 0),

--- a/web/src/components/diary/DiaryRequestCard.tsx
+++ b/web/src/components/diary/DiaryRequestCard.tsx
@@ -1,0 +1,315 @@
+/**
+ * DiaryRequestCard — shows one diary request's metadata, status chip,
+ * and (for active/completed requests) photos grouped by calendar day.
+ *
+ * Photos are sourced from the parent's `allPhotos` prop (already loaded
+ * by PlanPhotosTab) — filtered to photos whose `takenAt` falls within
+ * [acceptedAt, acceptedAt + durationDays) to associate them with this
+ * request.  Because PlanPhotoResponse2 doesn't carry diaryRequestId on
+ * the trainer aggregation endpoint, we rely on the date window heuristic.
+ *
+ * For Dismissed requests the dismiss reason is shown prominently instead.
+ *
+ * Design-of-record:
+ *   docs/prototypes/trainer/scenes/nutrition-plan-detail.html (Photos tab)
+ *   docs/prototypes/notion/scenes/nutrition.html (Foto-deník sidebar)
+ */
+
+import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DiaryRequestStatusChip } from './DiaryRequestStatusChip';
+import { ImageLightbox } from '@/components/ui/ImageLightbox';
+import type { PhotoDiaryRequestSummary } from '@/api/diary-requests';
+import { PhotoDiaryStatus, PhotoDiaryMode } from '@/api/generated';
+import type { PlanPhotoResponse2 } from '@/api/generated';
+
+interface Props {
+  request: PhotoDiaryRequestSummary;
+  /** All plan photos already loaded — this component filters by date window. */
+  allPhotos: PlanPhotoResponse2[];
+}
+
+/** Returns an ISO date string "YYYY-MM-DD" from a UTC timestamp string. */
+function toLocalDateKey(utcTimestamp: string): string {
+  return new Date(utcTimestamp).toLocaleDateString('sv-SE'); // 'sv-SE' gives ISO format
+}
+
+interface DayGroup {
+  dateKey: string;
+  /** Label like "Monday, 14 Apr" using the user's locale */
+  label: string;
+  dayNumber: number; // 1-based day number within diary period
+  photos: PlanPhotoResponse2[];
+}
+
+function buildDayGroups(
+  photos: PlanPhotoResponse2[],
+  acceptedAt: string,
+  durationDays: number,
+): DayGroup[] {
+  const acceptedDate = new Date(acceptedAt);
+  // End of diary window (exclusive)
+  const endDate = new Date(acceptedDate);
+  endDate.setDate(endDate.getDate() + durationDays);
+
+  // Filter photos within the window
+  const windowPhotos = photos.filter((p) => {
+    if (!p.takenAt && !p.uploadedAt) return false;
+    const ts = p.takenAt ?? p.uploadedAt ?? '';
+    const d = new Date(ts);
+    return d >= acceptedDate && d < endDate;
+  });
+
+  // Group by calendar day
+  const grouped = new Map<string, PlanPhotoResponse2[]>();
+  for (const photo of windowPhotos) {
+    const ts = photo.takenAt ?? photo.uploadedAt ?? '';
+    const key = toLocalDateKey(ts);
+    const arr = grouped.get(key) ?? [];
+    arr.push(photo);
+    grouped.set(key, arr);
+  }
+
+  // Convert to array and sort chronologically
+  const days: DayGroup[] = [];
+  for (const [dateKey, dayPhotos] of grouped) {
+    const date = new Date(dateKey);
+    const dayNumber = Math.floor(
+      (date.getTime() - new Date(toLocalDateKey(acceptedAt)).getTime()) / (1000 * 60 * 60 * 24),
+    ) + 1;
+    days.push({
+      dateKey,
+      label: date.toLocaleDateString(undefined, {
+        weekday: 'long',
+        day: 'numeric',
+        month: 'short',
+      }),
+      dayNumber: Math.max(1, Math.min(dayNumber, durationDays)),
+      photos: dayPhotos,
+    });
+  }
+  days.sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+  return days;
+}
+
+export function DiaryRequestCard({ request, allPhotos }: Props) {
+  const { t } = useTranslation();
+  const { status, acceptedAt, durationDays = 7, mode, dismissReason, createdAt } = request;
+
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+  const [lightboxDayPhotos, setLightboxDayPhotos] = useState<PlanPhotoResponse2[]>([]);
+
+  const dayGroups = useMemo(() => {
+    if (
+      status === PhotoDiaryStatus.InProgress ||
+      status === PhotoDiaryStatus.Completed ||
+      status === PhotoDiaryStatus.Accepted
+    ) {
+      if (!acceptedAt) return [];
+      return buildDayGroups(allPhotos, acceptedAt, durationDays);
+    }
+    return [];
+  }, [status, acceptedAt, durationDays, allPhotos]);
+
+  const totalPhotoCount = useMemo(
+    () => dayGroups.reduce((sum, g) => sum + g.photos.length, 0),
+    [dayGroups],
+  );
+
+  function openLightbox(dayPhotos: PlanPhotoResponse2[], index: number) {
+    setLightboxDayPhotos(dayPhotos);
+    setLightboxIndex(index);
+    setLightboxOpen(true);
+  }
+
+  const lightboxUrls = useMemo(
+    () => lightboxDayPhotos.map((p) => p.blobUrl ?? '').filter(Boolean),
+    [lightboxDayPhotos],
+  );
+
+  const modeLabel =
+    mode === PhotoDiaryMode.Bulk
+      ? t('diary.viewer.modeBulk')
+      : mode === PhotoDiaryMode.Workflow
+        ? t('diary.viewer.modeWorkflow')
+        : null;
+
+  const createdLabel = createdAt
+    ? new Date(createdAt).toLocaleDateString(undefined, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      })
+    : null;
+
+  const acceptedLabel = acceptedAt
+    ? new Date(acceptedAt).toLocaleDateString(undefined, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      })
+    : null;
+
+  // Colour the card border according to status
+  const cardBorderStyle: React.CSSProperties =
+    status === PhotoDiaryStatus.Completed
+      ? { border: '1px solid var(--status-completed-br)', background: 'var(--status-completed-bg)' }
+      : status === PhotoDiaryStatus.Dismissed
+        ? { border: '1px solid var(--status-dismissed-br)', background: 'var(--status-dismissed-bg)' }
+        : status === PhotoDiaryStatus.InProgress
+          ? { border: '1px solid var(--status-inprogress-br)', background: 'var(--status-inprogress-bg)' }
+          : { border: '1px solid var(--border)', background: 'var(--bg)' };
+
+  return (
+    <>
+      <div
+        className="rounded-md overflow-hidden"
+        style={cardBorderStyle}
+      >
+        {/* Card header: status + meta */}
+        <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border">
+          <DiaryRequestStatusChip request={request} />
+          {modeLabel && (
+            <span
+              className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+              style={{ color: 'var(--text3)', background: 'var(--bg2)', border: '1px solid var(--border)' }}
+            >
+              {modeLabel}
+            </span>
+          )}
+          <span className="ml-auto text-[11px] text-text3 tabular-nums">
+            {t('diary.viewer.durationDays', { count: durationDays })}
+          </span>
+        </div>
+
+        {/* Meta row: created / accepted date */}
+        {(createdLabel ?? acceptedLabel) && (
+          <div className="flex items-center gap-3 px-3 py-1.5 text-[11px] text-text3 border-b border-border">
+            {createdLabel && (
+              <span>
+                {t('diary.viewer.requestedOn')}{' '}
+                <span className="font-medium text-text2">{createdLabel}</span>
+              </span>
+            )}
+            {acceptedLabel && (
+              <span>
+                {t('diary.viewer.acceptedOn')}{' '}
+                <span className="font-medium text-text2">{acceptedLabel}</span>
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Dismissed — show reason prominently */}
+        {status === PhotoDiaryStatus.Dismissed && (
+          <div className="px-3 py-3">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.04em] text-text3 mb-1">
+              {t('diary.viewer.dismissReasonLabel')}
+            </div>
+            <div
+              className="text-[12px] rounded px-2.5 py-2"
+              style={{
+                color: 'var(--status-dismissed-text)',
+                background: 'var(--bg)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              {dismissReason ?? t('diary.viewer.dismissReasonEmpty')}
+            </div>
+          </div>
+        )}
+
+        {/* Photos section for Accepted / InProgress / Completed */}
+        {(status === PhotoDiaryStatus.InProgress ||
+          status === PhotoDiaryStatus.Completed ||
+          status === PhotoDiaryStatus.Accepted) && (
+          <div className="px-3 py-3">
+            {dayGroups.length === 0 ? (
+              <div className="text-[12px] text-text3 text-center py-4">
+                {t('diary.viewer.noPhotosYet')}
+              </div>
+            ) : (
+              <>
+                {/* Summary line */}
+                <div className="text-[11px] text-text3 mb-2 tabular-nums">
+                  {t('diary.viewer.photoCount', { count: totalPhotoCount })}
+                </div>
+                {/* Day groups */}
+                <div className="flex flex-col gap-3">
+                  {dayGroups.map((group) => (
+                    <div key={group.dateKey}>
+                      {/* Day label */}
+                      <div className="flex items-center gap-1.5 mb-1.5">
+                        <span
+                          className="inline-flex items-center justify-center rounded-full text-[10px] font-bold tabular-nums"
+                          style={{
+                            width: 20,
+                            height: 20,
+                            background: 'var(--status-inprogress-bg)',
+                            color: 'var(--status-inprogress-text)',
+                            border: '1px solid var(--status-inprogress-br)',
+                            flexShrink: 0,
+                          }}
+                        >
+                          {group.dayNumber}
+                        </span>
+                        <span className="text-[11px] font-semibold text-text2">
+                          {group.label}
+                        </span>
+                        <span className="text-[10px] text-text3 ml-auto tabular-nums">
+                          {t('diary.viewer.photoCount', { count: group.photos.length })}
+                        </span>
+                      </div>
+                      {/* Thumbnail strip */}
+                      <div className="flex flex-wrap gap-1.5">
+                        {group.photos.map((photo, idx) => (
+                          <button
+                            key={photo.id ?? idx}
+                            type="button"
+                            onClick={() => openLightbox(group.photos, idx)}
+                            className="relative overflow-hidden rounded transition-opacity hover:opacity-85 focus:outline-none"
+                            style={{ width: 64, height: 64, background: 'var(--bg3)', flexShrink: 0 }}
+                            title={photo.description ?? t('nutrition.photos.photoAlt')}
+                          >
+                            {photo.blobUrl ? (
+                              <img
+                                src={photo.blobUrl}
+                                alt={photo.description ?? `${t('nutrition.photos.photoAlt')} ${idx + 1}`}
+                                className="absolute inset-0 h-full w-full object-cover"
+                                loading="lazy"
+                              />
+                            ) : (
+                              <span className="absolute inset-0 flex items-center justify-center text-2xl opacity-30">
+                                📷
+                              </span>
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Pending — waiting message */}
+        {status === PhotoDiaryStatus.Pending && (
+          <div className="px-3 py-3 text-[12px] text-text3">
+            {t('diary.viewer.pendingHint')}
+          </div>
+        )}
+      </div>
+
+      <ImageLightbox
+        images={lightboxUrls}
+        startIndex={lightboxIndex}
+        open={lightboxOpen}
+        onClose={() => setLightboxOpen(false)}
+        altPrefix={t('nutrition.photos.photoAlt')}
+      />
+    </>
+  );
+}

--- a/web/src/components/diary/DiaryRequestStatusChip.tsx
+++ b/web/src/components/diary/DiaryRequestStatusChip.tsx
@@ -1,0 +1,101 @@
+/**
+ * DiaryRequestStatusChip — inline pill showing the lifecycle status of a
+ * photo diary request.
+ *
+ * For InProgress, it shows "Day N of M" computed from acceptedAt.
+ * For Dismissed, a separate DismissReason display is handled by the caller.
+ *
+ * Status-chip colours resolve through CSS custom properties defined in
+ * index.css (--status-*) so they respect the dark-mode theme.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { PhotoDiaryStatus } from '@/api/generated';
+import type { PhotoDiaryRequestSummary } from '@/api/diary-requests';
+
+interface Props {
+  request: PhotoDiaryRequestSummary;
+}
+
+function computeDay(acceptedAt: string, durationDays: number): number {
+  const accepted = new Date(acceptedAt);
+  const now = new Date();
+  const msDiff = now.getTime() - accepted.getTime();
+  const daysDiff = Math.floor(msDiff / (1000 * 60 * 60 * 24));
+  // Day 1 = the day of acceptance, so add 1; clamp to durationDays.
+  return Math.min(daysDiff + 1, durationDays);
+}
+
+export function DiaryRequestStatusChip({ request }: Props) {
+  const { t } = useTranslation();
+  const { status, acceptedAt, durationDays = 7 } = request;
+
+  let label: string;
+  let style: React.CSSProperties;
+
+  switch (status) {
+    case PhotoDiaryStatus.Pending:
+      label = t('diary.viewer.statusPending');
+      style = {
+        color: 'var(--status-pending-text)',
+        background: 'var(--status-pending-bg)',
+        border: '1px solid var(--status-pending-br)',
+      };
+      break;
+
+    case PhotoDiaryStatus.Accepted:
+      label = t('diary.viewer.statusAccepted');
+      style = {
+        color: 'var(--status-accepted-text)',
+        background: 'var(--status-accepted-bg)',
+        border: '1px solid var(--status-accepted-br)',
+      };
+      break;
+
+    case PhotoDiaryStatus.InProgress: {
+      const day = acceptedAt ? computeDay(acceptedAt, durationDays) : 1;
+      label = t('diary.viewer.statusInProgress', { day, total: durationDays });
+      style = {
+        color: 'var(--status-inprogress-text)',
+        background: 'var(--status-inprogress-bg)',
+        border: '1px solid var(--status-inprogress-br)',
+      };
+      break;
+    }
+
+    case PhotoDiaryStatus.Completed:
+      label = t('diary.viewer.statusCompleted');
+      style = {
+        color: 'var(--status-completed-text)',
+        background: 'var(--status-completed-bg)',
+        border: '1px solid var(--status-completed-br)',
+      };
+      break;
+
+    case PhotoDiaryStatus.Dismissed:
+      label = t('diary.viewer.statusDismissed');
+      style = {
+        color: 'var(--status-dismissed-text)',
+        background: 'var(--status-dismissed-bg)',
+        border: '1px solid var(--status-dismissed-br)',
+      };
+      break;
+
+    default:
+      label = status ?? '—';
+      style = {
+        color: 'var(--text3)',
+        background: 'var(--bg2)',
+        border: '1px solid var(--border)',
+      };
+  }
+
+  return (
+    <span
+      className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold whitespace-nowrap"
+      style={style}
+    >
+      {label}
+    </span>
+  );
+}

--- a/web/src/components/diary/DiaryViewerPanel.tsx
+++ b/web/src/components/diary/DiaryViewerPanel.tsx
@@ -1,0 +1,103 @@
+/**
+ * DiaryViewerPanel — panel shown in the Photos tab of a plan detail page.
+ *
+ * Lists all photo diary requests scoped to this plan (by planId).
+ * For each request, renders a DiaryRequestCard with status chip and
+ * day-grouped photo gallery.
+ *
+ * Query key: ['diary-requests', planId]
+ * Invalidated by SignalR events (see AppShell.tsx):
+ *   photoDiaryRequested, photoDiaryDismissed, photoDiarySubmitted →
+ *     invalidate ['diary-requests', planId]
+ *   photoDiaryPhotoUploaded → invalidate ['planPhotos', clientId, planId]
+ *     (already handled by AppShell, propagates through allPhotos prop)
+ *
+ * Design-of-record:
+ *   docs/prototypes/trainer/scenes/nutrition-plan-detail.html (Photos tab —
+ *     "Foto-deník" section above the regular photo grid)
+ *   docs/prototypes/notion/scenes/nutrition.html (Foto-deník sidebar panel)
+ */
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { listDiaryRequests } from '@/api/diary-requests';
+import { DiaryRequestCard } from './DiaryRequestCard';
+import type { PlanPhotoResponse2 } from '@/api/generated';
+
+interface Props {
+  planId: string;
+  /** All plan photos already loaded by PlanPhotosTab. Passed through to cards
+   *  so we don't fire a second request. */
+  allPhotos: PlanPhotoResponse2[];
+}
+
+export function DiaryViewerPanel({ planId, allPhotos }: Props) {
+  const { t } = useTranslation();
+
+  const { data: requests = [], isLoading } = useQuery({
+    queryKey: ['diary-requests', planId],
+    queryFn: () => listDiaryRequests({ planId }),
+    enabled: !!planId,
+    staleTime: 30_000,
+  });
+
+  // Sort: active (InProgress) first, then Accepted, Pending, Completed, Dismissed
+  const sortedRequests = useMemo(() => {
+    const ORDER: Record<string, number> = {
+      InProgress: 0,
+      Accepted: 1,
+      Pending: 2,
+      Completed: 3,
+      Dismissed: 4,
+    };
+    return [...requests].sort((a, b) => {
+      const aO = ORDER[a.status ?? ''] ?? 5;
+      const bO = ORDER[b.status ?? ''] ?? 5;
+      if (aO !== bO) return aO - bO;
+      // Secondary: newest first
+      return (b.createdAt ?? '').localeCompare(a.createdAt ?? '');
+    });
+  }, [requests]);
+
+  if (!isLoading && sortedRequests.length === 0) {
+    return null; // No diary requests for this plan — don't show the panel
+  }
+
+  return (
+    <div className="shrink-0 px-4 pt-4 pb-3 border-b border-border">
+      {/* Section header */}
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.04em] text-text3">
+          {t('diary.viewer.sectionTitle')}
+        </span>
+        {!isLoading && sortedRequests.length > 0 && (
+          <span
+            className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold tabular-nums"
+            style={{ background: 'var(--bg3)', color: 'var(--text3)' }}
+          >
+            {sortedRequests.length}
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="text-[12px] text-text3 py-2">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {!isLoading && sortedRequests.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {sortedRequests.map((request) => (
+            <DiaryRequestCard
+              key={request.id}
+              request={request}
+              allPhotos={allPhotos}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -203,6 +203,43 @@ export function AppShell() {
         queryClient.invalidateQueries({ queryKey: ['planPhotos'] });
       }
     },
+    // ── Photo diary real-time events (from #94 / #97) ────────────────────────
+    photodiaryrequested: (payload: unknown) => {
+      const data = payload as { planId?: string } | undefined;
+      if (data?.planId) {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests', data.planId] });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests'] });
+      }
+    },
+    photodiarydismissed: (payload: unknown) => {
+      const data = payload as { planId?: string } | undefined;
+      if (data?.planId) {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests', data.planId] });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests'] });
+      }
+    },
+    photodiaryphotoUploaded: (payload: unknown) => {
+      // Diary photo uploads re-use the planphotouploaded path for the photo
+      // grid; here we also refresh the diary request status (InProgress count).
+      const data = payload as { planId?: string } | undefined;
+      if (data?.planId) {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests', data.planId] });
+        queryClient.invalidateQueries({ queryKey: ['planPhotos', data.planId] });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests'] });
+        queryClient.invalidateQueries({ queryKey: ['planPhotos'] });
+      }
+    },
+    photodiarysubmitted: (payload: unknown) => {
+      const data = payload as { planId?: string } | undefined;
+      if (data?.planId) {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests', data.planId] });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['diary-requests'] });
+      }
+    },
     weeklycheckinupdated: (payload: unknown) => {
       if (import.meta.env.DEV) {
         console.debug('weeklycheckinupdated', payload);

--- a/web/src/components/photos/PlanPhotosTab.tsx
+++ b/web/src/components/photos/PlanPhotosTab.tsx
@@ -19,6 +19,7 @@ import { getPlanPhotos } from '@/api/photos';
 import { PlanPhotoCategory } from '@/api/generated';
 import { CardGrid, Card, CardBody } from '@/components/data';
 import { RequestDiaryDialog } from '@/components/diary/RequestDiaryDialog';
+import { DiaryViewerPanel } from '@/components/diary/DiaryViewerPanel';
 
 interface PlanPhotosTabProps {
   planId: string;
@@ -135,6 +136,9 @@ export function PlanPhotosTab({ planId, clientId, clientName, linkId }: PlanPhot
           <span>{t('diary.request.ctaButton')}</span>
         </button>
       </div>
+
+      {/* Diary viewer panel — shows diary requests for this plan (if any) */}
+      <DiaryViewerPanel planId={planId} allPhotos={allPhotos} />
 
       {/* Photo grid */}
       <div className="flex-1 overflow-y-auto p-5">

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1355,6 +1355,26 @@
     }
   },
   "diary": {
+    "viewer": {
+      "sectionTitle": "Foto-deník",
+      "statusPending": "Čeká na klienta",
+      "statusAccepted": "Přijato",
+      "statusInProgress": "Den {{day}} ze {{total}}",
+      "statusCompleted": "Hotovo",
+      "statusDismissed": "Odmítnuto",
+      "modeBulk": "Vše najednou",
+      "modeWorkflow": "Workflow",
+      "durationDays_one": "{{count}} den",
+      "durationDays_other": "{{count}} dní",
+      "requestedOn": "Odesláno",
+      "acceptedOn": "Přijato",
+      "dismissReasonLabel": "Důvod odmítnutí",
+      "dismissReasonEmpty": "Bez uvedeného důvodu.",
+      "noPhotosYet": "Zatím žádné fotky.",
+      "photoCount_one": "{{count}} fotka",
+      "photoCount_other": "{{count}} fotek",
+      "pendingHint": "Čeká se na akceptaci od klienta."
+    },
     "request": {
       "dialogTitle": "Požádat o foto-deník",
       "dialogSubtitle": "Klient uvidí žádost jako banner a může ji přijmout nebo odmítnout.",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1355,6 +1355,26 @@
     }
   },
   "diary": {
+    "viewer": {
+      "sectionTitle": "Fototagebuch",
+      "statusPending": "Ausstehend",
+      "statusAccepted": "Angenommen",
+      "statusInProgress": "Tag {{day}} von {{total}}",
+      "statusCompleted": "Abgeschlossen",
+      "statusDismissed": "Abgelehnt",
+      "modeBulk": "Alles auf einmal",
+      "modeWorkflow": "Workflow",
+      "durationDays_one": "{{count}} Tag",
+      "durationDays_other": "{{count}} Tage",
+      "requestedOn": "Angefragt am",
+      "acceptedOn": "Angenommen am",
+      "dismissReasonLabel": "Ablehnungsgrund",
+      "dismissReasonEmpty": "Kein Grund angegeben.",
+      "noPhotosYet": "Noch keine Fotos.",
+      "photoCount_one": "{{count}} Foto",
+      "photoCount_other": "{{count}} Fotos",
+      "pendingHint": "Warten auf Bestätigung durch den Klienten."
+    },
     "request": {
       "dialogTitle": "Fototagebuch anfordern",
       "dialogSubtitle": "Der Klient sieht die Anfrage als Banner und kann sie annehmen oder ablehnen.",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1356,6 +1356,26 @@
     }
   },
   "diary": {
+    "viewer": {
+      "sectionTitle": "Photo diary",
+      "statusPending": "Pending",
+      "statusAccepted": "Accepted",
+      "statusInProgress": "Day {{day}} of {{total}}",
+      "statusCompleted": "Completed",
+      "statusDismissed": "Dismissed",
+      "modeBulk": "All at once",
+      "modeWorkflow": "Workflow",
+      "durationDays_one": "{{count}} day",
+      "durationDays_other": "{{count}} days",
+      "requestedOn": "Requested",
+      "acceptedOn": "Accepted",
+      "dismissReasonLabel": "Dismiss reason",
+      "dismissReasonEmpty": "No reason provided.",
+      "noPhotosYet": "No photos yet.",
+      "photoCount_one": "{{count}} photo",
+      "photoCount_other": "{{count}} photos",
+      "pendingHint": "Waiting for the client to accept."
+    },
     "request": {
       "dialogTitle": "Request photo diary",
       "dialogSubtitle": "Client will see a banner and can accept or decline.",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -47,6 +47,27 @@
   --orange:    #ad5700;
   --orange-bg: rgba(173, 87, 0, 0.08);
 
+  /* Diary request status-chip tokens */
+  --status-pending-text:    #ad5700;
+  --status-pending-bg:      rgba(173, 87, 0, 0.10);
+  --status-pending-br:      rgba(173, 87, 0, 0.22);
+
+  --status-accepted-text:   #0b6e99;
+  --status-accepted-bg:     rgba(11, 110, 153, 0.10);
+  --status-accepted-br:     rgba(11, 110, 153, 0.22);
+
+  --status-inprogress-text: #0f7b6c;
+  --status-inprogress-bg:   rgba(15, 123, 108, 0.10);
+  --status-inprogress-br:   rgba(15, 123, 108, 0.22);
+
+  --status-completed-text:  #0f7b6c;
+  --status-completed-bg:    rgba(15, 123, 108, 0.10);
+  --status-completed-br:    rgba(15, 123, 108, 0.22);
+
+  --status-dismissed-text:  #6b6860;
+  --status-dismissed-bg:    rgba(107, 104, 96, 0.10);
+  --status-dismissed-br:    rgba(107, 104, 96, 0.22);
+
   /* Radii */
   --radius:    4px;
   --radius-md: 6px;


### PR DESCRIPTION
## Summary

- Backend exposes `DiaryRequestId` on the trainer-side `PlanPhotoResponse` (additive-only field in `ClientPhotos.Common`); web filters strictly by FK — no more date-window heuristic.
- New `DiaryViewerPanel` + `DiaryRequestCard` + `DiaryRequestStatusChip` components render diary requests on the plan Photos tab, grouped by calendar day.
- Status chip shows Day N of M for InProgress; dismiss reason surfaced for Dismissed.
- New `--status-{pending,accepted,inprogress,completed,dismissed}-{text,bg,br}` CSS tokens in `web/src/index.css`.
- SignalR-driven refresh via 4 new handlers in `AppShell.tsx`: `photodiaryrequested`, `photodiarydismissed`, `photodiaryphotoUploaded`, `photodiarysubmitted`.
- i18n keys present in cs/en/de.

## Related issue

Fixes #97

## Parent epic (sub-issue PRs only)

Part of epic #67 — base branch: `feature/67-diary-request`.

## Scope

cross-cut: backend + web

## QA verdict (from qa-tester)

OVERALL PASS at 200986b — all ACs verified (status chip, Day N of M, dismiss reason, i18n cs/en/de).

## Test plan

- [ ] Status chip shows correct state (Pending / Day N of M / Completed / Dismissed).
- [ ] Dismiss reason shown prominently when status is Dismissed.
- [ ] Photo gallery groups by calendar day under each diary request card.
- [ ] SignalR events (`photodiaryrequested`, `photodiarydismissed`, `photodiaryphotoUploaded`, `photodiarysubmitted`) invalidate the `diary-requests` query key in real time.
- [ ] i18n: all labels render correctly in cs, en, and de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)