### PR TITLE
chore: wire owasp-security skill into pr-reviewer first-pass

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -279,9 +279,18 @@ not improvise a parallel checklist.
 - FastEndpoints pattern in /backend: one endpoint per file,
   `Configure()` + `HandleAsync()`.
 - Security surface: auth, IDOR, injection, upload, invite endpoints
-  deserve extra scrutiny. If the diff touches them, mark the PR as
-  "recommend running `gc-sec-review` before merge" and add that to
-  your verdict — do not try to do a security review yourself.
+  deserve extra scrutiny. If the diff touches any of them:
+  1. Run a lightweight first-pass OWASP sweep by invoking
+     `Skill: owasp-security` with the diff as input — it surfaces
+     OWASP Top-10 / ASVS / LLM Top-10 hits at review time. Treat its
+     findings as inputs to your classification (BLOCKING / NIT /
+     QUESTION) per step 3c — same as any other hard-rule hit.
+  2. Mark the PR as "recommend running `gc-sec-review` before merge"
+     and add that to your verdict — do not try to do a deeper security
+     review yourself. `owasp-security` is a fast pre-screen; the
+     `gc-sec-review` chainable plugin is the deeper review and stays
+     a separate, recommended step (no duplication: owasp-security runs
+     inside first-pass, gc-sec-review runs as a follow-up).
 
 **3c. Classify every finding into BLOCKING / NIT / QUESTION** and tag
 each with a scope label (`[scope:backend]`, `[scope:web]`,


### PR DESCRIPTION
## Summary

- Wires the locally-installed `owasp-security` skill (from `agamm/claude-code-owasp`) into the `pr-reviewer` agent's first-pass hard-rule gate (section 3b).
- The skill is invoked **only when the diff touches the security surface** — auth, IDOR, injection, upload, invite endpoints — keeping cost bounded for non-security PRs.
- The existing `gc-sec-review` chainable-plugin recommendation is preserved as a separate, deeper follow-up step. Explicitly documented as non-duplicative: `owasp-security` is a fast pre-screen inside first-pass, `gc-sec-review` runs as a recommended follow-up before merge.

## Related issue

Fixes #178

## Parent epic

Part of epic #173 (already merged) — Phase 2 wire-up of the Claude Code ecosystem additions. The underlying skill `owasp-security` is now installed locally per #178's trigger.

## Scope

docs-infra (single-file edit to `.claude/agents/pr-reviewer.md`)

## QA verdict

QA: not applicable — docs-infra change to agent prompt; AC verified by reading the diff.

## Test plan

- [x] `.claude/agents/pr-reviewer.md` first-pass section references the OWASP skill with a clear invocation condition (diffs touching auth/upload/invite endpoints) — verified by reading the patched bullet under section 3b.
- [x] pr-reviewer invokes the OWASP skill during first-pass review on qualifying diffs — verified by the explicit `Skill: owasp-security` invocation line and the integration with step 3c classification.
- [x] Existing gc-sec-review plugin invocation is preserved without duplication — verified by the explicit boundary statement in the new sub-list ("no duplication: owasp-security runs inside first-pass, gc-sec-review runs as a follow-up").

🤖 Generated with [Claude Code](https://claude.com/claude-code)