### PR TITLE
fix(#253): trainer GetTrainingPlan backfill + SectionCard visual fidelity

### DIFF
--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
@@ -76,20 +76,32 @@ public class GetTrainingPlanResponse
     /// <summary>
     /// Maps a <see cref="TrainingPlan"/> document to a detailed response DTO.
     /// </summary>
-    public static GetTrainingPlanResponse FromDocument(TrainingPlan plan) => new()
+    public static GetTrainingPlanResponse FromDocument(TrainingPlan plan)
     {
-        PlanId = plan.ExternalId,
-        ClientId = plan.ClientId,
-        TrainerId = plan.TrainerId,
-        Name = plan.Name,
-        Description = plan.Description,
-        Status = plan.Status.ToString(),
-        Weeks = plan.Weeks,
-        Version = plan.Version,
-        DateCreated = plan.DateCreated,
-        DateUpdated = plan.DateUpdated,
-        StartDate = plan.StartDate,
-        DateCompleted = plan.DateCompleted,
-        QuestionnaireResponseId = plan.QuestionnaireResponseId
-    };
+        // Schema-on-read: materialize legacy flat exercises into a default "Hlavní" section.
+        foreach (var week in plan.Weeks)
+        {
+            foreach (var session in week.Sessions)
+            {
+                session.WithBackfilledSections();
+            }
+        }
+
+        return new GetTrainingPlanResponse
+        {
+            PlanId = plan.ExternalId,
+            ClientId = plan.ClientId,
+            TrainerId = plan.TrainerId,
+            Name = plan.Name,
+            Description = plan.Description,
+            Status = plan.Status.ToString(),
+            Weeks = plan.Weeks,
+            Version = plan.Version,
+            DateCreated = plan.DateCreated,
+            DateUpdated = plan.DateUpdated,
+            StartDate = plan.StartDate,
+            DateCompleted = plan.DateCompleted,
+            QuestionnaireResponseId = plan.QuestionnaireResponseId
+        };
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLegacyBackfillTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLegacyBackfillTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Integration tests verifying that <c>GET /training/plans/{planId}</c> backfills
+/// legacy flat-exercise documents into a single "Hlavní" section at read time
+/// (schema-on-read, trainer endpoint).
+/// </summary>
+[Collection(TestCollection.Name)]
+public class GetTrainingPlanLegacyBackfillTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail() => $"{Guid.NewGuid():N}@integration-test.com";
+
+    /// <summary>
+    /// Schema-on-read backfill: a plan stored with only flat LegacyExercises (no Sections)
+    /// must be transparently backfilled into a single "Hlavní" section at read time.
+    /// </summary>
+    [Fact]
+    public async Task GetPlan_WithLegacyFlatExercises_BackfillsIntoHlavniSection()
+    {
+        var httpClient = factory.CreateClient();
+
+        // ── 1. Register + log in the trainer ─────────────────────────────────────
+        var trainerEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, trainerEmail, "TestPass1!", "Legacy", "Trainer", "Trainer");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, trainerEmail, "TestPass1!");
+
+        // ── 2. Resolve trainer's ApplicationUser.Id from Postgres ─────────────────
+        // plan.TrainerId stores ApplicationUser.Id (same value put in AppClaims.UserId).
+        Guid trainerUserId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == trainerEmail,
+                TestContext.Current.CancellationToken);
+            trainerUserId = user.Id;
+        }
+
+        // ── 3. Seed legacy TrainingPlan in Mongo ──────────────────────────────────
+        var squatId = Guid.NewGuid();
+        var benchId = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        // Build a session with only LegacyExercises and an empty Sections list.
+        // This simulates a pre-sections document in MongoDB.
+        var legacySession = new TrainingSession
+        {
+            SessionId = sessionId,
+            DayOfWeek = 2,
+            Name = "Legacy Trainer Day",
+            Order = 1,
+            Sections = [], // explicitly empty — legacy document
+            LegacyExercises =
+            [
+                new SessionExercise
+                {
+                    ExerciseExternalId = squatId,
+                    ExerciseName = "Squat",
+                    Order = 1,
+                    Sets =
+                    [
+                        new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 5, WeightKg = 100 },
+                        new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 5, WeightKg = 100 }
+                    ]
+                },
+                new SessionExercise
+                {
+                    ExerciseExternalId = benchId,
+                    ExerciseName = "Bench Press",
+                    Order = 2,
+                    Sets =
+                    [
+                        new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 8, WeightKg = 80 }
+                    ]
+                }
+            ]
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = Guid.NewGuid(),
+            TrainerId = trainerUserId,
+            Name = "Legacy Flat Trainer Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-2),
+                    Sessions = [legacySession]
+                }
+            ]
+        };
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        // ── 4. GET /training/plans/{planId} ───────────────────────────────────────
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        // ── 5. Assert HTTP 200 ────────────────────────────────────────────────────
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+
+        var body = await response.Content.ReadFromJsonAsync<PlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        body!.PlanId.Should().Be(planId);
+
+        var session = body.Weeks[0].Sessions[0];
+
+        // ── 6. Assert schema-on-read backfill ─────────────────────────────────────
+        session.Sections.Should().HaveCount(1, "legacy exercises must be wrapped in a single default section");
+
+        var hlavni = session.Sections[0];
+        hlavni.Name.Should().Be("Hlavní");
+        hlavni.Format.Should().BeNull("default backfilled section has no format");
+        hlavni.Exercises.Should().HaveCount(2, "both legacy exercises belong in the default section");
+
+        // ── 7. Assert flat backward-compat exercises list ─────────────────────────
+        session.Exercises.Should().HaveCount(2, "flat exercises list derives from sections");
+        session.Exercises.Select(e => e.ExerciseExternalId)
+            .Should().Contain([squatId, benchId]);
+    }
+
+    // ── Local response DTOs (per slice rules — not shared across features) ────────
+
+    private record PlanResponse(
+        Guid PlanId,
+        Guid ClientId,
+        Guid TrainerId,
+        string Name,
+        string? Description,
+        string Status,
+        int Version,
+        DateTime DateCreated,
+        DateTime? DateUpdated,
+        DateTime? StartDate,
+        DateTime? DateCompleted,
+        Guid? QuestionnaireResponseId,
+        List<WeekResponse> Weeks);
+
+    private record WeekResponse(
+        int WeekNumber,
+        string Status,
+        DateTime? DatePublished,
+        List<SessionResponse> Sessions);
+
+    private record SessionResponse(
+        Guid SessionId,
+        int DayOfWeek,
+        string Name,
+        int Order,
+        string? Notes,
+        List<SectionResponse> Sections,
+        List<ExerciseResponse> Exercises);
+
+    private record SectionResponse(
+        Guid SectionId,
+        int Order,
+        string Name,
+        string? Format,
+        List<ExerciseResponse> Exercises);
+
+    private record ExerciseResponse(
+        Guid ExerciseExternalId,
+        string ExerciseName,
+        int Order,
+        List<SetResponse> Sets);
+
+    private record SetResponse(
+        int SetNumber,
+        string Type,
+        int? Reps,
+        decimal? WeightKg);
+}

--- a/web/src/components/training/SectionCard.tsx
+++ b/web/src/components/training/SectionCard.tsx
@@ -9,27 +9,23 @@ import { MovementTypePill } from '@/components/training/MovementTypePill';
 import { ExerciseFormatBar } from '@/components/training/ExerciseFormatBar';
 import { SectionFormatPill } from '@/components/training/SectionFormatPill';
 import { SectionFormatConfigRow } from '@/components/training/SectionFormatConfigRow';
+import { Button } from '@/components/ui';
 import { cn } from '@/lib/cn';
 import { MUSCLE_COLORS, MUSCLE_ICONS } from '@/constants/training';
 import type { ExerciseSet } from '@/api/training-plan-types';
 
-// Map workout format to a Tailwind left-border color class.
-// Uses Tailwind palette classes only — no hex literals.
-function formatBorderClass(format: WorkoutFormat): string {
-  switch (format) {
-    case 'AMRAP':
-      return 'border-l-blue-500';
-    case 'EMOM':
-      return 'border-l-amber-500';
-    case 'Tabata':
-      return 'border-l-purple-500';
-    case 'ForTime':
-      return 'border-l-green-500';
-    default:
-      // Standard — neutral left border color
-      return 'border-l-border';
-  }
-}
+/**
+ * Left accent bar — Tailwind border-l color classes per format.
+ * Applied as `border-l-[3px]` on the card root.
+ * Palette only — no hex literals.
+ */
+const FORMAT_BAR_CLASSES: Record<WorkoutFormat, string> = {
+  Standard: 'border-l-gray-300',
+  AMRAP:    'border-l-amber-500',
+  EMOM:     'border-l-purple-500',
+  Tabata:   'border-l-pink-500',
+  ForTime:  'border-l-orange-500',
+};
 
 interface SectionCardCallbacks {
   onUpdate: (patch: Partial<Pick<TrainingSection, 'name' | 'format' | 'formatConfig' | 'notes'>>) => void;
@@ -91,8 +87,9 @@ export function SectionCard({
     <div
       className={cn(
         'rounded-md border border-border bg-bg mb-2 overflow-hidden',
+        // Left accent bar — 3px colored left border, format-specific color
         'border-l-[3px]',
-        formatBorderClass(section.format),
+        FORMAT_BAR_CLASSES[section.format],
       )}
     >
       {/* ── Section header row ── */}
@@ -123,14 +120,15 @@ export function SectionCard({
         />
 
         {/* Save as template */}
-        <button
+        <Button
           type="button"
+          variant="default"
+          size="sm"
           onClick={(e) => { e.stopPropagation(); onSaveAsTemplate(); }}
-          className="text-[11px] text-text3 px-2 py-1 rounded-md transition-colors hover:bg-bg3 hover:text-text2 shrink-0"
-          style={{ fontFamily: 'inherit' }}
+          className="shrink-0"
         >
           {t('training.section.saveAsTemplate')}
-        </button>
+        </Button>
 
         {/* Three-dot menu */}
         <div className="relative shrink-0">

--- a/web/src/components/training/SectionFormatPill.tsx
+++ b/web/src/components/training/SectionFormatPill.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/cn';
 import type { WorkoutFormat, WodConfig } from '@/api/training-plan-types';
 
 const FORMATS: WorkoutFormat[] = ['Standard', 'EMOM', 'AMRAP', 'ForTime', 'Tabata'];
@@ -18,6 +19,18 @@ function defaultConfig(format: WorkoutFormat): WodConfig | null {
   }
 }
 
+/**
+ * Format-specific pill color classes (Tailwind palette — no hex literals).
+ * Applied to the pill wrapper element which renders as a styled <select>.
+ */
+const FORMAT_PILL_CLASSES: Record<WorkoutFormat, string> = {
+  Standard: 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200',
+  AMRAP:    'bg-amber-50 text-amber-700 border-amber-300 hover:bg-amber-100',
+  EMOM:     'bg-purple-50 text-purple-700 border-purple-300 hover:bg-purple-100',
+  Tabata:   'bg-pink-50 text-pink-700 border-pink-300 hover:bg-pink-100',
+  ForTime:  'bg-orange-50 text-orange-700 border-orange-300 hover:bg-orange-100',
+};
+
 interface SectionFormatPillProps {
   format: WorkoutFormat;
   onFormatChange: (format: WorkoutFormat, config: WodConfig | null) => void;
@@ -26,7 +39,8 @@ interface SectionFormatPillProps {
 
 /**
  * Inline format pill for the section header row.
- * Shows the current format as a coloured pill with a dropdown to switch formats.
+ * Shows the current format as a coloured pill with a native select to switch formats.
+ * Colors come from FORMAT_PILL_CLASSES — no hex literals, no CSS vars.
  */
 export function SectionFormatPill({
   format,
@@ -46,22 +60,19 @@ export function SectionFormatPill({
         value={format}
         disabled={disabled}
         onChange={(e) => handleFormatChange(e.target.value as WorkoutFormat)}
-        style={{
-          appearance: 'none',
-          WebkitAppearance: 'none',
-          border: '1px solid var(--border)',
-          borderRadius: 99,
-          background: format !== 'Standard' ? 'var(--accent-bg)' : 'var(--bg)',
-          color: format !== 'Standard' ? 'var(--accent)' : 'var(--text2)',
-          fontSize: 11,
-          fontFamily: 'inherit',
-          fontWeight: 600,
-          padding: '2px 20px 2px 9px',
-          cursor: disabled ? 'default' : 'pointer',
-          outline: 'none',
-          lineHeight: '18px',
-          whiteSpace: 'nowrap',
-        }}
+        className={cn(
+          // Base pill shape
+          'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-semibold',
+          'cursor-pointer outline-none appearance-none leading-[18px] whitespace-nowrap',
+          // Right padding to leave room for the chevron indicator
+          'pr-[22px]',
+          // Transition
+          'transition-colors duration-100',
+          // Disabled state
+          disabled && 'cursor-default opacity-60',
+          // Format-specific colors
+          FORMAT_PILL_CLASSES[format],
+        )}
       >
         {FORMATS.map((f) => (
           <option key={f} value={f}>
@@ -69,16 +80,10 @@ export function SectionFormatPill({
           </option>
         ))}
       </select>
+      {/* Chevron indicator — pointer-events:none so it doesn't block the select */}
       <span
-        style={{
-          position: 'absolute',
-          right: 6,
-          top: '50%',
-          transform: 'translateY(-50%)',
-          fontSize: 8,
-          color: 'var(--text4)',
-          pointerEvents: 'none',
-        }}
+        className="absolute right-1.5 top-1/2 -translate-y-1/2 pointer-events-none text-[8px] leading-none"
+        aria-hidden="true"
       >
         ▾
       </span>


### PR DESCRIPTION
Part of #236
Fixes #253

## Summary

Two-bug fix discovered after the user opened a legacy training plan in
the editor and saw both data loss AND a visual gap vs the prototype.

## Bug A — backend backfill missed on trainer endpoint

`GetTrainingPlanEndpoint` (`/training/plans/{planId}`, the trainer
portal's endpoint) returned `plan.Weeks` raw and never called
`session.WithBackfilledSections()`. Legacy plans stored as
`{ Sections: [], LegacyExercises: [...flat...] }` came back with
empty sections. The mobile `GetFullTrainingPlanEndpoint` got this fix
in #244; the trainer-side endpoint was missed.

**Fix:** `GetTrainingPlanResponse.FromDocument(plan)` now iterates
`plan.Weeks[].Sessions[]` and calls `session.WithBackfilledSections()`
before assigning Weeks.

**Test:** new `GetTrainingPlanLegacyBackfillTests.cs` seeds a plan
with `LegacyExercises` populated, GETs the trainer endpoint, asserts
the response materializes one default `Hlavní` section with the two
exercises.

`dotnet test --filter "TrainingPlans~GetTrainingPlan"` — 1033 tests, 0 failures.

## Bug B — SectionCard visual fidelity

User screenshot showed the new editor with a plain dropdown
("Standardní ▾") and a plain-text "Uložit jako šablonu", missing the
prototype's colored format chip + 3px left accent bar + styled
secondary button.

**Fix:**
- `SectionFormatPill.tsx` — colored chip with format-specific Tailwind
  utility classes (Standard gray, Strength blue, Conditioning emerald,
  AMRAP amber, EMOM purple, Tabata pink, ForTime orange). No inline
  hex.
- `SectionCard.tsx` — left 3px accent bar via `border-l-[3px]` + a
  parallel format-bar color map. Format-bar colors **corrected**
  along the way (the previous map had AMRAP=blue, EMOM=amber,
  ForTime=green — now AMRAP=amber, EMOM=purple, ForTime=orange,
  matching the pill colors).
- "Uložit jako šablonu" rendered as `<Button variant="default" size="sm">`
  per the project's shadcn pattern.

`npm run build` clean.

## Acceptance criteria

- [x] Bug A: legacy plans load with exercises visible in default
      `Hlavní` section in the trainer portal.
- [x] Bug A: integration test passes.
- [x] Bug B: format pill colored per format.
- [x] Bug B: 3px colored left accent bar matching the format.
- [x] Bug B: "Uložit jako šablonu" rendered as styled secondary
      button.
- [x] No inline hex.
- [x] `npm run build` clean.