### PR TITLE
chore: wire i18n-expert into web-page and mobile-screen skills

### DIFF
--- a/.claude/skills/mobile-screen/SKILL.md
+++ b/.claude/skills/mobile-screen/SKILL.md
@@ -188,6 +188,20 @@ renders but the hardware back button / swipe gesture breaks.
 3. Grep for hex literals in the new file — there should be none:
    `grep -E "#[0-9a-fA-F]{3,8}" mobile/app/<path>`.
 
+## Final step — i18n validation
+
+Before reporting done, invoke the `i18n-expert` skill to audit cs / en / de
+key parity for any new user-facing copy the scaffold introduced:
+
+```
+Skill: i18n-expert:i18n-expert  audit mobile/src/i18n/locales/{cs,en,de}.json for the new <prefix>.* keys (cs is the source of truth)
+```
+
+The skill flags missing keys per locale, hardcoded strings that bypassed
+`useTranslation()`, pluralization gaps, and ICU-format drift. Required when
+the scaffold introduces any new user-facing string — skip only when the
+new screen adds zero new copy (e.g. a pure-routing wrapper).
+
 ## Related skills to chain
 
 - **`design:design-critique`** — after the screen lands, quick pass on

--- a/.claude/skills/web-page/SKILL.md
+++ b/.claude/skills/web-page/SKILL.md
@@ -156,6 +156,20 @@ Adjust for the actual shape:
 4. Open devtools network tab — no polling (only initial load + post-mutation
    invalidation fetches).
 
+## Final step — i18n validation
+
+Before reporting done, invoke the `i18n-expert` skill to audit cs / en / de
+key parity for any new user-facing copy the scaffold introduced:
+
+```
+Skill: i18n-expert:i18n-expert  audit web/src/i18n/locales/{cs,en,de}.json for the new <prefix>.* keys (cs is the source of truth)
+```
+
+The skill flags missing keys per locale, hardcoded strings that bypassed
+`useTranslation()`, pluralization gaps, and ICU-format drift. Required when
+the scaffold introduces any new user-facing string — skip only when the
+new page adds zero new copy (e.g. a pure-routing wrapper).
+
 ## Related skills to chain
 
 - **`design:design-critique`** — after the page renders, run a pass on


### PR DESCRIPTION
## Summary

- Adds a `## Final step — i18n validation` section to both `web-page` and `mobile-screen` SKILL.md files instructing the scaffold to invoke `i18n-expert:i18n-expert` for cs/en/de key-parity auditing before reporting done.
- The invocation is **required** when the scaffold introduces any new user-facing string, with an explicit skip-condition for pure-routing wrappers that add zero copy.
- Each invocation passes the package-specific locale path (`web/src/i18n/locales/{cs,en,de}.json` or `mobile/src/i18n/locales/{cs,en,de}.json`) and explicitly states "cs is the source of truth" so the audit anchors on Czech per `rules/i18n.md#source-of-truth`.

## Related issue

Fixes #181

## Parent epic

Phase-2 follow-up under epic #173 — Phase 1 (the in-repo tooling) shipped via #201 (commit `0f6e790`). The epic branch has been deleted; #181 is a standalone follow-up against `develop` and not a sub-issue PR. Trigger condition (i18n-expert skill installed locally) has been met.

## Scope

docs-infra — only `.claude/skills/web-page/SKILL.md` and `.claude/skills/mobile-screen/SKILL.md` are modified, +14 / -0 lines each.

## QA

QA: not applicable — docs-infra change to skill scaffolds; AC verified by reading the diff. No runtime AC to test in qa-tester.

## Acceptance criteria mapping

- [x] `.claude/skills/web-page/SKILL.md` ends with an explicit step to invoke i18n-expert to validate cs/en/de coverage before reporting done — new section sits between "Verify" and "Related skills to chain".
- [x] `.claude/skills/mobile-screen/SKILL.md` ends with the same i18n-expert invocation step — identical block, package paths swapped.
- [x] The invocation condition is clear (any new user-facing string in the scaffolded output) — final paragraph states "Required when the scaffold introduces any new user-facing string — skip only when the new page/screen adds zero new copy (e.g. a pure-routing wrapper)".

## Reviewer note — locale targeting

The upstream `i18n-expert` skill description mentions defaults like en-US / zh-CN. The invocation line in both SKILL.md files explicitly enumerates `{cs,en,de}.json` so the audit targets this project's actual locale set rather than the skill's defaults. "cs is the source of truth" is part of the invocation argument so the parity check anchors on Czech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)