### PR TITLE
chore(#186): wire delightful design-system audit into scaffold skills

### DIFF
--- a/.claude/skills/mobile-screen/SKILL.md
+++ b/.claude/skills/mobile-screen/SKILL.md
@@ -188,6 +188,22 @@ renders but the hardware back button / swipe gesture breaks.
 3. Grep for hex literals in the new file — there should be none:
    `grep -E "#[0-9a-fA-F]{3,8}" mobile/app/<path>`.
 
+## Token-compliance scan (post-scaffold)
+
+After the screen renders, invoke the
+`delightful-design-system:audit-with-delightful` skill (or the
+`audit_css` MCP tool from the same plugin) to flag any hardcoded
+colors, spacing, font sizes, or radii in the new file. Use the
+output as a **hardcoded-value detector only** — the skill is
+opinionated toward Delightful's OKLCH neo-brutalist tokens, so
+ignore its replacement suggestions; route real fixes back to this
+project's `useTheme()` tokens (`theme.colors.*`, `theme.spacing.*`,
+`theme.typography.*`, `theme.radius.*`). Brand gold `#c9a84c` must
+only appear via the theme entry, never inline.
+
+Required when the scaffold introduces any new styling. Skip when
+the new screen is a pure-routing wrapper with no styling.
+
 ## Final step — i18n validation
 
 Before reporting done, invoke the `i18n-expert` skill to audit cs / en / de

--- a/.claude/skills/mobile-screen/SKILL.md
+++ b/.claude/skills/mobile-screen/SKILL.md
@@ -194,12 +194,12 @@ After the screen renders, invoke the
 `delightful-design-system:audit-with-delightful` skill (or the
 `audit_css` MCP tool from the same plugin) to flag any hardcoded
 colors, spacing, font sizes, or radii in the new file. Use the
-output as a **hardcoded-value detector only** — the skill is
-opinionated toward Delightful's OKLCH neo-brutalist tokens, so
-ignore its replacement suggestions; route real fixes back to this
-project's `useTheme()` tokens (`theme.colors.*`, `theme.spacing.*`,
-`theme.typography.*`, `theme.radius.*`). Brand gold `#c9a84c` must
-only appear via the theme entry, never inline.
+output as a **hardcoded-value detector only** — the skill maps to
+Delightful's OKLCH tokens by default, so ignore its replacement
+suggestions; route real fixes back to this project's `useTheme()`
+tokens (`theme.colors.*`, `theme.spacing.*`, `theme.typography.*`,
+`theme.radius.*`). Brand gold `#c9a84c` must only appear via the
+theme entry, never inline.
 
 Required when the scaffold introduces any new styling. Skip when
 the new screen is a pure-routing wrapper with no styling.

--- a/.claude/skills/web-page/SKILL.md
+++ b/.claude/skills/web-page/SKILL.md
@@ -156,6 +156,22 @@ Adjust for the actual shape:
 4. Open devtools network tab — no polling (only initial load + post-mutation
    invalidation fetches).
 
+## Token-compliance scan (post-scaffold)
+
+After the page renders, invoke the
+`delightful-design-system:audit-with-delightful` skill (or the
+`audit_css` MCP tool from the same plugin) to flag any hardcoded
+colors, spacing, font sizes, or radii in the new file. Use the
+output as a **hardcoded-value detector only** — the skill is
+opinionated toward Delightful's OKLCH neo-brutalist tokens, so
+ignore its replacement suggestions; route real fixes back to this
+project's Tailwind theme (`text-text`, `bg-surface`, `gap-6`,
+etc.). Brand gold `#c9a84c` must only appear via the theme entry,
+never inline.
+
+Required when the scaffold introduces any new styling. Skip when
+the new page is a pure-routing wrapper with no styling.
+
 ## Final step — i18n validation
 
 Before reporting done, invoke the `i18n-expert` skill to audit cs / en / de

--- a/.claude/skills/web-page/SKILL.md
+++ b/.claude/skills/web-page/SKILL.md
@@ -162,12 +162,11 @@ After the page renders, invoke the
 `delightful-design-system:audit-with-delightful` skill (or the
 `audit_css` MCP tool from the same plugin) to flag any hardcoded
 colors, spacing, font sizes, or radii in the new file. Use the
-output as a **hardcoded-value detector only** — the skill is
-opinionated toward Delightful's OKLCH neo-brutalist tokens, so
-ignore its replacement suggestions; route real fixes back to this
-project's Tailwind theme (`text-text`, `bg-surface`, `gap-6`,
-etc.). Brand gold `#c9a84c` must only appear via the theme entry,
-never inline.
+output as a **hardcoded-value detector only** — the skill maps to
+Delightful's OKLCH tokens by default, so ignore its replacement
+suggestions; route real fixes back to this project's Tailwind theme
+(`text-text`, `bg-surface`, `gap-6`, etc.). Brand gold `#c9a84c`
+must only appear via the theme entry, never inline.
 
 Required when the scaffold introduces any new styling. Skip when
 the new page is a pure-routing wrapper with no styling.


### PR DESCRIPTION
## Summary

- Adds a "Token-compliance scan (post-scaffold)" section to both `.claude/skills/web-page/SKILL.md` and `.claude/skills/mobile-screen/SKILL.md`, between Verify and the existing i18n validation step.
- Invokes the locally-installed `delightful-design-system:audit-with-delightful` skill (or its `audit_css` MCP tool) to surface hardcoded colors / spacing / font sizes / radii in newly-scaffolded UI files before review.
- **Adapter prose:** the audit is opinionated toward Delightful's OKLCH / neo-brutalist tokens, but this project uses Tailwind (web) and `useTheme()` (mobile). The new section explicitly tells the agent to treat the audit output as a hardcoded-value detector only and ignore Delightful's replacement suggestions — real fixes route back to the project's tokens.

## Related issue

Fixes #186

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`.

## Scope

docs-infra (`.claude/skills/web-page/SKILL.md`, `.claude/skills/mobile-screen/SKILL.md`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions.
- Skill confirmed loaded: `delightful-design-system:audit-with-delightful` appears in the active skill catalogue after `/reload-plugins`.
- MCP confirmed connected: `audit_css` tool available under `plugin:delightful-design-system:delightful`.

## QA

Not applicable — pure docs-infra. AC verified by reading the diff.

## Test plan

- [x] `.claude/skills/web-page/SKILL.md` includes a post-scaffold step that runs the token-compliance scan
- [x] `.claude/skills/mobile-screen/SKILL.md` includes the same post-scaffold step
- [x] The scan flags any hardcoded colors or spacing values in newly-scaffolded UI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)