### PR TITLE
feat(#255): collapsible section cards in TrainingPlanPage

### DIFF
--- a/web/src/components/training/SectionCard.tsx
+++ b/web/src/components/training/SectionCard.tsx
@@ -71,6 +71,7 @@ export function SectionCard({
   exerciseFullMap,
 }: SectionCardProps) {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(true);
   const [collapsedExercises, setCollapsedExercises] = useState<Set<number>>(new Set());
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -103,15 +104,43 @@ export function SectionCard({
           ⠿
         </span>
 
-        {/* Editable section name */}
-        <input
-          type="text"
-          value={section.name}
-          placeholder={t('training.section.placeholderName')}
-          onChange={(e) => onUpdate({ name: e.target.value })}
-          className="flex-1 bg-transparent text-[13px] font-semibold text-text outline-none"
-          style={{ fontFamily: 'inherit', minWidth: 0 }}
-        />
+        {/* Chevron collapse toggle */}
+        <button
+          type="button"
+          onClick={() => setIsExpanded((v) => !v)}
+          className="flex items-center justify-center shrink-0 w-4 h-4 text-text4 transition-colors hover:text-text2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border-md"
+          aria-label={isExpanded ? t('training.section.collapse') : t('training.section.expand')}
+          aria-expanded={isExpanded}
+        >
+          <span
+            className={cn(
+              'text-[10px] inline-flex items-center justify-center transition-transform duration-150',
+              isExpanded && 'rotate-90',
+            )}
+          >
+            ▶
+          </span>
+        </button>
+
+        {/* Editable section name — clicking the label area also toggles; the input itself does not */}
+        <div
+          className="flex-1 min-w-0 flex items-center"
+          onClick={(e) => {
+            // Only toggle when the click target is the wrapper div, not the input
+            if (e.target === e.currentTarget) {
+              setIsExpanded((v) => !v);
+            }
+          }}
+        >
+          <input
+            type="text"
+            value={section.name}
+            placeholder={t('training.section.placeholderName')}
+            onChange={(e) => onUpdate({ name: e.target.value })}
+            className="w-full bg-transparent text-[13px] font-semibold text-text outline-none cursor-text"
+            style={{ fontFamily: 'inherit', minWidth: 0 }}
+          />
+        </div>
 
         {/* Format pill — inline in header row */}
         <SectionFormatPill
@@ -165,175 +194,180 @@ export function SectionCard({
         </div>
       </div>
 
-      {/* ── Notes row (shown always; hide if empty and no focus) ── */}
-      <div style={{ padding: '3px 8px 4px' }} onClick={(e) => e.stopPropagation()}>
-        <input
-          type="text"
-          value={section.notes ?? ''}
-          placeholder={t('training.section.placeholderNotes')}
-          onChange={(e) => onUpdate({ notes: e.target.value || null })}
-          className="w-full bg-transparent text-[11px] text-text3 outline-none"
-          style={{ fontFamily: 'inherit', fontStyle: 'italic', padding: '2px 4px', borderRadius: 'var(--radius)', transition: 'background 0.1s' }}
-          onFocus={(e) => { e.target.style.background = 'var(--bg-hover)'; }}
-          onBlur={(e) => { e.target.style.background = 'transparent'; }}
-        />
-      </div>
+      {/* ── Collapsible body ── */}
+      {isExpanded && (
+        <>
+          {/* ── Notes row ── */}
+          <div style={{ padding: '3px 8px 4px' }} onClick={(e) => e.stopPropagation()}>
+            <input
+              type="text"
+              value={section.notes ?? ''}
+              placeholder={t('training.section.placeholderNotes')}
+              onChange={(e) => onUpdate({ notes: e.target.value || null })}
+              className="w-full bg-transparent text-[11px] text-text3 outline-none"
+              style={{ fontFamily: 'inherit', fontStyle: 'italic', padding: '2px 4px', borderRadius: 'var(--radius)', transition: 'background 0.1s' }}
+              onFocus={(e) => { e.target.style.background = 'var(--bg-hover)'; }}
+              onBlur={(e) => { e.target.style.background = 'transparent'; }}
+            />
+          </div>
 
-      {/* ── Format config row (non-Standard formats only) ── */}
-      {section.format !== 'Standard' && (
-        <SectionFormatConfigRow
-          format={section.format}
-          formatConfig={section.formatConfig}
-          onChange={(patch) =>
-            onUpdate({ formatConfig: { ...(section.formatConfig ?? {}), ...patch } })
-          }
-        />
-      )}
+          {/* ── Format config row (non-Standard formats only) ── */}
+          {section.format !== 'Standard' && (
+            <SectionFormatConfigRow
+              format={section.format}
+              formatConfig={section.formatConfig}
+              onChange={(patch) =>
+                onUpdate({ formatConfig: { ...(section.formatConfig ?? {}), ...patch } })
+              }
+            />
+          )}
 
-      {/* ── Exercise list ── */}
-      <div className="px-2 pt-1">
-        {section.exercises.map((ex, exIdx) => {
-          const exKey = exIdx;
-          const isExOpen = !collapsedExercises.has(exKey);
-          const setsCount = ex.sets.length;
-          const repsValues = ex.sets.map((s) => s.reps).filter((r): r is number => r != null);
-          const weightValues = ex.sets.map((s) => s.weightKg).filter((w): w is number => w != null);
-          const repsMin = repsValues.length > 0 ? Math.min(...repsValues) : null;
-          const repsMax = repsValues.length > 0 ? Math.max(...repsValues) : null;
-          const weightMin = weightValues.length > 0 ? Math.min(...weightValues) : null;
-          const weightMax = weightValues.length > 0 ? Math.max(...weightValues) : null;
-          const repsStr = repsMin == null ? '–' : repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
-          const weightStr = weightMin == null ? '–' : weightMin === weightMax ? `${weightMin}` : `${weightMin}-${weightMax}`;
-          const totalVolume = ex.sets.reduce((sum, s) => sum + ((s.reps ?? 0) * (s.weightKg ?? 0)), 0);
+          {/* ── Exercise list ── */}
+          <div className="px-2 pt-1">
+            {section.exercises.map((ex, exIdx) => {
+              const exKey = exIdx;
+              const isExOpen = !collapsedExercises.has(exKey);
+              const setsCount = ex.sets.length;
+              const repsValues = ex.sets.map((s) => s.reps).filter((r): r is number => r != null);
+              const weightValues = ex.sets.map((s) => s.weightKg).filter((w): w is number => w != null);
+              const repsMin = repsValues.length > 0 ? Math.min(...repsValues) : null;
+              const repsMax = repsValues.length > 0 ? Math.max(...repsValues) : null;
+              const weightMin = weightValues.length > 0 ? Math.min(...weightValues) : null;
+              const weightMax = weightValues.length > 0 ? Math.max(...weightValues) : null;
+              const repsStr = repsMin == null ? '–' : repsMin === repsMax ? `${repsMin}` : `${repsMin}-${repsMax}`;
+              const weightStr = weightMin == null ? '–' : weightMin === weightMax ? `${weightMin}` : `${weightMin}-${weightMax}`;
+              const totalVolume = ex.sets.reduce((sum, s) => sum + ((s.reps ?? 0) * (s.weightKg ?? 0)), 0);
 
-          const muscleGroups = exerciseDetailsMap?.get(ex.exerciseExternalId) ?? [];
-          const primaryMuscle = muscleGroups[0] as string | undefined;
-          const muscleColor = primaryMuscle ? (MUSCLE_COLORS[primaryMuscle] ?? 'var(--accent)') : 'var(--accent)';
-          const muscleIcon = primaryMuscle ? (MUSCLE_ICONS[primaryMuscle] ?? '🏋️') : '🏋️';
-          const difficulty = exerciseFullMap?.get(ex.exerciseExternalId)?.difficulty;
+              const muscleGroups = exerciseDetailsMap?.get(ex.exerciseExternalId) ?? [];
+              const primaryMuscle = muscleGroups[0] as string | undefined;
+              const muscleColor = primaryMuscle ? (MUSCLE_COLORS[primaryMuscle] ?? 'var(--accent)') : 'var(--accent)';
+              const muscleIcon = primaryMuscle ? (MUSCLE_ICONS[primaryMuscle] ?? '🏋️') : '🏋️';
+              const difficulty = exerciseFullMap?.get(ex.exerciseExternalId)?.difficulty;
 
-          return (
-            <div
-              key={exKey}
-              data-item-id={String(exIdx)}
-              className="rounded-md border border-border bg-bg mb-1.5 overflow-hidden transition-all duration-100 hover:border-border-md"
-            >
-              <ExerciseCardHeader
-                exercise={ex}
-                muscleGroups={muscleGroups}
-                repsStr={repsStr}
-                weightStr={weightStr}
-                setsCount={setsCount}
-                totalVolume={totalVolume}
-                isOpen={isExOpen}
-                onToggle={() => toggleExercise(exKey)}
-                onDuplicate={() => onDuplicateExercise(exIdx)}
-                onRemove={() => onRemoveExercise(exIdx)}
-                difficulty={difficulty}
-                muscleColor={muscleColor}
-                muscleIcon={muscleIcon}
-              />
-
-              <div className="collapse-grid" data-open={isExOpen}>
-                <div className="collapse-content">
-                  {/* Per-exercise format override */}
-                  <ExerciseFormatBar
-                    format={ex.format}
-                    formatConfig={ex.formatConfig}
-                    sessionFormat={sessionFormat}
-                    onFormatChange={(fmt, cfg) => onUpdateExerciseFormat(exIdx, fmt, cfg)}
+              return (
+                <div
+                  key={exKey}
+                  data-item-id={String(exIdx)}
+                  className="rounded-md border border-border bg-bg mb-1.5 overflow-hidden transition-all duration-100 hover:border-border-md"
+                >
+                  <ExerciseCardHeader
+                    exercise={ex}
+                    muscleGroups={muscleGroups}
+                    repsStr={repsStr}
+                    weightStr={weightStr}
+                    setsCount={setsCount}
+                    totalVolume={totalVolume}
+                    isOpen={isExOpen}
+                    onToggle={() => toggleExercise(exKey)}
+                    onDuplicate={() => onDuplicateExercise(exIdx)}
+                    onRemove={() => onRemoveExercise(exIdx)}
+                    difficulty={difficulty}
+                    muscleColor={muscleColor}
+                    muscleIcon={muscleIcon}
                   />
 
-                  <div className="px-3 py-2">
-                    {/* MovementType picker + column headers */}
-                    <div className="flex items-center justify-between mb-1">
-                      <MovementTypePill
-                        value={ex.movementType}
-                        onChange={(mt) => onUpdateExerciseMovementType(exIdx, mt)}
+                  <div className="collapse-grid" data-open={isExOpen}>
+                    <div className="collapse-content">
+                      {/* Per-exercise format override */}
+                      <ExerciseFormatBar
+                        format={ex.format}
+                        formatConfig={ex.formatConfig}
+                        sessionFormat={sessionFormat}
+                        onFormatChange={(fmt, cfg) => onUpdateExerciseFormat(exIdx, fmt, cfg)}
                       />
-                      <div className="flex items-center gap-2 text-[10px] font-medium text-text3 uppercase">
-                        {ex.movementType === 'Reps' && (
-                          <>
-                            <span className="w-[68px] text-right">{t('training.weightLabel')}</span>
-                            <span className="w-[68px] text-right">{t('training.repsLabel')}</span>
-                            <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
-                          </>
-                        )}
-                        {ex.movementType === 'Time' && (
-                          <>
-                            <span className="w-[80px] text-right">{t('training.wod.durationLabel')}</span>
-                            <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
-                          </>
-                        )}
-                        {ex.movementType === 'Distance' && (
-                          <>
-                            <span className="w-[80px] text-right">{t('training.wod.distanceLabel')}</span>
-                            <span className="w-[80px] text-right">{t('training.wod.durationLabel')}</span>
-                            <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
-                          </>
-                        )}
-                        {ex.movementType === 'RepsForTime' && (
-                          <>
-                            <span className="w-[68px] text-right">{t('training.repsLabel')}</span>
-                            <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
-                          </>
-                        )}
-                        <span className="w-5" />
+
+                      <div className="px-3 py-2">
+                        {/* MovementType picker + column headers */}
+                        <div className="flex items-center justify-between mb-1">
+                          <MovementTypePill
+                            value={ex.movementType}
+                            onChange={(mt) => onUpdateExerciseMovementType(exIdx, mt)}
+                          />
+                          <div className="flex items-center gap-2 text-[10px] font-medium text-text3 uppercase">
+                            {ex.movementType === 'Reps' && (
+                              <>
+                                <span className="w-[68px] text-right">{t('training.weightLabel')}</span>
+                                <span className="w-[68px] text-right">{t('training.repsLabel')}</span>
+                                <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
+                              </>
+                            )}
+                            {ex.movementType === 'Time' && (
+                              <>
+                                <span className="w-[80px] text-right">{t('training.wod.durationLabel')}</span>
+                                <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
+                              </>
+                            )}
+                            {ex.movementType === 'Distance' && (
+                              <>
+                                <span className="w-[80px] text-right">{t('training.wod.distanceLabel')}</span>
+                                <span className="w-[80px] text-right">{t('training.wod.durationLabel')}</span>
+                                <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
+                              </>
+                            )}
+                            {ex.movementType === 'RepsForTime' && (
+                              <>
+                                <span className="w-[68px] text-right">{t('training.repsLabel')}</span>
+                                <span className="w-[90px] text-right">{t('training.restSecondsLabel')}</span>
+                              </>
+                            )}
+                            <span className="w-5" />
+                          </div>
+                        </div>
+
+                        {/* Set rows */}
+                        {ex.sets.map((s, sIdx) => (
+                          <SetRow
+                            key={sIdx}
+                            set={s}
+                            movementType={ex.movementType}
+                            onUpdate={(updates) => onUpdateSet(exIdx, sIdx, updates)}
+                            onRemove={() => onRemoveSet(exIdx, sIdx)}
+                          />
+                        ))}
+
+                        {/* Add set */}
+                        <button
+                          type="button"
+                          onClick={() => onAddSet(exIdx)}
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '4px 0', fontSize: 11, color: 'var(--text4)', fontFamily: 'inherit', transition: 'color 0.1s' }}
+                          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--text3)'; }}
+                          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text4)'; }}
+                        >
+                          + {t('training.addSet')}
+                        </button>
+
+                        {/* Exercise note */}
+                        <div style={{ marginTop: 6, borderTop: '1px solid var(--border)', paddingTop: 6 }}>
+                          <input
+                            type="text"
+                            value={ex.notes ?? ''}
+                            onChange={(e) => onUpdateExerciseNotes(exIdx, e.target.value)}
+                            placeholder={t('training.notePlaceholder')}
+                            style={{
+                              width: '100%', border: 'none', outline: 'none', background: 'transparent',
+                              fontSize: 11, color: 'var(--text3)', fontFamily: 'inherit', fontStyle: 'italic',
+                              padding: '2px 4px', borderRadius: 'var(--radius)', transition: 'background 0.1s',
+                            }}
+                            onFocus={(e) => { e.target.style.background = 'var(--bg-hover)'; }}
+                            onBlur={(e) => { e.target.style.background = 'transparent'; }}
+                          />
+                        </div>
                       </div>
-                    </div>
-
-                    {/* Set rows */}
-                    {ex.sets.map((s, sIdx) => (
-                      <SetRow
-                        key={sIdx}
-                        set={s}
-                        movementType={ex.movementType}
-                        onUpdate={(updates) => onUpdateSet(exIdx, sIdx, updates)}
-                        onRemove={() => onRemoveSet(exIdx, sIdx)}
-                      />
-                    ))}
-
-                    {/* Add set */}
-                    <button
-                      type="button"
-                      onClick={() => onAddSet(exIdx)}
-                      style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '4px 0', fontSize: 11, color: 'var(--text4)', fontFamily: 'inherit', transition: 'color 0.1s' }}
-                      onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--text3)'; }}
-                      onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text4)'; }}
-                    >
-                      + {t('training.addSet')}
-                    </button>
-
-                    {/* Exercise note */}
-                    <div style={{ marginTop: 6, borderTop: '1px solid var(--border)', paddingTop: 6 }}>
-                      <input
-                        type="text"
-                        value={ex.notes ?? ''}
-                        onChange={(e) => onUpdateExerciseNotes(exIdx, e.target.value)}
-                        placeholder={t('training.notePlaceholder')}
-                        style={{
-                          width: '100%', border: 'none', outline: 'none', background: 'transparent',
-                          fontSize: 11, color: 'var(--text3)', fontFamily: 'inherit', fontStyle: 'italic',
-                          padding: '2px 4px', borderRadius: 'var(--radius)', transition: 'background 0.1s',
-                        }}
-                        onFocus={(e) => { e.target.style.background = 'var(--bg-hover)'; }}
-                        onBlur={(e) => { e.target.style.background = 'transparent'; }}
-                      />
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+              );
+            })}
+          </div>
 
-      {/* ── Add exercise ── */}
-      <div className="px-2 pb-2" onClick={(e) => e.stopPropagation()}>
-        <ExerciseSearch
-          onSelect={(exercise) => onAddExercise(exercise)}
-        />
-      </div>
+          {/* ── Add exercise ── */}
+          <div className="px-2 pb-2" onClick={(e) => e.stopPropagation()}>
+            <ExerciseSearch
+              onSelect={(exercise) => onAddExercise(exercise)}
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1031,7 +1031,9 @@
       "tabataWork": "Práce (s)",
       "tabataRest": "Pauza (s)",
       "tabataRounds": "Počet kol",
-      "fortimeTimeCap": "Časový limit (min)"
+      "fortimeTimeCap": "Časový limit (min)",
+      "collapse": "Sbalit sekci",
+      "expand": "Rozbalit sekci"
     },
     "template": {
       "pageTitle": "Šablony sekcí",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1031,7 +1031,9 @@
       "tabataWork": "Arbeit (s)",
       "tabataRest": "Pause (s)",
       "tabataRounds": "Runden",
-      "fortimeTimeCap": "Zeitlimit (min)"
+      "fortimeTimeCap": "Zeitlimit (min)",
+      "collapse": "Abschnitt zuklappen",
+      "expand": "Abschnitt aufklappen"
     },
     "template": {
       "pageTitle": "Abschnittsvorlagen",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1032,7 +1032,9 @@
       "tabataWork": "Work (s)",
       "tabataRest": "Rest (s)",
       "tabataRounds": "Rounds",
-      "fortimeTimeCap": "Time cap (min)"
+      "fortimeTimeCap": "Time cap (min)",
+      "collapse": "Collapse section",
+      "expand": "Expand section"
     },
     "template": {
       "pageTitle": "Section Templates",


### PR DESCRIPTION
Part of #236
Fixes #255

## Summary

Adds an expand/collapse chevron to each section card in
`TrainingPlanPage` so trainers can collapse a section to its header
strip when authoring multi-section sessions.

## Changes

- `web/src/components/training/SectionCard.tsx` — `isExpanded`
  component-local state (default `true`); chevron `<button>` after
  the drag handle (mirrors the `▶` + `rotate-90` pattern from
  `ExerciseCardHeader`); name-area click also toggles (without
  breaking the editable-name input). Body (notes, format-config row,
  exercises, "+ Přidat cvik" footer) renders only when expanded.
- `web/src/i18n/locales/{cs,en,de}.json` — `training.section.collapse`
  + `training.section.expand` for the chevron's accessible label.

## Acceptance criteria

- [x] Each section card has a collapse chevron in the header.
- [x] Click the chevron OR the name area toggles the body. Editing
      the name input is unaffected.
- [x] Default state is expanded.
- [x] Existing session-level collapse behavior unchanged.
- [x] `npm run build` clean.
- [x] i18n keys cs / en / de.