### PR TITLE
feat: time-based logging + WOD live timer screens (#207)

### DIFF
--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -45,7 +45,14 @@ import type { UpdateWorkoutRequest } from '@/api/workouts'
 import type { SessionExercise, ExerciseSet, MuscleGroup } from '@/api/training'
 import { getTodaySession } from '@/api/training'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
-import type { WorkoutFormat, WodConfig, WodResult, MovementType } from '@/api/wod-types'
+import type {
+  WorkoutFormat,
+  WodConfig,
+  WodResult,
+  MovementType,
+  UpdateWorkoutWodRequest,
+  UpdateWodExerciseRequest,
+} from '@/api/wod-types'
 
 import { useLiveSessionStore } from '@/stores/liveSessionStore'
 import { addPendingMutation } from '@/stores/offline'
@@ -833,8 +840,8 @@ export default function WorkoutLogScreen() {
 
   // ── Mutations ──
   const updateMutation = useMutation({
-    mutationFn: ({ logId, req }: { logId: string; req: UpdateWorkoutRequest }) =>
-      updateWorkout(logId, req),
+    mutationFn: ({ logId, req }: { logId: string; req: UpdateWorkoutWodRequest }) =>
+      updateWorkout(logId, req as UpdateWorkoutRequest),
     onError: (_err, vars) => {
       if (!isConnected) {
         addPendingMutation({
@@ -979,36 +986,47 @@ export default function WorkoutLogScreen() {
   // before React re-renders and this callback's closure is rebuilt. Using
   // `getState()` guarantees the PUT body reflects the freshly-marked set
   // instead of the pre-mutation snapshot (which would persist N-1 sets).
-  const buildRequest = useCallback((): UpdateWorkoutRequest => {
+  const buildRequest = useCallback((): UpdateWorkoutWodRequest => {
     const state = useLiveSessionStore.getState()
-    return {
-      exercises: exercises.map((ex) => {
-        const exId = ex.exerciseExternalId ?? ''
-        const doneSetIndices = state.completedSets[exId] ?? []
-        const skippedSetIndices = state.skippedSets[exId] ?? []
-        const sets = (ex.sets ?? []).map((planned, si) => {
-          const override = state.formOverrides[exId]?.[si]
-          const isDone = doneSetIndices.includes(si)
-          const isSkipped = skippedSetIndices.includes(si)
-          // `planned.setNumber` from the plan is already 1-based; fall back to
-          // `si + 1` only when the plan entry doesn't carry it. Previously this
-          // was `(planned.setNumber ?? si) + 1`, which double-incremented
-          // real plan set numbers (1,2,3 → 2,3,4) and left the WorkoutLog
-          // misaligned with the plan.
-          return {
-            setNumber: planned.setNumber ?? si + 1,
-            reps: isDone ? (override?.reps ?? planned.reps) : undefined,
-            weightKg: isDone ? (override?.weightKg ?? planned.weightKg) : undefined,
-            completedAt:
-              isDone || isSkipped ? new Date().toISOString() : undefined,
-          }
-        })
+    const exerciseList: UpdateWodExerciseRequest[] = exercises.map((ex) => {
+      const exId = ex.exerciseExternalId ?? ''
+      const doneSetIndices = state.completedSets[exId] ?? []
+      const skippedSetIndices = state.skippedSets[exId] ?? []
+      const sets = (ex.sets ?? []).map((planned, si) => {
+        const override = state.formOverrides[exId]?.[si]
+        const isDone = doneSetIndices.includes(si)
+        const isSkipped = skippedSetIndices.includes(si)
+        // `planned.setNumber` from the plan is already 1-based; fall back to
+        // `si + 1` only when the plan entry doesn't carry it. Previously this
+        // was `(planned.setNumber ?? si) + 1`, which double-incremented
+        // real plan set numbers (1,2,3 → 2,3,4) and left the WorkoutLog
+        // misaligned with the plan.
         return {
-          exerciseExternalId: exId,
-          exerciseName: ex.exerciseName ?? '',
-          sets,
+          setNumber: planned.setNumber ?? si + 1,
+          reps: isDone ? (override?.reps ?? planned.reps) : undefined,
+          weightKg: isDone ? (override?.weightKg ?? planned.weightKg) : undefined,
+          // Time-movement actuals: durationSeconds replaces the reps slot.
+          durationSeconds: isDone ? (override?.durationSeconds ?? null) : undefined,
+          // Distance-movement actuals: distanceMeters replaces the weightKg slot.
+          distanceMeters: isDone ? (override?.distanceMeters ?? null) : undefined,
+          completedAt:
+            isDone || isSkipped ? new Date().toISOString() : undefined,
         }
-      }),
+      })
+      // Per-exercise WOD result (only present when the exercise has a format override).
+      const exWodResult = state.wodResults[exId] ?? null
+      return {
+        exerciseExternalId: exId,
+        exerciseName: ex.exerciseName ?? '',
+        sets,
+        wodResult: exWodResult ?? undefined,
+      }
+    })
+    // Session-level WOD result (present when the whole session is a WOD format).
+    const sessionWodResult = state.wodResults['__session__'] ?? null
+    return {
+      exercises: exerciseList,
+      wodResult: sessionWodResult ?? undefined,
     }
   }, [exercises])
 
@@ -1450,10 +1468,12 @@ export default function WorkoutLogScreen() {
                     }
                     onSetDone={(durationSeconds, distanceMeters) => {
                       const exId = currentExercise.exerciseExternalId ?? `ex-${currentExerciseIdx}`
-                      // Record actuals — reuse formOverrides shape; duration→reps slot, distance→weight slot
+                      // Record actuals into their dedicated fields so buildRequest()
+                      // can forward them to UpdateWorkoutWodRequest correctly.
                       storeMarkSetDone(exId, currentSetIdx, {
-                        reps: durationSeconds != null ? Math.round(durationSeconds) : undefined,
-                        weightKg: distanceMeters != null ? distanceMeters : undefined,
+                        durationSeconds:
+                          durationSeconds != null ? Math.round(durationSeconds) : undefined,
+                        distanceMeters: distanceMeters != null ? distanceMeters : undefined,
                       })
                       const { nextExIdx, nextSetIdx, isLast } = computeNext(
                         currentExerciseIdx,

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -45,12 +45,15 @@ import type { UpdateWorkoutRequest } from '@/api/workouts'
 import type { SessionExercise, ExerciseSet, MuscleGroup } from '@/api/training'
 import { getTodaySession } from '@/api/training'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
+import type { WorkoutFormat, WodConfig, WodResult, MovementType } from '@/api/wod-types'
 
 import { useLiveSessionStore } from '@/stores/liveSessionStore'
 import { addPendingMutation } from '@/stores/offline'
 
 import { LiveSessionHeader } from '@/components/training/LiveSessionHeader'
 import { LiveExerciseFocus } from '@/components/training/LiveExerciseFocus'
+import { TimedExerciseFocus } from '@/components/training/TimedExerciseFocus'
+import { WodTimerHero } from '@/components/training/WodTimerHero'
 import { RestTimerHero } from '@/components/training/RestTimerHero'
 import { PrFlash } from '@/components/training/PrFlash'
 import { LiveFinishedSummary } from '@/components/training/LiveFinishedSummary'
@@ -62,6 +65,34 @@ import {
   formatSeconds,
 } from '@/components/training/liveTrainingHelpers'
 import type { ExerciseSummaryInput } from '@/components/training/liveTrainingHelpers'
+
+// ─── WOD-aware session/exercise type helpers ──────────────────────────────────
+
+/**
+ * The generated SessionExercise type doesn't yet include WOD fields (regen-api
+ * requires a running backend outside this agent's allowlist). Cast to this
+ * extended interface when reading movementType / format / formatConfig.
+ */
+interface WodAwareExercise extends SessionExercise {
+  movementType?: MovementType
+  format?: WorkoutFormat | null
+  formatConfig?: WodConfig | null
+}
+
+/**
+ * The generated TrainingSession type doesn't yet include WOD fields.
+ */
+interface WodAwareSession {
+  sessionId?: string
+  name?: string
+  exercises?: SessionExercise[]
+  format?: WorkoutFormat | null
+  formatConfig?: WodConfig | null
+}
+
+function isWodFormat(format: WorkoutFormat | null | undefined): format is WorkoutFormat {
+  return format != null && format !== 'Standard'
+}
 
 // ─── Muscle group → color map (mirrors the prototype) ────────────────────────
 
@@ -748,6 +779,7 @@ export default function WorkoutLogScreen() {
     startedAt,
     finishedAt,
     formOverrides,
+    wodResults,
     start: storeStart,
     markSetDone: storeMarkSetDone,
     skipSet: storeSkipSet,
@@ -758,6 +790,7 @@ export default function WorkoutLogScreen() {
     close: storeClose,
     finish: storeFinish,
     discard: storeDiscard,
+    finalizeWod: storeFinalizeWod,
   } = store
 
   // ── Phase: prestart | running | finished ──
@@ -777,6 +810,11 @@ export default function WorkoutLogScreen() {
   const [loadedLogId, setLoadedLogId] = useState<string | null>(
     id !== 'new' && id ? id : (activeLogId ?? null),
   )
+  // ── WOD session-level format info ──
+  const [sessionFormat, setSessionFormat] = useState<WorkoutFormat | null>(null)
+  const [sessionFormatConfig, setSessionFormatConfig] = useState<WodConfig | null>(null)
+  /** When true, the WOD hero is shown for the whole session block. */
+  const [showWodHero, setShowWodHero] = useState(false)
 
   // ── Local form state (reps / weight steppers) ──
   const [formReps, setFormReps] = useState(0)
@@ -841,13 +879,22 @@ export default function WorkoutLogScreen() {
       try {
         const resp = await getTodaySession()
         const sessions = resp.sessions ?? []
-        const session =
+        const rawSession =
           (sessionId && sessions.find((s) => s.sessionId === sessionId)) ||
           sessions[0]
-        if (!session) return
+        if (!rawSession) return
+        // Cast to WOD-aware type (new fields may not be in generated types yet)
+        const session = rawSession as unknown as WodAwareSession
         setSessionDisplayName(session.name ?? '')
         setExercises(session.exercises ?? [])
         setExerciseMuscleGroups(resp.exerciseMuscleGroups ?? {})
+        // Capture session-level WOD format
+        const fmt = session.format ?? null
+        setSessionFormat(fmt)
+        setSessionFormatConfig(session.formatConfig ?? null)
+        if (isWodFormat(fmt)) {
+          setShowWodHero(true)
+        }
       } catch {
         // Non-fatal — screen still works with empty exercises in pre-start
       }
@@ -1021,7 +1068,11 @@ export default function WorkoutLogScreen() {
     storeStart({ sessionId: sessionId ?? '' }, logId ?? '', planId ?? '')
     setPhase('running')
     prefillForm(0, 0, exercises)
-  }, [storeStart, loadedLogId, activeLogId, exercises, sessionId, planId, prefillForm])
+    // If session has a WOD format, show the hero overlay immediately after start
+    if (isWodFormat(sessionFormat)) {
+      setShowWodHero(true)
+    }
+  }, [storeStart, loadedLogId, activeLogId, exercises, sessionId, planId, prefillForm, sessionFormat])
 
   const handleSetDone = useCallback(() => {
     const ex = exercises[currentExerciseIdx]
@@ -1208,6 +1259,24 @@ export default function WorkoutLogScreen() {
     exitToToday()
   }, [storeDiscard, exitToToday, queryClient])
 
+  // ── WOD finalize ──
+  const handleWodFinish = useCallback(
+    (key: string, result: WodResult) => {
+      storeFinalizeWod(key, result)
+      setShowWodHero(false)
+      // After WOD hero, finish the session
+      storeFinish()
+      setPhase('finished')
+      const logId = loadedLogId ?? activeLogId
+      if (logId) void finalizeWorkout(logId)
+    },
+    [storeFinalizeWod, storeFinish, loadedLogId, activeLogId, finalizeWorkout],
+  )
+
+  const handleWodCancel = useCallback(() => {
+    setShowWodHero(false)
+  }, [])
+
   // ── Derived: total sets done (for header) ──
   const totalSetsDone = useMemo(() => {
     let n = 0
@@ -1327,30 +1396,116 @@ export default function WorkoutLogScreen() {
         {/* ── RUNNING ── */}
         {phase === 'running' && currentExercise && (
           <Animated.View key="running" entering={SlideInRight.duration(240)} exiting={SlideOutLeft.duration(180)}>
-            <LiveExerciseFocus
-              exerciseName={currentExercise.exerciseName ?? ''}
-              muscleColor={muscleColorFor(currentExercise)}
-              muscleLabel={currentExercise.exerciseName?.split(' ')[0] ?? ''}
-              exerciseIndex={currentExerciseIdx + 1}
-              exerciseTotal={exercises.length}
-              currentSet={currentSetIdx + 1}
-              totalSets={currentExercise.sets?.length ?? 0}
-              setStatuses={setStatuses}
-              reps={formReps}
-              plannedReps={currentExercise.sets?.[currentSetIdx]?.reps ?? 0}
-              weightKg={formWeight}
-              plannedWeightKg={currentExercise.sets?.[currentSetIdx]?.weightKg ?? 0}
-              onRepsChange={(delta) =>
-                setFormReps((prev) => Math.max(1, Math.round((prev + delta) * 10) / 10))
+            {/* Branch on per-exercise format or movement type */}
+            {(() => {
+              const wodEx = currentExercise as unknown as WodAwareExercise
+              const exFormat = wodEx.format
+              const movementType = wodEx.movementType ?? 'Reps'
+              const currentSet = currentExercise.sets?.[currentSetIdx]
+
+              // Per-exercise WOD format override → show WodTimerHero for this exercise
+              if (isWodFormat(exFormat) && wodEx.formatConfig) {
+                return (
+                  <WodTimerHero
+                    label={currentExercise.exerciseName ?? ''}
+                    format={exFormat}
+                    config={wodEx.formatConfig}
+                    onFinish={(result) => {
+                      const exId = currentExercise.exerciseExternalId ?? `ex-${currentExerciseIdx}`
+                      storeFinalizeWod(exId, result)
+                      // Advance to next exercise
+                      const nextExIdx = currentExerciseIdx + 1
+                      if (nextExIdx >= exercises.length) {
+                        storeFinish()
+                        setPhase('finished')
+                        const logId = loadedLogId ?? activeLogId
+                        if (logId) void finalizeWorkout(logId)
+                      } else {
+                        storeAdvance(nextExIdx, 0)
+                        prefillForm(nextExIdx, 0, exercises)
+                      }
+                    }}
+                    onCancel={handleWodCancel}
+                  />
+                )
               }
-              onWeightChange={(delta) =>
-                setFormWeight((prev) => Math.max(0, Math.round((prev + delta) * 10) / 10))
+
+              // Time or Distance movement type → show TimedExerciseFocus
+              if (movementType === 'Time' || movementType === 'Distance') {
+                return (
+                  <TimedExerciseFocus
+                    exerciseName={currentExercise.exerciseName ?? ''}
+                    muscleColor={muscleColorFor(currentExercise)}
+                    muscleLabel={currentExercise.exerciseName?.split(' ')[0] ?? ''}
+                    exerciseIndex={currentExerciseIdx + 1}
+                    exerciseTotal={exercises.length}
+                    currentSet={currentSetIdx + 1}
+                    totalSets={currentExercise.sets?.length ?? 0}
+                    setStatuses={setStatuses}
+                    movementType={movementType}
+                    plannedDurationSeconds={currentSet?.durationSeconds ?? 60}
+                    plannedDistanceMeters={
+                      (currentSet as (typeof currentSet & { distanceMeters?: number }) | undefined)
+                        ?.distanceMeters ?? 100
+                    }
+                    onSetDone={(durationSeconds, distanceMeters) => {
+                      const exId = currentExercise.exerciseExternalId ?? `ex-${currentExerciseIdx}`
+                      // Record actuals — reuse formOverrides shape; duration→reps slot, distance→weight slot
+                      storeMarkSetDone(exId, currentSetIdx, {
+                        reps: durationSeconds != null ? Math.round(durationSeconds) : undefined,
+                        weightKg: distanceMeters != null ? distanceMeters : undefined,
+                      })
+                      const { nextExIdx, nextSetIdx, isLast } = computeNext(
+                        currentExerciseIdx,
+                        currentSetIdx,
+                        exercises,
+                      )
+                      if (isLast) {
+                        storeFinish()
+                        setPhase('finished')
+                        const logId = loadedLogId ?? activeLogId
+                        if (logId) void finalizeWorkout(logId)
+                      } else {
+                        storeStartRest(currentExercise.restSeconds ?? currentSet?.restSeconds ?? 60)
+                        persistUpdate()
+                        pendingAdvanceRef.current = { ex: nextExIdx, set: nextSetIdx }
+                      }
+                    }}
+                    onSkipSet={handleSkipSet}
+                    onSkipExercise={() => setShowSkipExerciseConfirm(true)}
+                    onGoToSet={handleGoToSet}
+                  />
+                )
               }
-              onSetDone={handleSetDone}
-              onSkipSet={handleSkipSet}
-              onSkipExercise={() => setShowSkipExerciseConfirm(true)}
-              onGoToSet={handleGoToSet}
-            />
+
+              // Default: reps × weight (Reps or RepsForTime)
+              return (
+                <LiveExerciseFocus
+                  exerciseName={currentExercise.exerciseName ?? ''}
+                  muscleColor={muscleColorFor(currentExercise)}
+                  muscleLabel={currentExercise.exerciseName?.split(' ')[0] ?? ''}
+                  exerciseIndex={currentExerciseIdx + 1}
+                  exerciseTotal={exercises.length}
+                  currentSet={currentSetIdx + 1}
+                  totalSets={currentExercise.sets?.length ?? 0}
+                  setStatuses={setStatuses}
+                  reps={formReps}
+                  plannedReps={currentExercise.sets?.[currentSetIdx]?.reps ?? 0}
+                  weightKg={formWeight}
+                  plannedWeightKg={currentExercise.sets?.[currentSetIdx]?.weightKg ?? 0}
+                  onRepsChange={(delta) =>
+                    setFormReps((prev) => Math.max(1, Math.round((prev + delta) * 10) / 10))
+                  }
+                  onWeightChange={(delta) =>
+                    setFormWeight((prev) => Math.max(0, Math.round((prev + delta) * 10) / 10))
+                  }
+                  onSetDone={handleSetDone}
+                  onSkipSet={handleSkipSet}
+                  onSkipExercise={() => setShowSkipExerciseConfirm(true)}
+                  onGoToSet={handleGoToSet}
+                />
+              )
+            })()}
 
             {/* Sets list for current exercise */}
             <View style={styles.sectionHdrWrap}>
@@ -1453,6 +1608,24 @@ export default function WorkoutLogScreen() {
         onConfirm={handleSkipExercise}
         onCancel={() => setShowSkipExerciseConfirm(false)}
       />
+
+      {/* Session-level WOD hero overlay — shown when the whole session is a WOD format */}
+      {showWodHero && isWodFormat(sessionFormat) && sessionFormatConfig && (
+        <Animated.View
+          key="wod-overlay"
+          entering={SlideInDown.duration(280)}
+          exiting={SlideOutDown.duration(220)}
+          style={StyleSheet.absoluteFill}
+        >
+          <WodTimerHero
+            label={sessionDisplayName}
+            format={sessionFormat}
+            config={sessionFormatConfig}
+            onFinish={(result) => handleWodFinish('__session__', result)}
+            onCancel={handleWodCancel}
+          />
+        </Animated.View>
+      )}
     </SafeAreaView>
   )
 }

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -29,6 +29,16 @@ export type {
   SetDto,
 };
 
+// Re-export WOD types introduced in #205.
+// These are hand-declared until regen-api is run against the updated backend.
+export type {
+  WorkoutFormat,
+  MovementType,
+  WodConfig,
+  WodResult,
+  WodSessionExercise,
+} from './wod-types';
+
 /**
  * @deprecated Use `GetTodaySessionResponse` from generated. Kept as alias for backward compatibility.
  */

--- a/mobile/src/api/trainingCompletion.ts
+++ b/mobile/src/api/trainingCompletion.ts
@@ -12,6 +12,7 @@ import type {
   MarkWholeDayCompleteResponse,
   SessionCompletionSummary,
 } from './generated';
+import type { WodResult } from './wod-types';
 
 // Re-export generated request/response types so consumer imports
 // (`from '@/api/trainingCompletion'`) continue to work unchanged.
@@ -28,6 +29,9 @@ export type {
   MarkWholeDayCompleteResponse,
   SessionCompletionSummary,
 };
+
+// Re-export WodResult so callers can type-narrow their completion payloads.
+export type { WodResult };
 
 // ─── API calls ───────────────────────────────────────────────────────────────
 

--- a/mobile/src/api/wod-types.ts
+++ b/mobile/src/api/wod-types.ts
@@ -1,0 +1,115 @@
+/**
+ * WOD (Workout of the Day) domain types for time-based and format-aware training.
+ *
+ * These mirror the backend enums/documents introduced in #205:
+ *   - WorkoutFormat (Standard | ForTime | AMRAP | EMOM | Tabata)
+ *   - MovementType  (Reps | Time | Distance | RepsForTime)
+ *   - WodConfig     — configuration parameters per format
+ *   - WodResult     — outcome-only capture (no per-rep mid-round data)
+ *
+ * IMPORTANT: generated.ts does not yet include these shapes (regen-api requires
+ * a running backend which is outside mobile-expo's allowlist). Once the backend
+ * is running and regen-api is executed, these declarations should be replaced with
+ * re-exports from generated.ts and this file removed.
+ */
+
+/**
+ * Workout format / scoring methodology for a session or per-exercise override.
+ * Mirrors backend WorkoutFormat enum.
+ */
+export type WorkoutFormat = 'Standard' | 'ForTime' | 'AMRAP' | 'EMOM' | 'Tabata';
+
+/**
+ * How performance in an exercise is measured.
+ * Mirrors backend MovementType enum.
+ */
+export type MovementType = 'Reps' | 'Time' | 'Distance' | 'RepsForTime';
+
+/**
+ * Configuration parameters for a WOD format.
+ * Only fields relevant to the chosen format are expected to be set.
+ *
+ * - EMOM:    intervalSeconds + totalRounds
+ * - AMRAP:   timeCapSeconds
+ * - ForTime: timeCapSeconds
+ * - Tabata:  workSeconds + restSeconds + totalRounds
+ */
+export interface WodConfig {
+  timeCapSeconds?: number | null;
+  intervalSeconds?: number | null;
+  totalRounds?: number | null;
+  workSeconds?: number | null;
+  restSeconds?: number | null;
+}
+
+/**
+ * Outcome-only capture for a WOD format session or per-exercise result.
+ * Submitted at log root (session WOD) or per exercise (per-exercise format).
+ *
+ * - AMRAP:   roundsCompleted + extraReps
+ * - EMOM:    roundsCompleted + failedRounds
+ * - Tabata:  roundsCompleted + repsByRound (total reps per round, optional)
+ * - ForTime: totalTimeSeconds
+ */
+export interface WodResult {
+  roundsCompleted?: number | null;
+  extraReps?: number | null;
+  totalTimeSeconds?: number | null;
+  failedRounds?: number[] | null;
+  repsByRound?: number[] | null;
+}
+
+/**
+ * Extended SessionExercise shape that includes WOD fields from #205.
+ * Extends the generated SessionExercise with the new backend fields.
+ */
+export interface WodSessionExercise {
+  exerciseExternalId?: string;
+  exerciseName?: string;
+  order?: number;
+  notes?: string | null;
+  restSeconds?: number | null;
+  sets?: Array<{
+    setNumber?: number;
+    reps?: number | null;
+    weightKg?: number | null;
+    durationSeconds?: number | null;
+    distanceMeters?: number | null;
+    restSeconds?: number | null;
+  }>;
+  /** How performance for this exercise is measured. Defaults to Reps. */
+  movementType?: MovementType;
+  /** Per-exercise format override. Null means inherit the session format. */
+  format?: WorkoutFormat | null;
+  /** Per-exercise format config. Null when format is null or Standard. */
+  formatConfig?: WodConfig | null;
+}
+
+/**
+ * Extended UpdateWorkoutExerciseRequest that includes WodResult.
+ */
+export interface UpdateWodExerciseRequest {
+  exerciseExternalId?: string;
+  exerciseName?: string;
+  sets?: Array<{
+    setNumber?: number;
+    reps?: number | null;
+    weightKg?: number | null;
+    durationSeconds?: number | null;
+    distanceMeters?: number | null;
+    completedAt?: string | null;
+  }>;
+  /** WOD outcome for this exercise (when exercise has a format override). */
+  wodResult?: WodResult | null;
+}
+
+/**
+ * Extended UpdateWorkoutRequest that includes WodResult at root + per-exercise.
+ */
+export interface UpdateWorkoutWodRequest {
+  mood?: number | null;
+  notes?: string | null;
+  exercises?: UpdateWodExerciseRequest[];
+  /** WOD outcome for the whole session (when session has a non-Standard format). */
+  wodResult?: WodResult | null;
+}

--- a/mobile/src/components/training/TimedExerciseFocus.tsx
+++ b/mobile/src/components/training/TimedExerciseFocus.tsx
@@ -1,0 +1,522 @@
+/**
+ * TimedExerciseFocus — hero card for Time and Distance movement types.
+ *
+ * Exposes the same external API signature as LiveExerciseFocus so the
+ * parent screen can render either component based on the exercise's
+ * MovementType without branching on internal layout concerns.
+ *
+ * - MovementType === 'Time':     count-down from durationSeconds to 0.
+ *   On expiry calls onSetDone with the planned duration.
+ * - MovementType === 'Distance': numeric distance stepper; +/- 10 m.
+ *   Calls onSetDone with the entered distance.
+ *
+ * Timer state is owned locally (not in the store) because time-display
+ * ticks every second and should not trigger store writes. Only the
+ * final value goes to the store via onSetDone.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { useTranslation } from 'react-i18next'
+import type { MovementType } from '@/api/wod-types'
+
+// Shared set-status type mirrors LiveExerciseFocus
+type SetStatus = 'done' | 'active' | 'skipped' | 'pending'
+
+export interface TimedExerciseFocusProps {
+  /** Display name of the current exercise */
+  exerciseName: string
+  /** Small dot color corresponding to the muscle group */
+  muscleColor: string
+  /** Muscle group label, e.g. "Hrudník" */
+  muscleLabel: string
+  /** 1-based index of this exercise in the session */
+  exerciseIndex: number
+  /** Total number of exercises in the session */
+  exerciseTotal: number
+  /** 1-based current set number */
+  currentSet: number
+  /** Total sets for this exercise */
+  totalSets: number
+  /** Per-set status array (length = totalSets) */
+  setStatuses: SetStatus[]
+  /** Movement type — Time or Distance */
+  movementType: MovementType
+  /** Planned duration in seconds (for Time movements) */
+  plannedDurationSeconds: number
+  /** Planned distance in meters (for Distance movements) */
+  plannedDistanceMeters: number
+  onSetDone: (durationSeconds?: number, distanceMeters?: number) => void
+  onSkipSet: () => void
+  onSkipExercise: () => void
+  onGoToSet: (idx: number) => void
+}
+
+/**
+ * Format seconds as MM:SS.
+ */
+function formatCountdown(secs: number): string {
+  const s = Math.max(0, Math.ceil(secs))
+  const m = Math.floor(s / 60)
+  const remaining = s % 60
+  return `${String(m).padStart(2, '0')}:${String(remaining).padStart(2, '0')}`
+}
+
+export function TimedExerciseFocus({
+  exerciseName,
+  muscleColor,
+  muscleLabel,
+  exerciseIndex,
+  exerciseTotal,
+  currentSet,
+  totalSets,
+  setStatuses,
+  movementType,
+  plannedDurationSeconds,
+  plannedDistanceMeters,
+  onSetDone,
+  onSkipSet,
+  onSkipExercise,
+  onGoToSet,
+}: TimedExerciseFocusProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  // ── Timer state (Time movements) ─────────────────────────────────────────
+  const [timerRunning, setTimerRunning] = useState(false)
+  const [remaining, setRemaining] = useState(plannedDurationSeconds)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const startedAtRef = useRef<number | null>(null)
+
+  // Reset when the planned duration changes (next set)
+  useEffect(() => {
+    setRemaining(plannedDurationSeconds)
+    setTimerRunning(false)
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+    startedAtRef.current = null
+  }, [plannedDurationSeconds, currentSet])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [])
+
+  const handleStartTimer = useCallback(() => {
+    if (timerRunning) return
+    startedAtRef.current = Date.now()
+    setTimerRunning(true)
+    timerRef.current = setInterval(() => {
+      if (startedAtRef.current === null) return
+      const elapsed = (Date.now() - startedAtRef.current) / 1000
+      const rem = plannedDurationSeconds - elapsed
+      if (rem <= 0) {
+        setRemaining(0)
+        setTimerRunning(false)
+        if (timerRef.current) {
+          clearInterval(timerRef.current)
+          timerRef.current = null
+        }
+        onSetDone(plannedDurationSeconds, undefined)
+      } else {
+        setRemaining(rem)
+      }
+    }, 250)
+  }, [timerRunning, plannedDurationSeconds, onSetDone])
+
+  const handlePauseTimer = useCallback(() => {
+    if (!timerRunning) return
+    setTimerRunning(false)
+    if (timerRef.current) {
+      clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+    if (startedAtRef.current !== null) {
+      const elapsed = (Date.now() - startedAtRef.current) / 1000
+      setRemaining((r) => Math.max(0, r - elapsed))
+      startedAtRef.current = null
+    }
+  }, [timerRunning])
+
+  const handleFinishTimer = useCallback(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    timerRef.current = null
+    setTimerRunning(false)
+    const elapsed = startedAtRef.current
+      ? Math.round((Date.now() - startedAtRef.current) / 1000)
+      : Math.round(plannedDurationSeconds - remaining)
+    const duration = timerRunning
+      ? plannedDurationSeconds - remaining + elapsed
+      : plannedDurationSeconds - remaining
+    onSetDone(Math.round(duration), undefined)
+  }, [timerRunning, remaining, plannedDurationSeconds, onSetDone])
+
+  // ── Distance state ────────────────────────────────────────────────────────
+  const [distanceMeters, setDistanceMeters] = useState(plannedDistanceMeters)
+
+  useEffect(() => {
+    setDistanceMeters(plannedDistanceMeters)
+  }, [plannedDistanceMeters, currentSet])
+
+  const handleDistanceDec = useCallback(
+    () => setDistanceMeters((d) => Math.max(0, Math.round((d - 10) * 10) / 10)),
+    [],
+  )
+  const handleDistanceInc = useCallback(
+    () => setDistanceMeters((d) => Math.round((d + 10) * 10) / 10),
+    [],
+  )
+
+  const handleDistanceDone = useCallback(() => {
+    onSetDone(undefined, distanceMeters)
+  }, [onSetDone, distanceMeters])
+
+  const isTime = movementType === 'Time'
+
+  return (
+    <>
+      {/* Exercise hero */}
+      <View
+        style={[
+          styles.heroCard,
+          { backgroundColor: colors.bg2, borderColor: colors.sep2 },
+        ]}
+      >
+        <View style={styles.heroTop}>
+          <View style={styles.heroLeft}>
+            <View style={styles.muscleLine}>
+              <View style={[styles.muscleDot, { backgroundColor: muscleColor }]} />
+              <Text style={[styles.muscleLabel, { color: colors.label2 }]}>
+                {muscleLabel} · {t('training.live.exerciseProgress', {
+                  current: exerciseIndex,
+                  total: exerciseTotal,
+                })}
+              </Text>
+            </View>
+            <Text style={[styles.exerciseName, { color: colors.label }]} numberOfLines={2}>
+              {exerciseName}
+            </Text>
+          </View>
+
+          {/* SÉRIE badge */}
+          <View
+            style={[
+              styles.serieBadge,
+              { backgroundColor: colors.goldBg, borderColor: colors.gold + '4d' },
+            ]}
+          >
+            <Text style={[styles.serieCurr, { color: colors.gold }]}>{currentSet}</Text>
+            <Text style={[styles.serieSlash, { color: colors.label3 }]}>/{totalSets}</Text>
+            <Text style={[styles.serieLabel, { color: colors.label3 }]}>
+              {t('training.live.seriesLabel')}
+            </Text>
+          </View>
+        </View>
+
+        {/* Set dots */}
+        <View style={styles.dotsRow}>
+          {setStatuses.map((status, i) => (
+            <Pressable
+              key={i}
+              style={[
+                styles.setDot,
+                status === 'done' && { backgroundColor: colors.gold },
+                status === 'active' && { backgroundColor: colors.gold + '8c' },
+                status === 'skipped' && { backgroundColor: colors.label3 },
+                status === 'pending' && { backgroundColor: colors.fill },
+              ]}
+              onPress={() => onGoToSet(i)}
+              accessibilityLabel={`${t('training.live.setLabel')} ${i + 1}`}
+            />
+          ))}
+        </View>
+      </View>
+
+      {/* Input card */}
+      <View
+        style={[styles.inputCard, { backgroundColor: colors.bg2, borderColor: colors.sep2 }]}
+      >
+        {isTime ? (
+          /* ── TIME mode ── */
+          <>
+            {/* Big countdown display */}
+            <View style={styles.timerDisplay}>
+              <Text style={[styles.timerValue, { color: remaining <= 10 ? colors.red : colors.gold }]}>
+                {formatCountdown(remaining)}
+              </Text>
+              <Text style={[styles.timerHint, { color: colors.label3 }]}>
+                {t('training.wod.plannedDuration', { seconds: plannedDurationSeconds })}
+              </Text>
+            </View>
+
+            {/* Start / Pause button */}
+            {!timerRunning ? (
+              <Pressable
+                style={[styles.primaryBtn, { backgroundColor: colors.gold }]}
+                onPress={handleStartTimer}
+              >
+                <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+                  {remaining < plannedDurationSeconds
+                    ? t('training.wod.resume')
+                    : t('training.wod.startTimer')}
+                </Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                style={[styles.primaryBtn, { backgroundColor: colors.fill }]}
+                onPress={handlePauseTimer}
+              >
+                <Text style={[styles.primaryBtnText, { color: colors.label }]}>
+                  {t('training.wod.pauseTimer')}
+                </Text>
+              </Pressable>
+            )}
+
+            {/* Finish early */}
+            <Pressable
+              style={[styles.finishEarlyBtn]}
+              onPress={handleFinishTimer}
+            >
+              <Text style={[styles.secondaryBtnText, { color: colors.label3 }]}>
+                {t('training.wod.finishNow')}
+              </Text>
+            </Pressable>
+          </>
+        ) : (
+          /* ── DISTANCE mode ── */
+          <>
+            <Text style={[styles.distanceTitle, { color: colors.label3 }]}>
+              {t('training.wod.distanceMeters')}
+            </Text>
+            <View
+              style={[styles.stepper, { backgroundColor: colors.bg, borderColor: colors.sep }]}
+            >
+              <Pressable
+                style={styles.stepperBtn}
+                onPress={handleDistanceDec}
+                accessibilityLabel={t('training.wod.decreaseDistance')}
+              >
+                <Text style={[styles.stepperBtnText, { color: colors.label2 }]}>−</Text>
+              </Pressable>
+              <Text style={[styles.stepperValue, { color: colors.gold }]}>
+                {distanceMeters} m
+              </Text>
+              <Pressable
+                style={styles.stepperBtn}
+                onPress={handleDistanceInc}
+                accessibilityLabel={t('training.wod.increaseDistance')}
+              >
+                <Text style={[styles.stepperBtnText, { color: colors.label2 }]}>+</Text>
+              </Pressable>
+            </View>
+            <Text style={[styles.stepperHint, { color: colors.label3 }]}>
+              {t('training.live.planHint')}{' '}
+              <Text style={{ color: colors.label2, fontWeight: '600' }}>
+                {plannedDistanceMeters} m
+              </Text>
+            </Text>
+
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.gold, marginTop: 16 }]}
+              onPress={handleDistanceDone}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+                {t('training.live.seriesDone')}
+              </Text>
+            </Pressable>
+          </>
+        )}
+
+        {/* Secondary actions */}
+        <View style={styles.secondaryRow}>
+          <Pressable onPress={onSkipSet} style={styles.secondaryBtnWrap}>
+            <Text style={[styles.secondaryBtnText, { color: colors.label3 }]}>
+              {t('training.live.skipSet')}
+            </Text>
+          </Pressable>
+          <Text style={[styles.dot, { color: colors.label3 }]}>·</Text>
+          <Pressable onPress={onSkipExercise} style={styles.secondaryBtnWrap}>
+            <Text style={[styles.secondaryBtnText, { color: colors.label3 }]}>
+              {t('training.live.skipExercise')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  heroCard: {
+    marginHorizontal: 16,
+    marginTop: 14,
+    borderRadius: Radius.md,
+    padding: 18,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  heroTop: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  heroLeft: {
+    flex: 1,
+    minWidth: 0,
+  },
+  muscleLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 6,
+  },
+  muscleDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    flexShrink: 0,
+  },
+  muscleLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.08 * 11,
+  },
+  exerciseName: {
+    ...Type.title2,
+    lineHeight: 26,
+  },
+  serieBadge: {
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+  serieCurr: {
+    fontSize: 18,
+    fontWeight: '700',
+    lineHeight: 21,
+  },
+  serieSlash: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  serieLabel: {
+    fontSize: 9,
+    letterSpacing: 0.1 * 9,
+    marginTop: 2,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 6,
+    marginTop: 14,
+  },
+  setDot: {
+    flex: 1,
+    height: 6,
+    borderRadius: 99,
+  },
+  inputCard: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    borderRadius: Radius.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
+  },
+  timerDisplay: {
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  timerValue: {
+    fontSize: 64,
+    fontWeight: '700',
+    letterSpacing: -2,
+    fontVariant: ['tabular-nums'],
+    lineHeight: 72,
+  },
+  timerHint: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+  primaryBtn: {
+    borderRadius: Radius.sm,
+    paddingVertical: 15,
+    alignItems: 'center',
+  },
+  primaryBtnText: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+  },
+  finishEarlyBtn: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  distanceTitle: {
+    fontSize: 10,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.08 * 10,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  stepper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 10,
+    height: 44,
+    overflow: 'hidden',
+  },
+  stepperBtn: {
+    width: 52,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  stepperBtnText: {
+    fontSize: 22,
+    fontWeight: '500',
+  },
+  stepperValue: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 22,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    fontVariant: ['tabular-nums'],
+  },
+  stepperHint: {
+    fontSize: 10,
+    textAlign: 'center',
+    marginTop: 6,
+  },
+  secondaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 10,
+    gap: 4,
+  },
+  secondaryBtnWrap: {
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+  },
+  secondaryBtnText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  dot: {
+    fontSize: 12,
+  },
+})
+
+export default TimedExerciseFocus

--- a/mobile/src/components/training/WodTimerHero.tsx
+++ b/mobile/src/components/training/WodTimerHero.tsx
@@ -1,0 +1,1007 @@
+/**
+ * WodTimerHero — full-screen format-aware timer hero.
+ *
+ * Renders the live-timer UI for a WOD format. Outcome-only logging:
+ * no per-rep mid-round capture. Round counters bump on tap; failed rounds
+ * are toggled. Final outcome flows out via onFinish(result).
+ *
+ * Supported formats:
+ *   AMRAP   — count-up to time cap; big tap-to-bump round counter; extra-rep stepper.
+ *   EMOM    — interval bell every N seconds; SlideInRight phase animation; fail-this-round button.
+ *   Tabata  — 8×20s work / 10s rest default; distinct work/rest visuals; haptic on phase change;
+ *             optional reps-per-round field.
+ *   ForTime — count-up; single big FINISH button.
+ *
+ * Timer state is managed locally (no store writes during ticks).
+ * Haptics fire on phase transitions via expo-haptics.
+ * reanimated SlideInRight is used for EMOM interval transitions.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Platform,
+  TextInput,
+} from 'react-native'
+import Animated, { SlideInRight, SlideOutLeft, FadeIn } from 'react-native-reanimated'
+import * as Haptics from 'expo-haptics'
+import { useTheme } from '@/hooks/useTheme'
+import { Radius } from '@/constants/radius'
+import { useTranslation } from 'react-i18next'
+import type { WorkoutFormat, WodConfig, WodResult } from '@/api/wod-types'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function padTwo(n: number): string {
+  return String(Math.max(0, Math.floor(n))).padStart(2, '0')
+}
+
+function formatTime(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60)
+  const s = totalSeconds % 60
+  return `${padTwo(m)}:${padTwo(s)}`
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface WodTimerHeroProps {
+  /** Display name of the session or exercise */
+  label: string
+  /** Workout format to render */
+  format: WorkoutFormat
+  /** Config for the format (time cap, interval, rounds, etc.) */
+  config: WodConfig
+  /** Called when the WOD is complete with the outcome */
+  onFinish: (result: WodResult) => void
+  /** Called when the user wants to discard / go back */
+  onCancel: () => void
+}
+
+// ─── AMRAP component ──────────────────────────────────────────────────────────
+
+interface AmrapProps {
+  label: string
+  timeCapSeconds: number
+  onFinish: (result: WodResult) => void
+}
+
+function AmrapTimer({ label, timeCapSeconds, onFinish }: AmrapProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  const [elapsed, setElapsed] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [rounds, setRounds] = useState(0)
+  const [extraReps, setExtraReps] = useState(0)
+  const [done, setDone] = useState(false)
+
+  const startedAtRef = useRef<number | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const remaining = Math.max(0, timeCapSeconds - elapsed)
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [])
+
+  const handleStart = useCallback(() => {
+    startedAtRef.current = Date.now() - elapsed * 1000
+    setRunning(true)
+    intervalRef.current = setInterval(() => {
+      if (!startedAtRef.current) return
+      const el = Math.floor((Date.now() - startedAtRef.current) / 1000)
+      setElapsed(el)
+      if (el >= timeCapSeconds) {
+        clearInterval(intervalRef.current!)
+        intervalRef.current = null
+        setRunning(false)
+        setDone(true)
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
+      }
+    }, 250)
+  }, [elapsed, timeCapSeconds])
+
+  const handlePause = useCallback(() => {
+    setRunning(false)
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    startedAtRef.current = null
+  }, [])
+
+  const handleFinish = useCallback(() => {
+    handlePause()
+    onFinish({ roundsCompleted: rounds, extraReps })
+  }, [handlePause, onFinish, rounds, extraReps])
+
+  return (
+    <View style={styles.heroWrap}>
+      {/* Label */}
+      <Text style={[styles.formatLabel, { color: colors.label3 }]}>
+        {t('training.format.amrap')} · {label}
+      </Text>
+
+      {/* Time cap countdown */}
+      <Text
+        style={[
+          styles.bigTimer,
+          { color: remaining <= 10 && running ? colors.red : colors.gold },
+        ]}
+      >
+        {formatTime(remaining)}
+      </Text>
+      <Text style={[styles.timerCaption, { color: colors.label3 }]}>
+        {t('training.wod.timeCap')}
+      </Text>
+
+      {/* Round counter — big tap target */}
+      <Pressable
+        style={[styles.roundCounter, { backgroundColor: colors.goldBg, borderColor: colors.gold }]}
+        onPress={() => {
+          setRounds((r) => r + 1)
+          void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+        }}
+        accessibilityLabel={t('training.wod.tapToAddRound')}
+      >
+        <Text style={[styles.roundCounterValue, { color: colors.gold }]}>{rounds}</Text>
+        <Text style={[styles.roundCounterLabel, { color: colors.label3 }]}>
+          {t('training.wod.rounds')}
+        </Text>
+        <Text style={[styles.roundCounterHint, { color: colors.label3 }]}>
+          {t('training.wod.tapToAdd')}
+        </Text>
+      </Pressable>
+
+      {/* Extra reps stepper */}
+      <View style={styles.stepperRow}>
+        <Text style={[styles.stepperLabel, { color: colors.label2 }]}>
+          {t('training.wod.extraReps')}
+        </Text>
+        <View style={[styles.miniStepper, { borderColor: colors.sep }]}>
+          <Pressable
+            style={styles.miniStepBtn}
+            onPress={() => setExtraReps((r) => Math.max(0, r - 1))}
+            accessibilityLabel={t('training.wod.decreaseReps')}
+          >
+            <Text style={[styles.miniStepText, { color: colors.label2 }]}>−</Text>
+          </Pressable>
+          <Text style={[styles.miniStepValue, { color: colors.gold }]}>{extraReps}</Text>
+          <Pressable
+            style={styles.miniStepBtn}
+            onPress={() => setExtraReps((r) => r + 1)}
+            accessibilityLabel={t('training.wod.increaseReps')}
+          >
+            <Text style={[styles.miniStepText, { color: colors.label2 }]}>+</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Controls */}
+      {!done ? (
+        <>
+          {!running ? (
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.gold }]}
+              onPress={handleStart}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+                {elapsed > 0 ? t('training.wod.resume') : t('training.wod.start')}
+              </Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.fill }]}
+              onPress={handlePause}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.label }]}>
+                {t('training.wod.pause')}
+              </Text>
+            </Pressable>
+          )}
+          <Pressable style={styles.finishBtn} onPress={handleFinish}>
+            <Text style={[styles.finishBtnText, { color: colors.label3 }]}>
+              {t('training.wod.finish')}
+            </Text>
+          </Pressable>
+        </>
+      ) : (
+        <Pressable
+          style={[styles.primaryBtn, { backgroundColor: colors.green }]}
+          onPress={handleFinish}
+        >
+          <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+            {t('training.wod.saveResult')}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}
+
+// ─── EMOM component ───────────────────────────────────────────────────────────
+
+interface EmomProps {
+  label: string
+  intervalSeconds: number
+  totalRounds: number
+  onFinish: (result: WodResult) => void
+}
+
+function EmomTimer({ label, intervalSeconds, totalRounds, onFinish }: EmomProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  const [currentRound, setCurrentRound] = useState(1)
+  const [intervalElapsed, setIntervalElapsed] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [failedRounds, setFailedRounds] = useState<number[]>([])
+  const [done, setDone] = useState(false)
+  const [animKey, setAnimKey] = useState(0)
+
+  const startedAtRef = useRef<number | null>(null)
+  const roundStartedAtRef = useRef<number | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [])
+
+  const advanceRound = useCallback(() => {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)
+    setAnimKey((k) => k + 1)
+    setCurrentRound((r) => {
+      const next = r + 1
+      if (next > totalRounds) {
+        setDone(true)
+        setRunning(false)
+        clearInterval(intervalRef.current!)
+        intervalRef.current = null
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
+      }
+      return next
+    })
+    roundStartedAtRef.current = Date.now()
+    setIntervalElapsed(0)
+  }, [totalRounds])
+
+  const handleStart = useCallback(() => {
+    const now = Date.now()
+    startedAtRef.current = now
+    roundStartedAtRef.current = now
+    setRunning(true)
+    intervalRef.current = setInterval(() => {
+      if (!roundStartedAtRef.current) return
+      const elap = Math.floor((Date.now() - roundStartedAtRef.current) / 1000)
+      setIntervalElapsed(elap)
+      if (elap >= intervalSeconds) {
+        advanceRound()
+      }
+    }, 250)
+  }, [intervalSeconds, advanceRound])
+
+  const handlePause = useCallback(() => {
+    setRunning(false)
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [])
+
+  const handleFailRound = useCallback(() => {
+    setFailedRounds((f) =>
+      f.includes(currentRound) ? f.filter((r) => r !== currentRound) : [...f, currentRound],
+    )
+  }, [currentRound])
+
+  const handleFinish = useCallback(() => {
+    handlePause()
+    onFinish({
+      roundsCompleted: Math.min(currentRound, totalRounds),
+      failedRounds,
+    })
+  }, [handlePause, onFinish, currentRound, totalRounds, failedRounds])
+
+  const remaining = Math.max(0, intervalSeconds - intervalElapsed)
+  const isFailedRound = failedRounds.includes(currentRound)
+
+  return (
+    <View style={styles.heroWrap}>
+      <Text style={[styles.formatLabel, { color: colors.label3 }]}>
+        {t('training.format.emom')} · {label}
+      </Text>
+
+      {/* Round progress */}
+      <Animated.View key={animKey} entering={SlideInRight.duration(220)} exiting={SlideOutLeft.duration(180)}>
+        <Text
+          style={[
+            styles.roundBadge,
+            { color: isFailedRound ? colors.red : colors.gold },
+          ]}
+        >
+          {t('training.wod.roundOf', { current: Math.min(currentRound, totalRounds), total: totalRounds })}
+        </Text>
+      </Animated.View>
+
+      {/* Interval countdown */}
+      <Text
+        style={[
+          styles.bigTimer,
+          { color: remaining <= 5 && running ? colors.red : colors.label },
+        ]}
+      >
+        {formatTime(remaining)}
+      </Text>
+      <Text style={[styles.timerCaption, { color: colors.label3 }]}>
+        {t('training.wod.interval')} {intervalSeconds} s
+      </Text>
+
+      {/* Failed rounds display */}
+      {failedRounds.length > 0 && (
+        <Animated.View entering={FadeIn.duration(200)}>
+          <Text style={[styles.failedRoundsText, { color: colors.red }]}>
+            {t('training.wod.failedRoundsLabel')}: {failedRounds.join(', ')}
+          </Text>
+        </Animated.View>
+      )}
+
+      {/* Controls */}
+      {!done ? (
+        <>
+          {!running ? (
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.gold }]}
+              onPress={handleStart}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+                {intervalElapsed > 0 ? t('training.wod.resume') : t('training.wod.start')}
+              </Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.fill }]}
+              onPress={handlePause}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.label }]}>
+                {t('training.wod.pause')}
+              </Text>
+            </Pressable>
+          )}
+
+          <Pressable
+            style={[
+              styles.failRoundBtn,
+              {
+                backgroundColor: isFailedRound
+                  ? colors.red + '22'
+                  : colors.fill,
+                borderColor: isFailedRound ? colors.red : colors.sep,
+              },
+            ]}
+            onPress={handleFailRound}
+          >
+            <Text
+              style={[
+                styles.failRoundBtnText,
+                { color: isFailedRound ? colors.red : colors.label2 },
+              ]}
+            >
+              {isFailedRound
+                ? t('training.wod.unmarkFailed')
+                : t('training.wod.markFailed')}
+            </Text>
+          </Pressable>
+
+          <Pressable style={styles.finishBtn} onPress={handleFinish}>
+            <Text style={[styles.finishBtnText, { color: colors.label3 }]}>
+              {t('training.wod.finish')}
+            </Text>
+          </Pressable>
+        </>
+      ) : (
+        <Pressable
+          style={[styles.primaryBtn, { backgroundColor: colors.green }]}
+          onPress={handleFinish}
+        >
+          <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+            {t('training.wod.saveResult')}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}
+
+// ─── Tabata component ─────────────────────────────────────────────────────────
+
+interface TabataProps {
+  label: string
+  workSeconds: number
+  restSeconds: number
+  totalRounds: number
+  onFinish: (result: WodResult) => void
+}
+
+function TabataTimer({ label, workSeconds, restSeconds, totalRounds, onFinish }: TabataProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  type TabataPhase = 'work' | 'rest'
+
+  const [phase, setPhase] = useState<TabataPhase>('work')
+  const [currentRound, setCurrentRound] = useState(1)
+  const [phaseElapsed, setPhaseElapsed] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [done, setDone] = useState(false)
+  // repsByRound: optional per-round reps (index 0 = round 1)
+  const [repsByRound, setRepsByRound] = useState<(number | null)[]>(
+    Array.from({ length: totalRounds }, () => null),
+  )
+
+  const phaseStartedAtRef = useRef<number | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [])
+
+  const advancePhase = useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+
+    setPhase((p) => {
+      if (p === 'work') {
+        return 'rest'
+      }
+      // rest → next round work
+      setCurrentRound((r) => {
+        const next = r + 1
+        if (next > totalRounds) {
+          setDone(true)
+          setRunning(false)
+          clearInterval(intervalRef.current!)
+          intervalRef.current = null
+          void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
+          return r
+        }
+        return next
+      })
+      return 'work'
+    })
+
+    phaseStartedAtRef.current = Date.now()
+    setPhaseElapsed(0)
+  }, [totalRounds])
+
+  const handleStart = useCallback(() => {
+    phaseStartedAtRef.current = Date.now()
+    setRunning(true)
+    intervalRef.current = setInterval(() => {
+      if (!phaseStartedAtRef.current) return
+      const elap = Math.floor((Date.now() - phaseStartedAtRef.current) / 1000)
+      setPhaseElapsed(elap)
+      // Check current phase duration — read phase from closure is stale; use
+      // a ref-based approach instead.
+      setPhase((p) => {
+        const cap = p === 'work' ? workSeconds : restSeconds
+        if (elap >= cap) {
+          advancePhase()
+        }
+        return p
+      })
+    }, 250)
+  }, [workSeconds, restSeconds, advancePhase])
+
+  const handlePause = useCallback(() => {
+    setRunning(false)
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [])
+
+  const handleFinish = useCallback(() => {
+    handlePause()
+    const totalReps = repsByRound.reduce<number>((sum, r) => sum + (r ?? 0), 0)
+    onFinish({
+      roundsCompleted: Math.min(currentRound, totalRounds),
+      repsByRound: repsByRound.map((r) => r ?? 0),
+      totalTimeSeconds: totalRounds * (workSeconds + restSeconds),
+      extraReps: totalReps,
+    })
+  }, [handlePause, onFinish, currentRound, totalRounds, repsByRound, workSeconds, restSeconds])
+
+  const phaseCap = phase === 'work' ? workSeconds : restSeconds
+  const remaining = Math.max(0, phaseCap - phaseElapsed)
+  const isWork = phase === 'work'
+
+  return (
+    <View style={styles.heroWrap}>
+      <Text style={[styles.formatLabel, { color: colors.label3 }]}>
+        {t('training.format.tabata')} · {label}
+      </Text>
+
+      {/* Phase indicator */}
+      <View
+        style={[
+          styles.phaseChip,
+          {
+            backgroundColor: isWork ? colors.gold + '22' : colors.fill,
+            borderColor: isWork ? colors.gold : colors.sep,
+          },
+        ]}
+      >
+        <Text
+          style={[
+            styles.phaseChipText,
+            { color: isWork ? colors.gold : colors.label2 },
+          ]}
+        >
+          {isWork
+            ? t('training.wod.workPhase', { seconds: workSeconds })
+            : t('training.wod.restPhase', { seconds: restSeconds })}
+        </Text>
+      </View>
+
+      {/* Round progress */}
+      <Text style={[styles.roundBadge, { color: colors.label2 }]}>
+        {t('training.wod.roundOf', { current: Math.min(currentRound, totalRounds), total: totalRounds })}
+      </Text>
+
+      {/* Countdown */}
+      <Text
+        style={[
+          styles.bigTimer,
+          { color: isWork ? colors.gold : colors.blue },
+        ]}
+      >
+        {formatTime(remaining)}
+      </Text>
+
+      {/* Reps input for current round (only during work phase) */}
+      {isWork && (
+        <View style={styles.repInputRow}>
+          <Text style={[styles.stepperLabel, { color: colors.label2 }]}>
+            {t('training.wod.repsThisRound')}
+          </Text>
+          <View style={[styles.miniStepper, { borderColor: colors.sep }]}>
+            <Pressable
+              style={styles.miniStepBtn}
+              onPress={() =>
+                setRepsByRound((prev) => {
+                  const next = [...prev]
+                  next[currentRound - 1] = Math.max(0, (next[currentRound - 1] ?? 0) - 1)
+                  return next
+                })
+              }
+              accessibilityLabel={t('training.wod.decreaseReps')}
+            >
+              <Text style={[styles.miniStepText, { color: colors.label2 }]}>−</Text>
+            </Pressable>
+            <Text style={[styles.miniStepValue, { color: colors.gold }]}>
+              {repsByRound[currentRound - 1] ?? 0}
+            </Text>
+            <Pressable
+              style={styles.miniStepBtn}
+              onPress={() =>
+                setRepsByRound((prev) => {
+                  const next = [...prev]
+                  next[currentRound - 1] = (next[currentRound - 1] ?? 0) + 1
+                  return next
+                })
+              }
+              accessibilityLabel={t('training.wod.increaseReps')}
+            >
+              <Text style={[styles.miniStepText, { color: colors.label2 }]}>+</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {/* Controls */}
+      {!done ? (
+        <>
+          {!running ? (
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.gold }]}
+              onPress={handleStart}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+                {phaseElapsed > 0 ? t('training.wod.resume') : t('training.wod.start')}
+              </Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              style={[styles.primaryBtn, { backgroundColor: colors.fill }]}
+              onPress={handlePause}
+            >
+              <Text style={[styles.primaryBtnText, { color: colors.label }]}>
+                {t('training.wod.pause')}
+              </Text>
+            </Pressable>
+          )}
+
+          <Pressable style={styles.finishBtn} onPress={handleFinish}>
+            <Text style={[styles.finishBtnText, { color: colors.label3 }]}>
+              {t('training.wod.finish')}
+            </Text>
+          </Pressable>
+        </>
+      ) : (
+        <Pressable
+          style={[styles.primaryBtn, { backgroundColor: colors.green }]}
+          onPress={handleFinish}
+        >
+          <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+            {t('training.wod.saveResult')}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}
+
+// ─── ForTime component ────────────────────────────────────────────────────────
+
+interface ForTimeProps {
+  label: string
+  timeCapSeconds: number
+  onFinish: (result: WodResult) => void
+}
+
+function ForTimeTimer({ label, timeCapSeconds, onFinish }: ForTimeProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  const [elapsed, setElapsed] = useState(0)
+  const [running, setRunning] = useState(false)
+  const [cappedOut, setCappedOut] = useState(false)
+
+  const startedAtRef = useRef<number | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [])
+
+  const handleStart = useCallback(() => {
+    startedAtRef.current = Date.now() - elapsed * 1000
+    setRunning(true)
+    intervalRef.current = setInterval(() => {
+      if (!startedAtRef.current) return
+      const el = Math.floor((Date.now() - startedAtRef.current) / 1000)
+      setElapsed(el)
+      if (timeCapSeconds > 0 && el >= timeCapSeconds) {
+        clearInterval(intervalRef.current!)
+        intervalRef.current = null
+        setRunning(false)
+        setCappedOut(true)
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)
+      }
+    }, 250)
+  }, [elapsed, timeCapSeconds])
+
+  const handlePause = useCallback(() => {
+    setRunning(false)
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+    startedAtRef.current = null
+  }, [])
+
+  const handleFinish = useCallback(() => {
+    handlePause()
+    onFinish({ totalTimeSeconds: elapsed })
+  }, [handlePause, onFinish, elapsed])
+
+  const cappedTime = timeCapSeconds > 0 ? formatTime(Math.max(0, timeCapSeconds - elapsed)) : null
+
+  return (
+    <View style={styles.heroWrap}>
+      <Text style={[styles.formatLabel, { color: colors.label3 }]}>
+        {t('training.format.forTime')} · {label}
+      </Text>
+
+      {/* Count-up */}
+      <Text style={[styles.bigTimer, { color: colors.label }]}>
+        {formatTime(elapsed)}
+      </Text>
+
+      {/* Time cap remaining (when set) */}
+      {cappedTime !== null && (
+        <Text style={[styles.timerCaption, { color: cappedOut ? colors.red : colors.label3 }]}>
+          {cappedOut
+            ? t('training.wod.timeCapped')
+            : t('training.wod.timeCapRemaining', { time: cappedTime })}
+        </Text>
+      )}
+
+      {!running ? (
+        <Pressable
+          style={[styles.primaryBtn, { backgroundColor: colors.gold }]}
+          onPress={handleStart}
+        >
+          <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+            {elapsed > 0 ? t('training.wod.resume') : t('training.wod.start')}
+          </Text>
+        </Pressable>
+      ) : (
+        <Pressable
+          style={[styles.primaryBtn, { backgroundColor: colors.fill }]}
+          onPress={handlePause}
+        >
+          <Text style={[styles.primaryBtnText, { color: colors.label }]}>
+            {t('training.wod.pause')}
+          </Text>
+        </Pressable>
+      )}
+
+      {/* Big FINISH button */}
+      <Pressable
+        style={[styles.finishLargeBtn, { backgroundColor: colors.green }]}
+        onPress={handleFinish}
+      >
+        <Text style={[styles.finishLargeBtnText, { color: colors.onAccent }]}>
+          {t('training.wod.finish')}
+        </Text>
+      </Pressable>
+    </View>
+  )
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+/**
+ * WodTimerHero — selects the right sub-component based on `format`.
+ */
+export function WodTimerHero({ label, format, config, onFinish, onCancel }: WodTimerHeroProps) {
+  const colors = useTheme()
+  const { t } = useTranslation()
+
+  const renderTimer = () => {
+    switch (format) {
+      case 'AMRAP':
+        return (
+          <AmrapTimer
+            label={label}
+            timeCapSeconds={config.timeCapSeconds ?? 600}
+            onFinish={onFinish}
+          />
+        )
+      case 'EMOM':
+        return (
+          <EmomTimer
+            label={label}
+            intervalSeconds={config.intervalSeconds ?? 60}
+            totalRounds={config.totalRounds ?? 10}
+            onFinish={onFinish}
+          />
+        )
+      case 'Tabata':
+        return (
+          <TabataTimer
+            label={label}
+            workSeconds={config.workSeconds ?? 20}
+            restSeconds={config.restSeconds ?? 10}
+            totalRounds={config.totalRounds ?? 8}
+            onFinish={onFinish}
+          />
+        )
+      case 'ForTime':
+        return (
+          <ForTimeTimer
+            label={label}
+            timeCapSeconds={config.timeCapSeconds ?? 0}
+            onFinish={onFinish}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.card, { backgroundColor: colors.bg2, borderColor: colors.sep2 }]}>
+        {renderTimer()}
+      </View>
+
+      {/* Cancel link */}
+      <Pressable style={styles.cancelBtn} onPress={onCancel}>
+        <Text style={[styles.cancelBtnText, { color: colors.label3 }]}>
+          {t('common.cancel')}
+        </Text>
+      </Pressable>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    paddingBottom: Platform.OS === 'ios' ? 36 : 20,
+  },
+  card: {
+    borderRadius: Radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    flex: 1,
+  },
+  heroWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  formatLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.08 * 11,
+    marginBottom: 4,
+  },
+  bigTimer: {
+    fontSize: 72,
+    fontWeight: '700',
+    letterSpacing: -2,
+    fontVariant: ['tabular-nums'],
+    lineHeight: 80,
+  },
+  timerCaption: {
+    fontSize: 12,
+    marginTop: -4,
+  },
+  roundBadge: {
+    fontSize: 26,
+    fontWeight: '700',
+    letterSpacing: -0.5,
+  },
+  roundCounter: {
+    width: 160,
+    height: 160,
+    borderRadius: 80,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2,
+  },
+  roundCounterValue: {
+    fontSize: 56,
+    fontWeight: '700',
+    lineHeight: 62,
+    letterSpacing: -1,
+  },
+  roundCounterLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.08 * 11,
+  },
+  roundCounterHint: {
+    fontSize: 10,
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 4,
+  },
+  repInputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 4,
+  },
+  stepperLabel: {
+    fontSize: 13,
+  },
+  miniStepper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 10,
+    height: 38,
+    overflow: 'hidden',
+  },
+  miniStepBtn: {
+    width: 36,
+    height: 38,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  miniStepText: {
+    fontSize: 20,
+    fontWeight: '500',
+  },
+  miniStepValue: {
+    minWidth: 36,
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  failedRoundsText: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  phaseChip: {
+    borderRadius: 99,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+  },
+  phaseChipText: {
+    fontSize: 13,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.08 * 13,
+  },
+  primaryBtn: {
+    width: '100%',
+    borderRadius: Radius.sm,
+    paddingVertical: 15,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryBtnText: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+  },
+  finishBtn: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  finishBtnText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  finishLargeBtn: {
+    width: '100%',
+    borderRadius: Radius.sm,
+    paddingVertical: 18,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  finishLargeBtnText: {
+    fontSize: 20,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  failRoundBtn: {
+    width: '100%',
+    borderRadius: Radius.sm,
+    borderWidth: 1,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  failRoundBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  cancelBtn: {
+    alignItems: 'center',
+    paddingVertical: 14,
+  },
+  cancelBtnText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+})
+
+export default WodTimerHero

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -863,6 +863,52 @@
       "setSkipped": "přeskočeno",
       "preStartReady": "Připravený?",
       "preStartMeta": "{{exercises}} cviky · {{sets}} sérií · ~{{minutes}} min"
+    },
+    "format": {
+      "standard": "Standardní",
+      "emom": "EMOM",
+      "amrap": "AMRAP",
+      "tabata": "Tabata",
+      "forTime": "Na čas"
+    },
+    "movementType": {
+      "reps": "Opakování",
+      "time": "Čas",
+      "distance": "Vzdálenost",
+      "repsForTime": "Opak. na čas"
+    },
+    "wod": {
+      "timeCap": "Časový limit",
+      "timeCapRemaining": "Zbývá {{time}}",
+      "timeCapped": "Čas vypršel!",
+      "interval": "Interval",
+      "rounds": "Kola",
+      "workSeconds": "Práce (s)",
+      "restSeconds": "Odpočinek (s)",
+      "extraReps": "Bonusová opak.",
+      "failedRoundsLabel": "Nesplněná kola",
+      "roundOf": "Kolo {{current}} / {{total}}",
+      "tapToAdd": "klepnutím přidat",
+      "tapToAddRound": "Klepnutím přidat kolo",
+      "repsThisRound": "Opak. v tomto kole",
+      "workPhase": "PRÁCE · {{seconds}} s",
+      "restPhase": "ODPOČINEK · {{seconds}} s",
+      "start": "▶ Start",
+      "resume": "▶ Pokračovat",
+      "pause": "⏸ Pauza",
+      "finish": "DOKONČIT",
+      "finishNow": "Dokončit hned",
+      "saveResult": "✓ Uložit výsledek",
+      "markFailed": "Nesplněno toto kolo",
+      "unmarkFailed": "Vrátit jako splněné",
+      "startTimer": "▶ Spustit časovač",
+      "pauseTimer": "⏸ Pozastavit",
+      "plannedDuration": "Plán: {{seconds}} s",
+      "distanceMeters": "Vzdálenost (m)",
+      "decreaseDistance": "Snížit vzdálenost",
+      "increaseDistance": "Zvýšit vzdálenost",
+      "decreaseReps": "Snížit opakování",
+      "increaseReps": "Zvýšit opakování"
     }
   },
   "muscleGroup": {

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -835,6 +835,52 @@
       "setSkipped": "übersprungen",
       "preStartReady": "Bereit?",
       "preStartMeta": "{{exercises}} Übungen · {{sets}} Sätze · ~{{minutes}} Min"
+    },
+    "format": {
+      "standard": "Standard",
+      "emom": "EMOM",
+      "amrap": "AMRAP",
+      "tabata": "Tabata",
+      "forTime": "Auf Zeit"
+    },
+    "movementType": {
+      "reps": "Wiederholungen",
+      "time": "Zeit",
+      "distance": "Distanz",
+      "repsForTime": "Wdh. auf Zeit"
+    },
+    "wod": {
+      "timeCap": "Zeitlimit",
+      "timeCapRemaining": "Noch {{time}}",
+      "timeCapped": "Zeit abgelaufen!",
+      "interval": "Intervall",
+      "rounds": "Runden",
+      "workSeconds": "Arbeit (s)",
+      "restSeconds": "Pause (s)",
+      "extraReps": "Bonus-Wdh.",
+      "failedRoundsLabel": "Fehlgeschlagene Runden",
+      "roundOf": "Runde {{current}} / {{total}}",
+      "tapToAdd": "tippen zum Hinzufügen",
+      "tapToAddRound": "Tippen um Runde hinzuzufügen",
+      "repsThisRound": "Wdh. in dieser Runde",
+      "workPhase": "ARBEIT · {{seconds}} s",
+      "restPhase": "PAUSE · {{seconds}} s",
+      "start": "▶ Start",
+      "resume": "▶ Weiter",
+      "pause": "⏸ Pause",
+      "finish": "FERTIG",
+      "finishNow": "Jetzt beenden",
+      "saveResult": "✓ Ergebnis speichern",
+      "markFailed": "Runde als fehlgeschlagen markieren",
+      "unmarkFailed": "Als erfüllt markieren",
+      "startTimer": "▶ Timer starten",
+      "pauseTimer": "⏸ Anhalten",
+      "plannedDuration": "Plan: {{seconds}} s",
+      "distanceMeters": "Distanz (m)",
+      "decreaseDistance": "Distanz verringern",
+      "increaseDistance": "Distanz erhöhen",
+      "decreaseReps": "Wdh. verringern",
+      "increaseReps": "Wdh. erhöhen"
     }
   },
   "muscleGroup": {

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -637,6 +637,52 @@
       "setSkipped": "skipped",
       "preStartReady": "Ready?",
       "preStartMeta": "{{exercises}} exercises · {{sets}} sets · ~{{minutes}} min"
+    },
+    "format": {
+      "standard": "Standard",
+      "emom": "EMOM",
+      "amrap": "AMRAP",
+      "tabata": "Tabata",
+      "forTime": "For Time"
+    },
+    "movementType": {
+      "reps": "Reps",
+      "time": "Time",
+      "distance": "Distance",
+      "repsForTime": "Reps for Time"
+    },
+    "wod": {
+      "timeCap": "Time Cap",
+      "timeCapRemaining": "{{time}} left",
+      "timeCapped": "Time's up!",
+      "interval": "Interval",
+      "rounds": "Rounds",
+      "workSeconds": "Work (s)",
+      "restSeconds": "Rest (s)",
+      "extraReps": "Extra reps",
+      "failedRoundsLabel": "Failed rounds",
+      "roundOf": "Round {{current}} / {{total}}",
+      "tapToAdd": "tap to add",
+      "tapToAddRound": "Tap to add a round",
+      "repsThisRound": "Reps this round",
+      "workPhase": "WORK · {{seconds}} s",
+      "restPhase": "REST · {{seconds}} s",
+      "start": "▶ Start",
+      "resume": "▶ Resume",
+      "pause": "⏸ Pause",
+      "finish": "FINISH",
+      "finishNow": "Finish now",
+      "saveResult": "✓ Save result",
+      "markFailed": "Mark round failed",
+      "unmarkFailed": "Unmark failed",
+      "startTimer": "▶ Start timer",
+      "pauseTimer": "⏸ Pause",
+      "plannedDuration": "Plan: {{seconds}} s",
+      "distanceMeters": "Distance (m)",
+      "decreaseDistance": "Decrease distance",
+      "increaseDistance": "Increase distance",
+      "decreaseReps": "Decrease reps",
+      "increaseReps": "Increase reps"
     }
   },
   "muscleGroup": {

--- a/mobile/src/stores/liveSessionStore.ts
+++ b/mobile/src/stores/liveSessionStore.ts
@@ -40,6 +40,10 @@ export interface SessionLike {
 export interface FormOverride {
   reps?: number
   weightKg?: number
+  /** Actual duration for MovementType.Time exercises (seconds). */
+  durationSeconds?: number
+  /** Actual distance for MovementType.Distance exercises (metres). */
+  distanceMeters?: number
 }
 
 export interface LiveSessionState {

--- a/mobile/src/stores/liveSessionStore.ts
+++ b/mobile/src/stores/liveSessionStore.ts
@@ -21,6 +21,7 @@
 
 import { create } from 'zustand'
 import { createMMKV } from 'react-native-mmkv'
+import type { WodResult } from '@/api/wod-types'
 
 const MMKV_KEY = 'session'
 const mmkv = createMMKV({ id: 'mmkv.liveSession' })
@@ -70,6 +71,12 @@ export interface LiveSessionState {
    * Populated by markSetDone() when actuals differ from the plan.
    */
   formOverrides: Record<string, Record<number, FormOverride>>
+  /**
+   * WOD outcomes keyed by exerciseExternalId (for per-exercise format overrides)
+   * or by a special sentinel key `__session__` for session-level WODs.
+   * Populated by finalizeWod(); persisted to MMKV.
+   */
+  wodResults: Record<string, WodResult>
 }
 
 interface LiveSessionActions {
@@ -133,6 +140,33 @@ interface LiveSessionActions {
 
   /** Returns true iff activeLogId is set and finishedAt is null. */
   hasActiveSession: () => boolean
+
+  // ── WOD result actions ────────────────────────────────────────────────────
+
+  /**
+   * Increments `roundsCompleted` for the given key by 1.
+   * key = exerciseExternalId for per-exercise WODs, `__session__` for session WODs.
+   */
+  recordRound: (key: string) => void
+
+  /**
+   * Toggles a failed-round marker for the given round number.
+   * If the round is already in failedRounds it is removed; otherwise appended.
+   */
+  markRoundFailed: (key: string, roundNumber: number) => void
+
+  /**
+   * Sets `extraReps` for the given key.
+   * Used by AMRAP at the end of the time cap.
+   */
+  setExtraReps: (key: string, reps: number) => void
+
+  /**
+   * Writes the final WodResult for the given key to the store.
+   * Call at the moment the timer expires or the user taps FINISH.
+   * Persists to MMKV.
+   */
+  finalizeWod: (key: string, result: WodResult) => void
 }
 
 export type LiveSessionStore = LiveSessionState & LiveSessionActions
@@ -153,6 +187,7 @@ const INITIAL_STATE: LiveSessionState = {
   restSeconds: null,
   finishedAt: null,
   formOverrides: {},
+  wodResults: {},
 }
 
 function getPersistedSession(): LiveSessionState {
@@ -301,5 +336,60 @@ export const useLiveSessionStore = create<LiveSessionStore>((set, get) => ({
   hasActiveSession() {
     const { activeLogId, finishedAt } = get()
     return activeLogId !== null && finishedAt === null
+  },
+
+  recordRound(key) {
+    const s = get()
+    const prev = s.wodResults[key] ?? {}
+    const next: LiveSessionState = {
+      ...s,
+      wodResults: {
+        ...s.wodResults,
+        [key]: { ...prev, roundsCompleted: (prev.roundsCompleted ?? 0) + 1 },
+      },
+    }
+    persist(next)
+    set(next)
+  },
+
+  markRoundFailed(key, roundNumber) {
+    const s = get()
+    const prev = s.wodResults[key] ?? {}
+    const existing = prev.failedRounds ?? []
+    const next: LiveSessionState = {
+      ...s,
+      wodResults: {
+        ...s.wodResults,
+        [key]: {
+          ...prev,
+          failedRounds: existing.includes(roundNumber)
+            ? existing.filter((r) => r !== roundNumber)
+            : [...existing, roundNumber].sort((a, b) => a - b),
+        },
+      },
+    }
+    persist(next)
+    set(next)
+  },
+
+  setExtraReps(key, reps) {
+    const s = get()
+    const prev = s.wodResults[key] ?? {}
+    const next: LiveSessionState = {
+      ...s,
+      wodResults: { ...s.wodResults, [key]: { ...prev, extraReps: reps } },
+    }
+    persist(next)
+    set(next)
+  },
+
+  finalizeWod(key, result) {
+    const s = get()
+    const next: LiveSessionState = {
+      ...s,
+      wodResults: { ...s.wodResults, [key]: result },
+    }
+    persist(next)
+    set(next)
   },
 }))


### PR DESCRIPTION
## Summary
- New `TimedExerciseFocus` (count-down for `MovementType.Time`, +/- 10 m stepper for `MovementType.Distance`) — same external API as `LiveExerciseFocus` so the parent screen can swap them transparently.
- New `WodTimerHero` — full-screen format-aware live timer for AMRAP / EMOM / Tabata / ForTime, with haptics on phase transitions, Reanimated SlideInRight phase animation for EMOM, and outcome-only capture (no per-rep mid-round logging).
- `liveSessionStore` extended with `wodResults` slice (`Record<exerciseExternalId | '__session__', WodResult>`) — MMKV-persisted; `FormOverride` carries `durationSeconds` + `distanceMeters` first-class.
- `buildRequest()` in `training-session/[id].tsx` emits `durationSeconds` / `distanceMeters` on `UpdateWorkoutSetRequest` and attaches `wodResult` per exercise + at root.
- i18n: cs/en/de keys under `training.format.*`, `training.movementType.*`, `training.wod.*` — all 3 locales have parity.

## Related issue
Fixes #207

## Parent epic
Part of epic #203 — base branch: `feature/203-training-formats-wod`.

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS at `0d995f8`. All 9 ACs met. Three previously-blocking data-flow regressions (Time→DurationSeconds, Distance→DistanceMeters, WodResult serialization) all resolved. Typecheck clean.

## Test plan
- [x] Time movement: client sees a count-down timer; on completion, duration logs to `WorkoutSet.DurationSeconds`.
- [x] Distance movement: client enters distance; logs to `WorkoutSet.DistanceMeters`.
- [x] AMRAP: rounds + extra reps captured in `WodResult`.
- [x] EMOM: minutes completed + failed minutes captured.
- [x] Tabata: 8x20s/10s runs with haptic phase change; total reps captured.
- [x] ForTime: total seconds captured.
- [x] Per-exercise format inside a Standard session works (single-exercise WOD).
- [x] All new copy in cs / en / de.
- [x] `npx tsc --noEmit` clean (`npx expo prebuild --no-install --check` skipped — known SDK-55 incompatibility).

## Notes for reviewer
- `mobile/src/api/wod-types.ts` is a hand-declared mirror of the backend WOD enums/documents pending `regen-api`. `mobile/src/api/generated.ts` was NOT hand-edited (write-lock respected). Schedule a `regen-api` follow-up after the backend slice merges to `feature/203-training-formats-wod`.
- Two `as unknown as WodAware…` casts in `training-session/[id].tsx` exist for the same reason — remove once `regen-api` lands the WOD fields on `SessionExercise` and `TrainingSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)