### PR TITLE
chore(#185): reference testcontainers-dotnet skill in fe-endpoint

### DIFF
--- a/.claude/skills/fe-endpoint/SKILL.md
+++ b/.claude/skills/fe-endpoint/SKILL.md
@@ -230,20 +230,11 @@ sub-agent with `model: "haiku"` instead.
 
 ## Related skills to chain
 
-- **`testcontainers:testcontainers-dotnet`** — source of truth for
-  Testcontainers for .NET (4.10+) fixture patterns: container
-  lifecycle, image pinning, networking, parallel-test isolation, and
-  resource cleanup. **Invoke when** the test in step 5 needs a
-  container the existing `EndpointFixture` / `IntegrationTestFixture`
-  doesn't already cover — e.g. a new DB engine (Redis, RabbitMQ),
-  an S3-compatible blob mock outside MinIO, or a non-default
-  PostgreSQL/MongoDB version. The skill returns the canonical
-  `Container.Builder()` / `WaitUntil` / `OneTimeFixture` recipes you
-  can adapt into a new helper alongside the existing ones.
-  **Skip when** you're reusing the existing Postgres + Mongo + MinIO
-  fixtures (the common case — most new endpoints don't introduce new
-  infra). The fe-endpoint scaffold output above is unchanged by this
-  reference; the skill is purely a lookup for atypical fixtures.
+- **`testcontainers:testcontainers-dotnet`** — Testcontainers for .NET
+  4.10+ fixture patterns. Invoke when step 5 needs a container the
+  existing `EndpointFixture` / `IntegrationTestFixture` doesn't cover
+  (new DB engine, non-default Postgres/Mongo version, S3 mock outside
+  MinIO); returns canonical `Container.Builder()` / `WaitUntil` recipes.
 - **`gc-sec-review`** — run after scaffolding endpoints that touch auth,
   ownership, or abuse-prone surfaces (invites, password reset, file upload).
   It catches IDOR / injection / rate-limit gaps the template can't encode.

--- a/.claude/skills/fe-endpoint/SKILL.md
+++ b/.claude/skills/fe-endpoint/SKILL.md
@@ -230,6 +230,20 @@ sub-agent with `model: "haiku"` instead.
 
 ## Related skills to chain
 
+- **`testcontainers:testcontainers-dotnet`** — source of truth for
+  Testcontainers for .NET (4.10+) fixture patterns: container
+  lifecycle, image pinning, networking, parallel-test isolation, and
+  resource cleanup. **Invoke when** the test in step 5 needs a
+  container the existing `EndpointFixture` / `IntegrationTestFixture`
+  doesn't already cover — e.g. a new DB engine (Redis, RabbitMQ),
+  an S3-compatible blob mock outside MinIO, or a non-default
+  PostgreSQL/MongoDB version. The skill returns the canonical
+  `Container.Builder()` / `WaitUntil` / `OneTimeFixture` recipes you
+  can adapt into a new helper alongside the existing ones.
+  **Skip when** you're reusing the existing Postgres + Mongo + MinIO
+  fixtures (the common case — most new endpoints don't introduce new
+  infra). The fe-endpoint scaffold output above is unchanged by this
+  reference; the skill is purely a lookup for atypical fixtures.
 - **`gc-sec-review`** — run after scaffolding endpoints that touch auth,
   ownership, or abuse-prone surfaces (invites, password reset, file upload).
   It catches IDOR / injection / rate-limit gaps the template can't encode.


### PR DESCRIPTION
## Summary

- Adds `testcontainers:testcontainers-dotnet` to `.claude/skills/fe-endpoint/SKILL.md` "Related skills to chain" with a concrete **when / what / skip-when** invocation hint.
- Pure reference addition — the five .cs scaffold templates (Request / Response / Validator / Endpoint / Tests) in fe-endpoint are unchanged.
- The skill is the source of truth for Testcontainers for .NET 4.10+ container lifecycle, image pinning, and parallel-test isolation patterns. Reach for it only when the existing `EndpointFixture` / `IntegrationTestFixture` doesn't cover a new container scenario.

## Related issue

Fixes #185

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`.

## Scope

docs-infra (`.claude/skills/fe-endpoint/SKILL.md`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions.
- Skill confirmed installed locally: `~/.claude/plugins/cache/testcontainers-claude-skills/testcontainers/1.0.0/skills/testcontainers-dotnet/SKILL.md` exists.

## QA

Not applicable — pure docs-infra reference. AC verified by reading the diff.

## Test plan

- [x] `.claude/skills/fe-endpoint/SKILL.md` references the testcontainers skill as the source for test-fixture patterns
- [x] The reference includes a concrete invocation hint (when to call it, what it returns, when to skip)
- [x] Existing fe-endpoint scaffold output is not changed by this reference addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)