### PR TITLE
fix: 4 UpdateTrainingPlanFormatTests fail on Linux CI — pin PropertyName explicitly

### DIFF
--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
@@ -163,34 +163,48 @@ public class UpdateTrainingPlanValidator : Validator<UpdateTrainingPlanRequest>
         Func<T, WodConfig?> configSelector,
         string prefix)
     {
-        validator.RuleFor(x => configSelector(x)!.IntervalSeconds)
-            .NotNull().GreaterThan(0)
+        // Use Must() on the root object so FluentValidation does not need to resolve
+        // PropertyName from a delegate-chained expression such as
+        // `x => configSelector(x)!.IntervalSeconds`. Expression-visitor-based name
+        // resolution of that pattern is JIT-dependent and produces an empty string
+        // on Linux/x64 while resolving correctly on macOS/ARM64 (issue #276).
+        // WithName() pins the property name explicitly and WithMessage() ensures
+        // the field name appears in the error message on every platform.
+
+        validator.RuleFor(x => x)
+            .Must(x => configSelector(x)?.IntervalSeconds is > 0)
             .When(x => formatSelector(x) == WorkoutFormat.EMOM && configSelector(x) != null)
+            .WithName("IntervalSeconds")
             .WithMessage($"{prefix} EMOM requires IntervalSeconds > 0.");
 
-        validator.RuleFor(x => configSelector(x)!.TotalRounds)
-            .NotNull().GreaterThan(0)
+        validator.RuleFor(x => x)
+            .Must(x => configSelector(x)?.TotalRounds is > 0)
             .When(x => formatSelector(x) == WorkoutFormat.EMOM && configSelector(x) != null)
+            .WithName("TotalRounds")
             .WithMessage($"{prefix} EMOM requires TotalRounds > 0.");
 
-        validator.RuleFor(x => configSelector(x)!.TimeCapSeconds)
-            .NotNull().GreaterThan(0)
+        validator.RuleFor(x => x)
+            .Must(x => configSelector(x)?.TimeCapSeconds is > 0)
             .When(x => (formatSelector(x) == WorkoutFormat.AMRAP || formatSelector(x) == WorkoutFormat.ForTime) && configSelector(x) != null)
+            .WithName("TimeCapSeconds")
             .WithMessage($"{prefix} AMRAP and ForTime require TimeCapSeconds > 0.");
 
-        validator.RuleFor(x => configSelector(x)!.WorkSeconds)
-            .NotNull().GreaterThan(0)
+        validator.RuleFor(x => x)
+            .Must(x => configSelector(x)?.WorkSeconds is > 0)
             .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithName("WorkSeconds")
             .WithMessage($"{prefix} Tabata requires WorkSeconds > 0.");
 
-        validator.RuleFor(x => configSelector(x)!.RestSeconds)
-            .NotNull().GreaterThan(0)
+        validator.RuleFor(x => x)
+            .Must(x => configSelector(x)?.RestSeconds is > 0)
             .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithName("RestSeconds")
             .WithMessage($"{prefix} Tabata requires RestSeconds > 0.");
 
-        validator.RuleFor(x => configSelector(x)!.TotalRounds)
-            .NotNull().GreaterThan(0)
+        validator.RuleFor(x => x)
+            .Must(x => configSelector(x)?.TotalRounds is > 0)
             .When(x => formatSelector(x) == WorkoutFormat.Tabata && configSelector(x) != null)
+            .WithName("TotalRounds")
             .WithMessage($"{prefix} Tabata requires TotalRounds > 0.");
     }
 }


### PR DESCRIPTION
## Summary

- Replaces 6 `RuleFor(x => configSelector(x)!.Property).NotNull().GreaterThan(0)...WithMessage(...)` chains in `UpdateTrainingPlanValidator.ApplyFormatConfigRules` with `RuleFor(x => x).Must(x => configSelector(x)?.Property is > 0)...WithName("Property").WithMessage(...)`.
- Same validation semantics, but avoids FluentValidation's expression-visitor-based `PropertyName` extraction (which produced an empty `PropertyName` on Linux/x64 while resolving correctly on macOS/ARM64).
- `WithName("X")` pins the property name explicitly; the literal field name is also embedded in `WithMessage(...)` so `ErrorMessage.Contains("X")` works on every platform regardless of how the expression visitor behaves.

## Related issue

Fixes #276

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — AC1 (the Linux-only failure) explicitly deferred to CI on this PR per `qa-tester` note: unreproducible on macOS and in `mcr.microsoft.com/dotnet/sdk:10.0.103 linux/amd64`. macOS focused runs: 14/14 `UpdateTrainingPlanFormatTests`, 4/4 `UpdateTrainingPlanEndpointTests`, 155/155 `*Validator*`, 39/39 `*TrainingPlan*`. The optional AC (`.github/workflows/backend.yml` matrix entry) was deferred by the dev agent — issue body explicitly marks it "optional but recommended".

## Test plan

- [ ] All 4 `UpdateTrainingPlanFormatTests` pass on the CI Linux runner used in `.github/workflows/backend.yml`:
  - `HandleAsync_EmomSessionWithoutIntervalSeconds_RejectsValidation`
  - `HandleAsync_AmrapSessionWithoutTimeCapSeconds_RejectsValidation`
  - `HandleAsync_ForTimeSessionWithoutTimeCap_RejectsValidation`
  - `HandleAsync_TabataSessionMissingWorkSeconds_RejectsValidation`
- [ ] No regression in other `UpdatePlanFullState` or `TrainingPlanFormat`-related tests (full suite stays green on Linux CI).
- [ ] (Optional, deferred) `.github/workflows/backend.yml` extended to run `UpdateTrainingPlanFormatTests` explicitly on a Linux container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)