### PR TITLE
fix: Testcontainers cascade — isolate PhotoDiaryReminderScheduler + per-candidate EF scope (#278)

### DIFF
--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PhotoDiaryReminderScheduler.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PhotoDiaryReminderScheduler.cs
@@ -172,6 +172,7 @@ public class PhotoDiaryReminderScheduler(
     {
         // Load all active workflow-mode diary requests in the acceptance/in-progress window,
         // joined with the client user so we can read their time zone.
+        // Use AsNoTracking — the candidate list is read-only; writes happen in per-candidate scopes.
         var candidates = await db.PhotoDiaryRequests
             .AsNoTracking()
             .Where(r => r.Mode == PhotoDiaryMode.Workflow
@@ -202,7 +203,10 @@ public class PhotoDiaryReminderScheduler(
             if (request.AcceptedAt.HasValue
                 && now > request.AcceptedAt.Value.UtcDateTime.AddDays(request.DurationDays + 1))
             {
-                await AutoFinalizeAsync(db, services, request, clientUserId, now, ct);
+                // Candidate B: auto-finalize in its own scope so failures don't affect siblings.
+                using var finalizeScope = scopeFactory.CreateScope();
+                var finalizeDb = finalizeScope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+                await AutoFinalizeAsync(finalizeDb, services, request, clientUserId, now, ct);
                 continue;  // request is now Completed — no reminder needed
             }
 
@@ -255,8 +259,17 @@ public class PhotoDiaryReminderScheduler(
 
             var clientLocalDate = DateOnly.FromDateTime(localNow.Date);
 
+            // ── Candidate B: per-candidate scope ─────────────────────────────
+            // Each candidate gets its own IApplicationDbContext scope so that a 23505
+            // unique-violation (or any other DbUpdateException) on one candidate's
+            // SaveChanges cannot corrupt the change tracker and cascade to the next
+            // candidate's inserts.  This is the architecturally correct fix: after
+            // a failed SaveChanges the EF change tracker is in an undefined state;
+            // disposing the scope is the only safe recovery.
+            using var candidateScope = scopeFactory.CreateScope();
+            var candidateDb = candidateScope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+
             // ── Idempotency: insert log row ────────────────────────────────────
-            // NB: we need a tracking context for this insert so re-query with tracking.
             var logEntry = new PhotoDiaryReminderLog
             {
                 DiaryRequestId = request.Id,
@@ -264,20 +277,20 @@ public class PhotoDiaryReminderScheduler(
                 SentAt = now
             };
 
-            db.PhotoDiaryReminderLogs.Add(logEntry);
+            candidateDb.PhotoDiaryReminderLogs.Add(logEntry);
 
             try
             {
-                await db.SaveChangesAsync(ct);
+                await candidateDb.SaveChangesAsync(ct);
             }
             catch (DbUpdateException ex) when (IsUniqueViolation(ex))
             {
+                // Duplicate — reminder already fired for this (DiaryRequestId, date).
+                // The candidateScope is disposed at end-of-block; no tracker cleanup needed.
                 logger.LogWarning(
                     "PhotoDiaryReminderScheduler: duplicate reminder skipped for " +
                     "request={RequestId} date={Date}.",
                     request.Id, clientLocalDate);
-
-                db.PhotoDiaryReminderLogs.Remove(logEntry);
                 continue;
             }
 
@@ -304,8 +317,8 @@ public class PhotoDiaryReminderScheduler(
             // ── Persist in-app notification (best-effort) ────────────────────
             try
             {
-                db.Notifications.Add(notification);
-                await db.SaveChangesAsync(ct);
+                candidateDb.Notifications.Add(notification);
+                await candidateDb.SaveChangesAsync(ct);
             }
             catch (Exception ex)
             {

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
@@ -1,10 +1,12 @@
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using MongoDB.Driver;
 using Testcontainers.MongoDb;
 using Testcontainers.PostgreSql;
@@ -109,6 +111,21 @@ public class FitnessApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
             services.AddSingleton<FakePushNotificationService>();
             services.AddSingleton<IPushNotificationService>(
                 sp => sp.GetRequiredService<FakePushNotificationService>());
+
+            // Candidate A — test isolation: remove the IHostedService registration for
+            // PhotoDiaryReminderScheduler so it does not run autonomously during tests and
+            // cannot race with real-time clock at the :00 boundary on Linux CI.
+            //
+            // Targeted removal (implementation-type match) — preserves any other
+            // IHostedService registrations that are test-relevant.  The scheduler is still
+            // registered as a singleton DI service (via AddSingleton<PhotoDiaryReminderScheduler>)
+            // so existing tests that drive TickAsync directly can still resolve it with
+            //   factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>()
+            var schedulerHostedServiceDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(IHostedService)
+                     && d.ImplementationType == typeof(PhotoDiaryReminderScheduler));
+            if (schedulerHostedServiceDescriptor is not null)
+                services.Remove(schedulerHostedServiceDescriptor);
         });
 
         builder.UseEnvironment("Development");

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
@@ -112,20 +112,40 @@ public class FitnessApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
             services.AddSingleton<IPushNotificationService>(
                 sp => sp.GetRequiredService<FakePushNotificationService>());
 
-            // Candidate A — test isolation: remove the IHostedService registration for
+            // Candidate A — test isolation: remove all IHostedService registrations for
             // PhotoDiaryReminderScheduler so it does not run autonomously during tests and
-            // cannot race with real-time clock at the :00 boundary on Linux CI.
+            // cannot race with the real-time clock at the :00 boundary on Linux CI.
             //
-            // Targeted removal (implementation-type match) — preserves any other
-            // IHostedService registrations that are test-relevant.  The scheduler is still
-            // registered as a singleton DI service (via AddSingleton<PhotoDiaryReminderScheduler>)
-            // so existing tests that drive TickAsync directly can still resolve it with
+            // Three descriptor shapes are matched defensively because the production
+            // registration in Program.cs uses the factory overload:
+            //
+            //   builder.Services.AddSingleton<PhotoDiaryReminderScheduler>();          // line 199
+            //   builder.Services.AddHostedService(sp =>                                // line 200
+            //       sp.GetRequiredService<PhotoDiaryReminderScheduler>());
+            //
+            // The second call produces a ServiceDescriptor whose ImplementationType is null
+            // (factory-registered) and whose ImplementationFactory is a Func<IServiceProvider, object>
+            // whose MethodInfo.ReturnType is PhotoDiaryReminderScheduler (covariant delegate
+            // conversion).  Matching only ImplementationType == typeof(...) is a no-op against
+            // this shape — the ImplementationType check is always false for factory descriptors.
+            //
+            // All three variants are checked so the removal is robust against future
+            // registration-style changes without requiring another test-isolation fixup.
+            //
+            // The scheduler remains resolvable as a singleton via
             //   factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>()
-            var schedulerHostedServiceDescriptor = services.SingleOrDefault(
-                d => d.ServiceType == typeof(IHostedService)
-                     && d.ImplementationType == typeof(PhotoDiaryReminderScheduler));
-            if (schedulerHostedServiceDescriptor is not null)
-                services.Remove(schedulerHostedServiceDescriptor);
+            // so existing tests that drive TickAsync directly are unaffected.
+            var toRemove = services
+                .Where(d => d.ServiceType == typeof(IHostedService))
+                .Where(d =>
+                    d.ImplementationType == typeof(PhotoDiaryReminderScheduler) ||
+                    d.ImplementationInstance is PhotoDiaryReminderScheduler ||
+                    (d.ImplementationFactory is not null &&
+                     d.ImplementationFactory.Method.ReturnType == typeof(PhotoDiaryReminderScheduler)))
+                .ToList();
+
+            foreach (var d in toRemove)
+                services.Remove(d);
         });
 
         builder.UseEnvironment("Development");

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactoryTests.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactoryTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FitnessPlatform.Tests.Infrastructure;
+
+/// <summary>
+/// Smoke tests for <see cref="FitnessApiFactory"/> configuration correctness.
+/// These are the "would have caught the QA regression" tests that verify the
+/// hosted-service descriptor removal predicate actually works against the
+/// factory-registered shape used in Program.cs lines 199-200.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class FitnessApiFactoryTests(FitnessApiFactory factory)
+{
+    /// <summary>
+    /// Verifies that the <see cref="PhotoDiaryReminderScheduler"/> is NOT exposed as
+    /// an <see cref="IHostedService"/> in the test host.
+    ///
+    /// Regression guard for the factory-registered descriptor shape:
+    ///   AddHostedService(sp => sp.GetRequiredService&lt;PhotoDiaryReminderScheduler&gt;())
+    /// produces a ServiceDescriptor with ImplementationType == null (ImplementationFactory != null),
+    /// so a predicate that only checks ImplementationType is a no-op and the scheduler
+    /// continues to run autonomously, racing the clock on the :00 boundary in CI.
+    /// </summary>
+    [Fact]
+    public void PhotoDiaryReminderScheduler_IsNotRegisteredAsHostedService()
+    {
+        var hostedServices = factory.Services.GetServices<IHostedService>();
+
+        hostedServices
+            .Should().NotContain(
+                s => s is PhotoDiaryReminderScheduler,
+                "the scheduler must be removed from IHostedService registrations " +
+                "so it cannot race the real clock during integration tests");
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="PhotoDiaryReminderScheduler"/> singleton is still
+    /// resolvable from DI after the IHostedService descriptor is removed.
+    /// Tests that drive the scheduler directly via TickAsync must be able to call
+    /// factory.Services.GetRequiredService&lt;PhotoDiaryReminderScheduler&gt;().
+    /// </summary>
+    [Fact]
+    public void PhotoDiaryReminderScheduler_IsStillResolvableAsSingleton()
+    {
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+
+        scheduler.Should().NotBeNull(
+            "the singleton must remain resolvable so tests can drive TickAsync directly");
+    }
+}

--- a/backend/FitnessPlatform.Tests/Infrastructure/Services/PhotoDiaryReminderSchedulerTests.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/Services/PhotoDiaryReminderSchedulerTests.cs
@@ -587,4 +587,119 @@ public class PhotoDiaryReminderSchedulerTests(FitnessApiFactory factory)
 
         notification.Should().NotBeNull("in-app notification must still be persisted despite push failure");
     }
+
+    /// <summary>
+    /// Regression test for the EF Core change-tracker cascade (issue #278).
+    ///
+    /// When two candidates are processed in the same tick and the FIRST candidate's
+    /// reminder-log insert violates the unique constraint (ix_photo_diary_reminder_logs_request_date,
+    /// Postgres 23505), the SECOND candidate must still receive its reminder log,
+    /// in-app notification, and push notification.
+    ///
+    /// Before the fix: the catch block called db.Remove(logEntry) on a never-persisted entity,
+    /// leaving the shared DbContext's change tracker in a corrupted state.  The second candidate's
+    /// SaveChanges would then fail with a cascade exception.
+    ///
+    /// After the fix: each candidate runs inside its own IServiceScope / IApplicationDbContext,
+    /// so a failed SaveChanges disposes that scope and the next candidate starts clean.
+    ///
+    /// This test exercises the error_path from the design handoff:
+    ///   "Scheduler tick: first candidate's reminder-log insert violates the unique constraint.
+    ///    After the catch, the same DbContext is used for the second candidate — its SaveChanges
+    ///    must succeed cleanly (no cascade from the first failure)."
+    /// </summary>
+    [Fact]
+    public async Task Tick_UniqueViolationOnFirstCandidate_DoesNotCascadeToSecondCandidate()
+    {
+        // Arrange: two active diary requests, both in UTC so noon = 12:00 UTC.
+        var utcNow = DateTime.UtcNow;
+        var noonUtc = utcNow.Date.AddHours(12);
+        var acceptedAt = new DateTimeOffset(utcNow.AddDays(-1));
+
+        var (_, clientAId, requestAId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: acceptedAt,
+            clientTimeZone: "UTC");
+
+        var (_, clientBId, requestBId, _) = await SetupWorkflowRequestAsync(
+            acceptedAt: acceptedAt,
+            clientTimeZone: "UTC");
+
+        // Pre-seed a PhotoDiaryReminderLog row for candidate A's (DiaryRequestId, ClientLocalDate)
+        // so its insert will hit the 23505 unique violation.
+        var clientLocalDate = DateOnly.FromDateTime(utcNow.Date);
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var seedDb = seedScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            seedDb.PhotoDiaryReminderLogs.Add(new PhotoDiaryReminderLog
+            {
+                DiaryRequestId = requestAId,
+                ClientLocalDate = clientLocalDate,
+                SentAt = noonUtc.AddHours(-1)   // pre-existing log for today
+            });
+            await seedDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var push = factory.Services.GetRequiredService<FakePushNotificationService>();
+        push.Reset();
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var scheduler = factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>();
+        scheduler.ResetCursor();
+
+        // Seed cursor to one hour before noon so noon (12:00 UTC) is in the tick window.
+        scheduler.SetLastTickAt(noonUtc.AddHours(-1));
+        scheduler.OverrideNow = noonUtc.AddMinutes(30);
+
+        // Act — one tick processes both candidates (A hits 23505, B must succeed).
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Assert
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        // Candidate A: no new log row (the pre-seeded one remains, duplicate was rejected).
+        var logsForA = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestAId && l.ClientLocalDate == clientLocalDate)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        logsForA.Should().HaveCount(1,
+            "candidate A had a pre-existing log row — the unique violation must be swallowed, " +
+            "not crash the scheduler, and the existing row must not be deleted");
+
+        // Candidate B: reminder log must be inserted (no cascade from A's failure).
+        var logsForB = await db.PhotoDiaryReminderLogs
+            .Where(l => l.DiaryRequestId == requestBId && l.ClientLocalDate == clientLocalDate)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        logsForB.Should().HaveCount(1,
+            "candidate B's reminder-log insert must succeed despite A's 23505 violation");
+
+        // Candidate B: in-app notification must be created.
+        var notificationForB = await db.Notifications
+            .Where(n => n.RecipientUserId == clientBId && n.Type == NotificationType.PhotoDiaryReminder)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        notificationForB.Should().NotBeNull(
+            "candidate B's in-app notification must be persisted — it must not be affected by A's failure");
+
+        // Candidate A: no in-app notification (reminder was skipped as duplicate).
+        var notificationForA = await db.Notifications
+            .Where(n => n.RecipientUserId == clientAId && n.Type == NotificationType.PhotoDiaryReminder)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        notificationForA.Should().BeNull(
+            "candidate A's notification must NOT be created — the reminder was a duplicate and was skipped");
+
+        // Push must be invoked exactly once (for candidate B only).
+        push.Calls.Should().HaveCount(1,
+            "push must be sent for candidate B only — candidate A's reminder was a duplicate");
+        push.Calls[0].UserId.Should().Be(clientBId,
+            "the push must target candidate B's client");
+
+        // SignalR broadcast must fire exactly once (for candidate B's newnotification).
+        var newNotificationCalls = notifier.Calls
+            .Where(c => c.EventType == "newnotification")
+            .ToList();
+        newNotificationCalls.Should().HaveCount(1,
+            "newnotification must be broadcast once (for candidate B) — candidate A was skipped");
+        newNotificationCalls[0].UserId.Should().Be(clientBId);
+    }
 }


### PR DESCRIPTION
## Summary

Two-layer fix for the `photo_diary_reminder_logs` Postgres 23505 cascade that has been failing ~50 unrelated integration-test classes on the `ubuntu-latest` GitHub Actions runner since #277 (and ~133 pre-#277):

- **Layer 1 — production (`PhotoDiaryReminderScheduler.ProcessTickAsync`).** Each candidate now runs inside its own `IServiceScope`/`IApplicationDbContext` (`using var candidateScope = scopeFactory.CreateScope()`). A 23505 unique-constraint failure on one candidate's reminder-log insert disposes the scope on the catch path — the EF change tracker cannot corrupt the in-app notification insert on the next line, nor the next loop iteration's `SaveChanges`. The incorrect `db.PhotoDiaryReminderLogs.Remove(logEntry)` recovery (which transitioned a never-persisted entity through Deleted state) is gone. The auto-finalize branch also gets its own per-call scope.
- **Layer 2 — test infra (`FitnessApiFactory`).** Removes the `PhotoDiaryReminderScheduler` `IHostedService` registration so the `BackgroundService` does not run autonomously and race the real-time clock at the `:00` boundary during integration tests. The removal predicate matches **all three** `ServiceDescriptor` shapes (`ImplementationType`, `ImplementationInstance`, `ImplementationFactory.Method.ReturnType`) because the production registration at `Program.cs:200` is the factory overload, whose `ImplementationType` is `null` — a predicate that only checks `ImplementationType` is a no-op there.
- **Regression coverage.** A new `Tick_UniqueViolationOnFirstCandidate_DoesNotCascadeToSecondCandidate` integration test drives the exact error_path from the design handoff — first candidate hits 23505, second must succeed with reminder log + notification + push + SignalR broadcast. Plus two `FitnessApiFactoryTests` smoke tests assert the scheduler is NOT registered as `IHostedService` but IS still resolvable as a Singleton.

## Related issue

Fixes #278

## Scope

backend

## QA verdict (from qa-tester)

✅ PASS. AC1 verified locally via the regression test (12/12 scheduler tests green); AC1's full-cascade verification on Linux runs on the PR's CI job. No new warnings; `dotnet build` clean.

## Test plan

- [ ] The cascade is broken at its source: either the insert no longer violates the unique constraint, or its `SaveChanges` failure is isolated to the offending test so it does not poison subsequent fixtures sharing the same Postgres container.
- [ ] All ~50 currently cascade-failing tests listed in the issue return to green on the same `ubuntu-latest` runner, without disabling them via the workflow's `-class-` exclusion list.
- [ ] No regression in passing tests on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)