### PR TITLE
chore(#183): add playwright-skill visual-regression recipe to qa-tester

### DIFF
--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -555,22 +555,31 @@ For each linked scene:
    parity. First try the automated path:
 
    - Invoke `Skill: playwright-skill:playwright-skill` with the
-     visual-regression recipe — capture the current render of the
-     touched route (web at `:5173`, mobile-web at `:8081` for
-     `react-native-web` AC flows) and diff it against the stored
-     baseline at `.qa-artifacts/baselines/<scene>.png`.
-   - **No drift** → criterion ✅ PASS; no human eyeball needed.
-   - **Drift detected** → attach the diff PNG plus both screenshots
-     from step 2 to the verdict, mark the criterion ⚠️ UNVERIFIED —
-     REQUIRES HUMAN REVIEW, and ask the orchestrator to get the user
-     to eyeball them. Do not PASS on a visual claim you can't prove.
-   - **No baseline yet for this scene** → capture the current render
-     as the new baseline at `.qa-artifacts/baselines/<scene>.png`,
-     mention "baseline established this run" in the verdict, and
-     mark the criterion ✅ PASS for this run; subsequent runs diff
-     against it. Baselines live under `.qa-artifacts/baselines/`;
-     commit them if cross-machine / CI consistency is wanted, leave
-     them gitignored if the project treats them as local-only.
+     visual-regression recipe — capture the current render of every
+     route the AC exercises (web at `:5173`, mobile-web at `:8081`
+     for `react-native-web` AC flows) and diff each against its
+     stored baseline at `.qa-artifacts/baselines/<scene>-<route>.png`
+     (one baseline per (scene, route) pair, kept globally
+     cross-issue — the whole point of a regression baseline).
+   - **No drift on every route** → criterion ✅ PASS; no human
+     eyeball needed.
+   - **Drift detected on any route** → attach the diff PNG plus both
+     screenshots from step 2 to the verdict, mark the criterion ⚠️
+     UNVERIFIED — REQUIRES HUMAN REVIEW, and ask the orchestrator
+     to get the user to eyeball them. Do not PASS on a visual claim
+     you can't prove.
+   - **No baseline yet for a (scene, route) pair** → DO NOT
+     auto-adopt the current render; a silent first-run adoption
+     would bake in any regression the dev shipped. Attach the
+     candidate PNG to the verdict, mark the criterion ⚠️ UNVERIFIED
+     — REQUIRES HUMAN BASELINE APPROVAL, and ask the orchestrator
+     to get the user to confirm the render is correct before
+     committing it as `.qa-artifacts/baselines/<scene>-<route>.png`.
+     Future runs diff against it.
+
+   Baselines stay local-only by default — `.qa-artifacts/` is
+   gitignored repo-wide. Lift the gitignore rule for
+   `.qa-artifacts/baselines/` to share baselines across machines / CI.
 
 If the issue links no prototype, skip step 5 entirely and note
 "No prototype linked — fidelity check not applicable" in the verdict.

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -552,10 +552,25 @@ For each linked scene:
 
 4. **When the difference is inherently visual** (spacing that reads
    wrong, a shadow, a curve, a transition), code alone cannot prove
-   parity. Attach both screenshots from step 2 to the verdict, mark
-   the criterion ⚠️ UNVERIFIED — REQUIRES HUMAN REVIEW, and ask the
-   orchestrator to get the user to eyeball them. Do not PASS on a
-   visual claim you can't prove.
+   parity. First try the automated path:
+
+   - Invoke `Skill: playwright-skill:playwright-skill` with the
+     visual-regression recipe — capture the current render of the
+     touched route (web at `:5173`, mobile-web at `:8081` for
+     `react-native-web` AC flows) and diff it against the stored
+     baseline at `.qa-artifacts/baselines/<scene>.png`.
+   - **No drift** → criterion ✅ PASS; no human eyeball needed.
+   - **Drift detected** → attach the diff PNG plus both screenshots
+     from step 2 to the verdict, mark the criterion ⚠️ UNVERIFIED —
+     REQUIRES HUMAN REVIEW, and ask the orchestrator to get the user
+     to eyeball them. Do not PASS on a visual claim you can't prove.
+   - **No baseline yet for this scene** → capture the current render
+     as the new baseline at `.qa-artifacts/baselines/<scene>.png`,
+     mention "baseline established this run" in the verdict, and
+     mark the criterion ✅ PASS for this run; subsequent runs diff
+     against it. Baselines live under `.qa-artifacts/baselines/`;
+     commit them if cross-machine / CI consistency is wanted, leave
+     them gitignored if the project treats them as local-only.
 
 If the issue links no prototype, skip step 5 entirely and note
 "No prototype linked — fidelity check not applicable" in the verdict.


### PR DESCRIPTION
## Summary

- Modifies step 5.4 ("inherently visual" branch of the prototype-fidelity check) in `.claude/agents/qa-tester.md` to try **automated visual-regression first** before falling back to human eyeballing.
- Invokes `Skill: playwright-skill:playwright-skill` with the visual-regression recipe to capture the current render and diff it against a stored baseline at `.qa-artifacts/baselines/<scene>.png`.
- Three outcomes documented: **no drift** → PASS, **drift** → UNVERIFIED + escalate (existing behaviour), **no baseline yet** → capture and mark PASS for this run.
- Covers both web (`:5173`) and `react-native-web` (`:8081`) mobile-web AC flows per the issue's mobile-web emphasis.

## Related issue

Fixes #183

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`.

## Scope

docs-infra (`.claude/agents/qa-tester.md`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions.
- Skill confirmed installed: `~/.claude/plugins/cache/playwright-skill/playwright-skill/4.1.0/skills/playwright-skill/SKILL.md` exists.

## QA

Not applicable — pure docs-infra. AC verified by reading the diff.

## Test plan

- [x] `qa-tester.md` references the playwright-skill visual-regression recipe
- [x] qa-tester captures screenshots on react-native-web mobile screens during AC flows
- [x] Screenshots are compared against a stored baseline and failures are surfaced in the qa-tester verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)