### PR TITLE
chore(#187): cherry-pick Roslyn MCP into .mcp.json + backend-dotnet

### DIFF
--- a/.claude/agents/backend-dotnet.md
+++ b/.claude/agents/backend-dotnet.md
@@ -7,7 +7,7 @@ maxTurns: 150
 permissionMode: acceptEdits
 color: blue
 skills: fe-endpoint, mongo-document, regen-api, signalr-event, root-cause-swarm
-mcpServers: context7, mongodb
+mcpServers: context7, mongodb, roslyn-navigator
 ---
 
 # backend-dotnet — ASP.NET Core 10 specialist
@@ -188,6 +188,28 @@ reading them inline. Inline reads pollute your context with files you'll
 forget; Explore returns a summary you can act on. Reserve inline reads
 for ≤2 known files (single exemplar pattern — see Working Principles §6
 in root `CLAUDE.md`).
+
+## Symbol lookups — prefer the Roslyn MCP over `grep`
+
+For find-references, find-implementations, rename-symbol, "where is
+`X` defined", or "what calls this method" questions in `/backend`,
+use the `roslyn-navigator` MCP rather than `grep`. Roslyn understands
+the C# project graph: it resolves partial classes, generated code,
+and inheritance chains, and distinguishes `Foo.Bar` (the method) from
+a parameter named `Bar`. The MCP tools are stdout-streamed, so a
+"find all usages of `IRealtimeNotifier.Broadcast`" query returns a
+precise list with file:line, not a noisy text-match list.
+
+Reach for `grep` only for non-symbol text (literal strings, comments,
+config keys, JSON keys, route paths in attribute values that
+sometimes string-format around the symbol). When in doubt: try the
+Roslyn MCP first; fall back to `grep` only if the symbol is too
+synthetic for the compiler to model (e.g. dynamically-generated route
+templates).
+
+The MCP is registered in `.mcp.json` as `roslyn-navigator` and
+requires the `cwm-roslyn-navigator` dotnet global tool on `$PATH`
+(install per the tool's README on a fresh machine).
 
 ## When to reach for a skill
 - Creating a brand-new endpoint? Invoke the `fe-endpoint` skill to scaffold

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,10 @@
       "command": "npx",
       "args": ["-y", "xcodebuildmcp@latest", "mcp"]
     },
+    "roslyn-navigator": {
+      "command": "cwm-roslyn-navigator",
+      "args": []
+    },
     "github": {
       "command": ".claude/scripts/with-keychain-secret.sh",
       "args": [


### PR DESCRIPTION
## Summary

- Adds the locally-installed `cwm-roslyn-navigator` dotnet global tool as a project-level MCP server in `.mcp.json` (Roslyn-only — no other `dotnet-claude-kit` components imported, per issue scope).
- Threads `roslyn-navigator` into `backend-dotnet`'s `mcpServers:` frontmatter so the agent picks it up at dispatch.
- New section in `backend-dotnet.md` — "Symbol lookups — prefer the Roslyn MCP over `grep`" — documents when to reach for the MCP (find-refs, find-implementations, rename-symbol, "what calls this") vs `grep` (literal text, config keys, route templates).

## Related issue

Fixes #187

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`.

## Scope

docs-infra (`.claude/**`, root `.mcp.json`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions (warnings/suggestions out-of-scope per the parent epic's previously-shipped cclint cleanup).
- Locally connected: `claude mcp list` shows `cwm-roslyn-navigator: /Users/jan/.dotnet/tools/cwm-roslyn-navigator - ✓ Connected`.

## QA

Not applicable — docs-infra change. AC verified by reading the diff + the local MCP-connected status.

## Test plan

- [x] `.mcp.json` has a new entry for the Roslyn MCP server with the correct binary/command
- [x] No other dotnet-claude-kit components are added to `.mcp.json`
- [x] `backend-dotnet` references the MCP for symbol/usage queries (frontmatter + new prose section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)