### PR TITLE
feat(mobile,#101): photo diary workflow mode — daily banner + finalize prompt

### DIFF
--- a/mobile/app/(client)/(tabs)/index.tsx
+++ b/mobile/app/(client)/(tabs)/index.tsx
@@ -22,6 +22,7 @@ import { NotificationSheet } from '@/components/notifications/NotificationSheet'
 import { InviteCard } from '@/components/notifications/InviteCard'
 import { QuestionnaireBanner } from '@/components/notifications/QuestionnaireBanner'
 import { DiaryRequestBanner } from '@/components/today/DiaryRequestBanner'
+import { DiaryWorkflowBanner } from '@/components/today/DiaryWorkflowBanner'
 import { WeeklyCheckInBanner } from '@/components/today/WeeklyCheckInBanner'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useClientInvite } from '@/hooks/useClientInvite'
@@ -30,6 +31,10 @@ import {
   type PendingQuestionnairesResponse,
   type PendingDiaryRequestItem,
 } from '@/api/questionnaire'
+import {
+  getActiveWorkflowDiaryRequests,
+  type ClientPhotoDiaryRequestSummary,
+} from '@/api/diaryRequests'
 import { getCurrentCheckIns, type CheckInSummary } from '@/api/weeklyCheckIns'
 import { onEvent } from '@/api/signalr'
 import { Toast } from '@/lib/toast'
@@ -100,6 +105,26 @@ export default function TodayScreen() {
     [pendingQQuery.data?.pendingDiaryRequests],
   )
 
+  // Active workflow diary requests (Accepted or InProgress, Mode === Workflow)
+  const activeWorkflowQuery = useQuery<ClientPhotoDiaryRequestSummary[]>({
+    queryKey: ['active-workflow-diary-requests'],
+    queryFn: getActiveWorkflowDiaryRequests,
+    enabled: hasActiveLink,
+    staleTime: 30_000,
+  })
+  const activeWorkflowItems: ClientPhotoDiaryRequestSummary[] = activeWorkflowQuery.data ?? []
+
+  // Subscribe to photoDiarySubmitted so workflow banners disappear when the diary
+  // is auto-finalized server-side (day N+1 scheduler) or submitted manually.
+  useEffect(() => {
+    const unsub = onEvent('photodiarysubmitted', () => {
+      queryClient.invalidateQueries({ queryKey: ['active-workflow-diary-requests'] })
+      queryClient.invalidateQueries({ queryKey: ['pending-questionnaires'] })
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+    })
+    return unsub
+  }, [queryClient])
+
   const handleNotificationAction = useCallback(
     (n: (typeof notifications)[0]) => {
       markRead(n.id)
@@ -152,6 +177,7 @@ export default function TodayScreen() {
       queryClient.invalidateQueries({ queryKey: ['client-invite'] }),
       queryClient.invalidateQueries({ queryKey: ['pending-questionnaires'] }),
       queryClient.invalidateQueries({ queryKey: ['current-weekly-check-ins'] }),
+      queryClient.invalidateQueries({ queryKey: ['active-workflow-diary-requests'] }),
     ])
     setRefreshing(false)
   }, [queryClient])
@@ -225,6 +251,17 @@ export default function TodayScreen() {
                     }
                     onDismiss={() =>
                       router.push(href(`/(client)/diary/${item.requestPublicId}/dismiss`))
+                    }
+                  />
+                ))}
+
+                {/* Active workflow diary banners — one per active 7-day workflow */}
+                {activeWorkflowItems.map((item) => (
+                  <DiaryWorkflowBanner
+                    key={item.id}
+                    request={item}
+                    onOpen={() =>
+                      router.push(href(`/(client)/diary/${item.id}/workflow`))
                     }
                   />
                 ))}

--- a/mobile/app/(client)/diary/[requestId]/finalize.tsx
+++ b/mobile/app/(client)/diary/[requestId]/finalize.tsx
@@ -1,0 +1,467 @@
+/**
+ * Diary Finalize Screen — confirmation + submit on day N.
+ *
+ * Per prototype diary-finalize.html:
+ *   1. Modal-style header: "Day N · finish" + close button.
+ *   2. Hero block: ✅ icon, title, sub-text with photo/day counts.
+ *   3. Summary stats grid: total photos / days completed / attendance %.
+ *   4. "Add last photo" section — dashed placeholder CTA.
+ *   5. Pinned action bar: "Submit to coach" (gold) + "Add another photo".
+ *
+ * Route params: requestId (from [requestId] segment).
+ *
+ * Tapping "Submit to coach" → submitDiaryRequest() → toast → navigate back to Today.
+ * Tapping "Add another photo" → go back to the workflow screen.
+ */
+
+import React, { useCallback, useMemo } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '@/hooks/useTheme'
+import { useImagePicker } from '@/hooks/useImagePicker'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import {
+  getDiaryRequestById,
+  submitDiaryRequest,
+  type ClientPhotoDiaryRequestSummary,
+} from '@/api/diaryRequests'
+import {
+  getPlanPhotos,
+  generatePlanPhotoUploadUrl,
+  finalizePlanPhoto,
+  PlanPhotoCategory,
+  type PlanPhotoResponse,
+} from '@/api/planPhotos'
+import { Toast } from '@/lib/toast'
+import { href } from '@/lib/navigation'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function computeCurrentDay(
+  acceptedAt: string | undefined,
+  durationDays: number,
+): number {
+  if (!acceptedAt) return durationDays
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysSince = Math.floor((Date.now() - new Date(acceptedAt).getTime()) / msPerDay)
+  return Math.min(daysSince + 1, durationDays)
+}
+
+/** Count how many distinct days had at least one photo. */
+function countDaysWithPhotos(
+  photos: PlanPhotoResponse[],
+  acceptedAt: string,
+): number {
+  const msPerDay = 24 * 60 * 60 * 1000
+  const acceptedMidnight = new Date(
+    new Date(acceptedAt).getFullYear(),
+    new Date(acceptedAt).getMonth(),
+    new Date(acceptedAt).getDate(),
+  ).getTime()
+  const daySet = new Set(
+    photos
+      .filter((p) => !!p.dateCreated)
+      .map((p) =>
+        Math.max(
+          0,
+          Math.floor((new Date(p.dateCreated!).getTime() - acceptedMidnight) / msPerDay),
+        ),
+      ),
+  )
+  return daySet.size
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
+export function DiaryFinalizeScreen() {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  const { requestId } = useLocalSearchParams<{ requestId: string }>()
+
+  // ── Query: diary request metadata ──
+  const requestQuery = useQuery<ClientPhotoDiaryRequestSummary | undefined>({
+    queryKey: ['diary-request', requestId],
+    queryFn: () => getDiaryRequestById(requestId ?? ''),
+    enabled: !!requestId,
+    staleTime: 60_000,
+  })
+  const request = requestQuery.data
+
+  const durationDays = request?.durationDays ?? 7
+  const currentDay = computeCurrentDay(request?.acceptedAt, durationDays)
+
+  // ── Query: photos for this diary request ──
+  const planId = request?.planId
+  const photosQuery = useQuery<PlanPhotoResponse[]>({
+    queryKey: ['plan-photos', planId],
+    queryFn: () => getPlanPhotos(planId ?? '', 1, 200),
+    enabled: !!planId,
+    staleTime: 30_000,
+  })
+
+  const diaryPhotos = useMemo(
+    () => (photosQuery.data ?? []).filter((p) => p.diaryRequestId === requestId),
+    [photosQuery.data, requestId],
+  )
+
+  const daysWithPhotos = useMemo(
+    () =>
+      request?.acceptedAt
+        ? countDaysWithPhotos(diaryPhotos, request.acceptedAt)
+        : 0,
+    [diaryPhotos, request?.acceptedAt],
+  )
+
+  const attendancePct =
+    durationDays > 0 ? Math.round((daysWithPhotos / durationDays) * 100) : 0
+
+  // ── Submit mutation ──
+  const submitMutation = useMutation({
+    mutationFn: () => submitDiaryRequest(requestId ?? ''),
+    onSuccess: () => {
+      Toast.show(t('diary.finalize.successToast'))
+      queryClient.invalidateQueries({ queryKey: ['active-workflow-diary-requests'] })
+      queryClient.invalidateQueries({ queryKey: ['diary-request', requestId] })
+      queryClient.invalidateQueries({ queryKey: ['pending-questionnaires'] })
+      // Navigate to Today tab
+      router.replace(href('/(client)/(tabs)'))
+    },
+    onError: () => {
+      Toast.show(t('diary.finalize.errorSubmit'))
+    },
+  })
+
+  // ── Last-photo upload ──
+  const finalizeMutation = useMutation({
+    mutationFn: async (blobUrl: string) => {
+      if (!planId) throw new Error('No planId')
+      return finalizePlanPhoto(planId, {
+        blobUrl,
+        category: PlanPhotoCategory.FreeForm,
+        diaryRequestId: requestId,
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan-photos', planId] })
+    },
+    onError: () => {
+      Toast.show(t('diary.bulk.errorUpload'))
+    },
+  })
+
+  const { pick, uploading } = useImagePicker(
+    {
+      source: 'both',
+      requestUploadUrl: async ({ contentType, sizeBytes }) => {
+        if (!planId) throw new Error('No planId')
+        return generatePlanPhotoUploadUrl(planId, contentType, sizeBytes)
+      },
+    },
+    (blobUrl) => {
+      finalizeMutation.mutate(blobUrl)
+    },
+  )
+
+  const isUploading = uploading || finalizeMutation.isPending
+  const isSubmitting = submitMutation.isPending
+
+  const handleSubmit = useCallback(() => {
+    submitMutation.mutate()
+  }, [submitMutation])
+
+  const handleAddMore = useCallback(() => {
+    router.back()
+  }, [router])
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      edges={['top', 'bottom']}
+    >
+      {/* ── Modal header ── */}
+      <View style={[styles.header, { borderBottomColor: colors.sep2 }]}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.cancel')}
+          style={styles.headerSideBtn}
+        >
+          <Text style={[Type.subheadline, { color: colors.label2, fontWeight: '600' }]}>
+            {t('common.cancel')}
+          </Text>
+        </Pressable>
+        <Text style={[Type.subheadline, { color: colors.label, fontWeight: '600' }]}>
+          {t('diary.finalize.title', { day: currentDay })}
+        </Text>
+        <View style={styles.headerSideBtn} />
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Hero block ── */}
+        <View style={[styles.heroBlock, { backgroundColor: colors.bg2 }]}>
+          <Text style={styles.heroIcon}>✅</Text>
+          <Text style={[Type.title2, { color: colors.label, textAlign: 'center', marginBottom: 8 }]}>
+            {t('diary.finalize.heroTitle')}
+          </Text>
+          <Text style={[Type.footnote, { color: colors.label2, textAlign: 'center', lineHeight: 20 }]}>
+            {t('diary.finalize.heroSub', {
+              photos: diaryPhotos.length,
+              days: durationDays,
+            })}
+          </Text>
+        </View>
+
+        {/* ── Stats grid ── */}
+        <View style={styles.statsGrid}>
+          <View style={[styles.statCard, { backgroundColor: colors.bg2 }]}>
+            <Text style={styles.statEmoji}>📸</Text>
+            <Text style={[Type.title2, { color: colors.label }]}>{diaryPhotos.length}</Text>
+            <Text style={[Type.caption1, { color: colors.label2, textAlign: 'center' }]}>
+              {t('diary.finalize.statPhotos')}
+            </Text>
+          </View>
+          <View style={[styles.statCard, { backgroundColor: colors.bg2 }]}>
+            <Text style={styles.statEmoji}>📅</Text>
+            <Text style={[Type.title2, { color: colors.label }]}>
+              {daysWithPhotos}/{durationDays}
+            </Text>
+            <Text style={[Type.caption1, { color: colors.label2, textAlign: 'center' }]}>
+              {t('diary.finalize.statDays')}
+            </Text>
+          </View>
+          <View style={[styles.statCardWide, { backgroundColor: colors.bg2 }]}>
+            <Text style={styles.statEmoji}>💯</Text>
+            <Text style={[Type.title2, { color: colors.label }]}>{attendancePct} %</Text>
+            <Text style={[Type.caption1, { color: colors.label2, textAlign: 'center' }]}>
+              {t('diary.finalize.statAttendance')}
+            </Text>
+          </View>
+        </View>
+
+        {/* ── Last photo section ── */}
+        <View style={styles.sectionHeader}>
+          <Text style={[Type.footnote, styles.sectionTitle, { color: colors.label2 }]}>
+            {t('diary.finalize.lastPhotosSection')}
+          </Text>
+        </View>
+        <Pressable
+          onPress={pick}
+          disabled={isUploading}
+          accessibilityRole="button"
+          style={({ pressed }) => [
+            styles.lastPhotoBox,
+            {
+              backgroundColor: colors.bg2,
+              borderColor: colors.sep,
+              opacity: pressed || isUploading ? 0.7 : 1,
+            },
+          ]}
+        >
+          {isUploading ? (
+            <ActivityIndicator size="small" color={colors.gold} />
+          ) : (
+            <>
+              <Text style={styles.lastPhotoEmoji}>📷</Text>
+              <Text style={[Type.subheadline, { color: colors.label, fontWeight: '600', marginTop: 8 }]}>
+                {t('diary.finalize.lastPhotosCta')}
+              </Text>
+              <Text style={[Type.caption1, { color: colors.label2, marginTop: 2 }]}>
+                {t('diary.finalize.lastPhotosHint')}
+              </Text>
+            </>
+          )}
+        </Pressable>
+
+        <View style={{ height: 120 }} />
+      </ScrollView>
+
+      {/* ── Pinned action bar ── */}
+      <View
+        style={[
+          styles.actionBar,
+          {
+            backgroundColor: colors.bg,
+            borderTopColor: colors.sep2,
+          },
+        ]}
+      >
+        <Pressable
+          onPress={handleSubmit}
+          disabled={isSubmitting}
+          accessibilityRole="button"
+          style={({ pressed }) => [
+            styles.submitBtn,
+            { backgroundColor: colors.gold, opacity: pressed || isSubmitting ? 0.7 : 1 },
+          ]}
+        >
+          {isSubmitting ? (
+            <ActivityIndicator size="small" color={colors.onAccent} />
+          ) : (
+            <Text style={[Type.subheadline, { color: colors.onAccent, fontWeight: '600' }]}>
+              {t('diary.finalize.submitCta')}
+            </Text>
+          )}
+        </Pressable>
+        <Pressable
+          onPress={handleAddMore}
+          disabled={isSubmitting}
+          accessibilityRole="button"
+          style={({ pressed }) => [
+            styles.addMoreBtn,
+            {
+              backgroundColor: colors.bg2,
+              borderColor: colors.sep2,
+              opacity: pressed || isSubmitting ? 0.7 : 1,
+            },
+          ]}
+        >
+          <Text style={[Type.footnote, { color: colors.label, fontWeight: '600' }]}>
+            {t('diary.finalize.addMoreCta')}
+          </Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  )
+}
+
+export default DiaryFinalizeScreen
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerSideBtn: {
+    minWidth: 60,
+  },
+
+  scroll: {
+    paddingBottom: 20,
+  },
+
+  // Hero
+  heroBlock: {
+    margin: 20,
+    marginBottom: 0,
+    padding: 24,
+    borderRadius: Radius.lg,
+    alignItems: 'center',
+  },
+  heroIcon: {
+    fontSize: 48,
+    marginBottom: 8,
+  },
+
+  // Stats
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    paddingHorizontal: 20,
+    paddingTop: 14,
+  },
+  statCard: {
+    flex: 1,
+    minWidth: 100,
+    borderRadius: Radius.md,
+    padding: 16,
+    alignItems: 'center',
+    gap: 4,
+  },
+  statCardWide: {
+    flexBasis: '100%',
+    borderRadius: Radius.md,
+    padding: 16,
+    alignItems: 'center',
+    gap: 4,
+  },
+  statEmoji: {
+    fontSize: 24,
+  },
+
+  // Section header
+  sectionHeader: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 8,
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+
+  // Last photo box
+  lastPhotoBox: {
+    marginHorizontal: 20,
+    borderRadius: Radius.lg,
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    minHeight: 180,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 28,
+  },
+  lastPhotoEmoji: {
+    fontSize: 32,
+  },
+
+  // Action bar
+  actionBar: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 32,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: 10,
+  },
+  submitBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 48,
+  },
+  addMoreBtn: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    minHeight: 48,
+  },
+})

--- a/mobile/app/(client)/diary/[requestId]/workflow.tsx
+++ b/mobile/app/(client)/diary/[requestId]/workflow.tsx
@@ -1,94 +1,752 @@
 /**
- * 7-day workflow screen — placeholder.
+ * Diary Workflow Screen — 7-day live photo stream.
  *
- * TODO(#101): Implement the full 7-day workflow (daily reminder setup,
- * day-by-day progress view, per-day photo upload).
- * This file exists so the accept wizard's "Workflow" CTA navigates to a
- * valid route after the request is accepted.
+ * Layout (per prototype diary-workflow.html):
+ *   1. Page header: "Foto-deník" title + "Den X ze N · Coach" sub-line.
+ *   2. Progress banner: day counter + dot strip + days-left sub-text.
+ *   3. "Add photo today" primary CTA (gold button).
+ *   4. Today's photos section: 2-col grid filtered to client-local-today.
+ *   5. Previous days section: list rows grouped by day (Day N · date / N photos).
+ *   6. Coach note strip.
+ *   7. Finalize CTA — visible only on day N (currentDay >= durationDays).
+ *
+ * Data:
+ *   - Request metadata: getDiaryRequestById (query key: ['diary-request', requestId]).
+ *   - Photos: getPlanPhotos for the request's planId (query key: ['plan-photos', planId])
+ *     filtered to diaryRequestId === request.id.
+ *   - SignalR: planphotouploaded → invalidates photos; photoDiarySubmitted → navigates away.
+ *
+ * Upload pipeline: same as plan-photos.tsx (#66) — generatePlanPhotoUploadUrl +
+ * finalizePlanPhoto with diaryRequestId threaded through.
  */
-import React from 'react'
-import { View, Text, StyleSheet, Pressable } from 'react-native'
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  Image,
+  ActivityIndicator,
+  useWindowDimensions,
+  useColorScheme,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
+import { Ionicons } from '@expo/vector-icons'
 import { useTheme } from '@/hooks/useTheme'
+import { useThemeStore } from '@/stores/themeStore'
+import { useImagePicker } from '@/hooks/useImagePicker'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
+import { goldAlpha } from '@/constants/colors'
+import {
+  getDiaryRequestById,
+  type ClientPhotoDiaryRequestSummary,
+} from '@/api/diaryRequests'
+import {
+  getPlanPhotos,
+  generatePlanPhotoUploadUrl,
+  finalizePlanPhoto,
+  PlanPhotoCategory,
+  type PlanPhotoResponse,
+} from '@/api/planPhotos'
+import { onEvent } from '@/api/signalr'
+import { ImageLightbox } from '@/components/ui/ImageLightbox'
+import { Toast } from '@/lib/toast'
+import { href } from '@/lib/navigation'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Compute the current day number for a workflow request. */
+function computeCurrentDay(
+  acceptedAt: string | undefined,
+  durationDays: number,
+): number {
+  if (!acceptedAt) return 1
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysSince = Math.floor((Date.now() - new Date(acceptedAt).getTime()) / msPerDay)
+  return Math.min(daysSince + 1, durationDays)
+}
+
+/** ISO date string for the start of a given workflow day (midnight local). */
+function dayStartDate(acceptedAt: string, dayIndex: number): Date {
+  const accepted = new Date(acceptedAt)
+  // Reset to midnight local of accepted-at day, then add dayIndex days.
+  const base = new Date(accepted.getFullYear(), accepted.getMonth(), accepted.getDate())
+  base.setDate(base.getDate() + dayIndex)
+  return base
+}
+
+/** True if a photo's dateCreated falls on the client's local today. */
+function isToday(dateStr: string | undefined): boolean {
+  if (!dateStr) return false
+  const d = new Date(dateStr)
+  const now = new Date()
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  )
+}
+
+/** Day index (0-based) a photo belongs to, relative to acceptedAt midnight. */
+function photoDayIndex(dateStr: string | undefined, acceptedAt: string): number {
+  if (!dateStr) return 0
+  const msPerDay = 24 * 60 * 60 * 1000
+  const acceptedMidnight = new Date(
+    new Date(acceptedAt).getFullYear(),
+    new Date(acceptedAt).getMonth(),
+    new Date(acceptedAt).getDate(),
+  ).getTime()
+  return Math.max(0, Math.floor((new Date(dateStr).getTime() - acceptedMidnight) / msPerDay))
+}
+
+/** Format a Date as short locale date string. */
+function formatShortDate(date: Date, lng: string): string {
+  return date.toLocaleDateString(lng, { weekday: 'short', day: 'numeric', month: 'numeric' })
+}
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface PreviousDayGroup {
+  dayNumber: number   // 1-based
+  dayIndex: number    // 0-based (0 = Day 1)
+  date: Date
+  photos: PlanPhotoResponse[]
+}
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
 
 export function DiaryWorkflowScreen() {
   const colors = useTheme()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const router = useRouter()
+  const queryClient = useQueryClient()
+  const { width } = useWindowDimensions()
+  const systemScheme = useColorScheme()
+  const preference = useThemeStore((s) => s.preference)
+  const effectiveScheme = preference === 'system' ? (systemScheme ?? 'light') : preference
+
+  const goldBg = effectiveScheme === 'dark' ? goldAlpha['10'] : goldAlpha['08']
+  const goldBorder = effectiveScheme === 'dark' ? goldAlpha['25'] : goldAlpha['20']
+
   const { requestId } = useLocalSearchParams<{ requestId: string }>()
 
-  return (
-    <SafeAreaView
-      style={[styles.container, { backgroundColor: colors.bg }]}
-      edges={['top', 'bottom']}
-    >
-      <View style={styles.content}>
-        {/* Header */}
-        <Pressable
-          onPress={() => router.back()}
-          style={[styles.backBtn, { backgroundColor: colors.fill }]}
-          accessibilityRole="button"
-          accessibilityLabel={t('common.back')}
-        >
-          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
-        </Pressable>
+  // ── Lightbox state ──
+  const [lightboxVisible, setLightboxVisible] = useState(false)
+  const [lightboxImages, setLightboxImages] = useState<string[]>([])
+  const [lightboxNotes, setLightboxNotes] = useState<(string | null)[]>([])
+  const [lightboxIndex, setLightboxIndex] = useState(0)
 
-        {/* Placeholder content — replaced by workflow flow in #101 */}
-        <View style={styles.placeholder}>
-          <Text style={styles.icon}>📅</Text>
-          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
+  // ── Query: diary request metadata ──
+  const requestQuery = useQuery<ClientPhotoDiaryRequestSummary | undefined>({
+    queryKey: ['diary-request', requestId],
+    queryFn: () => getDiaryRequestById(requestId ?? ''),
+    enabled: !!requestId,
+    staleTime: 60_000,
+  })
+  const request = requestQuery.data
+
+  const durationDays = request?.durationDays ?? 7
+  const currentDay = computeCurrentDay(request?.acceptedAt, durationDays)
+  const isFinalDay = currentDay >= durationDays
+
+  // ── Query: plan photos filtered to this diary request ──
+  const planId = request?.planId
+  const photosQuery = useQuery<PlanPhotoResponse[]>({
+    queryKey: ['plan-photos', planId],
+    queryFn: () => getPlanPhotos(planId ?? '', 1, 200),
+    enabled: !!planId,
+    staleTime: 30_000,
+  })
+
+  // Photos belonging to this diary request
+  const diaryPhotos = useMemo(
+    () => (photosQuery.data ?? []).filter((p) => p.diaryRequestId === requestId),
+    [photosQuery.data, requestId],
+  )
+
+  // Today's photos
+  const todayPhotos = useMemo(
+    () => diaryPhotos.filter((p) => isToday(p.dateCreated)),
+    [diaryPhotos],
+  )
+
+  // Previous day groups (days before today, each with their photos)
+  const previousDayGroups = useMemo((): PreviousDayGroup[] => {
+    if (!request?.acceptedAt) return []
+
+    // We only show days 0..currentDay-2 (i.e., completed days before today)
+    const groups: PreviousDayGroup[] = []
+    for (let idx = 0; idx < currentDay - 1; idx++) {
+      const date = dayStartDate(request.acceptedAt, idx)
+      const dayNumber = idx + 1
+      const photos = diaryPhotos.filter(
+        (p) => photoDayIndex(p.dateCreated, request.acceptedAt!) === idx,
+      )
+      groups.push({ dayNumber, dayIndex: idx, date, photos })
+    }
+    // Show most recent first
+    return groups.slice().reverse()
+  }, [diaryPhotos, currentDay, request?.acceptedAt])
+
+  // ── SignalR: invalidate photos when new upload arrives ──
+  useEffect(() => {
+    const off = onEvent('planphotouploaded', (payload: unknown) => {
+      const data = payload as { planId?: string } | null
+      if (!data?.planId || data.planId === planId) {
+        queryClient.invalidateQueries({ queryKey: ['plan-photos', planId] })
+      }
+    })
+    return off
+  }, [planId, queryClient])
+
+  // ── SignalR: navigate away when diary is submitted (auto-close or manual) ──
+  useEffect(() => {
+    const off = onEvent('photodiarysubmitted', (payload: unknown) => {
+      const data = payload as { diaryRequestId?: string } | null
+      if (!data?.diaryRequestId || data.diaryRequestId === requestId) {
+        queryClient.invalidateQueries({ queryKey: ['active-workflow-diary-requests'] })
+        queryClient.invalidateQueries({ queryKey: ['diary-request', requestId] })
+        // Navigate back to Today — the diary is done
+        router.replace(href('/(client)/(tabs)'))
+      }
+    })
+    return off
+  }, [requestId, router, queryClient])
+
+  // ── Finalize photo mutation ──
+  const finalizeMutation = useMutation({
+    mutationFn: async (blobUrl: string) => {
+      if (!planId) throw new Error('No planId')
+      return finalizePlanPhoto(planId, {
+        blobUrl,
+        category: PlanPhotoCategory.FreeForm,
+        diaryRequestId: requestId,
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan-photos', planId] })
+    },
+    onError: () => {
+      Toast.show(t('diary.bulk.errorUpload'))
+    },
+  })
+
+  // ── Image picker ──
+  const { pick, uploading } = useImagePicker(
+    {
+      source: 'both',
+      requestUploadUrl: async ({ contentType, sizeBytes }) => {
+        if (!planId) throw new Error('No planId')
+        return generatePlanPhotoUploadUrl(planId, contentType, sizeBytes)
+      },
+    },
+    (blobUrl) => {
+      finalizeMutation.mutate(blobUrl)
+    },
+  )
+
+  const isUploading = uploading || finalizeMutation.isPending
+
+  // ── Lightbox helpers ──
+  const openLightboxForPhotos = useCallback(
+    (photos: PlanPhotoResponse[], index: number) => {
+      setLightboxImages(photos.map((p) => p.blobUrl ?? '').filter(Boolean))
+      setLightboxNotes(photos.map((p) => p.description ?? null))
+      setLightboxIndex(index)
+      setLightboxVisible(true)
+    },
+    [],
+  )
+
+  // ── Grid tile size (2 columns) ──
+  const MARGIN = 20
+  const GAP = 10
+  const tileSize = (width - MARGIN * 2 - GAP) / 2
+
+  // ── Loading state ──
+  if (requestQuery.isLoading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top']}>
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.gold} />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  // ── Completed state (shouldn't normally render — SignalR redirects) ──
+  if (request?.status === 'Completed') {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+        <View style={[styles.header, { borderBottomColor: colors.sep2 }]}>
+          <Pressable
+            onPress={() => router.back()}
+            hitSlop={12}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.back')}
+            style={[styles.closeBtn, { backgroundColor: colors.fill }]}
+          >
+            <Ionicons name="chevron-back" size={18} color={colors.label2} />
+          </Pressable>
+          <Text style={[Type.headline, { color: colors.label }]}>
             {t('diary.workflow.title')}
           </Text>
-          <Text
-            style={[
-              Type.footnote,
-              { color: colors.label2, marginTop: 8, textAlign: 'center' },
-            ]}
-          >
-            {requestId}
+          <View style={styles.closeBtnSpacer} />
+        </View>
+        <View style={styles.centered}>
+          <Text style={[Type.largeTitle, { textAlign: 'center' }]}>✅</Text>
+          <Text style={[Type.title3, { color: colors.label, marginTop: 12, textAlign: 'center' }]}>
+            {t('diary.workflow.completedTitle')}
           </Text>
-          <Text
-            style={[
-              Type.caption1,
-              { color: colors.label3, marginTop: 24, textAlign: 'center' },
-            ]}
-          >
-            {t('diary.workflow.placeholder')}
+          <Text style={[Type.footnote, { color: colors.label2, marginTop: 8, textAlign: 'center' }]}>
+            {t('diary.workflow.completedSub')}
           </Text>
         </View>
+      </SafeAreaView>
+    )
+  }
+
+  const daysLeft = Math.max(0, durationDays - currentDay)
+  const daysLeftKey =
+    daysLeft === 1
+      ? 'diary.workflow.daysLeft_one'
+      : daysLeft < 5
+        ? 'diary.workflow.daysLeft_few'
+        : 'diary.workflow.daysLeft_many'
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
+      {/* ── Header ── */}
+      <View style={[styles.header, { borderBottomColor: colors.sep2 }]}>
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+          style={[styles.closeBtn, { backgroundColor: colors.fill }]}
+        >
+          <Ionicons name="chevron-back" size={18} color={colors.label2} />
+        </Pressable>
+        <View style={styles.headerTextBlock}>
+          <Text style={[Type.headline, { color: colors.label }]} numberOfLines={1}>
+            {t('diary.workflow.title')}
+          </Text>
+          {request && (
+            <Text style={[Type.caption1, { color: colors.label2 }]} numberOfLines={1}>
+              {t('diary.workflow.headerSub', {
+                day: currentDay,
+                total: durationDays,
+                name: '',
+              }).replace(' · ', '')}
+            </Text>
+          )}
+        </View>
+        <View style={styles.closeBtnSpacer} />
       </View>
+
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Progress banner ── */}
+        <View
+          style={[
+            styles.progressBanner,
+            {
+              backgroundColor: goldBg,
+              borderColor: goldBorder,
+            },
+          ]}
+        >
+          <View style={styles.progressTopRow}>
+            <Text style={[Type.headline, { color: colors.label }]}>
+              {t('diary.workflow.dayCounter', { day: currentDay, total: durationDays })}
+            </Text>
+            <View style={styles.dots}>
+              {Array.from({ length: durationDays }).map((_, i) => {
+                const isDone = i < currentDay - 1
+                const isCurrent = i === currentDay - 1
+                return (
+                  <View
+                    key={i}
+                    style={[
+                      styles.dot,
+                      isDone
+                        ? { backgroundColor: colors.gold }
+                        : isCurrent
+                          ? {
+                              backgroundColor: 'transparent',
+                              borderWidth: 1.5,
+                              borderColor: colors.gold,
+                            }
+                          : { backgroundColor: colors.fill },
+                    ]}
+                  />
+                )
+              })}
+            </View>
+          </View>
+          <Text style={[Type.caption1, { color: colors.label2, marginTop: 6 }]}>
+            {daysLeft > 0
+              ? `${t(daysLeftKey, { count: daysLeft })} · ${t('diary.workflow.photosCount', { count: diaryPhotos.length })}`
+              : t('diary.workflow.photosCount', { count: diaryPhotos.length })}
+          </Text>
+        </View>
+
+        {/* ── Add photo CTA ── */}
+        <Pressable
+          onPress={pick}
+          disabled={isUploading}
+          accessibilityRole="button"
+          style={({ pressed }) => [
+            styles.addPhotoCta,
+            { backgroundColor: colors.gold, opacity: pressed || isUploading ? 0.7 : 1 },
+          ]}
+        >
+          {isUploading ? (
+            <ActivityIndicator size="small" color={colors.onAccent} />
+          ) : (
+            <Text style={[Type.subheadline, { color: colors.onAccent, fontWeight: '600' }]}>
+              + {t('diary.workflow.addPhoto')}
+            </Text>
+          )}
+        </Pressable>
+
+        {/* ── Today's photos ── */}
+        <View style={styles.sectionHeader}>
+          <Text style={[Type.footnote, styles.sectionTitle, { color: colors.label2 }]}>
+            {todayPhotos.length > 0
+              ? t('diary.workflow.todaySection', { count: todayPhotos.length })
+              : t('diary.workflow.todaySectionEmpty')}
+          </Text>
+        </View>
+
+        {todayPhotos.length === 0 ? (
+          <View style={[styles.emptyTodayBox, { backgroundColor: colors.bg2, borderColor: colors.sep2 }]}>
+            <Ionicons name="camera-outline" size={28} color={colors.label3} />
+            <Text style={[Type.footnote, { color: colors.label3, marginTop: 6 }]}>
+              {t('diary.workflow.addPhoto')}
+            </Text>
+          </View>
+        ) : (
+          <View style={[styles.photoGrid, { paddingHorizontal: MARGIN }]}>
+            {todayPhotos.map((photo, index) => (
+              <Pressable
+                key={photo.id ?? index}
+                onPress={() => openLightboxForPhotos(todayPhotos, index)}
+                accessibilityRole="button"
+                style={[styles.tile, { width: tileSize, height: tileSize, backgroundColor: colors.fill2 }]}
+              >
+                <Image
+                  source={{ uri: photo.blobUrl }}
+                  style={StyleSheet.absoluteFill}
+                  resizeMode="cover"
+                />
+                {photo.description ? (
+                  <View style={styles.tileCaption}>
+                    <Text style={styles.tileCaptionText} numberOfLines={1}>
+                      {photo.description}
+                    </Text>
+                  </View>
+                ) : null}
+              </Pressable>
+            ))}
+          </View>
+        )}
+
+        {/* ── Previous days ── */}
+        {previousDayGroups.length > 0 && (
+          <>
+            <View style={styles.sectionHeader}>
+              <Text style={[Type.footnote, styles.sectionTitle, { color: colors.label2 }]}>
+                {t('diary.workflow.previousSection')}
+              </Text>
+            </View>
+
+            <View style={[styles.listCard, { backgroundColor: colors.bg2, borderColor: colors.sep2 }]}>
+              {previousDayGroups.map((group, groupIndex) => {
+                const countKey =
+                  group.photos.length === 1
+                    ? 'diary.workflow.previousPhotoCount_one'
+                    : group.photos.length < 5
+                      ? 'diary.workflow.previousPhotoCount_few'
+                      : 'diary.workflow.previousPhotoCount_many'
+                return (
+                  <React.Fragment key={group.dayIndex}>
+                    {groupIndex > 0 && (
+                      <View style={[styles.separator, { backgroundColor: colors.sep2 }]} />
+                    )}
+                    <Pressable
+                      onPress={() => {
+                        if (group.photos.length > 0) {
+                          openLightboxForPhotos(group.photos, 0)
+                        }
+                      }}
+                      accessibilityRole="button"
+                      style={({ pressed }) => [
+                        styles.listRow,
+                        { opacity: pressed ? 0.7 : 1 },
+                      ]}
+                    >
+                      <View style={[styles.rowIcon, { backgroundColor: colors.goldBg }]}>
+                        <Text style={styles.rowIconEmoji}>📸</Text>
+                      </View>
+                      <View style={styles.rowBody}>
+                        <Text style={[Type.subheadline, { color: colors.label }]}>
+                          {t('diary.workflow.previousDayRow', {
+                            day: group.dayNumber,
+                            date: formatShortDate(group.date, i18n.language),
+                          })}
+                        </Text>
+                        <Text style={[Type.caption1, { color: colors.label2 }]}>
+                          {t(countKey, { count: group.photos.length })}
+                        </Text>
+                      </View>
+                      {group.photos.length > 0 && (
+                        <Text style={[Type.headline, { color: colors.label3 }]}>›</Text>
+                      )}
+                    </Pressable>
+                  </React.Fragment>
+                )
+              })}
+            </View>
+          </>
+        )}
+
+        {/* ── Coach note ── */}
+        <View
+          style={[
+            styles.coachNote,
+            { backgroundColor: colors.bg2, borderColor: colors.sep2 },
+          ]}
+        >
+          <Text style={[Type.footnote, { color: colors.label2, lineHeight: 20 }]}>
+            {t('diary.workflow.coachNote', { name: '' }).trim().replace(/^·\s*/, '')}
+          </Text>
+        </View>
+
+        {/* ── Finalize CTA — only on day N ── */}
+        {isFinalDay && (
+          <Pressable
+            onPress={() => router.push(href(`/(client)/diary/${requestId}/finalize`))}
+            accessibilityRole="button"
+            style={({ pressed }) => [
+              styles.finalizeBtn,
+              { borderColor: colors.gold, opacity: pressed ? 0.7 : 1 },
+            ]}
+          >
+            <Text style={[Type.subheadline, { color: colors.gold, fontWeight: '600' }]}>
+              {t('diary.workflow.finalizeCtaLabel')}
+            </Text>
+          </Pressable>
+        )}
+
+        <View style={styles.bottomSpacer} />
+      </ScrollView>
+
+      {/* ── Lightbox ── */}
+      <ImageLightbox
+        visible={lightboxVisible}
+        images={lightboxImages}
+        startIndex={lightboxIndex}
+        onClose={() => setLightboxVisible(false)}
+        imageNotes={lightboxNotes}
+      />
     </SafeAreaView>
   )
 }
 
+export default DiaryWorkflowScreen
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  content: {
-    flex: 1,
-    padding: 20,
-  },
-  backBtn: {
-    alignSelf: 'flex-start',
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: Radius.md,
-    marginBottom: 32,
-  },
-  placeholder: {
+  container: { flex: 1 },
+  centered: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    padding: 32,
+    gap: 8,
   },
-  icon: {
-    fontSize: 48,
-    marginBottom: 20,
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 8,
+  },
+  headerTextBlock: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  closeBtnSpacer: {
+    width: 32,
+    flexShrink: 0,
+  },
+
+  scroll: {
+    paddingBottom: 40,
+  },
+
+  // Progress banner
+  progressBanner: {
+    marginHorizontal: 20,
+    marginTop: 16,
+    marginBottom: 4,
+    padding: 16,
+    borderWidth: 1,
+    borderRadius: Radius.lg,
+  },
+  progressTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 2,
+  },
+  dots: {
+    flexDirection: 'row',
+    gap: 4,
+    alignItems: 'center',
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+
+  // Add photo CTA
+  addPhotoCta: {
+    marginHorizontal: 20,
+    marginTop: 16,
+    marginBottom: 4,
+    paddingVertical: 14,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 6,
+    minHeight: 48,
+  },
+
+  // Section header
+  sectionHeader: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 8,
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+
+  // Empty today state
+  emptyTodayBox: {
+    marginHorizontal: 20,
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+    paddingVertical: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderStyle: 'dashed',
+  },
+
+  // Photo grid
+  photoGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  tile: {
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+  },
+  tileCaption: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  tileCaptionText: {
+    color: '#ffffff',
+    fontSize: 11,
+  },
+
+  // List card (previous days)
+  listCard: {
+    marginHorizontal: 20,
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  listRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    gap: 12,
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    marginLeft: 16 + 36 + 12, // indent past icon
+  },
+  rowIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  rowIconEmoji: {
+    fontSize: 16,
+  },
+  rowBody: {
+    flex: 1,
+    minWidth: 0,
+  },
+
+  // Coach note
+  coachNote: {
+    marginHorizontal: 20,
+    marginTop: 20,
+    padding: 14,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+  },
+
+  // Finalize CTA
+  finalizeBtn: {
+    marginHorizontal: 20,
+    marginTop: 16,
+    paddingVertical: 14,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    borderWidth: 1.5,
+  },
+
+  bottomSpacer: {
+    height: 20,
   },
 })
-
-export default DiaryWorkflowScreen

--- a/mobile/src/api/diaryRequests.ts
+++ b/mobile/src/api/diaryRequests.ts
@@ -9,13 +9,14 @@ import type {
   AcceptRequestRequest,
   AcceptRequestResponse,
   ClientPhotoDiaryRequestSummary,
+  ListClientRequestsResponse,
   SubmitRequestResponse,
 } from './generated'
-import { PhotoDiaryMode } from './generated'
+import { PhotoDiaryMode, PhotoDiaryStatus } from './generated'
 
 // Re-export so consumers only need one import.
-export { PhotoDiaryMode }
-export type { ClientPhotoDiaryRequestSummary, SubmitRequestResponse }
+export { PhotoDiaryMode, PhotoDiaryStatus }
+export type { ClientPhotoDiaryRequestSummary, ListClientRequestsResponse, SubmitRequestResponse }
 
 /**
  * Accept a pending photo-diary request with the chosen upload mode.
@@ -34,6 +35,43 @@ export async function acceptDiaryRequest(
     body,
   )
   return data
+}
+
+/**
+ * Fetch a single photo-diary request by ID.
+ *
+ * The backend does not expose a dedicated GET-by-id endpoint; we fetch the
+ * full list filtered to the specific request's status and then find the one
+ * we care about. In practice the list for a single client is small (< 20).
+ *
+ * `GET /client/photo-diary-requests`
+ */
+export async function getDiaryRequestById(
+  requestId: string,
+): Promise<ClientPhotoDiaryRequestSummary | undefined> {
+  const { data } = await api.get<ListClientRequestsResponse>(
+    '/client/photo-diary-requests',
+    { params: { page: 1, pageSize: 50 } },
+  )
+  return (data.items ?? []).find((r) => r.id === requestId)
+}
+
+/**
+ * Fetch active workflow diary requests for the client.
+ * "Active" means Mode === Workflow AND Status ∈ {Accepted, InProgress}.
+ *
+ * `GET /client/photo-diary-requests`
+ */
+export async function getActiveWorkflowDiaryRequests(): Promise<ClientPhotoDiaryRequestSummary[]> {
+  const { data } = await api.get<ListClientRequestsResponse>(
+    '/client/photo-diary-requests',
+    { params: { page: 1, pageSize: 50 } },
+  )
+  return (data.items ?? []).filter(
+    (r) =>
+      r.mode === PhotoDiaryMode.Workflow &&
+      (r.status === PhotoDiaryStatus.Accepted || r.status === PhotoDiaryStatus.InProgress),
+  )
 }
 
 /**

--- a/mobile/src/api/signalr.ts
+++ b/mobile/src/api/signalr.ts
@@ -29,6 +29,10 @@ const KNOWN_EVENTS = [
   // Plan photo uploaded: fires when a PlanPhoto record is finalized.
   // Payload: { planId: string, photoId: string }
   'planphotouploaded',
+  // Photo diary submitted: fires when a diary request transitions to Completed
+  // (either via client submit OR the server-side auto-finalize scheduler on day N+1).
+  // Payload: { diaryRequestId: string }
+  'photodiarysubmitted',
 ]
 
 function createConnection(): HubConnection {

--- a/mobile/src/components/today/DiaryWorkflowBanner.tsx
+++ b/mobile/src/components/today/DiaryWorkflowBanner.tsx
@@ -1,0 +1,194 @@
+/**
+ * DiaryWorkflowBanner — persistent Today-screen banner for an active 7-day
+ * workflow diary request.
+ *
+ * Shown when Mode === Workflow AND Status ∈ {Accepted, InProgress}.
+ * Tapping opens the workflow screen.
+ */
+import React, { useEffect, useRef } from 'react'
+import { View, Text, StyleSheet, Pressable, Animated, useColorScheme } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { useThemeStore } from '@/stores/themeStore'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { goldAlpha } from '@/constants/colors'
+import type { ClientPhotoDiaryRequestSummary } from '@/api/diaryRequests'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the current day number: min(daysSince(acceptedAt) + 1, durationDays).
+ * Returns 1 when acceptedAt is absent as a safe fallback.
+ */
+function computeCurrentDay(
+  acceptedAt: string | undefined,
+  durationDays: number,
+): number {
+  if (!acceptedAt) return 1
+  const accepted = new Date(acceptedAt)
+  const now = new Date()
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysSince = Math.floor((now.getTime() - accepted.getTime()) / msPerDay)
+  return Math.min(daysSince + 1, durationDays)
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+interface DiaryWorkflowBannerProps {
+  request: ClientPhotoDiaryRequestSummary
+  professionalName?: string
+  onOpen: () => void
+}
+
+export function DiaryWorkflowBanner({
+  request,
+  professionalName,
+  onOpen,
+}: DiaryWorkflowBannerProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+  const systemScheme = useColorScheme()
+  const preference = useThemeStore((s) => s.preference)
+  const effectiveScheme = preference === 'system' ? (systemScheme ?? 'light') : preference
+
+  const goldBg = effectiveScheme === 'dark' ? goldAlpha['10'] : goldAlpha['08']
+  const goldBorder = effectiveScheme === 'dark' ? goldAlpha['25'] : goldAlpha['20']
+
+  const opacity = useRef(new Animated.Value(0)).current
+  const translateY = useRef(new Animated.Value(-40)).current
+
+  useEffect(() => {
+    Animated.parallel([
+      Animated.spring(translateY, {
+        toValue: 0,
+        damping: 16,
+        stiffness: 100,
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 500,
+        useNativeDriver: true,
+      }),
+    ]).start()
+  }, [opacity, translateY])
+
+  const durationDays = request.durationDays ?? 7
+  const currentDay = computeCurrentDay(request.acceptedAt, durationDays)
+  const daysLeft = Math.max(0, durationDays - currentDay)
+
+  const daysLeftKey =
+    daysLeft === 1
+      ? 'diary.workflow.daysLeft_one'
+      : daysLeft < 5
+        ? 'diary.workflow.daysLeft_few'
+        : 'diary.workflow.daysLeft_many'
+
+  return (
+    <Animated.View style={[styles.wrapper, { opacity, transform: [{ translateY }] }]}>
+      <Pressable
+        onPress={onOpen}
+        accessibilityRole="button"
+        accessibilityLabel={t('diary.workflowBanner.title')}
+        style={({ pressed }) => [
+          styles.card,
+          {
+            backgroundColor: goldBg,
+            borderColor: goldBorder,
+            opacity: pressed ? 0.8 : 1,
+          },
+        ]}
+      >
+        {/* Top row: title + open label */}
+        <View style={styles.topRow}>
+          <Text style={[Type.footnote, styles.eyebrow, { color: colors.gold }]}>
+            {t('diary.workflowBanner.title')}
+          </Text>
+          <Text style={[Type.footnote, { color: colors.gold }]}>
+            {t('diary.workflowBanner.open')} ›
+          </Text>
+        </View>
+
+        {/* Day counter row + dots */}
+        <View style={styles.counterRow}>
+          <Text style={[Type.headline, { color: colors.label }]}>
+            {t('diary.workflowBanner.dayCounter', { day: currentDay, total: durationDays })}
+          </Text>
+          <View style={styles.dots}>
+            {Array.from({ length: durationDays }).map((_, i) => {
+              const isDone = i < currentDay - 1
+              const isCurrent = i === currentDay - 1
+              return (
+                <View
+                  key={i}
+                  style={[
+                    styles.dot,
+                    isDone
+                      ? { backgroundColor: colors.gold }
+                      : isCurrent
+                        ? {
+                            backgroundColor: 'transparent',
+                            borderWidth: 1.5,
+                            borderColor: colors.gold,
+                          }
+                        : { backgroundColor: colors.fill },
+                  ]}
+                />
+              )
+            })}
+          </View>
+        </View>
+
+        {/* Sub-text */}
+        <Text style={[Type.caption1, { color: colors.label2, marginTop: 4 }]}>
+          {daysLeft > 0
+            ? t(daysLeftKey, { count: daysLeft })
+            : professionalName
+              ? t('diary.workflow.coachNote', { name: professionalName })
+              : t('diary.workflowBanner.title')}
+        </Text>
+      </Pressable>
+    </Animated.View>
+  )
+}
+
+export default DiaryWorkflowBanner
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginHorizontal: 16,
+    marginTop: 16,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: Radius.lg,
+    padding: 16,
+  },
+  topRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  eyebrow: {
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  counterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  dots: {
+    flexDirection: 'row',
+    gap: 4,
+    alignItems: 'center',
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+})

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -1013,8 +1013,48 @@
       "errorSubmit": "Odeslání se nezdařilo. Zkus to znovu."
     },
     "workflow": {
-      "title": "Sedmidenní workflow",
-      "placeholder": "Tady uvidíš každodenní průběh sdílení fotografií. (Implementováno v #101)"
+      "title": "Foto-deník",
+      "headerSub": "Den {{day}} ze {{total}} · {{name}}",
+      "daySuffix": "den",
+      "daysLeft_one": "Ještě {{count}} den do odevzdání",
+      "daysLeft_few": "Ještě {{count}} dny do odevzdání",
+      "daysLeft_many": "Ještě {{count}} dní do odevzdání",
+      "daysLeft_other": "Ještě {{count}} dní do odevzdání",
+      "dayCounter": "Den {{day}} ze {{total}}",
+      "photosCount": "{{count}} fotek nahráno",
+      "addPhoto": "Přidat fotku dnes",
+      "todaySection": "Dnešní fotky ({{count}})",
+      "todaySectionEmpty": "Dnešní fotky",
+      "previousSection": "Předchozí dny",
+      "previousDayRow": "Den {{day}} · {{date}}",
+      "previousPhotoCount_one": "{{count}} fotka",
+      "previousPhotoCount_few": "{{count}} fotky",
+      "previousPhotoCount_many": "{{count}} fotek",
+      "previousPhotoCount_other": "{{count}} fotek",
+      "coachNote": "{{name}} vidí tvé fotky v reálném čase. Buď upřímný — i když jsi zhřešil.",
+      "finalizeCtaLabel": "Odevzdat deník",
+      "completedTitle": "Deník byl odeslán",
+      "completedSub": "Tvůj kouč obdržel všechny fotky."
+    },
+    "finalize": {
+      "title": "Den {{day}} · dokončit",
+      "heroTitle": "Poslední den foto-deníku",
+      "heroSub": "Máš {{photos}} fotek za {{days}} dní. Můžeš ještě přidat dnešní, nebo rovnou odevzdat.",
+      "statPhotos": "fotek celkem",
+      "statDays": "dní splněno",
+      "statAttendance": "docházka",
+      "lastPhotosSection": "Naposledy přidat",
+      "lastPhotosCta": "Přidat poslední fotku",
+      "lastPhotosHint": "Galerie nebo fotoaparát",
+      "submitCta": "Odevzdat kouči",
+      "addMoreCta": "Přidat ještě fotku",
+      "successToast": "Deník odeslán!",
+      "errorSubmit": "Odeslání se nezdařilo. Zkus to znovu."
+    },
+    "workflowBanner": {
+      "title": "Foto-deník · aktivní",
+      "dayCounter": "Den {{day}} ze {{total}}",
+      "open": "Otevřít"
     }
   }
 }

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -1002,8 +1002,44 @@
       "errorSubmit": "Senden fehlgeschlagen. Bitte erneut versuchen."
     },
     "workflow": {
-      "title": "7-Tage-Workflow",
-      "placeholder": "Hier siehst du den täglichen Fotoablauf. (Implementiert in #101)"
+      "title": "Foto-Tagebuch",
+      "headerSub": "Tag {{day}} von {{total}} · {{name}}",
+      "daySuffix": "Tag",
+      "daysLeft_one": "Noch {{count}} Tag bis zur Abgabe",
+      "daysLeft_other": "Noch {{count}} Tage bis zur Abgabe",
+      "dayCounter": "Tag {{day}} von {{total}}",
+      "photosCount": "{{count}} Fotos hochgeladen",
+      "addPhoto": "Heute ein Foto hinzufügen",
+      "todaySection": "Heutige Fotos ({{count}})",
+      "todaySectionEmpty": "Heutige Fotos",
+      "previousSection": "Vorherige Tage",
+      "previousDayRow": "Tag {{day}} · {{date}}",
+      "previousPhotoCount_one": "{{count}} Foto",
+      "previousPhotoCount_other": "{{count}} Fotos",
+      "coachNote": "{{name}} sieht deine Fotos in Echtzeit. Sei ehrlich — auch wenn du gesündigt hast.",
+      "finalizeCtaLabel": "Tagebuch abgeben",
+      "completedTitle": "Tagebuch abgegeben",
+      "completedSub": "Dein Coach hat alle Fotos erhalten."
+    },
+    "finalize": {
+      "title": "Tag {{day}} · abschließen",
+      "heroTitle": "Letzter Tag des Foto-Tagebuchs",
+      "heroSub": "Du hast {{photos}} Fotos über {{days}} Tage. Du kannst heute noch mehr hinzufügen oder sofort abgeben.",
+      "statPhotos": "Fotos gesamt",
+      "statDays": "Tage abgeschlossen",
+      "statAttendance": "Teilnahme",
+      "lastPhotosSection": "Letztes Foto hinzufügen",
+      "lastPhotosCta": "Letztes Foto hinzufügen",
+      "lastPhotosHint": "Galerie oder Kamera",
+      "submitCta": "An Coach abgeben",
+      "addMoreCta": "Noch ein Foto hinzufügen",
+      "successToast": "Tagebuch abgegeben!",
+      "errorSubmit": "Abgabe fehlgeschlagen. Bitte erneut versuchen."
+    },
+    "workflowBanner": {
+      "title": "Foto-Tagebuch · aktiv",
+      "dayCounter": "Tag {{day}} von {{total}}",
+      "open": "Öffnen"
     }
   }
 }

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -1003,8 +1003,44 @@
       "errorSubmit": "Submission failed. Please try again."
     },
     "workflow": {
-      "title": "7-Day Workflow",
-      "placeholder": "Here you will see the daily photo-sharing flow. (Implemented in #101)"
+      "title": "Photo Diary",
+      "headerSub": "Day {{day}} of {{total}} · {{name}}",
+      "daySuffix": "day",
+      "daysLeft_one": "{{count}} day left until submission",
+      "daysLeft_other": "{{count}} days left until submission",
+      "dayCounter": "Day {{day}} of {{total}}",
+      "photosCount": "{{count}} photos uploaded",
+      "addPhoto": "Add a photo today",
+      "todaySection": "Today's photos ({{count}})",
+      "todaySectionEmpty": "Today's photos",
+      "previousSection": "Previous days",
+      "previousDayRow": "Day {{day}} · {{date}}",
+      "previousPhotoCount_one": "{{count}} photo",
+      "previousPhotoCount_other": "{{count}} photos",
+      "coachNote": "{{name}} sees your photos in real time. Be honest — even if you slipped.",
+      "finalizeCtaLabel": "Submit diary",
+      "completedTitle": "Diary submitted",
+      "completedSub": "Your coach has received all photos."
+    },
+    "finalize": {
+      "title": "Day {{day}} · finish",
+      "heroTitle": "Last day of photo diary",
+      "heroSub": "You have {{photos}} photos over {{days}} days. You can still add more today, or submit right away.",
+      "statPhotos": "photos total",
+      "statDays": "days completed",
+      "statAttendance": "attendance",
+      "lastPhotosSection": "Add one last photo",
+      "lastPhotosCta": "Add last photo",
+      "lastPhotosHint": "Gallery or camera",
+      "submitCta": "Submit to coach",
+      "addMoreCta": "Add another photo",
+      "successToast": "Diary submitted!",
+      "errorSubmit": "Submission failed. Please try again."
+    },
+    "workflowBanner": {
+      "title": "Photo diary · active",
+      "dayCounter": "Day {{day}} of {{total}}",
+      "open": "Open"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the placeholder screen at `mobile/app/(client)/diary/[requestId]/workflow.tsx` (created in #99) with the full 7-day live photo-stream implementation: day-counter header, progress dot strip, today's photo grid, previous-day grouped rows, and coach note.
- Adds the finalize prompt screen at `[requestId]/finalize.tsx` — visible only on day N; shows summary stats (photos, days attended, attendance %) and "Submit to coach" CTA.
- Adds `DiaryWorkflowBanner` (gold-tinted, uses `goldAlpha` tokens + `Radius.*` + `Type.*`) to the Today screen, one per active workflow request.
- Auto-close on day N+1 is server-side (#95 scheduler); the client consumes the `photodiarysubmitted` SignalR event to invalidate the `['active-workflow-diary-requests']` query so the banner disappears without a pull-to-refresh.
- Reuses #66's upload pipeline (`generatePlanPhotoUploadUrl`, `finalizePlanPhoto` with `diaryRequestId` threaded through) — no new backend endpoints needed; `generated.ts` is untouched.

## Related issue

Fixes #101

## Parent epic (sub-issue PR)

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL ✅ PASS at commit `3f4714a`.

## Test plan

- [ ] Auto-closes + submits on day N+1 if the client ignores finalize (server-side scheduler, client reacts to `photodiarysubmitted` SignalR).
- [ ] Push reminders rendered in-app too.
- [ ] Tokens only — no hardcoded brand colors or spacing (photo-overlay `rgba(0,0,0,0.5)` / `#ffffff` / emoji-glyph `fontSize` values follow established codebase pattern; verified against `training-session/[id].tsx`, `LiveFinishedSummary.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)