### PR TITLE
chore: keep-alive workflow for dev services

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,47 @@
+name: Keep dev services alive
+
+# Pings the deployed dev API's /health endpoint on a cron so:
+#   1. Render's free-tier API container doesn't sleep after 15 min idle
+#   2. Atlas Mongo (60-day idle pause) gets touched
+#   3. Supabase Postgres (7-day idle pause) gets touched
+#
+# Hitting /health (not /health/live) does all three in one HTTP call —
+# the readiness probe runs CanConnectAsync against Postgres + ping
+# command against Mongo.
+#
+# This is a workaround for free-tier sleep, not a fix. Once the dev env
+# moves to a paid Render plan (Starter+ doesn't sleep), drop this workflow.
+
+on:
+  schedule:
+    # Every 14 min — under Render's 15-min sleep threshold, with a 1-min
+    # buffer for GitHub Actions cron delivery delays (which can lag 5–30
+    # min under heavy GH load).
+    - cron: '*/14 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  # If GH cron delivery stacks runs (delayed firing), let the latest one
+  # finish without queueing duplicates.
+  group: keep-alive
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Ping /health (Render + Postgres + Mongo)
+        run: |
+          status=$(curl -sk -o /tmp/body -w "%{http_code}" \
+            --max-time 60 \
+            https://dev-fitnessplatform.onrender.com/health)
+          echo "HTTP $status"
+          cat /tmp/body 2>/dev/null || true
+          # Job's purpose is to wake the container, not gate on health.
+          # Log non-2xx as a warning but exit 0 so we don't spam alerts
+          # on transient failures (DB blip, deploy in progress, etc.).
+          case "$status" in
+            2*) exit 0 ;;
+            *)  echo "::warning::Non-2xx response: $status" ; exit 0 ;;
+          esac


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/keep-alive.yml` — a cron-driven workflow that pings the deployed dev API's `/health` endpoint every 14 min.
- One ping keeps **three** things from going idle: Render's API container (15-min sleep), Atlas Mongo (60-day pause), Supabase Postgres (7-day pause). The `/health` readiness probe runs `CanConnectAsync` against Postgres + ping against Mongo, so a single call exercises all three.

## Why

Free-tier dev infra auto-sleeps/auto-pauses. Without a keep-alive, the next request after a quiet period eats a 30–60 sec cold-start (or fails outright if a DB has paused). Pinging at 14-min intervals stays under Render's 15-min sleep threshold with buffer for GitHub cron delivery delays.

This is a workaround, not a fix. Once dev moves to a paid plan (Render Starter+ doesn't sleep), drop the workflow.

## Tradeoffs (in workflow comments)

- GH cron delivery can lag 5–30 min under load → `*/14` instead of `*/15` for buffer.
- Job exits 0 even on non-2xx so we don't spam alerts on transient failures (deploy in progress, brief DB blip).
- Public repo → free Actions minutes; private repo on free plan would cost ~25 min/day of the 2000-min budget.

## Test plan

- [ ] PR CI green
- [ ] After merge, the new workflow appears in **Actions** tab and fires on its first cron tick within 14 min
- [ ] First scheduled run shows HTTP 200 from `/health`
- [ ] Render dashboard shows no "starting up" cold-start in the request graph for ~24 hours after merge