### PR TITLE
fix(#273): reset selectedMonthKey when its month drops out of availableMonths

### DIFF
--- a/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
+++ b/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/cn';
 import type { ClientTimelineItem } from '@/api/timeline';
@@ -80,7 +80,20 @@ export function RecentActivitySection({
     return Array.from(monthSet).sort((a, b) => b.localeCompare(a));
   }, [items]);
 
-  // Ensure selectedMonthKey stays valid when items change (e.g. after load more)
+  // Durable state normalisation: when availableMonths changes and no longer
+  // contains the current selectedMonthKey, reset state to the first valid month.
+  // Dep array is [availableMonths] only — do NOT add selectedMonthKey (closure
+  // loop risk; the includes() check below handles staleness correctly).
+  useEffect(() => {
+    if (!availableMonths.includes(selectedMonthKey)) {
+      setSelectedMonthKey(availableMonths[0] ?? currentMonthKey());
+    }
+  }, [availableMonths]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Synchronous render-path safety net: covers the one-render gap between an
+  // availableMonths change and the effect flushing (state is normalised by the
+  // effect above; this ternary prevents a controlled-component value mismatch
+  // warning while the effect is still pending).
   const effectiveMonthKey = availableMonths.includes(selectedMonthKey)
     ? selectedMonthKey
     : (availableMonths[0] ?? currentMonthKey());

--- a/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
+++ b/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/cn';
 import type { ClientTimelineItem } from '@/api/timeline';
@@ -80,20 +80,33 @@ export function RecentActivitySection({
     return Array.from(monthSet).sort((a, b) => b.localeCompare(a));
   }, [items]);
 
-  // Durable state normalisation: when availableMonths changes and no longer
-  // contains the current selectedMonthKey, reset state to the first valid month.
-  // Dep array is [availableMonths] only — do NOT add selectedMonthKey (closure
-  // loop risk; the includes() check below handles staleness correctly).
-  useEffect(() => {
+  // Durable state normalisation — "adjust state during render" idiom (React docs).
+  // When availableMonths changes and selectedMonthKey is no longer present, we
+  // call setSelectedMonthKey synchronously in the render body. React detects the
+  // setState call, discards the in-progress render, and immediately re-renders
+  // with the corrected state — no intermediate commit, no visual flash.
+  //
+  // WHY NOT useEffect: ESLint's react-hooks/set-state-in-effect rule rejects
+  // useEffect(() => setState(...)) as the "you might not need an effect"
+  // anti-pattern, and correctly so — the reset is a pure derivation of prop
+  // changes, not a side effect.
+  //
+  // Sibling state tracks the previous availableMonths reference so we can
+  // detect when the prop identity changes between renders.
+  const [prevAvailableMonths, setPrevAvailableMonths] = useState(availableMonths);
+  if (availableMonths !== prevAvailableMonths) {
+    setPrevAvailableMonths(availableMonths);
     if (!availableMonths.includes(selectedMonthKey)) {
       setSelectedMonthKey(availableMonths[0] ?? currentMonthKey());
     }
-  }, [availableMonths]); // eslint-disable-line react-hooks/exhaustive-deps
+  }
 
-  // Synchronous render-path safety net: covers the one-render gap between an
-  // availableMonths change and the effect flushing (state is normalised by the
-  // effect above; this ternary prevents a controlled-component value mismatch
-  // warning while the effect is still pending).
+  // Synchronous render-path safety net: even on the very first render after
+  // availableMonths changes (before the adjust-during-render setState above has
+  // been processed), this ternary ensures <select value={...}> never holds a
+  // value that is absent from its <option> children. Do NOT remove this — it
+  // prevents a React controlled-component value mismatch warning on that
+  // first render pass.
   const effectiveMonthKey = availableMonths.includes(selectedMonthKey)
     ? selectedMonthKey
     : (availableMonths[0] ?? currentMonthKey());


### PR DESCRIPTION
## Summary
- `RecentActivitySection` held `selectedMonthKey` in state but only masked staleness with a render-time `effectiveMonthKey` ternary — when filter chips / load-more reduced `availableMonths` so the selected month dropped out, state stayed stale and the picker could jump back to the prior selection if that month later reappeared.
- Fix uses React's official **"adjust state during render"** idiom (React docs → *You Might Not Need an Effect*): a sibling `useState(prevAvailableMonths)` + a render-body `if (availableMonths !== prevAvailableMonths)` guard that synchronously calls `setSelectedMonthKey` when the current selection is no longer present. React detects the in-render setState, discards the in-progress render, and re-runs render with the corrected state — no intermediate commit, no flash, no `useEffect` lag.
- Why not `useEffect`: ESLint's `react-hooks/set-state-in-effect` rule rejects `useEffect(() => setState(...))` as the "you might not need an effect" anti-pattern. The reset is a pure derivation of prop changes, not a side effect — render-body adjustment is the correct primitive.
- The render-time `effectiveMonthKey` ternary is kept as a synchronous safety net for the one-render window before the adjust-during-render setState is processed. An inline comment explicitly forbids stripping it (prevents a `<select value=…>` controlled-component value-mismatch warning).

## Related issue
Fixes #273

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — both ACs met via code-walk verification. Live e2e was skipped because the dev seed does not contain multi-month timeline data; QA documented this justification in the handoff. Reasoning: the state-management behaviour is deterministic and observable directly from the diff, and the bug is structural (state-vs-render divergence) rather than visual.

## Test plan
- [x] `selectedMonthKey` resets when its month drops out of `availableMonths` (no longer just masked by render-time ternary).
- [x] When the previously-missing month reappears later in `availableMonths`, the picker stays on the reset value and does NOT jump back to the stale prior selection.
- [x] `web` build is green (CI: build-and-lint pass).
- [x] Playwright suite green (CI: playwright pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)