### PR TITLE
feat: TrainingSection document + SectionTemplate collection (#238)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -209,6 +209,23 @@ public static class ErrorCodes
     /// <summary>The referenced plan does not belong to the client associated with this link/invite.</summary>
     public const string PhotoDiaryRequestPlanNotOwned = "PHOTO_DIARY_REQUEST_PLAN_NOT_OWNED";
 
+    // ── Section Templates ────────────────────────────────────────────
+    /// <summary>Section template not found.</summary>
+    public const string SectionTemplateNotFound = "SECTION_TEMPLATE_NOT_FOUND";
+
+    /// <summary>Section template belongs to another trainer.</summary>
+    public const string SectionTemplateNotOwned = "SECTION_TEMPLATE_NOT_OWNED";
+
+    /// <summary>Section template version mismatch (optimistic concurrency).</summary>
+    public const string SectionTemplateVersionConflict = "SECTION_TEMPLATE_VERSION_CONFLICT";
+
+    // ── Training Sections ────────────────────────────────────────────
+    /// <summary>Session sections list is empty.</summary>
+    public const string SectionsRequired = "SECTIONS_REQUIRED";
+
+    /// <summary>Duplicate Order values across sections in the same session.</summary>
+    public const string SectionOrderDuplicate = "SECTION_ORDER_DUPLICATE";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
@@ -54,4 +54,9 @@ public static class MongoCollections
     /// Day-level diary log entries (photos + note per plan day).
     /// </summary>
     public const string DayLogs = "dayLogs";
+
+    /// <summary>
+    /// Section template documents (per-trainer reusable training section templates).
+    /// </summary>
+    public const string SectionTemplates = "sectionTemplates";
 }

--- a/backend/FitnessPlatform.Application/Domain/Documents/SectionTemplate.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/SectionTemplate.cs
@@ -1,0 +1,77 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// MongoDB root aggregate for a reusable training section template.
+/// Belongs to a specific trainer; not shared across tenants.
+/// </summary>
+public class SectionTemplate
+{
+    /// <summary>
+    /// MongoDB internal identifier.
+    /// </summary>
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public ObjectId Id { get; set; }
+
+    /// <summary>
+    /// Public-facing identifier used in API requests and responses.
+    /// </summary>
+    [BsonElement("externalId")]
+    public Guid ExternalId { get; set; }
+
+    /// <summary>
+    /// The trainer who owns this template. Used for per-trainer isolation on every query.
+    /// </summary>
+    [BsonElement("ownerTrainerId")]
+    public Guid OwnerTrainerId { get; set; }
+
+    /// <summary>
+    /// Display name of the template (e.g. "Warm-up", "AMRAP Finisher").
+    /// </summary>
+    [BsonElement("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default workout format for sections created from this template.
+    /// Null means no format override (Standard / inherits from session).
+    /// </summary>
+    [BsonElement("defaultFormat")]
+    [BsonIgnoreIfNull]
+    [BsonRepresentation(BsonType.String)]
+    public WorkoutFormat? DefaultFormat { get; set; }
+
+    /// <summary>
+    /// Default format configuration. Null when DefaultFormat is null or Standard.
+    /// </summary>
+    [BsonElement("defaultFormatConfig")]
+    [BsonIgnoreIfNull]
+    public WodConfig? DefaultFormatConfig { get; set; }
+
+    /// <summary>
+    /// Default exercises to pre-populate when applying this template.
+    /// </summary>
+    [BsonElement("defaultExercises")]
+    public List<SessionExercise> DefaultExercises { get; set; } = [];
+
+    /// <summary>
+    /// UTC timestamp when this document was created.
+    /// </summary>
+    [BsonElement("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// UTC timestamp when this document was last updated.
+    /// </summary>
+    [BsonElement("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Optimistic concurrency version. Incremented on each update.
+    /// </summary>
+    [BsonElement("version")]
+    public int Version { get; set; } = 1;
+}

--- a/backend/FitnessPlatform.Application/Domain/Documents/TrainingSection.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/TrainingSection.cs
@@ -1,0 +1,51 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// An ordered section within a training session (e.g. "Warm-up", "Hlavní", "Cool-down").
+/// Embedded sub-document inside <see cref="TrainingSession.Sections"/>.
+/// </summary>
+public class TrainingSection
+{
+    /// <summary>
+    /// Client-side stable identifier for this section.
+    /// </summary>
+    [BsonElement("sectionId")]
+    public Guid SectionId { get; set; }
+
+    /// <summary>
+    /// Display order within the session (0-based).
+    /// </summary>
+    [BsonElement("order")]
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Display name of the section (e.g. "Hlavní", "Warm-up").
+    /// </summary>
+    [BsonElement("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Workout format for this section. Null means the section inherits the session-level format.
+    /// </summary>
+    [BsonElement("format")]
+    [BsonIgnoreIfNull]
+    [BsonRepresentation(BsonType.String)]
+    public WorkoutFormat? Format { get; set; }
+
+    /// <summary>
+    /// Format configuration for this section. Null when Format is null or Standard.
+    /// </summary>
+    [BsonElement("formatConfig")]
+    [BsonIgnoreIfNull]
+    public WodConfig? FormatConfig { get; set; }
+
+    /// <summary>
+    /// Exercises in this section.
+    /// </summary>
+    [BsonElement("exercises")]
+    public List<SessionExercise> Exercises { get; set; } = [];
+}

--- a/backend/FitnessPlatform.Application/Domain/Documents/TrainingSession.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/TrainingSession.cs
@@ -41,22 +41,67 @@ public class TrainingSession
     public string? Notes { get; set; }
 
     /// <summary>
-    /// Workout format for this session. Defaults to Standard (sets-and-reps).
+    /// Session-level workout format. Kept nullable for one release as an inheritable default —
+    /// sections inherit when their own Format is null. Null means Standard.
     /// </summary>
     [BsonElement("format")]
+    [BsonIgnoreIfNull]
     [BsonRepresentation(BsonType.String)]
-    public WorkoutFormat Format { get; set; } = WorkoutFormat.Standard;
+    public WorkoutFormat? Format { get; set; }
 
     /// <summary>
-    /// Format configuration for non-Standard sessions. Null when Format is Standard.
+    /// Session-level format configuration. Null when Format is null or Standard.
     /// </summary>
     [BsonElement("formatConfig")]
     [BsonIgnoreIfNull]
     public WodConfig? FormatConfig { get; set; }
 
     /// <summary>
-    /// Exercises in this session.
+    /// Sections in this session. Each section contains its own exercises.
+    /// Schema-on-read: if a stored document has only flat <c>exercises</c> and no <c>sections</c>,
+    /// a single default section named "Hlavní" is synthesized via <see cref="WithBackfilledSections"/>.
+    /// </summary>
+    [BsonElement("sections")]
+    public List<TrainingSection> Sections { get; set; } = [];
+
+    /// <summary>
+    /// Legacy flat exercises list. Only present in documents written before the sections migration.
+    /// Not written on new saves. Used by <see cref="WithBackfilledSections"/> for schema-on-read.
     /// </summary>
     [BsonElement("exercises")]
-    public List<SessionExercise> Exercises { get; set; } = [];
+    [BsonIgnoreIfNull]
+    public List<SessionExercise>? LegacyExercises { get; set; }
+
+    /// <summary>
+    /// Returns a view of this session with legacy flat-exercise documents backfilled into a default section.
+    /// If <see cref="Sections"/> is already populated this is a no-op.
+    /// </summary>
+    public TrainingSession WithBackfilledSections()
+    {
+        if (Sections.Count > 0 || LegacyExercises is null || LegacyExercises.Count == 0)
+            return this;
+
+        Sections =
+        [
+            new TrainingSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Format = null,
+                FormatConfig = null,
+                Exercises = LegacyExercises
+            }
+        ];
+        LegacyExercises = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Flat view of all exercises across all sections. Read-only convenience accessor.
+    /// Not stored in MongoDB — computed from <see cref="Sections"/>.
+    /// </summary>
+    [BsonIgnore]
+    public IReadOnlyList<SessionExercise> Exercises =>
+        Sections.SelectMany(s => s.Exercises).ToList();
 }

--- a/backend/FitnessPlatform.Application/Domain/Documents/WorkoutLog.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/WorkoutLog.cs
@@ -83,10 +83,20 @@ public class WorkoutLog
     public WodResult? WodResult { get; set; }
 
     /// <summary>
-    /// Exercises performed in this workout.
+    /// Sections in this workout. Each section contains completed exercises.
+    /// Schema-on-read: if a stored document has only flat <c>exercises</c> and no <c>sections</c>,
+    /// a single default section named "Hlavní" is synthesized via <see cref="WithBackfilledSections"/>.
+    /// </summary>
+    [BsonElement("sections")]
+    public List<WorkoutSection> Sections { get; set; } = [];
+
+    /// <summary>
+    /// Legacy flat exercises list. Only present in documents written before the sections migration.
+    /// Not written on new saves. Used by <see cref="WithBackfilledSections"/> for schema-on-read.
     /// </summary>
     [BsonElement("exercises")]
-    public List<WorkoutExercise> Exercises { get; set; } = [];
+    [BsonIgnoreIfNull]
+    public List<WorkoutExercise>? LegacyExercises { get; set; }
 
     /// <summary>
     /// When this document was created.
@@ -100,4 +110,37 @@ public class WorkoutLog
     [BsonElement("dateUpdated")]
     [BsonIgnoreIfNull]
     public DateTime? DateUpdated { get; set; }
+
+    /// <summary>
+    /// Returns a view of this log with legacy flat-exercise documents backfilled into a default section.
+    /// If <see cref="Sections"/> is already populated this is a no-op.
+    /// </summary>
+    public WorkoutLog WithBackfilledSections()
+    {
+        if (Sections.Count > 0 || LegacyExercises is null || LegacyExercises.Count == 0)
+            return this;
+
+        Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Format = null,
+                WodResult = WodResult,
+                Exercises = LegacyExercises
+            }
+        ];
+        LegacyExercises = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Flat view of all exercises across all sections. Read-only convenience accessor.
+    /// Not stored in MongoDB — computed from <see cref="Sections"/>.
+    /// </summary>
+    [BsonIgnore]
+    public IReadOnlyList<WorkoutExercise> Exercises =>
+        Sections.SelectMany(s => s.Exercises).ToList();
 }

--- a/backend/FitnessPlatform.Application/Domain/Documents/WorkoutSection.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/WorkoutSection.cs
@@ -1,0 +1,53 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// An ordered section within a workout log — mirrors <see cref="TrainingSection"/> but
+/// contains completed <see cref="WorkoutExercise"/> entries instead of planned ones.
+/// Embedded sub-document inside <see cref="WorkoutLog.Sections"/>.
+/// </summary>
+public class WorkoutSection
+{
+    /// <summary>
+    /// Stable identifier matching the source <see cref="TrainingSection.SectionId"/>.
+    /// </summary>
+    [BsonElement("sectionId")]
+    public Guid SectionId { get; set; }
+
+    /// <summary>
+    /// Display order within the workout (0-based).
+    /// </summary>
+    [BsonElement("order")]
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Display name of the section (e.g. "Hlavní", "Warm-up").
+    /// </summary>
+    [BsonElement("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// WOD format for this section. Null means section inherits the session-level format.
+    /// </summary>
+    [BsonElement("format")]
+    [BsonIgnoreIfNull]
+    [BsonRepresentation(BsonType.String)]
+    public WorkoutFormat? Format { get; set; }
+
+    /// <summary>
+    /// WOD format result for this section (e.g. ForTime total, AMRAP rounds).
+    /// Null for Standard sections or when not yet recorded.
+    /// </summary>
+    [BsonElement("wodResult")]
+    [BsonIgnoreIfNull]
+    public WodResult? WodResult { get; set; }
+
+    /// <summary>
+    /// Exercises completed in this section.
+    /// </summary>
+    [BsonElement("exercises")]
+    public List<WorkoutExercise> Exercises { get; set; } = [];
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
@@ -89,6 +89,7 @@ public class MarkExerciseCompleteEndpoint(
             return;
         }
 
+        session.WithBackfilledSections();
         var exerciseExists = session.Exercises.Any(e => e.ExerciseExternalId == req.ExerciseExternalId);
         if (!exerciseExists)
         {

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseIncomplete/MarkExerciseIncompleteEndpoint.cs
@@ -89,6 +89,7 @@ public class MarkExerciseIncompleteEndpoint(
         }
 
         // Validate the exercise exists in the session
+        session.WithBackfilledSections();
         var exerciseExists = session.Exercises.Any(e => e.ExerciseExternalId == req.ExerciseExternalId);
         if (!exerciseExists)
         {
@@ -166,6 +167,7 @@ public class MarkExerciseIncompleteEndpoint(
 
             foreach (var log in matchingLogs)
             {
+                log.WithBackfilledSections();
                 var exerciseEntry = log.Exercises
                     .FirstOrDefault(e => e.ExerciseExternalId == req.ExerciseExternalId);
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionIncomplete/MarkSessionIncompleteEndpoint.cs
@@ -88,6 +88,8 @@ public class MarkSessionIncompleteEndpoint(
             return;
         }
 
+        session.WithBackfilledSections();
+
         var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
                                & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, targetDate)
                                & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, req.SessionId);
@@ -153,6 +155,7 @@ public class MarkSessionIncompleteEndpoint(
 
             foreach (var log in matchingLogs)
             {
+                log.WithBackfilledSections();
                 foreach (var exercise in log.Exercises)
                     foreach (var set in exercise.Sets)
                         set.CompletedAt = null;

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
@@ -88,6 +88,7 @@ public class MarkWholeDayCompleteEndpoint(
 
         foreach (var session in sessionsForDay)
         {
+            session.WithBackfilledSections();
             var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();
 
             var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressBroadcaster.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/TrainingProgressBroadcaster.cs
@@ -243,6 +243,7 @@ internal static class TrainingProgressBroadcaster
         var count = 0;
         foreach (var session in plannedSessions)
         {
+            session.WithBackfilledSections();
             if (session.Exercises.Count == 0)
                 continue;
 

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/CreateSectionTemplate/CreateSectionTemplateEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/CreateSectionTemplate/CreateSectionTemplateEndpoint.cs
@@ -1,0 +1,84 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.SectionTemplates.Shared;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.CreateSectionTemplate;
+
+/// <summary>
+/// Creates a new section template for the calling trainer.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+public class CreateSectionTemplateEndpoint(IMongoContext mongo)
+    : Endpoint<CreateSectionTemplateRequest, SectionTemplateResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/training/section-templates");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Create section template";
+            s.Description = "Creates a new reusable training section template owned by the calling trainer.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(CreateSectionTemplateRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+        var now = DateTime.UtcNow;
+
+        var template = new SectionTemplate
+        {
+            ExternalId = Guid.NewGuid(),
+            OwnerTrainerId = trainerId,
+            Name = req.Name.Trim(),
+            DefaultFormat = req.DefaultFormat,
+            DefaultFormatConfig = req.DefaultFormatConfig,
+            DefaultExercises = req.DefaultExercises.Select(e => new SessionExercise
+            {
+                ExerciseExternalId = e.ExerciseExternalId,
+                ExerciseName = e.ExerciseName,
+                Order = e.Order,
+                Notes = e.Notes?.Trim(),
+                RestSeconds = e.RestSeconds,
+                MovementType = e.MovementType,
+                Format = e.Format,
+                FormatConfig = e.FormatConfig,
+                Sets = e.Sets.Select(s => new ExerciseSet
+                {
+                    SetNumber = s.SetNumber,
+                    Type = s.Type,
+                    Reps = s.Reps,
+                    WeightKg = s.WeightKg,
+                    DurationSeconds = s.DurationSeconds,
+                    Rpe = s.Rpe,
+                    DistanceMeters = s.DistanceMeters,
+                    RestSeconds = s.RestSeconds
+                }).ToList()
+            }).ToList(),
+            CreatedAt = now,
+            UpdatedAt = now,
+            Version = 1
+        };
+
+        await mongo.SectionTemplates.InsertOneAsync(template, cancellationToken: ct);
+
+        await HttpContext.Response.SendAsync(
+            SectionTemplateResponse.FromDocument(template),
+            201,
+            cancellation: ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/CreateSectionTemplate/CreateSectionTemplateRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/CreateSectionTemplate/CreateSectionTemplateRequest.cs
@@ -1,0 +1,85 @@
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.CreateSectionTemplate;
+
+/// <summary>
+/// Request for creating a new section template.
+/// </summary>
+public class CreateSectionTemplateRequest
+{
+    /// <summary>Display name of the template.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Default workout format. Null means no format override (Standard / inherits from session).</summary>
+    public WorkoutFormat? DefaultFormat { get; set; }
+
+    /// <summary>Default format configuration. Null when DefaultFormat is null or Standard.</summary>
+    public WodConfig? DefaultFormatConfig { get; set; }
+
+    /// <summary>Default exercises to pre-populate when applying this template.</summary>
+    public List<CreateSectionTemplateExerciseRequest> DefaultExercises { get; set; } = [];
+}
+
+/// <summary>
+/// An exercise entry in a section template.
+/// </summary>
+public class CreateSectionTemplateExerciseRequest
+{
+    /// <summary>External (public) identifier of the exercise.</summary>
+    public Guid ExerciseExternalId { get; set; }
+
+    /// <summary>Display name of the exercise (snapshot).</summary>
+    public string ExerciseName { get; set; } = string.Empty;
+
+    /// <summary>Display order within the section (1-based).</summary>
+    public int Order { get; set; }
+
+    /// <summary>Optional coach notes for this exercise.</summary>
+    public string? Notes { get; set; }
+
+    /// <summary>Rest time between sets in seconds.</summary>
+    public int? RestSeconds { get; set; }
+
+    /// <summary>How performance for this exercise is measured. Defaults to Reps.</summary>
+    public MovementType MovementType { get; set; } = MovementType.Reps;
+
+    /// <summary>Per-exercise format override. Null means inherits the section's format.</summary>
+    public WorkoutFormat? Format { get; set; }
+
+    /// <summary>Per-exercise format configuration. Null when Format is null or Standard.</summary>
+    public WodConfig? FormatConfig { get; set; }
+
+    /// <summary>Planned sets for this exercise.</summary>
+    public List<CreateSectionTemplateSetRequest> Sets { get; set; } = [];
+}
+
+/// <summary>
+/// A planned set in a section template exercise.
+/// </summary>
+public class CreateSectionTemplateSetRequest
+{
+    /// <summary>Set number within the exercise (1-based).</summary>
+    public int SetNumber { get; set; }
+
+    /// <summary>Type of set.</summary>
+    public SetType Type { get; set; } = SetType.Normal;
+
+    /// <summary>Target number of repetitions.</summary>
+    public int? Reps { get; set; }
+
+    /// <summary>Target weight in kilograms.</summary>
+    public decimal? WeightKg { get; set; }
+
+    /// <summary>Target duration in seconds.</summary>
+    public int? DurationSeconds { get; set; }
+
+    /// <summary>Target RPE (1-10).</summary>
+    public decimal? Rpe { get; set; }
+
+    /// <summary>Target distance in meters.</summary>
+    public decimal? DistanceMeters { get; set; }
+
+    /// <summary>Rest time after this set in seconds.</summary>
+    public int? RestSeconds { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/CreateSectionTemplate/CreateSectionTemplateValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/CreateSectionTemplate/CreateSectionTemplateValidator.cs
@@ -1,0 +1,123 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.CreateSectionTemplate;
+
+/// <summary>
+/// Validates <see cref="CreateSectionTemplateRequest"/>.
+/// </summary>
+public class CreateSectionTemplateValidator : Validator<CreateSectionTemplateRequest>
+{
+    /// <summary>
+    /// Initializes validation rules for a new section template.
+    /// </summary>
+    public CreateSectionTemplateValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        // Format / FormatConfig invariants
+        RuleFor(x => x.DefaultFormatConfig)
+            .Null()
+            .When(x => x.DefaultFormat == WorkoutFormat.Standard)
+            .WithMessage("DefaultFormatConfig must be null for Standard format.");
+
+        RuleFor(x => x.DefaultFormatConfig)
+            .NotNull()
+            .When(x => x.DefaultFormat.HasValue && x.DefaultFormat != WorkoutFormat.Standard)
+            .WithMessage("DefaultFormatConfig is required for non-Standard formats.");
+
+        ApplyFormatConfigRules(this, x => x.DefaultFormat, x => x.DefaultFormatConfig);
+
+        RuleFor(x => x.DefaultExercises)
+            .Must(exercises => exercises.Count <= 30).WithMessage("A template may not have more than 30 exercises.");
+
+        RuleForEach(x => x.DefaultExercises).ChildRules(exercise =>
+        {
+            exercise.RuleFor(e => e.ExerciseExternalId)
+                .NotEmpty().WithMessage("ExerciseExternalId must not be empty.");
+
+            exercise.RuleFor(e => e.ExerciseName)
+                .NotEmpty().WithMessage("ExerciseName must not be empty.");
+
+            exercise.RuleFor(e => e.Order)
+                .GreaterThanOrEqualTo(1).WithMessage("Exercise Order must be >= 1.");
+
+            exercise.RuleFor(e => e.RestSeconds)
+                .InclusiveBetween(0, 600).When(e => e.RestSeconds.HasValue)
+                .WithMessage("RestSeconds must be between 0 and 600.");
+
+            exercise.RuleFor(e => e.FormatConfig)
+                .Null()
+                .When(e => e.Format == WorkoutFormat.Standard)
+                .WithMessage("Exercise FormatConfig must be null for Standard format.");
+
+            exercise.RuleFor(e => e.FormatConfig)
+                .NotNull()
+                .When(e => e.Format.HasValue && e.Format != WorkoutFormat.Standard)
+                .WithMessage("Exercise FormatConfig is required for non-Standard formats.");
+
+            ApplyFormatConfigRules(exercise, e => e.Format, e => e.FormatConfig);
+
+            exercise.RuleFor(e => e.Sets)
+                .Must(sets => sets.Count <= 20).WithMessage("An exercise may not have more than 20 sets.");
+
+            exercise.RuleForEach(e => e.Sets).ChildRules(set =>
+            {
+                set.RuleFor(s => s.SetNumber)
+                    .GreaterThanOrEqualTo(1).WithMessage("SetNumber must be >= 1.");
+
+                set.RuleFor(s => s.Reps)
+                    .InclusiveBetween(1, 1000).When(s => s.Reps.HasValue)
+                    .WithMessage("Reps must be between 1 and 1000.");
+
+                set.RuleFor(s => s.WeightKg)
+                    .GreaterThanOrEqualTo(0).When(s => s.WeightKg.HasValue)
+                    .WithMessage("WeightKg must be >= 0.");
+
+                set.RuleFor(s => s.Rpe)
+                    .InclusiveBetween(1, 10).When(s => s.Rpe.HasValue)
+                    .WithMessage("RPE must be between 1 and 10.");
+            });
+        });
+    }
+
+    internal static void ApplyFormatConfigRules<T>(
+        AbstractValidator<T> validator,
+        Func<T, WorkoutFormat?> formatSelector,
+        Func<T, WodConfig?> configSelector)
+    {
+        validator.RuleFor(x => configSelector(x)!.IntervalSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.EMOM && configSelector(x) != null)
+            .WithMessage("EMOM requires IntervalSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.TotalRounds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.EMOM && configSelector(x) != null)
+            .WithMessage("EMOM requires TotalRounds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.TimeCapSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => (formatSelector(x) == WorkoutFormat.AMRAP || formatSelector(x) == WorkoutFormat.ForTime) && configSelector(x) != null)
+            .WithMessage("AMRAP and ForTime require TimeCapSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.WorkSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithMessage("Tabata requires WorkSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.RestSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithMessage("Tabata requires RestSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.TotalRounds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithMessage("Tabata requires TotalRounds > 0.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/DeleteSectionTemplate/DeleteSectionTemplateEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/DeleteSectionTemplate/DeleteSectionTemplateEndpoint.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.DeleteSectionTemplate;
+
+/// <summary>
+/// Deletes a section template owned by the calling trainer.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+public class DeleteSectionTemplateEndpoint(IMongoContext mongo)
+    : Endpoint<DeleteSectionTemplateRequest>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Delete("/training/section-templates/{TemplateId}");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Delete section template";
+            s.Description = "Permanently deletes a section template. Returns 403 if owned by another trainer.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(DeleteSectionTemplateRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Load to verify ownership before deleting
+        using var cursor = await mongo.SectionTemplates.FindAsync(
+            Builders<SectionTemplate>.Filter.Eq(t => t.ExternalId, req.TemplateId),
+            cancellationToken: ct);
+        var template = await cursor.FirstOrDefaultAsync(ct);
+
+        if (template is null)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateNotFound, "Section template not found.");
+            return;
+        }
+
+        if (template.OwnerTrainerId != trainerId)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateNotOwned, "Section template belongs to another trainer.");
+            return;
+        }
+
+        await mongo.SectionTemplates.DeleteOneAsync(
+            Builders<SectionTemplate>.Filter.Eq(t => t.ExternalId, req.TemplateId),
+            cancellationToken: ct);
+
+        await Send.NoContentAsync(ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/DeleteSectionTemplate/DeleteSectionTemplateRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/DeleteSectionTemplate/DeleteSectionTemplateRequest.cs
@@ -1,0 +1,10 @@
+namespace FitnessPlatform.Application.Features.SectionTemplates.DeleteSectionTemplate;
+
+/// <summary>
+/// Request for deleting a section template.
+/// </summary>
+public class DeleteSectionTemplateRequest
+{
+    /// <summary>The template's public identifier (route parameter).</summary>
+    public Guid TemplateId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/GetSectionTemplate/GetSectionTemplateEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/GetSectionTemplate/GetSectionTemplateEndpoint.cs
@@ -1,0 +1,62 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Features.SectionTemplates.Shared;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.GetSectionTemplate;
+
+/// <summary>
+/// Returns a single section template owned by the calling trainer.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+public class GetSectionTemplateEndpoint(IMongoContext mongo)
+    : Endpoint<GetSectionTemplateRequest, SectionTemplateResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/training/section-templates/{TemplateId}");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Get section template";
+            s.Description = "Returns a single section template. Returns 403 if the template belongs to another trainer.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetSectionTemplateRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+
+        using var cursor = await mongo.SectionTemplates.FindAsync(
+            Builders<SectionTemplate>.Filter.Eq(t => t.ExternalId, req.TemplateId),
+            cancellationToken: ct);
+        var template = await cursor.FirstOrDefaultAsync(ct);
+
+        if (template is null)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateNotFound, "Section template not found.");
+            return;
+        }
+
+        if (template.OwnerTrainerId != trainerId)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateNotOwned, "Section template belongs to another trainer.");
+            return;
+        }
+
+        await Send.OkAsync(SectionTemplateResponse.FromDocument(template), ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/GetSectionTemplate/GetSectionTemplateRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/GetSectionTemplate/GetSectionTemplateRequest.cs
@@ -1,0 +1,10 @@
+namespace FitnessPlatform.Application.Features.SectionTemplates.GetSectionTemplate;
+
+/// <summary>
+/// Request for retrieving a single section template by its public identifier.
+/// </summary>
+public class GetSectionTemplateRequest
+{
+    /// <summary>The template's public identifier (route parameter).</summary>
+    public Guid TemplateId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/ListSectionTemplates/ListSectionTemplatesEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/ListSectionTemplates/ListSectionTemplatesEndpoint.cs
@@ -1,0 +1,61 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Features.SectionTemplates.Shared;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.ListSectionTemplates;
+
+/// <summary>
+/// Lists the calling trainer's section templates with pagination.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+public class ListSectionTemplatesEndpoint(IMongoContext mongo)
+    : Endpoint<ListSectionTemplatesRequest, List<SectionTemplateResponse>>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/training/section-templates");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "List section templates";
+            s.Description = "Returns the calling trainer's section templates, paginated.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(ListSectionTemplatesRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+        var filter = Builders<SectionTemplate>.Filter.Eq(t => t.OwnerTrainerId, trainerId);
+
+        var total = await mongo.SectionTemplates.CountDocumentsAsync(filter, cancellationToken: ct);
+
+        HttpContext.Response.Headers["X-Total-Count"] = total.ToString();
+
+        var skip = (req.Page - 1) * req.PageSize;
+        using var cursor = await mongo.SectionTemplates.FindAsync(
+            filter,
+            new FindOptions<SectionTemplate>
+            {
+                Sort = Builders<SectionTemplate>.Sort.Ascending(t => t.CreatedAt),
+                Skip = skip,
+                Limit = req.PageSize
+            },
+            ct);
+
+        var templates = await cursor.ToListAsync(ct);
+        await Send.OkAsync(templates.Select(SectionTemplateResponse.FromDocument).ToList(), ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/ListSectionTemplates/ListSectionTemplatesRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/ListSectionTemplates/ListSectionTemplatesRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.SectionTemplates.ListSectionTemplates;
+
+/// <summary>
+/// Request for listing the calling trainer's section templates.
+/// </summary>
+public class ListSectionTemplatesRequest
+{
+    /// <summary>Page number (1-based). Defaults to 1.</summary>
+    public int Page { get; set; } = 1;
+
+    /// <summary>Page size. Defaults to 50.</summary>
+    public int PageSize { get; set; } = 50;
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/ListSectionTemplates/ListSectionTemplatesValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/ListSectionTemplates/ListSectionTemplatesValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.ListSectionTemplates;
+
+/// <summary>
+/// Validates <see cref="ListSectionTemplatesRequest"/>.
+/// </summary>
+public class ListSectionTemplatesValidator : Validator<ListSectionTemplatesRequest>
+{
+    /// <summary>
+    /// Initializes pagination validation rules.
+    /// </summary>
+    public ListSectionTemplatesValidator()
+    {
+        RuleFor(x => x.Page).GreaterThanOrEqualTo(1).WithMessage("Page must be >= 1.");
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 200).WithMessage("PageSize must be between 1 and 200.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/Shared/SectionTemplateResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/Shared/SectionTemplateResponse.cs
@@ -1,0 +1,46 @@
+using FitnessPlatform.Application.Domain.Documents;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.Shared;
+
+/// <summary>
+/// Response DTO for a single section template.
+/// </summary>
+public class SectionTemplateResponse
+{
+    /// <summary>Template's public identifier.</summary>
+    public Guid TemplateId { get; set; }
+
+    /// <summary>Display name of the template.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Default workout format. Null means no format override.</summary>
+    public string? DefaultFormat { get; set; }
+
+    /// <summary>Default format configuration.</summary>
+    public WodConfig? DefaultFormatConfig { get; set; }
+
+    /// <summary>Default exercises pre-populated when applying this template.</summary>
+    public List<SessionExercise> DefaultExercises { get; set; } = [];
+
+    /// <summary>Optimistic concurrency version.</summary>
+    public int Version { get; set; }
+
+    /// <summary>When this template was created.</summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>When this template was last updated.</summary>
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>Maps a <see cref="SectionTemplate"/> document to the response DTO.</summary>
+    public static SectionTemplateResponse FromDocument(SectionTemplate t) => new()
+    {
+        TemplateId = t.ExternalId,
+        Name = t.Name,
+        DefaultFormat = t.DefaultFormat?.ToString(),
+        DefaultFormatConfig = t.DefaultFormatConfig,
+        DefaultExercises = t.DefaultExercises,
+        Version = t.Version,
+        CreatedAt = t.CreatedAt,
+        UpdatedAt = t.UpdatedAt
+    };
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/UpdateSectionTemplate/UpdateSectionTemplateEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/UpdateSectionTemplate/UpdateSectionTemplateEndpoint.cs
@@ -1,0 +1,112 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Features.SectionTemplates.Shared;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.UpdateSectionTemplate;
+
+/// <summary>
+/// Full-state update of a section template. Uses optimistic concurrency via the Version field.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+public class UpdateSectionTemplateEndpoint(IMongoContext mongo)
+    : Endpoint<UpdateSectionTemplateRequest, SectionTemplateResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Put("/training/section-templates/{TemplateId}");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Update section template";
+            s.Description = "Replaces name, format, and default exercises. Uses optimistic concurrency via the Version field.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(UpdateSectionTemplateRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Load
+        using var cursor = await mongo.SectionTemplates.FindAsync(
+            Builders<SectionTemplate>.Filter.Eq(t => t.ExternalId, req.TemplateId),
+            cancellationToken: ct);
+        var template = await cursor.FirstOrDefaultAsync(ct);
+
+        if (template is null)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateNotFound, "Section template not found.");
+            return;
+        }
+
+        // Ownership check
+        if (template.OwnerTrainerId != trainerId)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateNotOwned, "Section template belongs to another trainer.");
+            return;
+        }
+
+        // Optimistic concurrency — check version before mutating
+        if (template.Version != req.Version)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateVersionConflict, "Version conflict. The template was modified by another request.");
+            return;
+        }
+
+        // Mutate
+        template.Name = req.Name.Trim();
+        template.DefaultFormat = req.DefaultFormat;
+        template.DefaultFormatConfig = req.DefaultFormatConfig;
+        template.DefaultExercises = req.DefaultExercises.Select(e => new SessionExercise
+        {
+            ExerciseExternalId = e.ExerciseExternalId,
+            ExerciseName = e.ExerciseName,
+            Order = e.Order,
+            Notes = e.Notes?.Trim(),
+            RestSeconds = e.RestSeconds,
+            MovementType = e.MovementType,
+            Format = e.Format,
+            FormatConfig = e.FormatConfig,
+            Sets = e.Sets.Select(s => new ExerciseSet
+            {
+                SetNumber = s.SetNumber,
+                Type = s.Type,
+                Reps = s.Reps,
+                WeightKg = s.WeightKg,
+                DurationSeconds = s.DurationSeconds,
+                Rpe = s.Rpe,
+                DistanceMeters = s.DistanceMeters,
+                RestSeconds = s.RestSeconds
+            }).ToList()
+        }).ToList();
+        template.UpdatedAt = DateTime.UtcNow;
+        template.Version += 1;
+
+        // Persist with version check (double-check at DB level)
+        var versionFilter = Builders<SectionTemplate>.Filter.Eq(t => t.ExternalId, req.TemplateId)
+                            & Builders<SectionTemplate>.Filter.Eq(t => t.Version, req.Version);
+
+        var result = await mongo.SectionTemplates.ReplaceOneAsync(versionFilter, template, cancellationToken: ct);
+
+        if (result.ModifiedCount == 0)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.SectionTemplateVersionConflict, "Version conflict. The template was modified by another request.");
+            return;
+        }
+
+        await Send.OkAsync(SectionTemplateResponse.FromDocument(template), ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/UpdateSectionTemplate/UpdateSectionTemplateRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/UpdateSectionTemplate/UpdateSectionTemplateRequest.cs
@@ -1,0 +1,29 @@
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.SectionTemplates.CreateSectionTemplate;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.UpdateSectionTemplate;
+
+/// <summary>
+/// Request for updating an existing section template.
+/// </summary>
+public class UpdateSectionTemplateRequest
+{
+    /// <summary>The template's public identifier (route parameter).</summary>
+    public Guid TemplateId { get; set; }
+
+    /// <summary>Updated display name of the template.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Updated default workout format. Null means no format override.</summary>
+    public WorkoutFormat? DefaultFormat { get; set; }
+
+    /// <summary>Updated default format configuration.</summary>
+    public WodConfig? DefaultFormatConfig { get; set; }
+
+    /// <summary>Updated default exercises.</summary>
+    public List<CreateSectionTemplateExerciseRequest> DefaultExercises { get; set; } = [];
+
+    /// <summary>Expected version for optimistic concurrency control.</summary>
+    public int Version { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/SectionTemplates/UpdateSectionTemplate/UpdateSectionTemplateValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/SectionTemplates/UpdateSectionTemplate/UpdateSectionTemplateValidator.cs
@@ -1,0 +1,91 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.SectionTemplates.CreateSectionTemplate;
+
+namespace FitnessPlatform.Application.Features.SectionTemplates.UpdateSectionTemplate;
+
+/// <summary>
+/// Validates <see cref="UpdateSectionTemplateRequest"/>.
+/// </summary>
+public class UpdateSectionTemplateValidator : Validator<UpdateSectionTemplateRequest>
+{
+    /// <summary>
+    /// Initializes validation rules for a section template update.
+    /// </summary>
+    public UpdateSectionTemplateValidator()
+    {
+        RuleFor(x => x.TemplateId).NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.Version)
+            .GreaterThanOrEqualTo(1);
+
+        RuleFor(x => x.DefaultFormatConfig)
+            .Null()
+            .When(x => x.DefaultFormat == WorkoutFormat.Standard)
+            .WithMessage("DefaultFormatConfig must be null for Standard format.");
+
+        RuleFor(x => x.DefaultFormatConfig)
+            .NotNull()
+            .When(x => x.DefaultFormat.HasValue && x.DefaultFormat != WorkoutFormat.Standard)
+            .WithMessage("DefaultFormatConfig is required for non-Standard formats.");
+
+        CreateSectionTemplateValidator.ApplyFormatConfigRules(this, x => x.DefaultFormat, x => x.DefaultFormatConfig);
+
+        RuleFor(x => x.DefaultExercises)
+            .Must(exercises => exercises.Count <= 30).WithMessage("A template may not have more than 30 exercises.");
+
+        RuleForEach(x => x.DefaultExercises).ChildRules(exercise =>
+        {
+            exercise.RuleFor(e => e.ExerciseExternalId)
+                .NotEmpty().WithMessage("ExerciseExternalId must not be empty.");
+
+            exercise.RuleFor(e => e.ExerciseName)
+                .NotEmpty().WithMessage("ExerciseName must not be empty.");
+
+            exercise.RuleFor(e => e.Order)
+                .GreaterThanOrEqualTo(1).WithMessage("Exercise Order must be >= 1.");
+
+            exercise.RuleFor(e => e.RestSeconds)
+                .InclusiveBetween(0, 600).When(e => e.RestSeconds.HasValue)
+                .WithMessage("RestSeconds must be between 0 and 600.");
+
+            exercise.RuleFor(e => e.FormatConfig)
+                .Null()
+                .When(e => e.Format == WorkoutFormat.Standard)
+                .WithMessage("Exercise FormatConfig must be null for Standard format.");
+
+            exercise.RuleFor(e => e.FormatConfig)
+                .NotNull()
+                .When(e => e.Format.HasValue && e.Format != WorkoutFormat.Standard)
+                .WithMessage("Exercise FormatConfig is required for non-Standard formats.");
+
+            CreateSectionTemplateValidator.ApplyFormatConfigRules(exercise, e => e.Format, e => e.FormatConfig);
+
+            exercise.RuleFor(e => e.Sets)
+                .Must(sets => sets.Count <= 20).WithMessage("An exercise may not have more than 20 sets.");
+
+            exercise.RuleForEach(e => e.Sets).ChildRules(set =>
+            {
+                set.RuleFor(s => s.SetNumber)
+                    .GreaterThanOrEqualTo(1).WithMessage("SetNumber must be >= 1.");
+
+                set.RuleFor(s => s.Reps)
+                    .InclusiveBetween(1, 1000).When(s => s.Reps.HasValue)
+                    .WithMessage("Reps must be between 1 and 1000.");
+
+                set.RuleFor(s => s.WeightKg)
+                    .GreaterThanOrEqualTo(0).When(s => s.WeightKg.HasValue)
+                    .WithMessage("WeightKg must be >= 0.");
+
+                set.RuleFor(s => s.Rpe)
+                    .InclusiveBetween(1, 10).When(s => s.Rpe.HasValue)
+                    .WithMessage("RPE must be between 1 and 10.");
+            });
+        });
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
@@ -142,26 +142,34 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
                     Notes = rs.Notes?.Trim(),
                     Format = rs.Format,
                     FormatConfig = rs.FormatConfig,
-                    Exercises = rs.Exercises.Select(re => new SessionExercise
+                    Sections = rs.Sections.Select(rsec => new TrainingSection
                     {
-                        ExerciseExternalId = re.ExerciseExternalId,
-                        ExerciseName = re.ExerciseName,
-                        Order = re.Order,
-                        Notes = re.Notes?.Trim(),
-                        RestSeconds = re.RestSeconds,
-                        MovementType = re.MovementType,
-                        Format = re.Format,
-                        FormatConfig = re.FormatConfig,
-                        Sets = re.Sets.Select(rset => new ExerciseSet
+                        SectionId = rsec.SectionId ?? Guid.NewGuid(),
+                        Order = rsec.Order,
+                        Name = rsec.Name,
+                        Format = rsec.Format,
+                        FormatConfig = rsec.FormatConfig,
+                        Exercises = rsec.Exercises.Select(re => new SessionExercise
                         {
-                            SetNumber = rset.SetNumber,
-                            Type = rset.Type,
-                            Reps = rset.Reps,
-                            WeightKg = rset.WeightKg,
-                            DurationSeconds = rset.DurationSeconds,
-                            Rpe = rset.Rpe,
-                            DistanceMeters = rset.DistanceMeters,
-                            RestSeconds = rset.RestSeconds
+                            ExerciseExternalId = re.ExerciseExternalId,
+                            ExerciseName = re.ExerciseName,
+                            Order = re.Order,
+                            Notes = re.Notes?.Trim(),
+                            RestSeconds = re.RestSeconds,
+                            MovementType = re.MovementType,
+                            Format = re.Format,
+                            FormatConfig = re.FormatConfig,
+                            Sets = re.Sets.Select(rset => new ExerciseSet
+                            {
+                                SetNumber = rset.SetNumber,
+                                Type = rset.Type,
+                                Reps = rset.Reps,
+                                WeightKg = rset.WeightKg,
+                                DurationSeconds = rset.DurationSeconds,
+                                Rpe = rset.Rpe,
+                                DistanceMeters = rset.DistanceMeters,
+                                RestSeconds = rset.RestSeconds
+                            }).ToList()
                         }).ToList()
                     }).ToList()
                 }).ToList()

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
@@ -1,11 +1,12 @@
 using FastEndpoints;
 using FluentValidation;
+using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 
 namespace FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
 
 /// <summary>
-/// Validates <see cref="UpdateTrainingPlanRequest"/> including all nested weeks, sessions, exercises, and sets.
+/// Validates <see cref="UpdateTrainingPlanRequest"/> including all nested weeks, sessions, sections, exercises, and sets.
 /// </summary>
 public class UpdateTrainingPlanValidator : Validator<UpdateTrainingPlanRequest>
 {
@@ -58,128 +59,138 @@ public class UpdateTrainingPlanValidator : Validator<UpdateTrainingPlanRequest>
                 session.RuleFor(s => s.Order)
                     .GreaterThanOrEqualTo(1).WithMessage("Session Order must be >= 1.");
 
-                session.RuleFor(s => s.Exercises)
-                    .Must(exercises => exercises.Count <= 30).WithMessage("A session may not have more than 30 exercises.");
+                // Session must have at least one section
+                session.RuleFor(s => s.Sections)
+                    .NotEmpty().WithMessage("A session must have at least one section.");
 
-                // Session-level format config invariants
+                // No duplicate Order values within a session's sections
+                session.RuleFor(s => s.Sections)
+                    .Must(sections => sections.Select(sec => sec.Order).Distinct().Count() == sections.Count)
+                    .WithMessage("Duplicate Order values are not allowed within a session's sections.");
+
+                // Session-level format config invariants (optional, nullable)
                 session.RuleFor(s => s.FormatConfig)
                     .Null()
                     .When(s => s.Format == WorkoutFormat.Standard)
-                    .WithMessage("FormatConfig must be null for Standard format.");
+                    .WithMessage("Session FormatConfig must be null for Standard format.");
 
                 session.RuleFor(s => s.FormatConfig)
                     .NotNull()
-                    .When(s => s.Format != WorkoutFormat.Standard)
-                    .WithMessage("FormatConfig is required for non-Standard formats.");
+                    .When(s => s.Format.HasValue && s.Format != WorkoutFormat.Standard)
+                    .WithMessage("Session FormatConfig is required for non-Standard formats.");
 
-                session.RuleFor(s => s.FormatConfig!.IntervalSeconds)
-                    .NotNull().GreaterThan(0)
-                    .When(s => s.Format == WorkoutFormat.EMOM && s.FormatConfig != null)
-                    .WithMessage("EMOM requires IntervalSeconds > 0.");
+                ApplyFormatConfigRules(session, s => s.Format, s => s.FormatConfig, "Session");
 
-                session.RuleFor(s => s.FormatConfig!.TotalRounds)
-                    .NotNull().GreaterThan(0)
-                    .When(s => s.Format == WorkoutFormat.EMOM && s.FormatConfig != null)
-                    .WithMessage("EMOM requires TotalRounds > 0.");
-
-                session.RuleFor(s => s.FormatConfig!.TimeCapSeconds)
-                    .NotNull().GreaterThan(0)
-                    .When(s => (s.Format == WorkoutFormat.AMRAP || s.Format == WorkoutFormat.ForTime) && s.FormatConfig != null)
-                    .WithMessage("AMRAP and ForTime require TimeCapSeconds > 0.");
-
-                session.RuleFor(s => s.FormatConfig!.WorkSeconds)
-                    .NotNull().GreaterThan(0)
-                    .When(s => s.Format == WorkoutFormat.Tabata && s.FormatConfig != null)
-                    .WithMessage("Tabata requires WorkSeconds > 0.");
-
-                session.RuleFor(s => s.FormatConfig!.RestSeconds)
-                    .NotNull().GreaterThan(0)
-                    .When(s => s.Format == WorkoutFormat.Tabata && s.FormatConfig != null)
-                    .WithMessage("Tabata requires RestSeconds > 0.");
-
-                session.RuleFor(s => s.FormatConfig!.TotalRounds)
-                    .NotNull().GreaterThan(0)
-                    .When(s => s.Format == WorkoutFormat.Tabata && s.FormatConfig != null)
-                    .WithMessage("Tabata requires TotalRounds > 0.");
-
-                session.RuleForEach(s => s.Exercises).ChildRules(exercise =>
+                session.RuleForEach(s => s.Sections).ChildRules(section =>
                 {
-                    exercise.RuleFor(e => e.ExerciseExternalId)
-                        .NotEmpty().WithMessage("ExerciseExternalId must not be empty.");
+                    section.RuleFor(sec => sec.Name)
+                        .NotEmpty().WithMessage("Section Name must not be empty.")
+                        .MaximumLength(200);
 
-                    exercise.RuleFor(e => e.ExerciseName)
-                        .NotEmpty().WithMessage("ExerciseName must not be empty.");
+                    section.RuleFor(sec => sec.Exercises)
+                        .Must(exercises => exercises.Count <= 30).WithMessage("A section may not have more than 30 exercises.");
 
-                    exercise.RuleFor(e => e.Order)
-                        .GreaterThanOrEqualTo(1).WithMessage("Exercise Order must be >= 1.");
-
-                    exercise.RuleFor(e => e.RestSeconds)
-                        .InclusiveBetween(0, 600).When(e => e.RestSeconds.HasValue)
-                        .WithMessage("RestSeconds must be between 0 and 600.");
-
-                    // Per-exercise format config invariants (same rules as session level)
-                    exercise.RuleFor(e => e.FormatConfig)
+                    // Section-level format config invariants
+                    section.RuleFor(sec => sec.FormatConfig)
                         .Null()
-                        .When(e => e.Format == WorkoutFormat.Standard)
-                        .WithMessage("Exercise FormatConfig must be null for Standard format.");
+                        .When(sec => sec.Format == WorkoutFormat.Standard)
+                        .WithMessage("Section FormatConfig must be null for Standard format.");
 
-                    exercise.RuleFor(e => e.FormatConfig)
+                    section.RuleFor(sec => sec.FormatConfig)
                         .NotNull()
-                        .When(e => e.Format.HasValue && e.Format != WorkoutFormat.Standard)
-                        .WithMessage("Exercise FormatConfig is required for non-Standard formats.");
+                        .When(sec => sec.Format.HasValue && sec.Format != WorkoutFormat.Standard)
+                        .WithMessage("Section FormatConfig is required for non-Standard formats.");
 
-                    exercise.RuleFor(e => e.FormatConfig!.IntervalSeconds)
-                        .NotNull().GreaterThan(0)
-                        .When(e => e.Format == WorkoutFormat.EMOM && e.FormatConfig != null)
-                        .WithMessage("EMOM exercise requires IntervalSeconds > 0.");
+                    ApplyFormatConfigRules(section, sec => sec.Format, sec => sec.FormatConfig, "Section");
 
-                    exercise.RuleFor(e => e.FormatConfig!.TotalRounds)
-                        .NotNull().GreaterThan(0)
-                        .When(e => e.Format == WorkoutFormat.EMOM && e.FormatConfig != null)
-                        .WithMessage("EMOM exercise requires TotalRounds > 0.");
-
-                    exercise.RuleFor(e => e.FormatConfig!.TimeCapSeconds)
-                        .NotNull().GreaterThan(0)
-                        .When(e => (e.Format == WorkoutFormat.AMRAP || e.Format == WorkoutFormat.ForTime) && e.FormatConfig != null)
-                        .WithMessage("AMRAP/ForTime exercise requires TimeCapSeconds > 0.");
-
-                    exercise.RuleFor(e => e.FormatConfig!.WorkSeconds)
-                        .NotNull().GreaterThan(0)
-                        .When(e => e.Format == WorkoutFormat.Tabata && e.FormatConfig != null)
-                        .WithMessage("Tabata exercise requires WorkSeconds > 0.");
-
-                    exercise.RuleFor(e => e.FormatConfig!.RestSeconds)
-                        .NotNull().GreaterThan(0)
-                        .When(e => e.Format == WorkoutFormat.Tabata && e.FormatConfig != null)
-                        .WithMessage("Tabata exercise requires RestSeconds > 0.");
-
-                    exercise.RuleFor(e => e.FormatConfig!.TotalRounds)
-                        .NotNull().GreaterThan(0)
-                        .When(e => e.Format == WorkoutFormat.Tabata && e.FormatConfig != null)
-                        .WithMessage("Tabata exercise requires TotalRounds > 0.");
-
-                    exercise.RuleFor(e => e.Sets)
-                        .Must(sets => sets.Count <= 20).WithMessage("An exercise may not have more than 20 sets.");
-
-                    exercise.RuleForEach(e => e.Sets).ChildRules(set =>
+                    section.RuleForEach(sec => sec.Exercises).ChildRules(exercise =>
                     {
-                        set.RuleFor(s => s.SetNumber)
-                            .GreaterThanOrEqualTo(1).WithMessage("SetNumber must be >= 1.");
+                        exercise.RuleFor(e => e.ExerciseExternalId)
+                            .NotEmpty().WithMessage("ExerciseExternalId must not be empty.");
 
-                        set.RuleFor(s => s.Reps)
-                            .InclusiveBetween(1, 1000).When(s => s.Reps.HasValue)
-                            .WithMessage("Reps must be between 1 and 1000.");
+                        exercise.RuleFor(e => e.ExerciseName)
+                            .NotEmpty().WithMessage("ExerciseName must not be empty.");
 
-                        set.RuleFor(s => s.WeightKg)
-                            .GreaterThanOrEqualTo(0).When(s => s.WeightKg.HasValue)
-                            .WithMessage("WeightKg must be >= 0.");
+                        exercise.RuleFor(e => e.Order)
+                            .GreaterThanOrEqualTo(1).WithMessage("Exercise Order must be >= 1.");
 
-                        set.RuleFor(s => s.Rpe)
-                            .InclusiveBetween(1, 10).When(s => s.Rpe.HasValue)
-                            .WithMessage("RPE must be between 1 and 10.");
+                        exercise.RuleFor(e => e.RestSeconds)
+                            .InclusiveBetween(0, 600).When(e => e.RestSeconds.HasValue)
+                            .WithMessage("RestSeconds must be between 0 and 600.");
+
+                        // Per-exercise format config invariants
+                        exercise.RuleFor(e => e.FormatConfig)
+                            .Null()
+                            .When(e => e.Format == WorkoutFormat.Standard)
+                            .WithMessage("Exercise FormatConfig must be null for Standard format.");
+
+                        exercise.RuleFor(e => e.FormatConfig)
+                            .NotNull()
+                            .When(e => e.Format.HasValue && e.Format != WorkoutFormat.Standard)
+                            .WithMessage("Exercise FormatConfig is required for non-Standard formats.");
+
+                        ApplyFormatConfigRules(exercise, e => e.Format, e => e.FormatConfig, "Exercise");
+
+                        exercise.RuleFor(e => e.Sets)
+                            .Must(sets => sets.Count <= 20).WithMessage("An exercise may not have more than 20 sets.");
+
+                        exercise.RuleForEach(e => e.Sets).ChildRules(set =>
+                        {
+                            set.RuleFor(s => s.SetNumber)
+                                .GreaterThanOrEqualTo(1).WithMessage("SetNumber must be >= 1.");
+
+                            set.RuleFor(s => s.Reps)
+                                .InclusiveBetween(1, 1000).When(s => s.Reps.HasValue)
+                                .WithMessage("Reps must be between 1 and 1000.");
+
+                            set.RuleFor(s => s.WeightKg)
+                                .GreaterThanOrEqualTo(0).When(s => s.WeightKg.HasValue)
+                                .WithMessage("WeightKg must be >= 0.");
+
+                            set.RuleFor(s => s.Rpe)
+                                .InclusiveBetween(1, 10).When(s => s.Rpe.HasValue)
+                                .WithMessage("RPE must be between 1 and 10.");
+                        });
                     });
                 });
             });
         });
+    }
+
+    private static void ApplyFormatConfigRules<T>(
+        AbstractValidator<T> validator,
+        Func<T, WorkoutFormat?> formatSelector,
+        Func<T, WodConfig?> configSelector,
+        string prefix)
+    {
+        validator.RuleFor(x => configSelector(x)!.IntervalSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.EMOM && configSelector(x) != null)
+            .WithMessage($"{prefix} EMOM requires IntervalSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.TotalRounds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.EMOM && configSelector(x) != null)
+            .WithMessage($"{prefix} EMOM requires TotalRounds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.TimeCapSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => (formatSelector(x) == WorkoutFormat.AMRAP || formatSelector(x) == WorkoutFormat.ForTime) && configSelector(x) != null)
+            .WithMessage($"{prefix} AMRAP and ForTime require TimeCapSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.WorkSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithMessage($"{prefix} Tabata requires WorkSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.RestSeconds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithMessage($"{prefix} Tabata requires RestSeconds > 0.");
+
+        validator.RuleFor(x => configSelector(x)!.TotalRounds)
+            .NotNull().GreaterThan(0)
+            .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithMessage($"{prefix} Tabata requires TotalRounds > 0.");
     }
 }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingWeekRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingWeekRequest.cs
@@ -55,23 +55,60 @@ public class UpdateSessionRequest
     public string? Notes { get; set; }
 
     /// <summary>
-    /// Workout format for this session. Defaults to Standard.
+    /// Session-level workout format. Null means no format override at session level.
+    /// Sections inherit this when their own Format is null.
     /// </summary>
-    public WorkoutFormat Format { get; set; } = WorkoutFormat.Standard;
+    public WorkoutFormat? Format { get; set; }
 
     /// <summary>
-    /// Format configuration. Required for non-Standard formats; must be null for Standard.
+    /// Session-level format configuration. Null when Format is null or Standard.
     /// </summary>
     public WodConfig? FormatConfig { get; set; }
 
     /// <summary>
-    /// Exercises in this session.
+    /// Ordered sections in this session. Each section contains its own exercises.
+    /// </summary>
+    public List<UpdateSectionRequest> Sections { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a training section submitted in a full-state session update.
+/// </summary>
+public class UpdateSectionRequest
+{
+    /// <summary>
+    /// Optional existing section identifier. New GUID generated if null.
+    /// </summary>
+    public Guid? SectionId { get; set; }
+
+    /// <summary>
+    /// Display order within the session (0-based).
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Display name of the section (e.g. "Hlavní", "Warm-up").
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Workout format for this section. Null means section inherits the session-level format.
+    /// </summary>
+    public WorkoutFormat? Format { get; set; }
+
+    /// <summary>
+    /// Format configuration. Required for non-Standard, non-null section formats; must be null for Standard.
+    /// </summary>
+    public WodConfig? FormatConfig { get; set; }
+
+    /// <summary>
+    /// Exercises in this section.
     /// </summary>
     public List<UpdateSessionExerciseRequest> Exercises { get; set; } = [];
 }
 
 /// <summary>
-/// Represents an exercise entry in a training session update.
+/// Represents an exercise entry in a training section update.
 /// </summary>
 public class UpdateSessionExerciseRequest
 {
@@ -86,7 +123,7 @@ public class UpdateSessionExerciseRequest
     public string ExerciseName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Display order within the session (1-based).
+    /// Display order within the section (1-based).
     /// </summary>
     public int Order { get; set; }
 
@@ -106,7 +143,7 @@ public class UpdateSessionExerciseRequest
     public MovementType MovementType { get; set; } = MovementType.Reps;
 
     /// <summary>
-    /// Per-exercise format override. Null means the exercise inherits the session's format.
+    /// Per-exercise format override. Null means the exercise inherits the section's format.
     /// </summary>
     public WorkoutFormat? Format { get; set; }
 

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
@@ -160,6 +160,7 @@ public class CompleteWorkoutEndpoint(
             return;
         }
 
+        session.WithBackfilledSections();
         var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();
 
         // Resolve clientId as PublicId — TrainingCompletion keyed by ClientProfile.PublicId,

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/GetExerciseProgress/GetExerciseProgressEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/GetExerciseProgress/GetExerciseProgressEndpoint.cs
@@ -65,6 +65,7 @@ public class GetExerciseProgressEndpoint(IMongoContext mongo, ProfessionalAuthHe
 
         foreach (var log in logs)
         {
+            log.WithBackfilledSections();
             var exercise = log.Exercises
                 .FirstOrDefault(e => e.ExerciseExternalId == req.ExerciseId);
 

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/Shared/WorkoutLogDetail.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/Shared/WorkoutLogDetail.cs
@@ -60,7 +60,7 @@ public class WorkoutLogDetail
         Mood = log.Mood,
         Notes = log.Notes,
         IsCompleted = log.IsCompleted,
-        Exercises = log.Exercises,
+        Exercises = log.Exercises.ToList(),
         HasPR = log.Exercises.Any(e => e.Sets.Any(s => s.IsPR))
     };
 }

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
@@ -45,7 +45,7 @@ public class StartWorkoutEndpoint(IMongoContext mongo) : Endpoint<StartWorkoutRe
             SessionId = req.SessionId,
             StartedAt = now,
             IsCompleted = false,
-            Exercises = [],
+            Sections = [],
             DateCreated = now
         };
 

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
@@ -70,6 +70,7 @@ public class UpdateWorkoutEndpoint(
         // ── Snapshot previously-completed sets BEFORE we overwrite them ──────────
         // Key: (exerciseExternalId, setNumber) → true if already completed.
         // Used downstream to determine which sets are *newly* completed this call.
+        log.WithBackfilledSections();
         var previouslyCompleted = log.Exercises
             .SelectMany(e => e.Sets
                 .Where(s => s.CompletedAt.HasValue)
@@ -77,10 +78,12 @@ public class UpdateWorkoutEndpoint(
             .ToHashSet();
 
         // ── Build new exercise list from request ──────────────────────────────────
+        // The UpdateWorkout API accepts a flat exercise list (offline-first protocol).
+        // Exercises are stored inside a single default section named "Hlavní".
         log.Mood = req.Mood;
         log.Notes = req.Notes?.Trim();
         log.WodResult = req.WodResult;
-        log.Exercises = req.Exercises.Select(re => new WorkoutExercise
+        var exercises = req.Exercises.Select(re => new WorkoutExercise
         {
             ExerciseExternalId = re.ExerciseExternalId,
             ExerciseName = re.ExerciseName,
@@ -96,6 +99,24 @@ public class UpdateWorkoutEndpoint(
                 CompletedAt = rs.CompletedAt
             }).ToList()
         }).ToList();
+        // Preserve existing section structure when available; otherwise use a single default section.
+        if (log.Sections.Count == 1)
+        {
+            log.Sections[0].Exercises = exercises;
+        }
+        else
+        {
+            log.Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = log.Sections.Count > 0 ? log.Sections[0].SectionId : Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises = exercises
+                }
+            ];
+        }
         log.DateUpdated = DateTime.UtcNow;
 
         await mongo.WorkoutLogs.ReplaceOneAsync(
@@ -167,14 +188,13 @@ public class UpdateWorkoutEndpoint(
             var exercise = exerciseGroup.First().Exercise;
 
             // ── 1. Historical max from prior COMPLETED workout logs ───────────────
-            // Filter to logs that actually contain this exercise to minimise scan.
+            // Exercises now live inside sections, so ElemMatch on a flat exercises field is not
+            // available. Filter by clientId + isCompleted + not-this-log; exercise lookup is done
+            // in-memory below.
             var priorLogFilter = Builders<WorkoutLog>.Filter.And(
                 Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientId),
                 Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true),
-                Builders<WorkoutLog>.Filter.Ne(w => w.ExternalId, log.ExternalId),
-                Builders<WorkoutLog>.Filter.ElemMatch(
-                    w => w.Exercises,
-                    Builders<WorkoutExercise>.Filter.Eq(e => e.ExerciseExternalId, exerciseExternalId)));
+                Builders<WorkoutLog>.Filter.Ne(w => w.ExternalId, log.ExternalId));
 
             using var priorCursor = await mongo.WorkoutLogs.FindAsync(
                 priorLogFilter,
@@ -186,6 +206,7 @@ public class UpdateWorkoutEndpoint(
 
             foreach (var priorLog in priorLogs)
             {
+                priorLog.WithBackfilledSections();
                 var priorEx = priorLog.Exercises
                     .FirstOrDefault(e => e.ExerciseExternalId == exerciseExternalId);
 

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
@@ -58,4 +58,9 @@ public interface IMongoContext
     /// Day-level diary log entries (photos + note per plan day).
     /// </summary>
     IMongoCollection<DayLog> DayLogs { get; }
+
+    /// <summary>
+    /// Section template documents (per-trainer reusable training section templates).
+    /// </summary>
+    IMongoCollection<SectionTemplate> SectionTemplates { get; }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
@@ -25,6 +25,7 @@ public class MongoContext : IMongoContext
         TrainingCompletions = database.GetCollection<TrainingCompletion>(MongoCollections.TrainingCompletions);
         PersonalRecords = database.GetCollection<PersonalRecord>(MongoCollections.PersonalRecords);
         DayLogs = database.GetCollection<DayLog>(MongoCollections.DayLogs);
+        SectionTemplates = database.GetCollection<SectionTemplate>(MongoCollections.SectionTemplates);
     }
 
     /// <inheritdoc />
@@ -56,4 +57,7 @@ public class MongoContext : IMongoContext
 
     /// <inheritdoc />
     public IMongoCollection<DayLog> DayLogs { get; }
+
+    /// <inheritdoc />
+    public IMongoCollection<SectionTemplate> SectionTemplates { get; }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoIndexInitializer.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoIndexInitializer.cs
@@ -36,6 +36,7 @@ public class MongoIndexInitializer : IHostedService
         await CreateWorkoutLogIndexes(cancellationToken);
         await CreateTrainingCompletionIndexes(cancellationToken);
         await CreatePersonalRecordIndexes(cancellationToken);
+        await CreateSectionTemplateIndexes(cancellationToken);
 
         _logger.LogInformation("MongoDB indexes created successfully");
     }
@@ -273,5 +274,22 @@ public class MongoIndexInitializer : IHostedService
             });
 
         await indexes.CreateManyAsync([clientDateIndex, clientExerciseIndex, idempotencyIndex], ct);
+    }
+
+    private async Task CreateSectionTemplateIndexes(CancellationToken ct)
+    {
+        var indexes = _mongo.SectionTemplates.Indexes;
+
+        // Unique index on externalId for API lookups
+        var externalIdIndex = new CreateIndexModel<SectionTemplate>(
+            Builders<SectionTemplate>.IndexKeys.Ascending(t => t.ExternalId),
+            new CreateIndexOptions { Name = "idx_sectiontemplate_externalId", Unique = true });
+
+        // Index on ownerTrainerId for per-trainer list queries
+        var ownerIndex = new CreateIndexModel<SectionTemplate>(
+            Builders<SectionTemplate>.IndexKeys.Ascending(t => t.OwnerTrainerId),
+            new CreateIndexOptions { Name = "idx_sectiontemplate_ownerTrainerId" });
+
+        await indexes.CreateManyAsync([externalIdIndex, ownerIndex], ct);
     }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/ComplianceService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/ComplianceService.cs
@@ -326,6 +326,7 @@ public class ComplianceService : IComplianceService
     private async Task<bool> IsSessionCompleteForDateAsync(
         Guid clientId, TrainingSession session, DateTime date, CancellationToken ct)
     {
+        session.WithBackfilledSections();
         if (session.Exercises.Count == 0)
             return false;
 

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PrDetectionService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PrDetectionService.cs
@@ -13,6 +13,7 @@ public class PrDetectionService(IMongoContext mongo) : IPrDetectionService
     /// <inheritdoc />
     public async Task<List<string>> DetectAndMarkPRsAsync(WorkoutLog workoutLog, CancellationToken ct)
     {
+        workoutLog.WithBackfilledSections();
         var prDescriptions = new List<string>();
 
         foreach (var exercise in workoutLog.Exercises)
@@ -31,6 +32,7 @@ public class PrDetectionService(IMongoContext mongo) : IPrDetectionService
 
             foreach (var log in previousLogs)
             {
+                log.WithBackfilledSections();
                 var prevExercise = log.Exercises
                     .FirstOrDefault(e => e.ExerciseExternalId == exercise.ExerciseExternalId);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/Client/Training/GetFullTrainingPlanIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Client/Training/GetFullTrainingPlanIntegrationTests.cs
@@ -117,19 +117,28 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
                             Name = "Leg Day",
                             Order = 1,
                             Notes = "Focus on depth",
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = squatId,
-                                    ExerciseName = "Squat",
-                                    Order = 1,
-                                    RestSeconds = 120,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 8, WeightKg = 100 },
-                                        new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 8, WeightKg = 100 },
-                                        new ExerciseSet { SetNumber = 3, Type = SetType.Normal, Reps = 8, WeightKg = 100 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = squatId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            RestSeconds = 120,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 8, WeightKg = 100 },
+                                                new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 8, WeightKg = 100 },
+                                                new ExerciseSet { SetNumber = 3, Type = SetType.Normal, Reps = 8, WeightKg = 100 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -141,19 +150,28 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
                             DayOfWeek = 1,
                             Name = "Push Day",
                             Order = 2,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = benchId,
-                                    ExerciseName = "Bench Press",
-                                    Order = 1,
-                                    RestSeconds = 90,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 10, WeightKg = 80 },
-                                        new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 10, WeightKg = 80 },
-                                        new ExerciseSet { SetNumber = 3, Type = SetType.Normal, Reps = 10, WeightKg = 80 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = benchId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            RestSeconds = 90,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 10, WeightKg = 80 },
+                                                new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 10, WeightKg = 80 },
+                                                new ExerciseSet { SetNumber = 3, Type = SetType.Normal, Reps = 10, WeightKg = 80 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -175,18 +193,27 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
             StartedAt = DateTime.UtcNow.AddDays(-6),
             IsCompleted = false,
             DateCreated = DateTime.UtcNow.AddDays(-6),
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = squatId,
-                    ExerciseName = "Squat",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, Reps = 8, WeightKg = 100, CompletedAt = DateTime.UtcNow.AddDays(-6).AddMinutes(5) },
-                        new WorkoutSet { SetNumber = 2, Reps = 8, WeightKg = 100, CompletedAt = DateTime.UtcNow.AddDays(-6).AddMinutes(8) },
-                        // Set 3 not completed
-                        new WorkoutSet { SetNumber = 3, Reps = 0, WeightKg = 100, CompletedAt = null }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = squatId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, Reps = 8, WeightKg = 100, CompletedAt = DateTime.UtcNow.AddDays(-6).AddMinutes(5) },
+                                new WorkoutSet { SetNumber = 2, Reps = 8, WeightKg = 100, CompletedAt = DateTime.UtcNow.AddDays(-6).AddMinutes(8) },
+                                // Set 3 not completed
+                                new WorkoutSet { SetNumber = 3, Reps = 0, WeightKg = 100, CompletedAt = null }
+                            ]
+                        }
                     ]
                 }
             ]

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionEndpointTests.cs
@@ -211,7 +211,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Morning Session",
                             Order = 1,
-                            Exercises = []
+                            Sections = []
                         },
                         new TrainingSession
                         {
@@ -219,7 +219,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Evening Session",
                             Order = 2,
-                            Exercises = []
+                            Sections = []
                         }
                     ]
                 }
@@ -285,7 +285,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Second Session",
                             Order = 2,
-                            Exercises = []
+                            Sections = []
                         },
                         new TrainingSession
                         {
@@ -293,7 +293,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "First Session",
                             Order = 1,
-                            Exercises = []
+                            Sections = []
                         }
                     ]
                 }
@@ -354,7 +354,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Only Session",
                             Order = 1,
-                            Exercises = []
+                            Sections = []
                         }
                     ]
                 }
@@ -417,7 +417,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = otherDow,
                             Name = "Not Today",
                             Order = 1,
-                            Exercises = []
+                            Sections = []
                         }
                     ]
                 }
@@ -586,16 +586,25 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Pull Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Pull-up",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Pull-up",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -616,15 +625,24 @@ public class GetTodaySessionEndpointTests
             SessionId = sessionId,
             PlanId = plan.ExternalId,
             StartedAt = DateTime.UtcNow,
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Pull-up",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Pull-up",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -696,18 +714,27 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Push Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Bench Press",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 },
-                                        new ExerciseSet { SetNumber = 2 },
-                                        new ExerciseSet { SetNumber = 3 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 },
+                                                new ExerciseSet { SetNumber = 2 },
+                                                new ExerciseSet { SetNumber = 3 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -729,17 +756,26 @@ public class GetTodaySessionEndpointTests
             PlanId = plan.ExternalId,
             StartedAt = DateTime.UtcNow,
             IsCompleted = false,
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Bench Press",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = null },
-                        new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Bench Press",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = null },
+                                new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -806,17 +842,26 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Pull Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Pull-up",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 },
-                                        new ExerciseSet { SetNumber = 2 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Pull-up",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 },
+                                                new ExerciseSet { SetNumber = 2 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -841,16 +886,25 @@ public class GetTodaySessionEndpointTests
             StartedAt = olderStartedAt,
             IsCompleted = true,
             CompletedAt = olderStartedAt.AddHours(1),
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Pull-up",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = olderStartedAt.AddMinutes(10) },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = olderStartedAt.AddMinutes(20) }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Pull-up",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = olderStartedAt.AddMinutes(10) },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = olderStartedAt.AddMinutes(20) }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -865,16 +919,25 @@ public class GetTodaySessionEndpointTests
             PlanId = plan.ExternalId,
             StartedAt = DateTime.UtcNow.AddMinutes(-5),
             IsCompleted = false,
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Pull-up",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow.AddMinutes(-2) },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = null }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Pull-up",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow.AddMinutes(-2) },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = null }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -946,18 +1009,27 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Push Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Bench Press",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 },
-                                        new ExerciseSet { SetNumber = 2 },
-                                        new ExerciseSet { SetNumber = 3 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 },
+                                                new ExerciseSet { SetNumber = 2 },
+                                                new ExerciseSet { SetNumber = 3 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -978,17 +1050,26 @@ public class GetTodaySessionEndpointTests
             PlanId = plan.ExternalId,
             StartedAt = DateTime.UtcNow,
             IsCompleted = false,
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Bench Press",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = null },
-                        new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Bench Press",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = null },
+                                new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -1058,18 +1139,27 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Pull Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Pull-up",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 },
-                                        new ExerciseSet { SetNumber = 2 },
-                                        new ExerciseSet { SetNumber = 3 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Pull-up",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 },
+                                                new ExerciseSet { SetNumber = 2 },
+                                                new ExerciseSet { SetNumber = 3 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -1093,17 +1183,26 @@ public class GetTodaySessionEndpointTests
             StartedAt = olderStartedAt,
             IsCompleted = true,
             CompletedAt = olderStartedAt.AddHours(1),
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Pull-up",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = olderStartedAt.AddMinutes(10) },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = olderStartedAt.AddMinutes(20) },
-                        new WorkoutSet { SetNumber = 3, CompletedAt = olderStartedAt.AddMinutes(30) }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Pull-up",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = olderStartedAt.AddMinutes(10) },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = olderStartedAt.AddMinutes(20) },
+                                new WorkoutSet { SetNumber = 3, CompletedAt = olderStartedAt.AddMinutes(30) }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -1118,17 +1217,26 @@ public class GetTodaySessionEndpointTests
             PlanId = plan.ExternalId,
             StartedAt = DateTime.UtcNow.AddMinutes(-5),
             IsCompleted = false,
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Pull-up",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow.AddMinutes(-2) },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = null },
-                        new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Pull-up",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow.AddMinutes(-2) },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = null },
+                                new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -1199,18 +1307,27 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Push Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Bench Press",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 },
-                                        new ExerciseSet { SetNumber = 2 },
-                                        new ExerciseSet { SetNumber = 3 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 },
+                                                new ExerciseSet { SetNumber = 2 },
+                                                new ExerciseSet { SetNumber = 3 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -1300,18 +1417,27 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Pull Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId,
-                                    ExerciseName = "Pull-up",
-                                    Order = 1,
-                                    Sets =
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
                                     [
-                                        new ExerciseSet { SetNumber = 1 },
-                                        new ExerciseSet { SetNumber = 2 },
-                                        new ExerciseSet { SetNumber = 3 }
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Pull-up",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1 },
+                                                new ExerciseSet { SetNumber = 2 },
+                                                new ExerciseSet { SetNumber = 3 }
+                                            ]
+                                        }
                                     ]
                                 }
                             ]
@@ -1332,17 +1458,26 @@ public class GetTodaySessionEndpointTests
             PlanId = plan.ExternalId,
             StartedAt = DateTime.UtcNow,
             IsCompleted = false,
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Pull-up",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow },
-                        new WorkoutSet { SetNumber = 2, CompletedAt = null },
-                        new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Pull-up",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow },
+                                new WorkoutSet { SetNumber = 2, CompletedAt = null },
+                                new WorkoutSet { SetNumber = 3, CompletedAt = null }
+                            ]
+                        }
                     ]
                 }
             ]
@@ -1434,21 +1569,30 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Push Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseA,
-                                    ExerciseName = "Exercise A",
-                                    Order = 1,
-                                    Sets = [new ExerciseSet { SetNumber = 1 }]
-                                },
-                                new SessionExercise
-                                {
-                                    ExerciseExternalId = exerciseB,
-                                    ExerciseName = "Exercise B",
-                                    Order = 2,
-                                    Sets = [new ExerciseSet { SetNumber = 1 }]
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseA,
+                                            ExerciseName = "Exercise A",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1 }]
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseB,
+                                            ExerciseName = "Exercise B",
+                                            Order = 2,
+                                            Sets = [new ExerciseSet { SetNumber = 1 }]
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -1469,13 +1613,22 @@ public class GetTodaySessionEndpointTests
             StartedAt = sharedStartedAt,
             IsCompleted = false,
             DateCreated = sharedStartedAt,                        // earlier insert
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseA,
-                    ExerciseName = "Exercise A",
-                    Sets = [new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow }]
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseA,
+                            ExerciseName = "Exercise A",
+                            Sets = [new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow }]
+                        }
+                    ]
                 }
             ]
         };
@@ -1490,13 +1643,22 @@ public class GetTodaySessionEndpointTests
             StartedAt = sharedStartedAt,                         // identical StartedAt
             IsCompleted = false,
             DateCreated = sharedStartedAt.AddSeconds(2),         // later insert — wins tie-break
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseB,
-                    ExerciseName = "Exercise B",
-                    Sets = [new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow }]
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseB,
+                            ExerciseName = "Exercise B",
+                            Sets = [new WorkoutSet { SetNumber = 1, CompletedAt = DateTime.UtcNow }]
+                        }
+                    ]
                 }
             ]
         };
@@ -1555,21 +1717,30 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Legs",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseId1,
-                                    ExerciseName = "Squat",
-                                    Order = 1,
-                                    Sets = []
-                                },
-                                new SessionExercise
-                                {
-                                    ExerciseExternalId = exerciseId2,
-                                    ExerciseName = "Lunge",
-                                    Order = 2,
-                                    Sets = []
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId1,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            Sets = []
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId2,
+                                            ExerciseName = "Lunge",
+                                            Order = 2,
+                                            Sets = []
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -1650,21 +1821,30 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Push Day",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exercise1Id,
-                                    ExerciseName = "Bench Press",
-                                    Order = 1,
-                                    Sets = []
-                                },
-                                new SessionExercise
-                                {
-                                    ExerciseExternalId = exercise2Id,
-                                    ExerciseName = "Overhead Press",
-                                    Order = 2,
-                                    Sets = []
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exercise1Id,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets = []
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exercise2Id,
+                                            ExerciseName = "Overhead Press",
+                                            Order = 2,
+                                            Sets = []
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -1732,7 +1912,7 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Legs",
                             Order = 1,
-                            Exercises = []
+                            Sections = []
                         }
                     ]
                 }
@@ -1787,21 +1967,30 @@ public class GetTodaySessionEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Push",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = knownExerciseId,
-                                    ExerciseName = "Bench Press",
-                                    Order = 1,
-                                    Sets = []
-                                },
-                                new SessionExercise
-                                {
-                                    ExerciseExternalId = unknownExerciseId,
-                                    ExerciseName = "Deleted Exercise",
-                                    Order = 2,
-                                    Sets = []
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = knownExerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets = []
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = unknownExerciseId,
+                                            ExerciseName = "Deleted Exercise",
+                                            Order = 2,
+                                            Sets = []
+                                        }
+                                    ]
                                 }
                             ]
                         }

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseIncompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseIncompleteEndpointTests.cs
@@ -298,25 +298,34 @@ public class MarkExerciseIncompleteEndpointTests
             SessionId = _sessionId,
             StartedAt = now.Date.AddHours(9),
             IsCompleted = true,
-            Exercises =
+            Sections =
             [
-                new Application.Domain.Documents.WorkoutExercise
+                new Application.Domain.Documents.WorkoutSection
                 {
-                    ExerciseExternalId = _exercise1,
-                    ExerciseName = "Squat",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new Application.Domain.Documents.WorkoutSet { SetNumber = 1, Reps = 5, WeightKg = 100m, CompletedAt = now },
-                        new Application.Domain.Documents.WorkoutSet { SetNumber = 2, Reps = 5, WeightKg = 100m, CompletedAt = now }
-                    ]
-                },
-                new Application.Domain.Documents.WorkoutExercise
-                {
-                    ExerciseExternalId = _exercise2,
-                    ExerciseName = "Deadlift",
-                    Sets =
-                    [
-                        new Application.Domain.Documents.WorkoutSet { SetNumber = 1, Reps = 3, WeightKg = 140m, CompletedAt = now }
+                        new Application.Domain.Documents.WorkoutExercise
+                        {
+                            ExerciseExternalId = _exercise1,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new Application.Domain.Documents.WorkoutSet { SetNumber = 1, Reps = 5, WeightKg = 100m, CompletedAt = now },
+                                new Application.Domain.Documents.WorkoutSet { SetNumber = 2, Reps = 5, WeightKg = 100m, CompletedAt = now }
+                            ]
+                        },
+                        new Application.Domain.Documents.WorkoutExercise
+                        {
+                            ExerciseExternalId = _exercise2,
+                            ExerciseName = "Deadlift",
+                            Sets =
+                            [
+                                new Application.Domain.Documents.WorkoutSet { SetNumber = 1, Reps = 3, WeightKg = 140m, CompletedAt = now }
+                            ]
+                        }
                     ]
                 }
             ]

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionIncompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionIncompleteEndpointTests.cs
@@ -263,16 +263,25 @@ public class MarkSessionIncompleteEndpointTests
             SessionId = _sessionId,
             StartedAt = now.Date.AddHours(9),
             IsCompleted = true,
-            Exercises =
+            Sections =
             [
-                new Application.Domain.Documents.WorkoutExercise
+                new Application.Domain.Documents.WorkoutSection
                 {
-                    ExerciseExternalId = _exercise1,
-                    ExerciseName = "Bench Press",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new Application.Domain.Documents.WorkoutSet { SetNumber = 1, Reps = 10, WeightKg = 80m, CompletedAt = now },
-                        new Application.Domain.Documents.WorkoutSet { SetNumber = 2, Reps = 8,  WeightKg = 80m, CompletedAt = now }
+                        new Application.Domain.Documents.WorkoutExercise
+                        {
+                            ExerciseExternalId = _exercise1,
+                            ExerciseName = "Bench Press",
+                            Sets =
+                            [
+                                new Application.Domain.Documents.WorkoutSet { SetNumber = 1, Reps = 10, WeightKg = 80m, CompletedAt = now },
+                                new Application.Domain.Documents.WorkoutSet { SetNumber = 2, Reps = 8,  WeightKg = 80m, CompletedAt = now }
+                            ]
+                        }
                     ]
                 }
             ]

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
@@ -69,9 +69,18 @@ public class MarkWholeDayCompleteEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Session 1",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise { ExerciseExternalId = _exercise1, ExerciseName = "Ex1", Order = 1, Sets = [] }
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise { ExerciseExternalId = _exercise1, ExerciseName = "Ex1", Order = 1, Sets = [] }
+                                    ]
+                                }
                             ]
                         },
                         new TrainingSession
@@ -80,9 +89,18 @@ public class MarkWholeDayCompleteEndpointTests
                             DayOfWeek = todayDow,
                             Name = "Session 2",
                             Order = 2,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise { ExerciseExternalId = _exercise2, ExerciseName = "Ex2", Order = 1, Sets = [] }
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise { ExerciseExternalId = _exercise2, ExerciseName = "Ex2", Order = 1, Sets = [] }
+                                    ]
+                                }
                             ]
                         }
                     ]

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingCompletionTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingCompletionTestHelpers.cs
@@ -48,13 +48,22 @@ public static class TrainingCompletionTestHelpers
                         DayOfWeek = d,
                         Name = $"Day {d} Session",
                         Order = 1,
-                        Exercises = exIds.Select((id, i) => new SessionExercise
-                        {
-                            ExerciseExternalId = id,
-                            ExerciseName = $"Exercise {i + 1}",
-                            Order = i + 1,
-                            Sets = []
-                        }).ToList()
+                        Sections =
+                        [
+                            new TrainingSection
+                            {
+                                SectionId = Guid.NewGuid(),
+                                Order = 0,
+                                Name = "Hlavní",
+                                Exercises = exIds.Select((id, i) => new SessionExercise
+                                {
+                                    ExerciseExternalId = id,
+                                    ExerciseName = $"Exercise {i + 1}",
+                                    Order = i + 1,
+                                    Sets = []
+                                }).ToList()
+                            }
+                        ]
                     }).ToList()
                 }
             ],

--- a/backend/FitnessPlatform.Tests/Endpoints/SectionTemplates/SectionTemplateEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/SectionTemplates/SectionTemplateEndpointTests.cs
@@ -1,0 +1,390 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FastEndpoints.Testing;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.SectionTemplates.CreateSectionTemplate;
+using FitnessPlatform.Application.Features.SectionTemplates.DeleteSectionTemplate;
+using FitnessPlatform.Application.Features.SectionTemplates.GetSectionTemplate;
+using FitnessPlatform.Application.Features.SectionTemplates.ListSectionTemplates;
+using FitnessPlatform.Application.Features.SectionTemplates.Shared;
+using FitnessPlatform.Application.Features.SectionTemplates.UpdateSectionTemplate;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.AspNetCore.Http;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.SectionTemplates;
+
+/// <summary>
+/// Unit tests for SectionTemplate CRUD endpoints:
+/// Create, Get, List, Update, Delete — plus ownership isolation and optimistic-concurrency (409).
+/// </summary>
+public class SectionTemplateEndpointTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    // ── Helper factories ────────────────────────────────────────────────────
+
+    private IMongoContext CreateMockMongo(List<SectionTemplate>? templates = null)
+    {
+        templates ??= [];
+        var mongo = Substitute.For<IMongoContext>();
+        var collection = CreateMockCollection(templates);
+        mongo.SectionTemplates.Returns(collection);
+        return mongo;
+    }
+
+    private static IMongoCollection<SectionTemplate> CreateMockCollection(
+        List<SectionTemplate> templates,
+        long modifiedCount = 1)
+    {
+        var collection = Substitute.For<IMongoCollection<SectionTemplate>>();
+
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<SectionTemplate>>(),
+                Arg.Any<FindOptions<SectionTemplate, SectionTemplate>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(templates));
+
+        collection.CountDocumentsAsync(
+                Arg.Any<FilterDefinition<SectionTemplate>>(),
+                Arg.Any<CountOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(templates.Count);
+
+        var replaceResult = Substitute.For<ReplaceOneResult>();
+        replaceResult.ModifiedCount.Returns(modifiedCount);
+        collection.ReplaceOneAsync(
+                Arg.Any<FilterDefinition<SectionTemplate>>(),
+                Arg.Any<SectionTemplate>(),
+                Arg.Any<ReplaceOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(replaceResult);
+
+        var deleteResult = Substitute.For<DeleteResult>();
+        deleteResult.DeletedCount.Returns(1L);
+        collection.DeleteOneAsync(
+                Arg.Any<FilterDefinition<SectionTemplate>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(deleteResult);
+
+        return collection;
+    }
+
+    private static IAsyncCursor<SectionTemplate> CreateCursor(List<SectionTemplate> items)
+    {
+        var cursor = Substitute.For<IAsyncCursor<SectionTemplate>>();
+        var moved = false;
+        cursor.Current.Returns(items);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return items.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return items.Count > 0;
+        });
+        return cursor;
+    }
+
+    private SectionTemplate MakeTemplate(Guid? ownerId = null, int version = 1) => new()
+    {
+        ExternalId = Guid.NewGuid(),
+        OwnerTrainerId = ownerId ?? _trainerId,
+        Name = "Strength Block",
+        DefaultFormat = null,
+        DefaultFormatConfig = null,
+        DefaultExercises = [],
+        CreatedAt = DateTime.UtcNow.AddDays(-1),
+        UpdatedAt = DateTime.UtcNow.AddDays(-1),
+        Version = version
+    };
+
+    private Action<DefaultHttpContext> TrainerAuth() =>
+        ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+            new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer)));
+
+    private CreateSectionTemplateEndpoint CreateCreateEndpoint(IMongoContext mongo) =>
+        Factory.Create<CreateSectionTemplateEndpoint>(TrainerAuth(), mongo);
+
+    private GetSectionTemplateEndpoint CreateGetEndpoint(IMongoContext mongo) =>
+        Factory.Create<GetSectionTemplateEndpoint>(TrainerAuth(), mongo);
+
+    private ListSectionTemplatesEndpoint CreateListEndpoint(IMongoContext mongo) =>
+        Factory.Create<ListSectionTemplatesEndpoint>(TrainerAuth(), mongo);
+
+    private UpdateSectionTemplateEndpoint CreateUpdateEndpoint(IMongoContext mongo) =>
+        Factory.Create<UpdateSectionTemplateEndpoint>(TrainerAuth(), mongo);
+
+    private DeleteSectionTemplateEndpoint CreateDeleteEndpoint(IMongoContext mongo) =>
+        Factory.Create<DeleteSectionTemplateEndpoint>(TrainerAuth(), mongo);
+
+    // ── CREATE ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_WithValidRequest_Returns201AndPersistsTemplate()
+    {
+        var mongo = CreateMockMongo();
+        var ep = CreateCreateEndpoint(mongo);
+
+        var req = new CreateSectionTemplateRequest
+        {
+            Name = "Push Block",
+            DefaultFormat = WorkoutFormat.Standard,
+            DefaultExercises = []
+        };
+
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.SectionTemplates.Received(1).InsertOneAsync(
+            Arg.Is<SectionTemplate>(t =>
+                t.Name == "Push Block" &&
+                t.OwnerTrainerId == _trainerId &&
+                t.Version == 1),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Create_WithEmomFormat_PersistsFormatConfig()
+    {
+        var mongo = CreateMockMongo();
+        var ep = CreateCreateEndpoint(mongo);
+
+        var req = new CreateSectionTemplateRequest
+        {
+            Name = "EMOM Section",
+            DefaultFormat = WorkoutFormat.EMOM,
+            DefaultFormatConfig = new WodConfig { IntervalSeconds = 60, TotalRounds = 10 },
+            DefaultExercises = []
+        };
+
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.SectionTemplates.Received(1).InsertOneAsync(
+            Arg.Is<SectionTemplate>(t =>
+                t.DefaultFormat == WorkoutFormat.EMOM &&
+                t.DefaultFormatConfig!.IntervalSeconds == 60 &&
+                t.DefaultFormatConfig!.TotalRounds == 10),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── GET ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_OwnedTemplate_Returns200AndResponse()
+    {
+        var template = MakeTemplate();
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateGetEndpoint(mongo);
+
+        var req = new GetSectionTemplateRequest { TemplateId = template.ExternalId };
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.TemplateId.Should().Be(template.ExternalId);
+        ep.Response.Name.Should().Be("Strength Block");
+        ep.Response.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Get_NotFound_Returns404()
+    {
+        var mongo = CreateMockMongo([]);
+        var ep = CreateGetEndpoint(mongo);
+
+        var req = new GetSectionTemplateRequest { TemplateId = Guid.NewGuid() };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task Get_TemplateOwnedByAnotherTrainer_Returns403()
+    {
+        var otherTrainerId = Guid.NewGuid();
+        var template = MakeTemplate(ownerId: otherTrainerId);
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateGetEndpoint(mongo);
+
+        var req = new GetSectionTemplateRequest { TemplateId = template.ExternalId };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    // ── LIST ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_ReturnsOnlyOwnedTemplates()
+    {
+        var t1 = MakeTemplate();
+        t1.Name = "Block A";
+        var t2 = MakeTemplate();
+        t2.Name = "Block B";
+        var mongo = CreateMockMongo([t1, t2]);
+        var ep = CreateListEndpoint(mongo);
+
+        var req = new ListSectionTemplatesRequest { Page = 1, PageSize = 20 };
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Should().HaveCount(2);
+        ep.Response.Select(r => r.Name).Should().Contain(["Block A", "Block B"]);
+    }
+
+    // ── UPDATE ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_OwnedTemplate_Returns200AndBumpsVersion()
+    {
+        var template = MakeTemplate(version: 1);
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateUpdateEndpoint(mongo);
+
+        var req = new UpdateSectionTemplateRequest
+        {
+            TemplateId = template.ExternalId,
+            Name = "Updated Name",
+            Version = 1,
+            DefaultExercises = []
+        };
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.SectionTemplates.Received(1).ReplaceOneAsync(
+            Arg.Any<FilterDefinition<SectionTemplate>>(),
+            Arg.Is<SectionTemplate>(t => t.Name == "Updated Name" && t.Version == 2),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_WrongVersion_Returns409()
+    {
+        var template = MakeTemplate(version: 2);
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateUpdateEndpoint(mongo);
+
+        var req = new UpdateSectionTemplateRequest
+        {
+            TemplateId = template.ExternalId,
+            Name = "Stale Update",
+            Version = 1, // stale — template is now at version 2
+            DefaultExercises = []
+        };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task Update_TemplateOwnedByAnotherTrainer_Returns403()
+    {
+        var otherTrainerId = Guid.NewGuid();
+        var template = MakeTemplate(ownerId: otherTrainerId, version: 1);
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateUpdateEndpoint(mongo);
+
+        var req = new UpdateSectionTemplateRequest
+        {
+            TemplateId = template.ExternalId,
+            Name = "Hijack",
+            Version = 1,
+            DefaultExercises = []
+        };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task Update_DbVersionConflict_Returns409()
+    {
+        // Version matches in-memory but DB ReplaceOne returns ModifiedCount=0 (concurrent writer won)
+        var template = MakeTemplate(version: 1);
+
+        // Build a collection where ReplaceOne returns modifiedCount=0
+        var collection = CreateMockCollection([template], modifiedCount: 0);
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.SectionTemplates.Returns(collection);
+
+        var ep = CreateUpdateEndpoint(mongo);
+
+        var req = new UpdateSectionTemplateRequest
+        {
+            TemplateId = template.ExternalId,
+            Name = "Race Update",
+            Version = 1,
+            DefaultExercises = []
+        };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    // ── DELETE ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_OwnedTemplate_Returns204()
+    {
+        var template = MakeTemplate();
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateDeleteEndpoint(mongo);
+
+        var req = new DeleteSectionTemplateRequest { TemplateId = template.ExternalId };
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        await mongo.SectionTemplates.Received(1).DeleteOneAsync(
+            Arg.Any<FilterDefinition<SectionTemplate>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Delete_NotFound_Returns404()
+    {
+        var mongo = CreateMockMongo([]);
+        var ep = CreateDeleteEndpoint(mongo);
+
+        var req = new DeleteSectionTemplateRequest { TemplateId = Guid.NewGuid() };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task Delete_TemplateOwnedByAnotherTrainer_Returns403()
+    {
+        var template = MakeTemplate(ownerId: Guid.NewGuid());
+        var mongo = CreateMockMongo([template]);
+        var ep = CreateDeleteEndpoint(mongo);
+
+        var req = new DeleteSectionTemplateRequest { TemplateId = template.ExternalId };
+
+        var act = async () => await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientTimelineEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientTimelineEndpointTests.cs
@@ -250,7 +250,7 @@ public class GetClientTimelineEndpointTests(FitnessApiFactory factory)
                 StartedAt = t3.AddMinutes(-30),
                 CompletedAt = t3,
                 IsCompleted = true,
-                Exercises = [],
+                Sections = [],
                 DateCreated = DateTime.UtcNow,
             }, cancellationToken: TestContext.Current.CancellationToken);
         }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanFormatTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanFormatTests.cs
@@ -15,7 +15,7 @@ namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
 
 /// <summary>
 /// Tests for WorkoutFormat, MovementType, and WodConfig round-trips through
-/// <see cref="UpdateTrainingPlanEndpoint"/> at both session and per-exercise level,
+/// <see cref="UpdateTrainingPlanEndpoint"/> at both session and per-section/exercise level,
 /// plus validator rejection of invalid format configurations.
 /// </summary>
 public class UpdateTrainingPlanFormatTests
@@ -28,6 +28,10 @@ public class UpdateTrainingPlanFormatTests
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
             mongo);
+
+    /// <summary>Builds a minimal single-section request for a given session.</summary>
+    private static UpdateSectionRequest DefaultSection(List<UpdateSessionExerciseRequest>? exercises = null) =>
+        new() { Name = "Hlavní", Order = 0, Exercises = exercises ?? [] };
 
     // ── Session-level format round-trip tests ────────────────────────────────
 
@@ -58,7 +62,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.EMOM,
                             FormatConfig = new WodConfig { IntervalSeconds = 60, TotalRounds = 10 },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -106,7 +110,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.AMRAP,
                             FormatConfig = new WodConfig { TimeCapSeconds = 1200 },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -153,7 +157,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.ForTime,
                             FormatConfig = new WodConfig { TimeCapSeconds = 600 },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -200,7 +204,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.Tabata,
                             FormatConfig = new WodConfig { WorkSeconds = 20, RestSeconds = 10, TotalRounds = 8 },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -249,7 +253,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.Standard,
                             FormatConfig = null,
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -297,16 +301,19 @@ public class UpdateTrainingPlanFormatTests
                             Name = "Session",
                             Order = 1,
                             Format = WorkoutFormat.Standard,
-                            Exercises =
+                            Sections =
                             [
-                                new UpdateSessionExerciseRequest
-                                {
-                                    ExerciseExternalId = Guid.NewGuid(),
-                                    ExerciseName = "Plank",
-                                    Order = 1,
-                                    MovementType = MovementType.Time,
-                                    Sets = []
-                                }
+                                DefaultSection(
+                                [
+                                    new UpdateSessionExerciseRequest
+                                    {
+                                        ExerciseExternalId = Guid.NewGuid(),
+                                        ExerciseName = "Plank",
+                                        Order = 1,
+                                        MovementType = MovementType.Time,
+                                        Sets = []
+                                    }
+                                ])
                             ]
                         }
                     ]
@@ -352,18 +359,21 @@ public class UpdateTrainingPlanFormatTests
                             Name = "Session",
                             Order = 1,
                             Format = WorkoutFormat.Standard,
-                            Exercises =
+                            Sections =
                             [
-                                new UpdateSessionExerciseRequest
-                                {
-                                    ExerciseExternalId = Guid.NewGuid(),
-                                    ExerciseName = "Burpees",
-                                    Order = 1,
-                                    MovementType = MovementType.Reps,
-                                    Format = WorkoutFormat.AMRAP,
-                                    FormatConfig = new WodConfig { TimeCapSeconds = 300 },
-                                    Sets = []
-                                }
+                                DefaultSection(
+                                [
+                                    new UpdateSessionExerciseRequest
+                                    {
+                                        ExerciseExternalId = Guid.NewGuid(),
+                                        ExerciseName = "Burpees",
+                                        Order = 1,
+                                        MovementType = MovementType.Reps,
+                                        Format = WorkoutFormat.AMRAP,
+                                        FormatConfig = new WodConfig { TimeCapSeconds = 300 },
+                                        Sets = []
+                                    }
+                                ])
                             ]
                         }
                     ]
@@ -411,18 +421,21 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.EMOM,
                             FormatConfig = new WodConfig { IntervalSeconds = 60, TotalRounds = 10 },
-                            Exercises =
+                            Sections =
                             [
-                                new UpdateSessionExerciseRequest
-                                {
-                                    ExerciseExternalId = Guid.NewGuid(),
-                                    ExerciseName = "Pull-ups",
-                                    Order = 1,
-                                    MovementType = MovementType.Reps,
-                                    Format = null, // inherits from session
-                                    FormatConfig = null,
-                                    Sets = []
-                                }
+                                DefaultSection(
+                                [
+                                    new UpdateSessionExerciseRequest
+                                    {
+                                        ExerciseExternalId = Guid.NewGuid(),
+                                        ExerciseName = "Pull-ups",
+                                        Order = 1,
+                                        MovementType = MovementType.Reps,
+                                        Format = null, // inherits from session
+                                        FormatConfig = null,
+                                        Sets = []
+                                    }
+                                ])
                             ]
                         }
                     ]
@@ -453,22 +466,31 @@ public class UpdateTrainingPlanFormatTests
         var planId = Guid.NewGuid();
         var plan = TrainingPlanTestHelpers.CreatePlan(externalId: planId, trainerId: _trainerId);
 
-        // Add a session with an exercise — Format and MovementType will be at their C# defaults.
+        // Add a session with a section containing an exercise — Format and MovementType at C# defaults.
         plan.Weeks[0].Sessions.Add(new TrainingSession
         {
             SessionId = Guid.NewGuid(),
             DayOfWeek = 1,
             Name = "Legacy Session",
             Order = 1,
-            // Format defaults to Standard, FormatConfig defaults to null
-            Exercises =
+            // Format defaults to null, FormatConfig defaults to null
+            Sections =
             [
-                new SessionExercise
+                new TrainingSection
                 {
-                    ExerciseExternalId = Guid.NewGuid(),
-                    ExerciseName = "Squat",
-                    Order = 1
-                    // MovementType defaults to Reps, Format defaults to null, FormatConfig defaults to null
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new SessionExercise
+                        {
+                            ExerciseExternalId = Guid.NewGuid(),
+                            ExerciseName = "Squat",
+                            Order = 1
+                            // MovementType defaults to Reps, Format defaults to null
+                        }
+                    ]
                 }
             ]
         });
@@ -519,7 +541,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.EMOM,
                             FormatConfig = new WodConfig { TotalRounds = 10 /* IntervalSeconds missing */ },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -555,7 +577,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.AMRAP,
                             FormatConfig = new WodConfig { /* TimeCapSeconds missing */ },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -591,7 +613,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.Tabata,
                             FormatConfig = new WodConfig { RestSeconds = 10, TotalRounds = 8 /* WorkSeconds missing */ },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -627,7 +649,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.Standard,
                             FormatConfig = new WodConfig { TimeCapSeconds = 600 }, // must be null for Standard
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }
@@ -664,7 +686,7 @@ public class UpdateTrainingPlanFormatTests
                             Order = 1,
                             Format = WorkoutFormat.ForTime,
                             FormatConfig = new WodConfig { /* TimeCapSeconds missing */ },
-                            Exercises = []
+                            Sections = [DefaultSection()]
                         }
                     ]
                 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
@@ -113,19 +113,28 @@ public class CompleteWorkoutEndpointTests
                             DayOfWeek = 1,
                             Name = "Test Session",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseA,
-                                    ExerciseName = "Exercise A",
-                                    Order = 1
-                                },
-                                new SessionExercise
-                                {
-                                    ExerciseExternalId = exerciseB,
-                                    ExerciseName = "Exercise B",
-                                    Order = 2
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseA,
+                                            ExerciseName = "Exercise A",
+                                            Order = 1
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseB,
+                                            ExerciseName = "Exercise B",
+                                            Order = 2
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -223,19 +232,28 @@ public class CompleteWorkoutEndpointTests
                             DayOfWeek = 1,
                             Name = "Test Session",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseA,
-                                    ExerciseName = "Exercise A",
-                                    Order = 1
-                                },
-                                new SessionExercise
-                                {
-                                    ExerciseExternalId = exerciseB,
-                                    ExerciseName = "Exercise B",
-                                    Order = 2
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseA,
+                                            ExerciseName = "Exercise A",
+                                            Order = 1
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseB,
+                                            ExerciseName = "Exercise B",
+                                            Order = 2
+                                        }
+                                    ]
                                 }
                             ]
                         }
@@ -334,13 +352,22 @@ public class CompleteWorkoutEndpointTests
                             DayOfWeek = 1,
                             Name = "Midnight Session",
                             Order = 1,
-                            Exercises =
+                            Sections =
                             [
-                                new SessionExercise
+                                new TrainingSection
                                 {
-                                    ExerciseExternalId = exerciseA,
-                                    ExerciseName = "Exercise A",
-                                    Order = 1
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseA,
+                                            ExerciseName = "Exercise A",
+                                            Order = 1
+                                        }
+                                    ]
                                 }
                             ]
                         }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/PersonalRecordDetectionTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/PersonalRecordDetectionTests.cs
@@ -243,21 +243,30 @@ public class PersonalRecordDetectionTests(FitnessApiFactory factory)
             IsCompleted = true,
             CompletedAt = DateTime.UtcNow.AddDays(-1).AddHours(1),
             DateCreated = DateTime.UtcNow.AddDays(-1),
-            Exercises =
+            Sections =
             [
-                new WorkoutExercise
+                new WorkoutSection
                 {
-                    ExerciseExternalId = exerciseId,
-                    ExerciseName = "Deadlift",
-                    Sets =
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
                     [
-                        new WorkoutSet
+                        new WorkoutExercise
                         {
-                            SetNumber = 1,
-                            Reps = 5,
-                            WeightKg = 100m,
-                            CompletedAt = DateTime.UtcNow.AddDays(-1).AddMinutes(10),
-                            IsPR = true
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Deadlift",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 5,
+                                    WeightKg = 100m,
+                                    CompletedAt = DateTime.UtcNow.AddDays(-1).AddMinutes(10),
+                                    IsPR = true
+                                }
+                            ]
                         }
                     ]
                 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/WorkoutLogTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/WorkoutLogTestHelpers.cs
@@ -32,7 +32,7 @@ public static class WorkoutLogTestHelpers
             SessionId = sessionId,
             StartedAt = startedAt ?? DateTime.UtcNow,
             IsCompleted = isCompleted,
-            Exercises = [],
+            Sections = [],
             DateCreated = DateTime.UtcNow
         };
     }

--- a/backend/FitnessPlatform.Tests/Services/ComplianceServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/ComplianceServiceTests.cs
@@ -525,7 +525,7 @@ public class ComplianceServiceTests
                             DayOfWeek = yesterdayDow,
                             Name = "Session A",
                             Order = 1,
-                            Exercises = [new SessionExercise { ExerciseExternalId = ex1, ExerciseName = "Ex1", Order = 1, Sets = [] }]
+                            Sections = [new TrainingSection { SectionId = Guid.NewGuid(), Order = 0, Name = "Hlavní", Exercises = [new SessionExercise { ExerciseExternalId = ex1, ExerciseName = "Ex1", Order = 1, Sets = [] }] }]
                         },
                         new TrainingSession
                         {
@@ -533,7 +533,7 @@ public class ComplianceServiceTests
                             DayOfWeek = yesterdayDow,
                             Name = "Session B",
                             Order = 2,
-                            Exercises = [new SessionExercise { ExerciseExternalId = ex1, ExerciseName = "Ex1", Order = 1, Sets = [] }]
+                            Sections = [new TrainingSection { SectionId = Guid.NewGuid(), Order = 0, Name = "Hlavní", Exercises = [new SessionExercise { ExerciseExternalId = ex1, ExerciseName = "Ex1", Order = 1, Sets = [] }] }]
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary

- Adds `TrainingSection` (embedded sub-document on `TrainingSession`) and `WorkoutSection` (embedded on `WorkoutLog`), each carrying `SectionId`, `Order`, `Name`, `Format`, `FormatConfig`, and an `Exercises` list — moves the workout structure one level deeper so EMOM/AMRAP/Tabata/ForTime can be scoped per section instead of per session.
- Introduces `SectionTemplate` as a new MongoDB root aggregate (Id, ExternalId, OwnerTrainerId, Version, audit fields, default format + exercises). Five trainer-only CRUD endpoints under `Features/SectionTemplates/` (List, Get, Create, Update, Delete) at `/training/section-templates`. Per-trainer ownership enforced on every read/write path.
- Schema-on-read backfill: legacy `TrainingSession` / `WorkoutLog` documents that still carry flat `Exercises` materialize as a single section named `Hlavní`. No data migration, no EF migration — pure deserialization-time default. `WithBackfilledSections()` is wired into 13 read paths across `ClientTraining`, `WorkoutLogs`, `ComplianceService`, and `PrDetectionService`.
- `UpdateTrainingPlan` request surfaces `Sections`; per-section format invariants (Standard → no FormatConfig; EMOM → rounds; AMRAP/ForTime → time cap; Tabata → work/rest/rounds) enforced by `UpdateTrainingPlanValidator`.

## Related issue

Fixes #238

## Parent epic

Part of epic #236 — base branch: `feature/236-training-sections`.

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — 1030/1030 tests green. SectionTemplates 13/13, TrainingPlans 27/27, WorkoutLogs 29/29, ClientTraining 61/61. `dotnet build` clean (0 errors, 6 pre-existing unrelated warnings).

## Test plan

- [x] `Domain/Documents/TrainingSection.cs` with Id, Order, Name, Format, FormatConfig, Exercises.
- [x] `TrainingSession.cs` replaces inline Exercises with Sections; Format/FormatConfig nullable at session level for one release.
- [x] `Domain/Documents/SectionTemplate.cs` root aggregate with Id, ExternalId, Version, audit fields; collection registered in `MongoContext`.
- [x] `Features/SectionTemplates/` has list/get/create/update/delete; trainer-only auth.
- [x] `UpdateTrainingPlan` surfaces Sections; format invariants enforced per-section.
- [x] Old session shape (flat Exercises) materializes as single default `Hlavní` section; same backfill for old `WorkoutLog`; integration tests cover the read path.
- [x] `dotnet build` clean; `dotnet test` green for TrainingPlans, SectionTemplates, WorkoutLogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)