### PR TITLE
chore(#188): integrate Git Worktree MCP into ship-epic + pr-reviewer

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -770,6 +770,17 @@ branches may live in their own worktrees with their own dev sub-agents
 mid-task. The orchestrator decides whether to rebase now or after the
 sibling's next push.
 
+When you do need to inspect / list / remove a worktree as part of a
+post-merge cleanup (e.g. confirming the sub-issue branch's worktree
+has been torn down), prefer the `git-worktree` MCP (registered in
+`.mcp.json`) over raw `git worktree` shell calls. The MCP returns
+structured results and avoids path-escape bugs on slugged sub-issue
+titles. Fall back to `git worktree list` / `git worktree remove` only
+if the MCP isn't reachable in the session — but actual worktree
+create/remove operations are owned by `ship-epic`, not by you;
+typically you only ever *report* the cleanup needed and let the
+orchestrator drive the MCP calls.
+
 ### S6. Return the merge verdict
 
 ```

--- a/.claude/skills/ship-epic/SKILL.md
+++ b/.claude/skills/ship-epic/SKILL.md
@@ -326,7 +326,22 @@ concurrently. Each dev sub-agent is started inside its own worktree
 ### 1a. Worktree setup (parallel dispatches only)
 
 Before dispatching the dev sub-agent, create the worktree off the epic
-branch:
+branch. **Prefer the `git-worktree` MCP** (registered in `.mcp.json`)
+over raw shell — it returns structured paths/branch names, surfaces
+errors as MCP responses instead of stderr the orchestrator has to
+parse, and avoids path-escaping bugs on slugged titles. Call its
+worktree-create tool with:
+
+- `path`: `.worktrees/<N>-<short>` (relative to repo root)
+- `branch`: `<type>/<N>-<short-kebab>` (new branch — the child's)
+- `commit` / `base`: `origin/$EPIC_BRANCH`
+
+Where `<N>` is the child issue number, `<short>` is ≤20 chars of the
+title slugged, and `<type>` matches the child's `type:*` label.
+
+If the MCP isn't reachable in the current session (e.g. running
+ship-epic from an environment without the `git-worktree` server), fall
+back to:
 
 ```bash
 git fetch origin "$EPIC_BRANCH"
@@ -334,12 +349,10 @@ git worktree add .worktrees/<N>-<short> \
     -b <type>/<N>-<short-kebab> "origin/$EPIC_BRANCH"
 ```
 
-Where `<N>` is the child issue number, `<short>` is ≤20 chars of the
-title slugged, and `<type>` matches the child's `type:*` label. For
-serial dispatches on a freshly-merged epic branch, skip the worktree
-and let the dev sub-agent branch off the main checkout — but make sure
-the main checkout is on `$EPIC_BRANCH` first (`git checkout
-$EPIC_BRANCH && git pull --ff-only`).
+For serial dispatches on a freshly-merged epic branch, skip the
+worktree entirely and let the dev sub-agent branch off the main
+checkout — but make sure the main checkout is on `$EPIC_BRANCH` first
+(`git checkout $EPIC_BRANCH && git pull --ff-only`).
 
 ### 1b. Run design-review (Rule 5.5)
 
@@ -417,7 +430,9 @@ Sub-issue PRs auto-merge per rule 8a — no per-PR user pause.
   pass). For exclusion BLOCKED (migrations, Mongo data scripts), the
   user merges that one PR by hand onto the epic branch and tells you
   to continue.
-- When `pr-reviewer` returns MERGED, remove the worktree:
+- When `pr-reviewer` returns MERGED, remove the worktree. **Prefer
+  the `git-worktree` MCP's worktree-remove tool** with `path:
+  .worktrees/<N>-<short>`. Fallback when the MCP isn't reachable:
   ```bash
   git worktree remove .worktrees/<N>-<short>
   ```

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,6 +8,10 @@
       "command": "cwm-roslyn-navigator",
       "args": []
     },
+    "git-worktree": {
+      "command": "npx",
+      "args": ["-y", "github:Mandalorian007/git-worktree-mcp"]
+    },
     "github": {
       "command": ".claude/scripts/with-keychain-secret.sh",
       "args": [


### PR DESCRIPTION
## Summary

- Registers `git-worktree` (the `github:Mandalorian007/git-worktree-mcp` npm package) in `.mcp.json` so the project gets structured worktree calls.
- `ship-epic` SKILL.md — 1a "Worktree setup" and the post-merge cleanup step now prefer the MCP's worktree-create / worktree-remove tools over raw `git worktree add` / `git worktree remove`. Raw shell kept as a labeled fallback when the MCP isn't reachable.
- `pr-reviewer.md` — new paragraph in S5 (epic merge sync) noting that worktree inspection during post-merge cleanup goes through the MCP first, with raw shell as fallback. Ownership of worktree create/remove stays with `ship-epic`.
- Sibling rebase block (`git -C .worktrees/<sibling>/`) left untouched — that's CLI-only territory the MCP doesn't help with.

## Related issue

Fixes #188

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`.

## Scope

docs-infra (`.claude/**`, `.mcp.json`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions (warnings/suggestions are out-of-scope per the previously-shipped cclint cleanup #202).
- `claude mcp list` shows the server connected:
  `git-worktree: /opt/homebrew/bin/npx -y github:Mandalorian007/git-worktree-mcp - ✓ Connected`

## QA

Not applicable — docs-infra change. AC verified by reading the diff + locally-connected MCP.

## Test plan

- [x] `pr-reviewer.md` references `git-worktree` MCP for worktree setup and teardown
- [x] `ship-epic` SKILL.md uses `git-worktree` MCP instead of raw `git worktree` shell calls for parallel sub-issue dispatch (with shell fallback)
- [x] Existing worktree cleanup (remove after merge) is covered by the MCP-based path

🤖 Generated with [Claude Code](https://claude.com/claude-code)