### PR TITLE
chore(mobile,#67): apply colors.onAccent + colors.overlay tokens to workflow.tsx

### DIFF
--- a/mobile/app/(client)/diary/[requestId]/workflow.tsx
+++ b/mobile/app/(client)/diary/[requestId]/workflow.tsx
@@ -449,8 +449,8 @@ export function DiaryWorkflowScreen() {
                   resizeMode="cover"
                 />
                 {photo.description ? (
-                  <View style={styles.tileCaption}>
-                    <Text style={styles.tileCaptionText} numberOfLines={1}>
+                  <View style={[styles.tileCaption, { backgroundColor: colors.overlay }]}>
+                    <Text style={[styles.tileCaptionText, { color: colors.onAccent }]} numberOfLines={1}>
                       {photo.description}
                     </Text>
                   </View>
@@ -686,10 +686,8 @@ const styles = StyleSheet.create({
     bottom: 0,
     paddingHorizontal: 8,
     paddingVertical: 6,
-    backgroundColor: 'rgba(0,0,0,0.5)',
   },
   tileCaptionText: {
-    color: '#ffffff',
     fontSize: 11,
   },
 


### PR DESCRIPTION
## Summary

- Replaces two hardcoded style values in `mobile/app/(client)/diary/[requestId]/workflow.tsx` with design tokens, picking up BLOCKING findings from the consolidated review of epic PR #163.
- `tileCaption` `backgroundColor: 'rgba(0,0,0,0.5)'` removed from `StyleSheet.create`; render site now applies `[styles.tileCaption, { backgroundColor: colors.overlay }]`.
- `tileCaptionText` `color: '#ffffff'` removed from `StyleSheet.create`; render site now applies `[styles.tileCaptionText, { color: colors.onAccent }]`.
- `colors` is already destructured from `useTheme()` at the component top — no import changes needed.

## Related issue

Part of epic #67 — base branch: `feature/67-diary-request`.

## Parent epic (sub-issue PRs only)

Part of epic #67 — base branch: `feature/67-diary-request`.

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL ✅ PASS — mechanical token-swap rework; no logic change, no new UI surface.

## Test plan

- [ ] Diary workflow tile captions render with `colors.overlay` semi-transparent overlay and `colors.onAccent` text.
- [ ] No raw hex or rgba values remain in `workflow.tsx`.
- [ ] TypeScript strict — both `colors.overlay` and `colors.onAccent` are typed as `string` on `Theme.colors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)