### PR TITLE
chore(#167): DRY status-completed CSS vars + use Type.subheadline in diary wizard

### DIFF
--- a/mobile/app/(client)/diary/[requestId]/index.tsx
+++ b/mobile/app/(client)/diary/[requestId]/index.tsx
@@ -179,7 +179,7 @@ export function DiaryAcceptWizardScreen() {
           <View style={[styles.coachCard, { backgroundColor: colors.bg2 }]}>
             <Avatar name={displayName} size="sm" />
             <View style={styles.coachText}>
-              <Text style={[Type.headline, { color: colors.label, fontSize: 15 }]}>
+              <Text style={[Type.subheadline, { color: colors.label, fontWeight: '600' }]}>
                 {displayName}
               </Text>
               {roleLabel ? (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -64,9 +64,9 @@
   --status-inprogress-bg:   var(--accent-bg);
   --status-inprogress-br:   var(--accent-br);
 
-  --status-completed-text:  #0f7b6c;
-  --status-completed-bg:    rgba(15, 123, 108, 0.10);
-  --status-completed-br:    rgba(15, 123, 108, 0.22);
+  --status-completed-text:  var(--green);
+  --status-completed-bg:    var(--green-bg);
+  --status-completed-br:    var(--green-br);
 
   --status-dismissed-text:  var(--red);
   --status-dismissed-bg:    var(--red-bg);


### PR DESCRIPTION
Closes #167

## Summary

Two non-blocking NITs that pr-reviewer surfaced when reviewing the Epic #67 PR ([#163](https://github.com/JanProkorat/fitness-platform/pull/163), commit \`c21854d\`). Captured here as a tracked chore so they didn't drift.

- **web/src/index.css** — \`--status-completed-{text,bg,br}\` now reference \`var(--green)\` / \`var(--green-bg)\` / \`var(--green-br)\` instead of literal hex / rgba values. Brings the completed status tokens in line with \`--status-inprogress-*\` (which references \`var(--accent*)\`) and \`--status-dismissed-*\` (which references \`var(--red*)\`).
- **mobile/app/(client)/diary/[requestId]/index.tsx** — Coach-card name uses \`[Type.subheadline, { color: ..., fontWeight: '600' }]\` instead of \`[Type.headline, { color: ..., fontSize: 15 }]\`. Drops the size override on the headline token; explicit semi-bold weight carries the original visual.

## Notes

- Tiny visual shift on the completed cards: background alpha drops 0.10 → 0.08, border alpha drops 0.22 → 0.2. Acceptable for consistency.
- Mobile coach-card font weight stays at 600 (semi-bold). The token swap drops the headline override and is more honest about what's happening.

## Test plan

- [x] \`npx tsc --noEmit\` (mobile) — passes
- [x] \`npx tsc --noEmit\` (web) — passes
- [ ] Visual: trainer's nutrition-plan Photos → Foto-deníky tab → completed diary card border / bg are still tinted teal-green; card differs only marginally from the previous shade
- [ ] Visual: mobile diary wizard coach card → name renders 15 px / semi-bold (no perceptible change vs before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)