### PR TITLE
fix(deploy): unblock Render Docker build (MSB3552)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,16 @@ RUN dotnet restore FitnessPlatform.Application/FitnessPlatform.Application.cspro
 
 # Copy everything else and publish
 COPY . .
+
+# Workaround for a Linux MSBuild bug in .NET SDK 10.0.103: the glob evaluation
+# for EmbeddedResource/Compile items enumerates `DefaultItemExcludes` (bin/**,
+# obj/**) and throws DirectoryNotFoundException if any exclude subfolder is
+# missing. The exception is swallowed, and the literal `**/*.resx` glob reaches
+# the compiler as a filename, producing MSB3552. Pre-creating the Debug folder
+# lets the enumeration walk cleanly. The Release publish never writes to it.
+# Mirrors .github/workflows/backend.yml.
+RUN mkdir -p FitnessPlatform.Application/bin/Debug
+
 RUN dotnet publish FitnessPlatform.Application/FitnessPlatform.Application.csproj \
     -c Release \
     -o /app \


### PR DESCRIPTION
## Summary

- Mirrors the CI workaround for .NET SDK 10.0.103's Linux MSBuild glob bug into the Render Docker build.
- Pre-creates `FitnessPlatform.Application/bin/Debug` before `dotnet publish` so the `EmbeddedResource` glob enumeration walks cleanly. Without it, `DirectoryNotFoundException` on the missing folder is swallowed and the literal `**/*.resx` glob reaches the compiler → MSB3552 → publish fails.

## Why

PR #223 set up the Render dev deployment, but the first deploy on develop failed with:

```
error MSB3552: Resource file "**/*.resx" cannot be found.
```

The same root cause was already documented and fixed in `.github/workflows/backend.yml`. This PR mirrors that fix in `backend/Dockerfile` so Render's build matches CI behavior.

## Test plan

- [x] `docker build -t fitness-api-test backend/` completes locally without MSB3552
- [ ] Render deploy of develop succeeds after merge
- [ ] `/health/live` returns 200 on the deployed service