### PR TITLE
refactor: rename totalDaysInMonth to daysElapsedThisMonth (#272)

### DIFF
--- a/web/src/components/domain/RecentActivity/ThisMonthCard.tsx
+++ b/web/src/components/domain/RecentActivity/ThisMonthCard.tsx
@@ -29,7 +29,7 @@ export function ThisMonthCard({ data }: ThisMonthCardProps) {
         <div className="flex justify-between items-baseline">
           <span className="text-text2">🥗 {t('clients.recentActivity.completedDays')}</span>
           <span className="font-bold text-[15px] text-text">
-            {data.completedDays} / {data.totalDaysInMonth}
+            {data.completedDays} / {data.daysElapsedThisMonth}
           </span>
         </div>
       </div>

--- a/web/src/components/domain/RecentActivity/useRecentActivityAggregates.ts
+++ b/web/src/components/domain/RecentActivity/useRecentActivityAggregates.ts
@@ -33,7 +33,7 @@ export interface ThisMonthAggregates {
   /** unique meal_day dates in current calendar month */
   completedDays: number;
   /** total days elapsed in current calendar month (up to today) */
-  totalDaysInMonth: number;
+  daysElapsedThisMonth: number;
 }
 
 export interface TopPrRecord {
@@ -146,7 +146,7 @@ export function useRecentActivityAggregates(
     }
 
     // How many days have elapsed so far this month (1 → today's day number)
-    const totalDaysInMonth = now.getDate();
+    const daysElapsedThisMonth = now.getDate();
 
     // --- Top PR (this month, highest weightKg) ---
     let topPr: TopPrRecord | null = null;
@@ -200,7 +200,7 @@ export function useRecentActivityAggregates(
         workoutTotal: monthWorkout,
         measurementTotal: monthMeasurement,
         completedDays: monthMealDays.size,
-        totalDaysInMonth,
+        daysElapsedThisMonth,
       },
       topPr,
       thisWeek: {


### PR DESCRIPTION
## Summary
- Pure identifier rename in `/web` — no behaviour change.
- `totalDaysInMonth` → `daysElapsedThisMonth` in the RecentActivity feature. The old name implied the calendar-month day count (28/30/31), but the value is `now.getDate()` — i.e. days elapsed in the current month up to today. The new name describes what the field actually holds.
- Follow-up from #261 / #267 (NIT finding in the two-pass PR review).

## Related issue
Fixes #272

## Scope
web (refactor only — single feature folder)

## Files changed
- `web/src/components/domain/RecentActivity/useRecentActivityAggregates.ts` — rename the interface field (`ThisMonthAggregates.daysElapsedThisMonth`), the local const at the assignment site, and the return-object shorthand.
- `web/src/components/domain/RecentActivity/ThisMonthCard.tsx` — rename the consumed field in the JSX denominator (`data.completedDays / data.daysElapsedThisMonth`).

## Verification
- Dev handoff: `web-build` passed (`tsc -b && vite build` clean, 2.06s).
- QA handoff (#272): all three ACs met — `rg 'totalDaysInMonth' web/` → 0 hits; `rg 'daysElapsedThisMonth' web/src/` → 4 expected sites; `npm run build` clean; pure token-only edits (+4/-4).
- No i18n keys, no write-locked files, no exclusion-list paths.

## QA verdict (from qa-tester)
OVERALL PASS — pure rename verified, no callers outside the touched files, build clean.

## Test plan
- [x] No references to the old identifier `totalDaysInMonth` remain in `web/src/`.
- [x] `npm run build` succeeds (typecheck included).
- [x] RecentActivity ThisMonthCard still renders "completedDays / daysElapsedThisMonth" correctly.

Generated with Claude Code