### PR TITLE
chore(epic,#173): Claude Code ecosystem additions — Phase 1 in-repo tooling

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -587,8 +587,13 @@ Handle each status:
 
 - **Any `fail` row** → STOP. Do NOT merge. Return BLOCKED with the
   failing job name, a one-line root-cause hypothesis from reading
-  `gh run view <run-id> --log-failed` (or the job's web log), and a
-  scope-tagged fix list. The orchestrator routes to the owning dev
+  the failing job's log, and a scope-tagged fix list. Prefer the
+  tightest fetch first to keep context lean per Working Principles §6:
+  if a GitHub MCP is configured (see `.mcp.json`), use
+  `mcp__github__get_workflow_run_logs` with `tail_lines: 200`;
+  otherwise `gh run view <run-id> --log-failed --job <failing-job-id>`
+  scoped to the single failing job; full `gh run view <run-id>
+  --log-failed` is the last resort. The orchestrator routes to the owning dev
   sub-agent (backend → `backend-dotnet`, web → `web-react`,
   mobile → `mobile-expo`). When the fix is pushed, CI re-runs
   automatically; the orchestrator re-dispatches you once checks go

--- a/.claude/skills/daily-resercher/SKILL.md
+++ b/.claude/skills/daily-resercher/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: daily-resercher
+description: Survey what's new in the Claude Code ecosystem — plugins, skills, MCP servers, agents, hooks. Invoke for "daily research run", "weekly claude survey", "what's new in claude code", "new claude plugins", "new MCP servers". Reports back a structured markdown digest grouping findings by adoption-readiness (drop-in / wire-up / tracking-only). Surveys curated registries first and only falls back to broad WebSearch when the curated list is exhausted.
+---
+
+# daily-resercher — Claude Code ecosystem survey
+
+Run this when the user asks "what's new in Claude Code", "weekly claude survey",
+"any new plugins / skills / MCPs worth looking at?", "daily research run", or
+similar.
+
+The output is a **structured markdown digest** the user (or a follow-up
+orchestrator pass) can act on directly — file tracking issues, run installs,
+dispatch wire-up PRs.
+
+## Why curated registries first
+
+Broad `WebSearch` for "claude code plugin <topic>" returns lots of noise:
+abandoned forks, unrelated wrappers, AI-generated link-farm pages. The
+curated registries listed below are maintained lists where each item has been
+manually vetted at least once. Survey those first and only fall back to broad
+search when an explicit topic isn't represented in any of them.
+
+## Sources to survey (in order)
+
+1. **`hesreallyhim/awesome-claude-code`** —
+   <https://github.com/hesreallyhim/awesome-claude-code> — community-curated
+   list of skills, slash commands, agents, hooks, statuslines, MCPs.
+2. **`ComposioHQ/awesome-claude-plugins`** —
+   <https://github.com/ComposioHQ/awesome-claude-plugins> — focused on
+   plugin marketplace entries with brief reviews.
+3. **Anthropic official `claude-code/plugins/`** —
+   <https://github.com/anthropics/claude-code> tree under `plugins/` —
+   first-party plugins shipped in the Claude Code repo.
+4. **`claudemarketplace.com`** —
+   <https://claudemarketplace.com> — searchable index of plugins,
+   skills, and MCPs with install counts and recent-update timestamps.
+5. **Anthropic blog / changelog** —
+   <https://www.anthropic.com/news> filtered to Claude Code posts —
+   first-party announcements (HTTP hooks, Agent Teams, hosted Code Review,
+   etc.).
+
+If the user names a specific topic ("a11y", "i18n", "security", "Roslyn") and
+none of the above surface a strong match, then run `WebSearch` with the
+**Haiku** model per Working Principles §6 — never with Opus or Sonnet, since
+these calls return long-form pages and burn context.
+
+## Survey procedure
+
+1. **Frame the question.** Confirm with the user what bucket they care about
+   (general digest, vs. "anything new for X"). If unspecified, default to
+   general digest of the last 14 days.
+2. **Survey each registry** in the order above, stopping at the first 3–5
+   high-value items per registry. Capture:
+   - Name + URL
+   - One-line description
+   - Last-updated date (if visible)
+   - Stars / install count (if visible)
+3. **Tag each finding** with one of three adoption-readiness buckets:
+   - **drop-in** — install + works out of the box; no wire-up needed.
+   - **wire-up** — install required, then a small edit in our `.claude/`
+     tree to chain it into the right agent / skill / workflow.
+   - **tracking-only** — interesting but premature (alpha, missing GA,
+     unclear fit). Track the trigger condition for revisiting.
+4. **Add a 2-line take** per finding: line 1 says what it does, line 2 says
+   why we'd (or wouldn't) want it.
+5. **Propose an action** per finding:
+   - drop-in / wire-up → "file a sub-issue under epic #N to install + wire"
+   - tracking-only → "add to deferred list in epic #N with trigger `<X>`"
+6. **Group by package surface** — backend, web, mobile, docs-infra, all-up —
+   so the user can scan by where the impact lands.
+7. **Sanity-check** at least one finding against the running repo: does the
+   project actually need this? Don't propose tooling for problems we don't
+   have.
+
+## Output format
+
+```markdown
+# Claude Code ecosystem digest — <YYYY-MM-DD>
+
+## Summary
+- Surveyed: <list registries hit>
+- Findings: <N total> (<X drop-in> / <Y wire-up> / <Z tracking>)
+- Recommended next action: <one sentence>
+
+## docs-infra
+### <Item name>
+- **Source:** <URL>
+- **Status:** drop-in | wire-up | tracking-only
+- **Take:** <line 1: what it does>. <line 2: why we want it / don't>.
+- **Action:** <file sub-issue / track in epic / skip>
+
+## backend
+### <Item name>
+…
+
+## web
+### <Item name>
+…
+
+## mobile
+### <Item name>
+…
+```
+
+Sections with no findings can be omitted.
+
+## When NOT to run
+
+- The user is asking for help on a specific implementation problem — that's a
+  task for the relevant dev sub-agent, not a survey.
+- The user is asking about a *specific* tool they've already named — go
+  straight to fetching its docs (`mcp__plugin_context7_context7__query-docs`
+  or the tool's GitHub README), don't run the broader survey.
+- Less than 14 days since the last digest unless the user explicitly asks for
+  a fresh run — most ecosystem items don't change daily.
+
+## After running
+
+If any findings produced "file a sub-issue" actions, hand off to
+`github-issues` with the extracted facts (one paragraph per finding).
+Don't paste the full digest into the github-issues prompt — it's expensive
+and most of the digest is context the agent doesn't need.

--- a/.github/workflows/cclint.yml
+++ b/.github/workflows/cclint.yml
@@ -3,9 +3,9 @@ name: Claude Code Lint
 on:
   push:
     branches: [main, develop]
-    paths: ['.claude/**', 'CLAUDE.md']
+    paths: ['.claude/**', 'CLAUDE.md', '.github/workflows/cclint.yml']
   pull_request:
-    paths: ['.claude/**', 'CLAUDE.md']
+    paths: ['.claude/**', 'CLAUDE.md', '.github/workflows/cclint.yml']
 
 jobs:
   cclint:

--- a/.github/workflows/cclint.yml
+++ b/.github/workflows/cclint.yml
@@ -1,0 +1,32 @@
+name: Claude Code Lint
+
+on:
+  push:
+    branches: [main, develop]
+    paths: ['.claude/**', 'CLAUDE.md']
+  pull_request:
+    paths: ['.claude/**', 'CLAUDE.md']
+
+jobs:
+  cclint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Informational at introduction: cclint surfaces findings on .claude/**
+      # but does not block the build. Tighten to fail-on=error in a follow-up
+      # once the existing tree is clean (see #175 follow-up cleanup issue).
+      - name: Run cclint
+        id: cclint
+        continue-on-error: true
+        run: npx -y @carlrannaberg/cclint --root .
+
+      - name: Note status
+        if: steps.cclint.outcome == 'failure'
+        run: echo "::warning::cclint reported findings — see the previous step's log. Workflow will not fail the PR while introduction is informational."


### PR DESCRIPTION
## Summary

Phase 1 of the [Claude Code ecosystem additions epic (#173)](https://github.com/JanProkorat/fitness-platform/issues/173) — three small in-repo improvements that don't require external installs. Each sub-issue shipped as its own PR against the epic branch and auto-merged on green CI per `rules/merge-strategy.md#sub-issue-auto-merge`.

## Sub-issues landed

| # | Title | Diff |
|---|-------|------|
| #174 | Tighten CI failure-log fetch in pr-reviewer agent | 9 lines (`.claude/agents/pr-reviewer.md`) |
| #175 | Add cclint informational CI workflow for `.claude/` | 32 lines (`.github/workflows/cclint.yml`) |
| #176 | Scaffold project-local daily-resercher skill | 123 lines (`.claude/skills/daily-resercher/SKILL.md`) |

Total: 4 commits, ~165 lines added, 2 deleted, across 3 files (1 modified, 2 new).

## What's in / out

**In Phase 1 (this PR):**
- Tighter CI log-fetch hint for `pr-reviewer` (3-tier preference: GitHub MCP → scoped `gh run view` → full `gh run view`).
- New `cclint` GitHub Action workflow on `.claude/**` path-filter, configured as **informational** (`continue-on-error: true`) at introduction so existing-tree findings don't block PRs.
- New `daily-resercher` project-local skill that surveys curated registries before broad WebSearch.

**Deferred (still open under epic #173, ~18 sub-issues):**
- External-install + wire-up issues (CCometixLine, OWASP, i18n-expert, a11y, Playwright, Roslyn MCP, Worktree MCP, security-guardrails, Expo MCP, Testcontainers skill, design-system, security-review GH action) — each waits on the user installing the underlying plugin/skill/MCP locally.
- Long-horizon trials (Anthropic hosted Code Review, claude-mem, HTTP hooks, Agent Teams, Pact, CocoIndex, testID coverage sweep).
- Source-survey-doc commit (#197) and revisit-`github-mcp-server` (#198) trackers.

## Follow-up

A separate cleanup issue should track tightening cclint to `--fail-on=error` once the existing-tree findings (8 errors today: YAML parse error in `pr-reviewer.md`, magenta color in `design-reviewer.md`, missing `matcher` fields in `.claude/settings.json` hooks) are cleared. Filing that as part of this PR's review feedback would be a clean follow-on.

## Merge strategy

Per `rules/merge-strategy.md`, `type:chore` defaults to `--rebase --delete-branch`. If you'd prefer the whole epic to land as a single commit on `develop`, override to `--squash` when authorizing.

Closes #173.