### PR TITLE
fix: emit Sections in GetFullTrainingPlan response (#244)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
@@ -81,7 +81,14 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
             return;
         }
 
-        // ── 3. Batch-fetch Exercise docs for muscle-group enrichment ──────────────
+        // ── 3. Backfill legacy flat-exercise sessions, then batch-fetch Exercise docs ─
+        // Schema-on-read: call WithBackfilledSections() on every session so that
+        // documents stored before the sections migration (with only flat LegacyExercises)
+        // are transparently migrated into a single "Hlavní" section in memory.
+        // This must happen before any iteration of s.Exercises or s.Sections.
+        foreach (var session in plan.Weeks.SelectMany(w => w.Sessions))
+            session.WithBackfilledSections();
+
         var exerciseIds = plan.Weeks
             .SelectMany(w => w.Sessions)
             .SelectMany(s => s.Exercises)
@@ -242,44 +249,61 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
 
             var sessionDtos = week.Sessions.Select(session =>
             {
-                var exerciseDtos = session.Exercises.Select(ex =>
+                // Build per-section DTOs, ordering sections by their Order field.
+                var sectionDtos = session.Sections.OrderBy(sec => sec.Order).Select(sec =>
                 {
-                    var muscleGroups = muscleGroupMap.TryGetValue(ex.ExerciseExternalId, out var mg)
-                        ? mg
-                        : [];
-
-                    var setDtos = ex.Sets.Select(set =>
+                    var sectionExerciseDtos = sec.Exercises.Select(ex =>
                     {
-                        var key = (session.SessionId, ex.ExerciseExternalId, set.SetNumber);
-                        completedSets.TryGetValue(key, out var completedAt);
+                        var muscleGroups = muscleGroupMap.TryGetValue(ex.ExerciseExternalId, out var mg)
+                            ? mg
+                            : [];
 
-                        return new SetDto
+                        var setDtos = ex.Sets.Select(set =>
                         {
-                            SetNumber = set.SetNumber,
-                            Type = set.Type.ToString(),
-                            Reps = set.Reps,
-                            WeightKg = set.WeightKg,
-                            DurationSeconds = set.DurationSeconds,
-                            RestSeconds = set.RestSeconds,
-                            CompletedAt = completedAt == default ? null : completedAt
+                            var key = (session.SessionId, ex.ExerciseExternalId, set.SetNumber);
+                            completedSets.TryGetValue(key, out var completedAt);
+
+                            return new SetDto
+                            {
+                                SetNumber = set.SetNumber,
+                                Type = set.Type.ToString(),
+                                Reps = set.Reps,
+                                WeightKg = set.WeightKg,
+                                DurationSeconds = set.DurationSeconds,
+                                RestSeconds = set.RestSeconds,
+                                CompletedAt = completedAt == default ? null : completedAt
+                            };
+                        }).ToList();
+
+                        // An exercise is complete only when every planned set has a log entry.
+                        var isCompleted = setDtos.Count > 0 && setDtos.All(s => s.CompletedAt is not null);
+
+                        return new ExerciseDto
+                        {
+                            ExerciseExternalId = ex.ExerciseExternalId,
+                            ExerciseName = ex.ExerciseName,
+                            Order = ex.Order,
+                            Notes = ex.Notes,
+                            RestSeconds = ex.RestSeconds,
+                            MuscleGroups = muscleGroups,
+                            IsCompleted = isCompleted,
+                            Sets = setDtos
                         };
                     }).ToList();
 
-                    // An exercise is complete only when every planned set has a log entry.
-                    var isCompleted = setDtos.Count > 0 && setDtos.All(s => s.CompletedAt is not null);
-
-                    return new ExerciseDto
+                    return new SectionDto
                     {
-                        ExerciseExternalId = ex.ExerciseExternalId,
-                        ExerciseName = ex.ExerciseName,
-                        Order = ex.Order,
-                        Notes = ex.Notes,
-                        RestSeconds = ex.RestSeconds,
-                        MuscleGroups = muscleGroups,
-                        IsCompleted = isCompleted,
-                        Sets = setDtos
+                        SectionId = sec.SectionId,
+                        Order = sec.Order,
+                        Name = sec.Name,
+                        Format = sec.Format?.ToString(),
+                        Exercises = sectionExerciseDtos
                     };
                 }).ToList();
+
+                // Flat exercise list derived from sections in order — backward-compat for callers
+                // that don't yet consume the Sections field.
+                var exerciseDtos = sectionDtos.SelectMany(s => s.Exercises).ToList();
 
                 var completedExerciseCount = exerciseDtos.Count(e => e.IsCompleted);
 
@@ -293,6 +317,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                     CompletedExerciseCount = completedExerciseCount,
                     TotalExerciseCount = exerciseDtos.Count,
                     EstimatedDurationMinutes = null, // deferred — requires product-defined set-duration heuristic
+                    Sections = sectionDtos,
                     Exercises = exerciseDtos
                 };
             }).ToList();

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
@@ -104,7 +104,41 @@ public class SessionDto
     /// </summary>
     public int? EstimatedDurationMinutes { get; set; }
 
-    /// <summary>Exercises in this session.</summary>
+    /// <summary>
+    /// Sections in this session, ordered by their Order field.
+    /// Schema-on-read: legacy documents with only flat exercises are backfilled into a single
+    /// "Hlavní" section before this response is built.
+    /// </summary>
+    public List<SectionDto> Sections { get; set; } = [];
+
+    /// <summary>
+    /// Flat list of all exercises across all sections, in section order.
+    /// Kept for backward-compatibility with callers that don't yet read Sections.
+    /// </summary>
+    public List<ExerciseDto> Exercises { get; set; } = [];
+}
+
+/// <summary>
+/// An ordered section within a session (e.g. "Hlavní", "Warm-up", "Cool-down").
+/// </summary>
+public class SectionDto
+{
+    /// <summary>Stable identifier for this section.</summary>
+    public Guid SectionId { get; set; }
+
+    /// <summary>Display order within the session (0-based).</summary>
+    public int Order { get; set; }
+
+    /// <summary>Display name (e.g. "Hlavní", "Warm-up").</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Workout format for this section (e.g. "Emom", "Amrap", "Tabata", "ForTime").
+    /// Null means the section uses the default Standard format.
+    /// </summary>
+    public string? Format { get; set; }
+
+    /// <summary>Exercises within this section.</summary>
     public List<ExerciseDto> Exercises { get; set; } = [];
 }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/Client/Training/GetFullTrainingPlanIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Client/Training/GetFullTrainingPlanIntegrationTests.cs
@@ -373,6 +373,320 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
             "non-owner must receive 404 so plan existence is not revealed");
     }
 
+    /// <summary>
+    /// Section round-trip: a plan with explicit sections must return those sections in the response,
+    /// preserving order, name, format, and per-section exercises.
+    /// The backward-compat flat Exercises list must equal the concatenation across sections in order.
+    /// </summary>
+    [Fact]
+    public async Task GetFullPlan_WithExplicitSections_ReturnsSectionsAndFlatExercises()
+    {
+        var httpClient = factory.CreateClient();
+
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, clientEmail, "TestPass1!", "Section", "Client", "Client");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, clientEmail, "TestPass1!");
+
+        Guid clientPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == clientEmail,
+                TestContext.Current.CancellationToken);
+            var profile = await db.ClientProfiles.FirstAsync(
+                cp => cp.UserId == user.Id,
+                TestContext.Current.CancellationToken);
+            clientPublicId = profile.PublicId;
+        }
+
+        var squatId = Guid.NewGuid();
+        var benchId = Guid.NewGuid();
+
+        var squatExercise = new Exercise
+        {
+            ExternalId = squatId,
+            Name = "Squat",
+            MuscleGroups = [MuscleGroup.Quadriceps],
+            Equipment = ExerciseEquipment.Barbell,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var benchExercise = new Exercise
+        {
+            ExternalId = benchId,
+            Name = "Bench Press",
+            MuscleGroups = [MuscleGroup.Chest],
+            Equipment = ExerciseEquipment.Barbell,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var warmUpSectionId = Guid.NewGuid();
+        var mainSectionId = Guid.NewGuid();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Sections Round-trip Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-5),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-4),
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 2,
+                            Name = "Full Body",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = warmUpSectionId,
+                                    Order = 0,
+                                    Name = "Warm-up",
+                                    Format = null,
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = squatId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Warmup, Reps = 10 }]
+                                        }
+                                    ]
+                                },
+                                new TrainingSection
+                                {
+                                    SectionId = mainSectionId,
+                                    Order = 1,
+                                    Name = "Hlavní",
+                                    Format = Application.Domain.Enums.WorkoutFormat.AMRAP,
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = benchId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 8, WeightKg = 80 }]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.Exercises.InsertOneAsync(squatExercise, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.Exercises.InsertOneAsync(benchExercise, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/client/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+
+        var body = await response.Content.ReadFromJsonAsync<FullPlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+
+        var session = body!.Weeks[0].Sessions[0];
+
+        // ── Sections round-trip ───────────────────────────────────────────────────
+        session.Sections.Should().HaveCount(2, "two sections were persisted");
+
+        var warmUp = session.Sections.First(s => s.SectionId == warmUpSectionId);
+        warmUp.Order.Should().Be(0);
+        warmUp.Name.Should().Be("Warm-up");
+        warmUp.Format.Should().BeNull("Warm-up has no format");
+        warmUp.Exercises.Should().HaveCount(1);
+        warmUp.Exercises[0].ExerciseExternalId.Should().Be(squatId);
+
+        var main = session.Sections.First(s => s.SectionId == mainSectionId);
+        main.Order.Should().Be(1);
+        main.Name.Should().Be("Hlavní");
+        main.Format.Should().Be("AMRAP");
+        main.Exercises.Should().HaveCount(1);
+        main.Exercises[0].ExerciseExternalId.Should().Be(benchId);
+
+        // ── Backward-compat flat list equals sections concatenated in order ────────
+        session.Exercises.Should().HaveCount(2, "total exercises across both sections");
+        session.Exercises[0].ExerciseExternalId.Should().Be(squatId, "Warm-up exercise comes first (Order=0)");
+        session.Exercises[1].ExerciseExternalId.Should().Be(benchId, "Hlavní exercise comes second (Order=1)");
+    }
+
+    /// <summary>
+    /// Schema-on-read backfill: a plan stored with only flat LegacyExercises (no Sections)
+    /// must be transparently backfilled into a single "Hlavní" section at read time.
+    /// </summary>
+    [Fact]
+    public async Task GetFullPlan_WithLegacyFlatExercises_BackfillsIntoHlavniSection()
+    {
+        var httpClient = factory.CreateClient();
+
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, clientEmail, "TestPass1!", "Legacy", "Client", "Client");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, clientEmail, "TestPass1!");
+
+        Guid clientPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == clientEmail,
+                TestContext.Current.CancellationToken);
+            var profile = await db.ClientProfiles.FirstAsync(
+                cp => cp.UserId == user.Id,
+                TestContext.Current.CancellationToken);
+            clientPublicId = profile.PublicId;
+        }
+
+        var squatId = Guid.NewGuid();
+        var squatExercise = new Exercise
+        {
+            ExternalId = squatId,
+            Name = "Squat",
+            MuscleGroups = [MuscleGroup.Quadriceps],
+            Equipment = ExerciseEquipment.Barbell,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        // Build a plan whose session has only LegacyExercises and an empty Sections list.
+        // This simulates a pre-sections document in MongoDB.
+        var legacySession = new TrainingSession
+        {
+            SessionId = sessionId,
+            DayOfWeek = 3,
+            Name = "Legacy Day",
+            Order = 1,
+            Sections = [], // explicitly empty — legacy document
+            LegacyExercises =
+            [
+                new SessionExercise
+                {
+                    ExerciseExternalId = squatId,
+                    ExerciseName = "Squat",
+                    Order = 1,
+                    Sets =
+                    [
+                        new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 5, WeightKg = 80 },
+                        new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 5, WeightKg = 80 }
+                    ]
+                }
+            ]
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Legacy Flat Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-2),
+                    Sessions = [legacySession]
+                }
+            ]
+        };
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.Exercises.InsertOneAsync(squatExercise, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/client/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+
+        var body = await response.Content.ReadFromJsonAsync<FullPlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+
+        var session = body!.Weeks[0].Sessions[0];
+
+        // ── Schema-on-read: one section backfilled as "Hlavní" ───────────────────
+        session.Sections.Should().HaveCount(1, "legacy exercises must be wrapped in a single default section");
+        var hlavni = session.Sections[0];
+        hlavni.Name.Should().Be("Hlavní");
+        hlavni.Format.Should().BeNull();
+        hlavni.Exercises.Should().HaveCount(1);
+        hlavni.Exercises[0].ExerciseExternalId.Should().Be(squatId);
+        hlavni.Exercises[0].Sets.Should().HaveCount(2);
+
+        // ── Backward-compat flat list also populated ─────────────────────────────
+        session.Exercises.Should().HaveCount(1);
+        session.Exercises[0].ExerciseExternalId.Should().Be(squatId);
+
+        // ── Muscle-group enrichment works for backfilled exercises ────────────────
+        session.Exercises[0].MuscleGroups.Should().Contain(MuscleGroup.Quadriceps);
+    }
+
     // ── Local response DTOs (per slice rules — not shared across features) ────────
 
     private record FullPlanResponse(
@@ -405,6 +719,14 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
         int CompletedExerciseCount,
         int TotalExerciseCount,
         int? EstimatedDurationMinutes,
+        List<SectionResponse> Sections,
+        List<ExerciseResponse> Exercises);
+
+    private record SectionResponse(
+        Guid SectionId,
+        int Order,
+        string Name,
+        string? Format,
         List<ExerciseResponse> Exercises);
 
     private record ExerciseResponse(


### PR DESCRIPTION
## Summary
- `GetFullTrainingPlanResponse.cs` — adds `SectionDto` (`SectionId`, `Order`, `Name`, `Format`, `Exercises`) and a new `Sessions[].Sections: SectionDto[]` array on `SessionDto`. Flat `Sessions[].Exercises` preserved for backward-compatible callers (mobile pre-#240).
- `GetFullTrainingPlanEndpoint.cs` — calls `session.WithBackfilledSections()` per session **before** the muscle-group ExerciseId batch and the `sessionExerciseLookup` build, so legacy flat-exercise documents are transparently promoted to a single "Hlavní" section on read. The exercise-id batch and the `TrainingCompletion` lookup both consume the backfilled view.
- `GetFullTrainingPlanIntegrationTests.cs` — two new integration tests:
  - `GetFullPlan_WithExplicitSections_ReturnsSectionsAndFlatExercises` — seeds a session with explicit Warm-up (no format) + Hlavní (AMRAP) sections, asserts both round-trip with order/name/format and that the backward-compat flat `Exercises` equals the concatenation.
  - `GetFullPlan_WithLegacyFlatExercises_BackfillsIntoHlavniSection` — seeds a session with `Sections = []` + populated `LegacyExercises`, asserts the response surfaces a single "Hlavní" section (Format = null), the flat list still works, and muscle-group enrichment fires (proving the backfill ran before the ExerciseId batch).

## Related issue
Fixes #244

## Parent epic
Part of epic #236 — base branch: `feature/236-training-sections`.

## Scope
backend

## QA verdict (from dev verification)
QA gate skipped per orchestrator instruction (small backend bug fix, AC verifiable by integration tests). Dev ran full backend suite — `dotnet test` 1032/1032 green, including the two new tests. Handoff: `.claude/state/handoff-dev-244.json`.

## Test plan
- [x] `SectionDto` added to `GetFullTrainingPlanResponse.cs` with `SectionId`, `Order`, `Name`, `Format`, `Exercises`.
- [x] `SessionDto.Sections` populated from `WithBackfilledSections()` and ordered by `Section.Order`.
- [x] Backward-compat: `SessionDto.Exercises` still emitted as a flat view (concatenation of section exercises in order).
- [x] Integration test asserts the explicit-sections shape (round-trip Order/Name/Format/Exercises).
- [x] Integration test asserts the schema-on-read backfill — legacy `LegacyExercises`-only document materializes one "Hlavní" section in the response.
- [x] `dotnet build` clean; `dotnet test --filter "FullyQualifiedName~ClientTraining"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)