### PR TITLE
feat(mobile,#102): photo diary dismiss flow with optional reason

### DIFF
--- a/mobile/app/(client)/diary/[requestId]/dismiss.tsx
+++ b/mobile/app/(client)/diary/[requestId]/dismiss.tsx
@@ -294,7 +294,7 @@ const styles = StyleSheet.create({
     paddingTop: 14,
     paddingBottom: 14,
     minHeight: 110,
-    fontSize: 15,
+    ...Type.subheadline,
     lineHeight: 22,
   },
 

--- a/mobile/app/(client)/diary/[requestId]/dismiss.tsx
+++ b/mobile/app/(client)/diary/[requestId]/dismiss.tsx
@@ -1,61 +1,224 @@
 /**
- * Diary request dismiss flow.
+ * Diary Dismiss Screen — confirm + optional reason sheet.
  *
- * TODO(#102): Implement the full dismiss confirmation UI (reason picker,
- * confirmation message, API call to dismiss the request).
- * This file is a placeholder so the DiaryRequestBanner's "Dismiss" CTA
- * navigates to a real route instead of a 404.
+ * Per prototype docs/prototypes/mobile/scenes/diary-dismiss.html:
+ *   1. Modal-style header: screen title + "Cancel" (close) button.
+ *   2. Warning block: orange tint with ⚠️ icon + explanation copy.
+ *   3. Optional reason textarea with character counter (max 500).
+ *   4. Pinned action bar: "Dismiss request" (red) + "Cancel" (secondary).
+ *
+ * Route params: requestId (from [requestId] parent segment).
+ *
+ * Submit flow:
+ *   dismissDiaryRequest({ id, reason }) → toast → invalidate queries → Today.
+ * Cancel: router.back() — no API call.
  */
-import React from 'react'
-import { View, Text, StyleSheet, Pressable } from 'react-native'
+
+import React, { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  TextInput,
+  ActivityIndicator,
+  Platform,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
+import { dismissDiaryRequest } from '@/api/diaryRequests'
+import { Toast } from '@/lib/toast'
+import { href } from '@/lib/navigation'
 
-export default function DiaryDismissScreen() {
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const REASON_MAX_LENGTH = 500
+
+// ─── Screen ──────────────────────────────────────────────────────────────────
+
+export function DiaryDismissScreen() {
   const colors = useTheme()
   const { t } = useTranslation()
   const router = useRouter()
+  const queryClient = useQueryClient()
+
   const { requestId } = useLocalSearchParams<{ requestId: string }>()
 
-  return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]} edges={['top', 'bottom']}>
-      <View style={styles.content}>
-        {/* Header */}
-        <Pressable
-          onPress={() => router.back()}
-          style={[styles.backBtn, { backgroundColor: colors.fill }]}
-          accessibilityRole="button"
-          accessibilityLabel={t('common.back')}
-        >
-          <Text style={[Type.body, { color: colors.label }]}>‹</Text>
-        </Pressable>
+  const [reason, setReason] = useState('')
 
-        {/* Placeholder content — replaced by dismiss flow in #102 */}
-        <View style={styles.placeholder}>
-          <Text style={{ fontSize: 40, marginBottom: 20 }}>🙅</Text>
-          <Text style={[Type.title3, { color: colors.label, textAlign: 'center' }]}>
-            {t('today.diaryBanner.dismissScreenTitle')}
+  // ── Dismiss mutation ──
+  const dismissMutation = useMutation({
+    mutationFn: () =>
+      dismissDiaryRequest({ id: requestId ?? '', reason }),
+    onSuccess: () => {
+      Toast.show(t('diary.dismiss.successToast'))
+      queryClient.invalidateQueries({ queryKey: ['pending-questionnaires'] })
+      queryClient.invalidateQueries({ queryKey: ['active-workflow-diary-requests'] })
+      router.replace(href('/(client)/(tabs)'))
+    },
+    onError: () => {
+      Toast.show(t('diary.dismiss.errorDismiss'))
+    },
+  })
+
+  const handleDismiss = useCallback(() => {
+    dismissMutation.mutate()
+  }, [dismissMutation])
+
+  const handleCancel = useCallback(() => {
+    router.back()
+  }, [router])
+
+  const isPending = dismissMutation.isPending
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      edges={['top', 'bottom']}
+    >
+      {/* ── Modal header ── */}
+      <View style={[styles.header, { borderBottomColor: colors.sep2 }]}>
+        <Pressable
+          onPress={handleCancel}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel={t('diary.dismiss.ctaCancel')}
+          style={styles.headerSideBtn}
+        >
+          <Text style={[Type.subheadline, { color: colors.label2, fontWeight: '600' }]}>
+            {t('diary.dismiss.ctaCancel')}
           </Text>
-          <Text style={[Type.footnote, { color: colors.label2, marginTop: 8, textAlign: 'center' }]}>
-            {requestId}
-          </Text>
-          <Text style={[Type.caption1, { color: colors.label3, marginTop: 24, textAlign: 'center' }]}>
-            {/* This screen will be implemented in issue #102 */}
-            {t('today.diaryBanner.dismissPlaceholder')}
+        </Pressable>
+        <Text style={[Type.subheadline, { color: colors.label, fontWeight: '600' }]}>
+          {t('diary.dismiss.screenTitle')}
+        </Text>
+        {/* Spacer to balance the left button */}
+        <View style={styles.headerSideBtn} />
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Warning block ── */}
+        <View
+          style={[
+            styles.warningBlock,
+            { backgroundColor: colors.fill, borderColor: colors.sep2 },
+          ]}
+        >
+          <Text style={styles.warningIcon}>⚠️</Text>
+          <Text
+            style={[
+              Type.footnote,
+              styles.warningText,
+              { color: colors.label2 },
+            ]}
+          >
+            {t('diary.dismiss.warningText')}
           </Text>
         </View>
 
-        {/* Go back */}
+        {/* ── Reason textarea ── */}
+        <View style={styles.reasonSection}>
+          <View style={styles.reasonLabelRow}>
+            <Text
+              style={[
+                Type.footnote,
+                styles.reasonLabel,
+                { color: colors.label2 },
+              ]}
+            >
+              {t('diary.dismiss.reasonLabel')}
+            </Text>
+            <Text style={[Type.caption1, { color: colors.label3 }]}>
+              {t('diary.dismiss.charCount', {
+                count: reason.length,
+                max: REASON_MAX_LENGTH,
+              })}
+            </Text>
+          </View>
+
+          <TextInput
+            style={[
+              styles.textInput,
+              {
+                backgroundColor: colors.bg2,
+                borderColor: colors.sep2,
+                color: colors.label,
+              },
+            ]}
+            placeholder={t('diary.dismiss.reasonPlaceholder')}
+            placeholderTextColor={colors.label3}
+            multiline
+            textAlignVertical="top"
+            maxLength={REASON_MAX_LENGTH}
+            value={reason}
+            onChangeText={setReason}
+            editable={!isPending}
+            returnKeyType="default"
+            accessibilityLabel={t('diary.dismiss.reasonLabel')}
+          />
+        </View>
+      </ScrollView>
+
+      {/* ── Pinned action bar ── */}
+      <View
+        style={[
+          styles.actionBar,
+          {
+            backgroundColor: colors.bg,
+            borderTopColor: colors.sep2,
+          },
+        ]}
+      >
+        {/* Primary: Dismiss (red) */}
         <Pressable
-          onPress={() => router.back()}
-          style={[styles.goBackBtn, { backgroundColor: colors.fill }]}
+          onPress={handleDismiss}
+          disabled={isPending}
+          accessibilityRole="button"
+          accessibilityLabel={t('diary.dismiss.ctaDismiss')}
+          style={({ pressed }) => [
+            styles.ctaDismiss,
+            {
+              backgroundColor: colors.red,
+              opacity: pressed || isPending ? 0.7 : 1,
+            },
+          ]}
         >
-          <Text style={[Type.subheadline, { color: colors.label, fontWeight: '600' }]}>
-            {t('common.back')}
+          {isPending ? (
+            <ActivityIndicator color={colors.onAccent} size="small" />
+          ) : (
+            <Text style={[Type.subheadline, styles.ctaDismissText, { color: colors.onAccent }]}>
+              {t('diary.dismiss.ctaDismiss')}
+            </Text>
+          )}
+        </Pressable>
+
+        {/* Secondary: Cancel */}
+        <Pressable
+          onPress={handleCancel}
+          disabled={isPending}
+          accessibilityRole="button"
+          accessibilityLabel={t('diary.dismiss.ctaCancel')}
+          style={({ pressed }) => [
+            styles.ctaCancel,
+            {
+              backgroundColor: colors.fill,
+              borderColor: colors.sep2,
+              opacity: pressed || isPending ? 0.7 : 1,
+            },
+          ]}
+        >
+          <Text style={[Type.subheadline, styles.ctaCancelText, { color: colors.label }]}>
+            {t('diary.dismiss.ctaCancel')}
           </Text>
         </Pressable>
       </View>
@@ -63,29 +226,111 @@ export default function DiaryDismissScreen() {
   )
 }
 
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  content: {
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingTop: Platform.OS === 'ios' ? 4 : 8,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerSideBtn: {
+    minWidth: 56,
+  },
+
+  // Scroll content
+  scroll: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 24,
+  },
+
+  // Warning block
+  warningBlock: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    padding: 16,
+    borderRadius: Radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  warningIcon: {
+    fontSize: 20,
+    flexShrink: 0,
+  },
+  warningText: {
     flex: 1,
-    padding: 20,
+    lineHeight: 20,
   },
-  backBtn: {
-    alignSelf: 'flex-start',
-    paddingHorizontal: 14,
-    paddingVertical: 8,
+
+  // Reason section
+  reasonSection: {
+    marginTop: 24,
+  },
+  reasonLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  reasonLabel: {
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  textInput: {
+    borderWidth: StyleSheet.hairlineWidth,
     borderRadius: Radius.md,
-    marginBottom: 32,
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 14,
+    minHeight: 110,
+    fontSize: 15,
+    lineHeight: 22,
   },
-  placeholder: {
+
+  // Action bar
+  actionBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  ctaDismiss: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  goBackBtn: {
     paddingVertical: 14,
     borderRadius: Radius.md,
+    minHeight: 48,
+  },
+  ctaDismissText: {
+    fontWeight: '600',
+  },
+  ctaCancel: {
     alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    borderRadius: Radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    minHeight: 48,
+  },
+  ctaCancelText: {
+    fontWeight: '600',
   },
 })
+
+export default DiaryDismissScreen

--- a/mobile/src/api/diaryRequests.ts
+++ b/mobile/src/api/diaryRequests.ts
@@ -9,6 +9,8 @@ import type {
   AcceptRequestRequest,
   AcceptRequestResponse,
   ClientPhotoDiaryRequestSummary,
+  DismissRequestRequest,
+  DismissRequestResponse,
   ListClientRequestsResponse,
   SubmitRequestResponse,
 } from './generated'
@@ -16,7 +18,12 @@ import { PhotoDiaryMode, PhotoDiaryStatus } from './generated'
 
 // Re-export so consumers only need one import.
 export { PhotoDiaryMode, PhotoDiaryStatus }
-export type { ClientPhotoDiaryRequestSummary, ListClientRequestsResponse, SubmitRequestResponse }
+export type {
+  ClientPhotoDiaryRequestSummary,
+  DismissRequestResponse,
+  ListClientRequestsResponse,
+  SubmitRequestResponse,
+}
 
 /**
  * Accept a pending photo-diary request with the chosen upload mode.
@@ -89,6 +96,34 @@ export async function submitDiaryRequest(
   const { data } = await api.post<SubmitRequestResponse>(
     `/client/photo-diary-requests/${requestId}/submit`,
     {},
+  )
+  return data
+}
+
+/**
+ * Dismiss a pending photo-diary request with an optional reason.
+ *
+ * `POST /client/photo-diary-requests/{id}/dismiss`
+ *
+ * Transitions the request from Pending → Dismissed and notifies the
+ * trainer via the `photoDiaryDismissed` SignalR event.
+ * Only Pending requests can be dismissed; calling on any other status
+ * returns 409 from the backend.
+ *
+ * The reason is omitted entirely from the request body when it is
+ * empty or whitespace — the backend accepts `null` / missing field as
+ * "no reason given".
+ */
+export async function dismissDiaryRequest(params: {
+  id: string
+  reason?: string
+}): Promise<DismissRequestResponse> {
+  const { id, reason } = params
+  const trimmed = reason?.trim()
+  const body: DismissRequestRequest = trimmed ? { reason: trimmed } : {}
+  const { data } = await api.post<DismissRequestResponse>(
+    `/client/photo-diary-requests/${id}/dismiss`,
+    body,
   )
   return data
 }

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -1055,6 +1055,17 @@
       "title": "Foto-deník · aktivní",
       "dayCounter": "Den {{day}} ze {{total}}",
       "open": "Otevřít"
+    },
+    "dismiss": {
+      "screenTitle": "Odmítnout žádost",
+      "warningText": "Tvůj kouč bude informován, že žádost odmítáš. Pokud chceš, napiš mu krátce proč — pomůže mu to.",
+      "reasonLabel": "Důvod (volitelné)",
+      "reasonPlaceholder": "Např. Necítím se zatím na sdílení fotek, raději bychom začali jinak…",
+      "charCount": "{{count}} / {{max}}",
+      "ctaDismiss": "Odmítnout žádost",
+      "ctaCancel": "Zrušit",
+      "successToast": "Žádost odmítnuta",
+      "errorDismiss": "Odmítnutí se nezdařilo. Zkus to znovu."
     }
   }
 }

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -1040,6 +1040,17 @@
       "title": "Foto-Tagebuch · aktiv",
       "dayCounter": "Tag {{day}} von {{total}}",
       "open": "Öffnen"
+    },
+    "dismiss": {
+      "screenTitle": "Anfrage ablehnen",
+      "warningText": "Dein Coach wird darüber informiert, dass du die Anfrage ablehnst. Wenn du möchtest, erkläre kurz warum — das hilft ihm weiter.",
+      "reasonLabel": "Grund (optional)",
+      "reasonPlaceholder": "Z.B. Ich fühle mich noch nicht bereit, Fotos zu teilen, ich würde lieber anders beginnen…",
+      "charCount": "{{count}} / {{max}}",
+      "ctaDismiss": "Anfrage ablehnen",
+      "ctaCancel": "Abbrechen",
+      "successToast": "Anfrage abgelehnt",
+      "errorDismiss": "Ablehnen fehlgeschlagen. Bitte erneut versuchen."
     }
   }
 }

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -1041,6 +1041,17 @@
       "title": "Photo diary · active",
       "dayCounter": "Day {{day}} of {{total}}",
       "open": "Open"
+    },
+    "dismiss": {
+      "screenTitle": "Dismiss request",
+      "warningText": "Your coach will be notified that you are dismissing the request. If you want, let them know why briefly — it will help them.",
+      "reasonLabel": "Reason (optional)",
+      "reasonPlaceholder": "E.g. I don't feel ready to share photos yet, I'd prefer to start differently…",
+      "charCount": "{{count}} / {{max}}",
+      "ctaDismiss": "Dismiss request",
+      "ctaCancel": "Cancel",
+      "successToast": "Request dismissed",
+      "errorDismiss": "Dismiss failed. Please try again."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the placeholder at `mobile/app/(client)/diary/[requestId]/dismiss.tsx` (created in #98) with the full confirmation + optional-reason screen.
- Adds `dismissDiaryRequest()` wrapper in `mobile/src/api/diaryRequests.ts` — `POST /client/photo-diary-requests/{id}/dismiss`.
- Optional reason field with 500-char limit (matches backend `DismissRequestRequest` validator from #91); empty/whitespace reason is omitted entirely from the POST body.
- On success: invalidates `pending-questionnaires` + `active-workflow-diary-requests` queries so the Today banner and workflow banner both disappear, then navigates to Today.

## Related issue

Fixes #102

## Parent epic (sub-issue PRs only)

Part of #67 — base branch: `feature/67-diary-request`.

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL ✅ PASS — token violation resolved with `...Type.subheadline` spread (re-verified after fix commit `83e0ca5`).

## Test plan

- [ ] Reason is optional — dismiss succeeds with empty reason field (no submit gate on blank).
- [ ] Reason is optional — dismiss succeeds with a populated reason (trimmed, ≤500 chars).
- [ ] On success: `pending-questionnaires` query invalidated → Today banner gone.
- [ ] On success: `active-workflow-diary-requests` query invalidated → workflow banner gone.
- [ ] On success: navigates to Today screen (`/(client)/(tabs)`).
- [ ] Cancel (header button or action-bar button): `router.back()`, no API call.
- [ ] Dismiss button shows `ActivityIndicator` while mutation is in-flight; inputs locked.
- [ ] Error toast shown on API failure.
- [ ] All copy present in cs, en, de.

## Prototype deviation notes

- Warning block uses neutral `colors.fill` / `colors.sep2` tokens (not orange tint) — accepted deviation from prototype per QA.
- Character limit 500 (prototype showed 300) — matches backend `DismissRequestRequest` validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)