### PR TITLE
chore(#175): add cclint informational CI workflow for .claude/

### DIFF
--- a/.github/workflows/cclint.yml
+++ b/.github/workflows/cclint.yml
@@ -3,9 +3,9 @@ name: Claude Code Lint
 on:
   push:
     branches: [main, develop]
-    paths: ['.claude/**', 'CLAUDE.md']
+    paths: ['.claude/**', 'CLAUDE.md', '.github/workflows/cclint.yml']
   pull_request:
-    paths: ['.claude/**', 'CLAUDE.md']
+    paths: ['.claude/**', 'CLAUDE.md', '.github/workflows/cclint.yml']
 
 jobs:
   cclint:

--- a/.github/workflows/cclint.yml
+++ b/.github/workflows/cclint.yml
@@ -1,0 +1,32 @@
+name: Claude Code Lint
+
+on:
+  push:
+    branches: [main, develop]
+    paths: ['.claude/**', 'CLAUDE.md']
+  pull_request:
+    paths: ['.claude/**', 'CLAUDE.md']
+
+jobs:
+  cclint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Informational at introduction: cclint surfaces findings on .claude/**
+      # but does not block the build. Tighten to fail-on=error in a follow-up
+      # once the existing tree is clean (see #175 follow-up cleanup issue).
+      - name: Run cclint
+        id: cclint
+        continue-on-error: true
+        run: npx -y @carlrannaberg/cclint --root .
+
+      - name: Note status
+        if: steps.cclint.outcome == 'failure'
+        run: echo "::warning::cclint reported findings — see the previous step's log. Workflow will not fail the PR while introduction is informational."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/cclint.yml` — runs `npx @carlrannaberg/cclint` on PRs that touch `.claude/**` or `CLAUDE.md`. Configured as informational (`continue-on-error: true` on the lint step) at introduction so existing-tree findings (8 errors today, see issue #175 comments) are surfaced without blocking PRs. Tightens to `--fail-on=error` in a follow-up once the existing tree is clean.

## Sub-issue of

#173 (epic — Claude Code ecosystem additions rollout).

## ✅ AC mapping

- [x] Workflow runs on `pull_request` paths `.claude/**` (also `CLAUDE.md` and on push to develop/main)
- [x] Uses `npx @carlrannaberg/cclint`
- [x] Mirrors `.github/workflows/web.yml` style (Node 20 + `actions/checkout@v4` + `setup-node@v4`)
- [x] Workflow passes against the current `.claude/` tree on this PR (informational mode → green, findings emitted as a `::warning::`)
- [x] No husky pre-commit added; this workflow is the lint surface

## Follow-up

Existing-tree cclint findings (~8 errors, ~21 warnings) will be cleaned up in a separate issue before tightening `--fail-on=error`. Notable: YAML parse error in `.claude/agents/pr-reviewer.md` (unquoted colon in description), magenta color in design-reviewer.md, missing `matcher` fields in `.claude/settings.json` hooks.

Closes #175.