### PR TITLE
chore(#182): wire axe-core MCP into qa-tester post-AC pass

### DIFF
--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -599,10 +599,16 @@ MCP against every web (`:5173`) and mobile-web (`:8081`,
 or `test_html_string` on the rendered DOM if the page lives behind
 auth and you've already pulled HTML via Playwright.
 
+If the diff touches **prototype scenes** under `docs/prototypes/**`
+(also user-facing HTML), audit them too — load each touched scene via
+`file://` and run `test_accessibility`, or read the file and pipe its
+contents to `test_html_string`. Same severity classification as web /
+mobile-web flows.
+
 Skip the pass when, and only when:
 
-- The diff has zero `/web` or `/mobile` UI changes (pure backend /
-  docs / config PR).
+- The diff has zero `/web`, `/mobile`, or `docs/prototypes/**` UI
+  changes (pure backend / non-prototype docs / config PR).
 - All ACs in step 4 came back ⚠️ UNVERIFIED for missing-tooling
   reasons (Playwright unavailable etc.) — accessibility can't be
   tested either; flag both in the verdict.
@@ -626,8 +632,8 @@ spec, and `check_aria_attributes` when introducing a new interactive
 component (combobox, dialog, tab, listbox).
 
 Tool prefix: `mcp__a11y-accessibility__*` — load via ToolSearch with
-`select:mcp__a11y-accessibility__test_accessibility,...` if missing
-from the initial list.
+`select:mcp__a11y-accessibility__test_accessibility,mcp__a11y-accessibility__test_html_string,mcp__a11y-accessibility__check_aria_attributes,mcp__a11y-accessibility__check_color_contrast,mcp__a11y-accessibility__check_orientation_lock,mcp__a11y-accessibility__get_rules`
+if missing from the initial list.
 
 If the MCP isn't reachable in the agent's environment, say so
 explicitly in the verdict (`a11y-accessibility unavailable —

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -5,7 +5,7 @@ model: opus
 tools: Bash, Read, Grep, Glob, Write
 maxTurns: 80
 color: green
-mcpServers: plugin_playwright_playwright, xcodebuildmcp
+mcpServers: plugin_playwright_playwright, xcodebuildmcp, a11y-accessibility
 ---
 
 # qa-tester — Acceptance-criteria + regression + prototype-fidelity gate
@@ -46,9 +46,9 @@ orchestrator routes the fix back to the owning dev sub-agent.
   that went green, a `curl` response, a Playwright accessibility-tree
   snapshot, a screenshot filename.
 
-## External tooling — Playwright + XcodeBuildMCP MCP
+## External tooling — Playwright + XcodeBuildMCP + a11y MCP
 
-Two MCP plugins drive the interactive verification surface:
+Three MCP plugins drive the interactive verification surface:
 
 - **Playwright** (https://claude.com/plugins/playwright, Microsoft) —
   browser automation as `mcp__playwright__*` tools (navigate, click, fill,
@@ -60,6 +60,12 @@ Two MCP plugins drive the interactive verification surface:
   `mcp__plugin_xcodebuildmcp_*` tools (boot/shutdown simulator, install /
   launch / terminate app, tap-at-coordinates, swipe, type, screenshot,
   read simulator log). Used only for the Expo-web caveat list below.
+- **a11y-accessibility** (axe-core wrapper) — accessibility audits as
+  `mcp__a11y-accessibility__*` tools: `test_accessibility` (drive a
+  live URL), `test_html_string` (audit a string of HTML),
+  `check_aria_attributes`, `check_color_contrast`,
+  `check_orientation_lock`, `get_rules`. Used in the post-AC
+  accessibility pass (step 5b below) on web and mobile-web AC flows.
 
 You don't have to list either set of tools here — they're discovered at
 runtime in the sub-agent environment.
@@ -584,6 +590,50 @@ For each linked scene:
 If the issue links no prototype, skip step 5 entirely and note
 "No prototype linked — fidelity check not applicable" in the verdict.
 
+### 5b. Accessibility pass (axe-core MCP, post-AC)
+
+After step 4's per-criterion verification finishes, run the axe-core
+MCP against every web (`:5173`) and mobile-web (`:8081`,
+`react-native-web`) route the AC exercised. Use
+`mcp__a11y-accessibility__test_accessibility` against the route URL,
+or `test_html_string` on the rendered DOM if the page lives behind
+auth and you've already pulled HTML via Playwright.
+
+Skip the pass when, and only when:
+
+- The diff has zero `/web` or `/mobile` UI changes (pure backend /
+  docs / config PR).
+- All ACs in step 4 came back ⚠️ UNVERIFIED for missing-tooling
+  reasons (Playwright unavailable etc.) — accessibility can't be
+  tested either; flag both in the verdict.
+- The orchestrator's brief explicitly says skip a11y (rare; flag in
+  the verdict so the user sees the skip).
+
+Classify findings by axe severity:
+
+- **`critical` / `serious` violations** → AC fail. Add a per-route
+  bullet under "Additional findings (not in the AC but blocking)"
+  with the rule (`color-contrast`, `aria-required-attr`, etc.) and
+  the offending selector. Do not PASS the AC even if every step-4
+  criterion individually passed.
+- **`moderate` / `minor` violations** → surface as NIT under
+  "Additional findings (non-blocking)". Don't fail the run.
+- **No violations** → one-line note in the verdict
+  (`a11y: 0 violations across <N> routes`).
+
+Use `check_color_contrast` directly when the AC mentions a contrast
+spec, and `check_aria_attributes` when introducing a new interactive
+component (combobox, dialog, tab, listbox).
+
+Tool prefix: `mcp__a11y-accessibility__*` — load via ToolSearch with
+`select:mcp__a11y-accessibility__test_accessibility,...` if missing
+from the initial list.
+
+If the MCP isn't reachable in the agent's environment, say so
+explicitly in the verdict (`a11y-accessibility unavailable —
+accessibility pass skipped`). Do not mark ACs PASS while silently
+skipping the pass — record the skip so the user sees it.
+
 ### 6. Return the verdict
 
 Structure the response exactly like this so the orchestrator can parse
@@ -697,6 +747,10 @@ For each dev server in step 3b marked "started by qa-tester":
   tap-at-coordinates, tap-by-accessibility-id, swipe, type, screenshot,
   read simulator log, build via xcodebuild) for native iOS verification
   on the Expo-web caveat list.
+- **a11y-accessibility MCP tools** (`mcp__a11y-accessibility__*`:
+  `test_accessibility`, `test_html_string`, `check_aria_attributes`,
+  `check_color_contrast`, `check_orientation_lock`, `get_rules`) for
+  the post-AC accessibility pass (step 5b).
 - `Agent` — only for a genuinely isolated sub-probe (e.g. "parse the
   prototype HTML and list every i18n-worthy label"). Do not use it to
   parallelise the whole AC check.

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,6 +12,10 @@
       "command": "npx",
       "args": ["-y", "github:Mandalorian007/git-worktree-mcp"]
     },
+    "a11y-accessibility": {
+      "command": "npx",
+      "args": ["-y", "a11y-mcp-server"]
+    },
     "github": {
       "command": ".claude/scripts/with-keychain-secret.sh",
       "args": [


### PR DESCRIPTION
## Summary

- Registers the locally-installed axe-core wrapper (`a11y-accessibility` MCP, npm package `a11y-mcp-server`) as a project-level entry in `.mcp.json` and threads it through `qa-tester`'s `mcpServers:` frontmatter.
- Adds a new **### 5b. Accessibility pass (axe-core MCP, post-AC)** section between step 5 (prototype-fidelity) and step 6 (return verdict). Numbered `5b` to avoid cascading renumbering through 6/7/8 and their cross-references.
- Step 5b runs `mcp__a11y-accessibility__test_accessibility` against every web (`:5173`) and mobile-web (`:8081`, `react-native-web`) route the AC exercised; falls back to `test_html_string` for auth-gated pages.
- Severity classification: critical/serious → AC fail (added to blocking findings); moderate/minor → NIT under non-blocking findings; clean → one-line verdict note. `check_color_contrast` and `check_aria_attributes` called out for AC-specific contrast specs and new interactive components.

## Related issue

Fixes #182 (skill-half intentionally simplified to MCP-only — the axe-core MCP covers the AC's "axe checks on web/mobile-web AC flows" requirement; no separate `claude-a11y-skill` was installed locally).

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`.

## Scope

docs-infra (`.claude/agents/qa-tester.md`, `.mcp.json`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions.
- MCP confirmed connected: `claude mcp list` shows `a11y-accessibility: /opt/homebrew/bin/npx -y a11y-mcp-server - ✓ Connected`.
- Tool surface verified loaded: `mcp__a11y-accessibility__test_accessibility`, `test_html_string`, `check_aria_attributes`, `check_color_contrast`, `check_orientation_lock`, `get_rules`.

## QA

Not applicable — pure docs-infra. AC verified by reading the diff plus the locally-connected MCP.

## Test plan

- [x] `qa-tester.md` documents a post-AC accessibility pass using the axe-core MCP
- [x] qa-tester runs axe checks on web AC flows (Playwright-driven routes at `:5173`)
- [x] qa-tester runs axe checks on mobile-web (`react-native-web`) AC flows at `:8081`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
