### PR TITLE
fix(#221): drop --token-limit max from ccline-convo block segment

### DIFF
--- a/.claude/claude-tooling.md
+++ b/.claude/claude-tooling.md
@@ -121,6 +121,12 @@ The script lives in this repo at
   stale. Delete the baseline file to refresh.
 - The script assumes the **1M-token Opus 4.7 cap** by default. Set
   `CCLINE_CAP_TOKENS=200000` (or whatever) for non-1M models.
+- The right-side 5h-block percentage is computed by `ccusage` with
+  auto-detection by default — that matches what `/status` reports for
+  the same window. Set `CCLINE_BLOCK_TOKEN_LIMIT=max` (or `pro` /
+  `max5` / `max20`) to force a specific tier cap; useful for
+  projection / planning views, but the default auto-detect is what
+  most people want.
 
 ### Troubleshooting
 

--- a/.claude/scripts/ccline-convo.sh
+++ b/.claude/scripts/ccline-convo.sh
@@ -96,9 +96,22 @@ fi
 left="⚡ ${pct}% [${bar}] · ${pretty} convo"
 
 # Right side — 5h-block usage from ccusage. Optional; degrades gracefully.
+#
+# By default we let ccusage auto-detect the cap from usage history, which
+# matches what Claude Code's `/status` reports. Hardcoding `--token-limit
+# max` would force the Max20 tier cap (~6.5M tokens) regardless of the
+# user's actual plan, so the percentage would diverge from /status (e.g.
+# 12.6% here vs 82% in /status on a Max5 plan).
+#
+# Override via CCLINE_BLOCK_TOKEN_LIMIT (e.g. "max", "pro", "max5") if the
+# auto-detected cap isn't what you want.
 block_summary=""
 if command -v ccusage >/dev/null 2>&1; then
-  block_summary="$(ccusage blocks --active --token-limit max --json 2>/dev/null \
+  ccusage_args=(blocks --active --json)
+  if [ -n "${CCLINE_BLOCK_TOKEN_LIMIT:-}" ]; then
+    ccusage_args+=(--token-limit "$CCLINE_BLOCK_TOKEN_LIMIT")
+  fi
+  block_summary="$(ccusage "${ccusage_args[@]}" 2>/dev/null \
     | "$PYTHON" -c '
 import json, sys, datetime
 try:


### PR DESCRIPTION
## Summary

- Drops the hardcoded `--token-limit max` flag from `ccusage blocks --active` in `.claude/scripts/ccline-convo.sh`. ccusage's default auto-detects the cap from usage history, which matches what `/status` reports for the same window.
- Adds `CCLINE_BLOCK_TOKEN_LIMIT` env-var override for users who genuinely want a different cap (e.g. forcing `max` for projection / planning views).
- Inline comment in the script explains the tradeoff so future readers don't re-introduce the bug.
- Updates the "Optional: show only conversation tokens (delta wrapper)" caveats list in `.claude/claude-tooling.md` to mention the env var and the cap-mismatch behaviour.

## Bug

`/status` reported `82% used` while the statusline right segment showed `12.6%`. The cap mismatch explained the gap exactly: 820k tokens used on a Max5 plan (~1M cap) → `/status` = 82%; same 820k against ~6.5M Max20 cap → wrapper = 12.6%.

## Related issue

Fixes #221

## Parent epic

Phase-2 follow-up under epic #173 (already merged); standalone PR against `develop`. Direct follow-up to PR #220 (#219) which shipped the original wrapper.

## Scope

docs-infra (`.claude/scripts/ccline-convo.sh`, `.claude/claude-tooling.md`)

## Verification

- `npx -y @carlrannaberg/cclint@0.2.10 --root .` → 0 errors, 23 warnings, 7 suggestions.
- `bash -n .claude/scripts/ccline-convo.sh` → syntax-clean.
- The fix is the hardcoded-flag removal + env-var override; runtime verification (statusline % matching `/status` %) is best done by the user pointing their `~/.claude/settings.json` `statusLine.command` at the updated script.

## QA

Not applicable — pure docs-infra fix. Behavioural verification is the user observing the new statusline number matching `/status`.

## Test plan

- [x] `.claude/scripts/ccline-convo.sh` no longer hardcodes `--token-limit max`
- [x] `CCLINE_BLOCK_TOKEN_LIMIT` env var, when set, is forwarded to ccusage
- [x] `.claude/claude-tooling.md` documents the env var and the cap-mismatch caveat
- [x] cclint reports 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)