### PR TITLE
chore(#219): conversation-delta statusline wrapper for ccline

### DIFF
--- a/.claude/claude-tooling.md
+++ b/.claude/claude-tooling.md
@@ -58,6 +58,70 @@ flag it. If `~/.claude/settings.json` ends up with two `statusLine`
 entries, delete the stale one. The `statusline-setup` agent
 (`Agent: statusline-setup`) handles this cleanly on request.
 
+### Optional: show only conversation tokens (delta wrapper)
+
+Out of the box, ccline reads its token total by tallying everything in
+the active transcript — system prompt, tool definitions, skill
+catalogue, MCP schemas, agent definitions, active `CLAUDE.md` files,
+auto-memory, plus your conversation. On a project with many plugins
+that **structural baseline** alone fills 50–60% of the 1M Opus 4.7
+context window before you've typed anything. `/clear` does not drop
+the percentage meaningfully because it only wipes conversation
+history, not the baseline.
+
+If you'd rather see "tokens added since session start" — a counter
+that actually drops to ~0% on a fresh session — point your statusline
+at the project's wrapper script instead of `ccline` directly:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/path/to/repo/.claude/scripts/ccline-convo.sh",
+    "padding": 0
+  }
+}
+```
+
+The script lives in this repo at
+[`.claude/scripts/ccline-convo.sh`](scripts/ccline-convo.sh) and:
+
+- Reads `session_id` and `transcript_path` from the JSON Claude Code
+  pipes to the statusline command on every render.
+- Sums the `usage` fields across the transcript JSONL
+  (`input_tokens` + `output_tokens` + cache reads / creates).
+- Persists the first-seen total per session to
+  `~/.claude/.statusline-baselines/<session-id>.txt`.
+- Displays `current − baseline` against the available room
+  (`1M − baseline`, configurable via `CCLINE_CAP_TOKENS`).
+- Keeps the existing 5h-block segment on the right (`⏳ Xh YYm · NN.N%`)
+  when `ccusage` is on `$PATH`.
+
+#### `/clear` behavior
+
+- If your Claude Code version mints a new `session_id` on `/clear`,
+  the wrapper auto-snapshots a fresh baseline.
+- If `session_id` survives `/clear`, manually reset the counter:
+
+  ```bash
+  rm -rf ~/.claude/.statusline-baselines
+  mkdir -p ~/.claude/.statusline-baselines
+  ```
+
+#### Caveats
+
+- The token sum reads `usage` fields that Claude Code writes into the
+  transcript JSONL. If your version uses a different shape, the count
+  reads 0 and the bar shows `0% [        ] · 0 convo`. Inspect the
+  transcript first:
+  `head -3 "$(jq -r .transcript_path < /tmp/last-statusline-input.json)"`
+  (after capturing one render).
+- Baseline includes whatever was in the transcript at first render —
+  installing or uninstalling plugins mid-session makes the baseline
+  stale. Delete the baseline file to refresh.
+- The script assumes the **1M-token Opus 4.7 cap** by default. Set
+  `CCLINE_CAP_TOKENS=200000` (or whatever) for non-1M models.
+
 ### Troubleshooting
 
 - **Statusline doesn't render.** Confirm the binary is executable:
@@ -67,9 +131,10 @@ entries, delete the stale one. The `statusline-setup` agent
   per-session.
 - **Two statuslines stacking.** See the duplicate-keys note above —
   it's almost always two `statusLine` entries.
-- **Token-budget reads wrong.** ccline pulls from Claude Code's session
-  state; if `/usage` shows the right numbers but ccline doesn't, restart
-  Claude Code to refresh the IPC channel.
+- **ccline % stays fixed and `/clear` doesn't budge it.** That's
+  expected — ccline reads total context fill, not conversation delta.
+  See "Optional: show only conversation tokens (delta wrapper)" above
+  for the wrapper that drops to ~0% on a fresh session.
 
 ---
 

--- a/.claude/scripts/ccline-convo.sh
+++ b/.claude/scripts/ccline-convo.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Statusline wrapper:
+#   Left:  conversation tokens since session start (delta vs first-render baseline)
+#   Right: 5h-block usage (time remaining + token % with bar)
+#
+# By default ccline reports total context fill — system prompt + tool defs +
+# skill catalogue + MCP schemas + your conversation. On a project with many
+# plugins that baseline alone can fill 50–60% of the 1M context window before
+# you type anything, and `/clear` does not drop it (it only wipes conversation
+# history, not the structural baseline).
+#
+# This wrapper snapshots the first-render total per session_id as the baseline
+# and then reports `current − baseline` so the percentage reflects only what
+# has been added since session start. See .claude/claude-tooling.md for the
+# full setup notes.
+set -u
+
+BASELINE_DIR="$HOME/.claude/.statusline-baselines"
+mkdir -p "$BASELINE_DIR"
+
+input="$(cat)"
+
+session_id="$(printf '%s' "$input" | /usr/bin/python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("session_id",""))' 2>/dev/null)"
+transcript="$(printf '%s' "$input" | /usr/bin/python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("transcript_path",""))' 2>/dev/null)"
+
+current_tokens=0
+if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+  current_tokens="$(/usr/bin/python3 -c '
+import json, sys
+total = 0
+try:
+    with open(sys.argv[1]) as f:
+        for line in f:
+            try:
+                msg = json.loads(line)
+                u = msg.get("usage") or msg.get("message", {}).get("usage") or {}
+                total += int(u.get("input_tokens", 0)) \
+                       + int(u.get("output_tokens", 0)) \
+                       + int(u.get("cache_read_input_tokens", 0)) \
+                       + int(u.get("cache_creation_input_tokens", 0))
+            except Exception:
+                pass
+except Exception:
+    pass
+print(total)
+' "$transcript" 2>/dev/null)"
+  current_tokens="${current_tokens:-0}"
+fi
+
+baseline_file="$BASELINE_DIR/$session_id.txt"
+if [ -n "$session_id" ] && [ ! -f "$baseline_file" ]; then
+  echo "$current_tokens" > "$baseline_file"
+fi
+baseline="$(cat "$baseline_file" 2>/dev/null || echo 0)"
+
+delta=$(( current_tokens - baseline ))
+[ "$delta" -lt 0 ] && delta=0
+
+# Default 1M cap (Opus 4.7 1M). Override with CCLINE_CAP_TOKENS env var.
+cap="${CCLINE_CAP_TOKENS:-1000000}"
+room=$(( cap - baseline ))
+pct=0
+[ "$room" -gt 0 ] && pct=$(( delta * 100 / room ))
+[ "$pct" -gt 100 ] && pct=100
+
+filled=$(( pct * 8 / 100 ))
+empty=$(( 8 - filled ))
+bar=""
+while [ "$filled" -gt 0 ]; do bar="${bar}█"; filled=$((filled-1)); done
+while [ "$empty"  -gt 0 ]; do bar="${bar} "; empty=$((empty-1));   done
+
+if [ "$delta" -ge 1000 ]; then
+  pretty="$(( delta / 1000 )).$(( (delta % 1000) / 100 ))k"
+else
+  pretty="$delta"
+fi
+
+left="⚡ ${pct}% [${bar}] · ${pretty} convo"
+
+# Right side — 5h-block usage from ccusage. Optional; degrades gracefully.
+block_summary=""
+if command -v ccusage >/dev/null 2>&1; then
+  block_summary="$(ccusage blocks --active --token-limit max --json 2>/dev/null \
+    | /usr/bin/python3 -c '
+import json, sys, datetime
+try:
+    d = json.load(sys.stdin)
+    b = (d.get("blocks") or [None])[0]
+    if not b or not b.get("isActive"):
+        sys.exit(0)
+    end = datetime.datetime.fromisoformat(b["endTime"].replace("Z", "+00:00"))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    mins = max(0, int((end - now).total_seconds() / 60))
+    h, m = divmod(mins, 60)
+    used = b.get("totalTokens") or 0
+    tls = b.get("tokenLimitStatus") or {}
+    limit = tls.get("limit") or 0
+    cur_pct = (used / limit * 100) if limit else 0
+    print(f"⏳ {h}h {m:02d}m · {cur_pct:.1f}%")
+except Exception:
+    pass
+' 2>/dev/null)" || block_summary=""
+fi
+
+if [ -n "$left" ] && [ -n "$block_summary" ]; then
+  printf '%s | %s\n' "$left" "$block_summary"
+else
+  printf '%s%s\n' "$left" "$block_summary"
+fi

--- a/.claude/scripts/ccline-convo.sh
+++ b/.claude/scripts/ccline-convo.sh
@@ -13,19 +13,31 @@
 # and then reports `current − baseline` so the percentage reflects only what
 # has been added since session start. See .claude/claude-tooling.md for the
 # full setup notes.
+
+# Intentional: `set -u` only, no `-e` / `-o pipefail`. The statusline must
+# never crash the prompt — every command degrades gracefully via 2>/dev/null
+# fallbacks. Adding -e/pipefail would convert benign python parse failures
+# (transcript shape drift, ccusage missing) into a blank statusline.
 set -u
 
 BASELINE_DIR="$HOME/.claude/.statusline-baselines"
 mkdir -p "$BASELINE_DIR"
 
+# Prune baseline files older than 14 days. Tiny single-int files, but they'd
+# accumulate one-per-session indefinitely without this. Best-effort.
+find "$BASELINE_DIR" -type f -name '*.txt' -mtime +14 -delete 2>/dev/null || true
+
+# Resolve python3 portably — prefer PATH, fall back to the macOS system path.
+PYTHON="$(command -v python3 || echo /usr/bin/python3)"
+
 input="$(cat)"
 
-session_id="$(printf '%s' "$input" | /usr/bin/python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("session_id",""))' 2>/dev/null)"
-transcript="$(printf '%s' "$input" | /usr/bin/python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("transcript_path",""))' 2>/dev/null)"
+session_id="$(printf '%s' "$input" | "$PYTHON" -c 'import json,sys; d=json.load(sys.stdin); print(d.get("session_id",""))' 2>/dev/null)"
+transcript="$(printf '%s' "$input" | "$PYTHON" -c 'import json,sys; d=json.load(sys.stdin); print(d.get("transcript_path",""))' 2>/dev/null)"
 
 current_tokens=0
 if [ -n "$transcript" ] && [ -f "$transcript" ]; then
-  current_tokens="$(/usr/bin/python3 -c '
+  current_tokens="$("$PYTHON" -c '
 import json, sys
 total = 0
 try:
@@ -47,11 +59,17 @@ print(total)
   current_tokens="${current_tokens:-0}"
 fi
 
-baseline_file="$BASELINE_DIR/$session_id.txt"
-if [ -n "$session_id" ] && [ ! -f "$baseline_file" ]; then
-  echo "$current_tokens" > "$baseline_file"
+# Baseline logic — only when we have a session_id AND a non-zero current
+# total. Persisting a 0 baseline (silent python parse failure or empty
+# transcript) would lock the wrapper into "delta == current" forever.
+baseline=0
+if [ -n "$session_id" ]; then
+  baseline_file="$BASELINE_DIR/$session_id.txt"
+  if [ ! -f "$baseline_file" ] && [ "$current_tokens" -gt 0 ]; then
+    echo "$current_tokens" > "$baseline_file"
+  fi
+  baseline="$(cat "$baseline_file" 2>/dev/null || echo 0)"
 fi
-baseline="$(cat "$baseline_file" 2>/dev/null || echo 0)"
 
 delta=$(( current_tokens - baseline ))
 [ "$delta" -lt 0 ] && delta=0
@@ -81,7 +99,7 @@ left="⚡ ${pct}% [${bar}] · ${pretty} convo"
 block_summary=""
 if command -v ccusage >/dev/null 2>&1; then
   block_summary="$(ccusage blocks --active --token-limit max --json 2>/dev/null \
-    | /usr/bin/python3 -c '
+    | "$PYTHON" -c '
 import json, sys, datetime
 try:
     d = json.load(sys.stdin)


### PR DESCRIPTION
## Summary

- Adds `.claude/scripts/ccline-convo.sh` — a drop-in statusline command that shows **only conversation tokens** (delta vs first-render baseline per `session_id`), instead of ccline's default total-context-fill.
- Documents it as a new "Optional: show only conversation tokens (delta wrapper)" subsection in `.claude/claude-tooling.md` with install snippet, `/clear` behavior, and caveats.
- Replaces the stale "Token-budget reads wrong" troubleshooting bullet (which assumed an IPC channel ccline doesn't use) with a pointer to the wrapper for the "ccline % stays fixed and `/clear` doesn't budge it" symptom.

## Why

ccline tallies the entire transcript — system prompt, tool defs, skill catalogue, MCP schemas, agents, memory, plus conversation. On a project with this orchestration setup the structural baseline alone fills ~50–60% of the 1M context window before any user input, and `/clear` only drops conversation history (not the baseline), so the percentage doesn't visibly reset. The wrapper snapshots that baseline once and shows the delta from that point.

## How it works

- Reads `session_id` and `transcript_path` from the JSON Claude Code pipes to the statusLine command on every render.
- Sums `usage` fields across the transcript JSONL.
- Persists first-seen total to `~/.claude/.statusline-baselines/<session-id>.txt`.
- Displays `current − baseline` against `1M − baseline` (configurable via `CCLINE_CAP_TOKENS`).
- Keeps the right-side 5h-block segment from `ccusage` when available; degrades gracefully when not.

## Related issue

Fixes #219

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`. Direct follow-up to PR #218 (#177) which shipped the original CCometixLine setup.

## Scope

docs-infra (`.claude/scripts/ccline-convo.sh`, `.claude/claude-tooling.md`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions.
- `bash -n .claude/scripts/ccline-convo.sh` → syntax-clean.

## QA

Not applicable — pure docs-infra. The script's runtime behavior is best-tested by the user pointing their `~/.claude/settings.json` `statusLine.command` at it and observing.

## Test plan

- [x] `.claude/scripts/ccline-convo.sh` exists, is executable, syntax-clean
- [x] `.claude/claude-tooling.md` has the new "Optional: show only conversation tokens (delta wrapper)" subsection
- [x] Stale "Token-budget reads wrong" bullet replaced with pointer to wrapper
- [x] cclint reports 0 errors on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
