### PR TITLE
fix(#259,#260): mark empty-exercise workouts complete on Today + plan detail

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
@@ -174,6 +174,8 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                     .GroupBy(e => e.ExerciseExternalId)
                     .ToDictionary(g => g.Key, g => g.First()));
 
+        var completedSectionIdsBySession = new Dictionary<Guid, HashSet<Guid>>();
+
         if (planSessionIds.Count > 0)
         {
             var completionFilter = Builders<TrainingCompletion>.Filter.And(
@@ -183,6 +185,12 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
             var trainingCompletions = await mongo.TrainingCompletions
                 .Find(completionFilter)
                 .ToListAsync(ct);
+
+            completedSectionIdsBySession = trainingCompletions
+                .GroupBy(tc => tc.SessionId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.SelectMany(tc => tc.CompletedSectionIds ?? new List<Guid>()).ToHashSet());
 
             foreach (var tc in trainingCompletions)
             {
@@ -306,6 +314,11 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                         };
                     }).ToList();
 
+                    var sectionIsCompleted = sectionExerciseDtos.Count > 0
+                        ? sectionExerciseDtos.All(e => e.IsCompleted)
+                        : completedSectionIdsBySession.TryGetValue(session.SessionId, out var completedSecs)
+                            && completedSecs.Contains(sec.SectionId);
+
                     return new SectionDto
                     {
                         SectionId = sec.SectionId,
@@ -314,6 +327,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                         Format = sec.Format?.ToString(),
                         FormatConfig = sec.FormatConfig,
                         Notes = sec.Notes,
+                        IsCompleted = sectionIsCompleted,
                         Exercises = sectionExerciseDtos
                     };
                 }).ToList();

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
@@ -152,6 +152,12 @@ public class SectionDto
     /// </summary>
     public string? Notes { get; set; }
 
+    /// <summary>True when this section is considered complete:
+    /// for sections with exercises → every exercise has IsCompleted=true;
+    /// for sections without exercises → the section's id is in the
+    /// TrainingCompletion.CompletedSectionIds set for the owning session.</summary>
+    public bool IsCompleted { get; set; }
+
     /// <summary>Exercises within this section.</summary>
     public List<ExerciseDto> Exercises { get; set; } = [];
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/Client/Training/GetFullTrainingPlanIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Client/Training/GetFullTrainingPlanIntegrationTests.cs
@@ -687,6 +687,570 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
         session.Exercises[0].MuscleGroups.Should().Contain(MuscleGroup.Quadriceps);
     }
 
+    // ── SectionDto.IsCompleted tests ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Empty-exercise section where MarkWholeDayComplete wrote a CompletedSectionIds entry
+    /// must return IsCompleted = true.
+    /// </summary>
+    [Fact]
+    public async Task Returns_IsCompleted_True_For_Empty_Section_With_Completion_Row()
+    {
+        var httpClient = factory.CreateClient();
+
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, clientEmail, "TestPass1!", "Empty", "Section", "Client");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, clientEmail, "TestPass1!");
+
+        Guid clientPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == clientEmail,
+                TestContext.Current.CancellationToken);
+            var profile = await db.ClientProfiles.FirstAsync(
+                cp => cp.UserId == user.Id,
+                TestContext.Current.CancellationToken);
+            clientPublicId = profile.PublicId;
+        }
+
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var emptySectionId = Guid.NewGuid();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Empty Section Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-2),
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Running",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = emptySectionId,
+                                    Order = 0,
+                                    Name = "Running",
+                                    Exercises = []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientPublicId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = [],
+            CompletedSectionIds = [emptySectionId],
+            DateCreated = DateTime.UtcNow,
+            Version = 1
+        };
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/client/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var body = await response.Content.ReadFromJsonAsync<FullPlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        var section = body!.Weeks[0].Sessions[0].Sections[0];
+        section.SectionId.Should().Be(emptySectionId);
+        section.Exercises.Should().BeEmpty();
+        section.IsCompleted.Should().BeTrue(
+            "empty section was added to CompletedSectionIds by MarkWholeDayComplete");
+    }
+
+    /// <summary>
+    /// Non-empty section where all exercises are completed via TrainingCompletion
+    /// must return IsCompleted = true.
+    /// </summary>
+    [Fact]
+    public async Task Returns_IsCompleted_True_For_NonEmpty_Section_With_All_Exercises_Done()
+    {
+        var httpClient = factory.CreateClient();
+
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, clientEmail, "TestPass1!", "Nonempty", "Done", "Client");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, clientEmail, "TestPass1!");
+
+        Guid clientPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == clientEmail,
+                TestContext.Current.CancellationToken);
+            var profile = await db.ClientProfiles.FirstAsync(
+                cp => cp.UserId == user.Id,
+                TestContext.Current.CancellationToken);
+            clientPublicId = profile.PublicId;
+        }
+
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
+        var ex1Id = Guid.NewGuid();
+        var ex2Id = Guid.NewGuid();
+
+        var ex1 = new Exercise
+        {
+            ExternalId = ex1Id,
+            Name = "Squat",
+            MuscleGroups = [MuscleGroup.Quadriceps],
+            Equipment = ExerciseEquipment.Barbell,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var ex2 = new Exercise
+        {
+            ExternalId = ex2Id,
+            Name = "Deadlift",
+            MuscleGroups = [MuscleGroup.Hamstrings],
+            Equipment = ExerciseEquipment.Barbell,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = Guid.NewGuid(),
+            Name = "All Done Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-2),
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Leg Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = ex1Id,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 5, WeightKg = 100 }]
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = ex2Id,
+                                            ExerciseName = "Deadlift",
+                                            Order = 2,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 5, WeightKg = 120 }]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Mark both exercises complete via TrainingCompletion
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientPublicId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = [ex1Id, ex2Id],
+            DateCreated = DateTime.UtcNow,
+            Version = 1
+        };
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.Exercises.InsertOneAsync(ex1, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.Exercises.InsertOneAsync(ex2, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/client/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var body = await response.Content.ReadFromJsonAsync<FullPlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        var section = body!.Weeks[0].Sessions[0].Sections[0];
+        section.Exercises.Should().HaveCount(2);
+        section.IsCompleted.Should().BeTrue("both exercises are marked complete via TrainingCompletion");
+    }
+
+    /// <summary>
+    /// Non-empty section where only one of two exercises is done must return IsCompleted = false.
+    /// </summary>
+    [Fact]
+    public async Task Returns_IsCompleted_False_For_Partially_Completed_NonEmpty_Section()
+    {
+        var httpClient = factory.CreateClient();
+
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, clientEmail, "TestPass1!", "Partial", "Section", "Client");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, clientEmail, "TestPass1!");
+
+        Guid clientPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == clientEmail,
+                TestContext.Current.CancellationToken);
+            var profile = await db.ClientProfiles.FirstAsync(
+                cp => cp.UserId == user.Id,
+                TestContext.Current.CancellationToken);
+            clientPublicId = profile.PublicId;
+        }
+
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
+        var ex1Id = Guid.NewGuid();
+        var ex2Id = Guid.NewGuid();
+
+        var ex1 = new Exercise
+        {
+            ExternalId = ex1Id,
+            Name = "Pull-up",
+            MuscleGroups = [MuscleGroup.Back],
+            Equipment = ExerciseEquipment.Bodyweight,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var ex2 = new Exercise
+        {
+            ExternalId = ex2Id,
+            Name = "Row",
+            MuscleGroups = [MuscleGroup.Back],
+            Equipment = ExerciseEquipment.Barbell,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Intermediate,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Partial Section Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-2),
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 2,
+                            Name = "Pull Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = ex1Id,
+                                            ExerciseName = "Pull-up",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 8 }]
+                                        },
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = ex2Id,
+                                            ExerciseName = "Row",
+                                            Order = 2,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 10 }]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Only ex1 is marked complete (not ex2)
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientPublicId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = [ex1Id],
+            DateCreated = DateTime.UtcNow,
+            Version = 1
+        };
+
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.Exercises.InsertOneAsync(ex1, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.Exercises.InsertOneAsync(ex2, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/client/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var body = await response.Content.ReadFromJsonAsync<FullPlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        var section = body!.Weeks[0].Sessions[0].Sections[0];
+        section.Exercises.Should().HaveCount(2);
+        section.IsCompleted.Should().BeFalse("only one of two exercises is done — partial completion");
+    }
+
+    /// <summary>
+    /// When no TrainingCompletion row exists at all, IsCompleted must be false
+    /// for both empty and non-empty sections.
+    /// </summary>
+    [Fact]
+    public async Task Returns_IsCompleted_False_When_No_TrainingCompletion_Exists()
+    {
+        var httpClient = factory.CreateClient();
+
+        var clientEmail = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, clientEmail, "TestPass1!", "No", "Completion", "Client");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, clientEmail, "TestPass1!");
+
+        Guid clientPublicId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == clientEmail,
+                TestContext.Current.CancellationToken);
+            var profile = await db.ClientProfiles.FirstAsync(
+                cp => cp.UserId == user.Id,
+                TestContext.Current.CancellationToken);
+            clientPublicId = profile.PublicId;
+        }
+
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var emptySectionId = Guid.NewGuid();
+        var nonEmptySectionId = Guid.NewGuid();
+        var exId = Guid.NewGuid();
+
+        var exercise = new Exercise
+        {
+            ExternalId = exId,
+            Name = "Lunge",
+            MuscleGroups = [MuscleGroup.Quadriceps],
+            Equipment = ExerciseEquipment.Bodyweight,
+            Category = ExerciseCategory.Strength,
+            Difficulty = ExerciseDifficulty.Beginner,
+            IsActive = true,
+            Source = "system",
+            DateCreated = DateTime.UtcNow
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = Guid.NewGuid(),
+            Name = "No Completion Plan",
+            Status = TrainingPlanStatus.Active,
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-2),
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 3,
+                            Name = "Mixed Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = emptySectionId,
+                                    Order = 0,
+                                    Name = "Running",
+                                    Exercises = []
+                                },
+                                new TrainingSection
+                                {
+                                    SectionId = nonEmptySectionId,
+                                    Order = 1,
+                                    Name = "Strength",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exId,
+                                            ExerciseName = "Lunge",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 12 }]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // No TrainingCompletion inserted at all
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.Exercises.InsertOneAsync(exercise, cancellationToken: TestContext.Current.CancellationToken);
+            await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.GetAsync(
+            $"/client/training/plans/{planId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var body = await response.Content.ReadFromJsonAsync<FullPlanResponse>(
+            jsonOptions,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        body.Should().NotBeNull();
+        var sections = body!.Weeks[0].Sessions[0].Sections;
+        sections.Should().HaveCount(2);
+
+        var emptySection = sections.First(s => s.SectionId == emptySectionId);
+        emptySection.IsCompleted.Should().BeFalse("no TrainingCompletion exists — empty section must be false");
+
+        var nonEmptySection = sections.First(s => s.SectionId == nonEmptySectionId);
+        nonEmptySection.IsCompleted.Should().BeFalse("no TrainingCompletion exists — non-empty section must be false");
+    }
+
     // ── Local response DTOs (per slice rules — not shared across features) ────────
 
     private record FullPlanResponse(
@@ -729,6 +1293,7 @@ public class GetFullTrainingPlanIntegrationTests(FitnessApiFactory factory)
         string? Format,
         WodConfigResponse? FormatConfig,
         string? Notes,
+        bool IsCompleted,
         List<ExerciseResponse> Exercises);
 
     private record WodConfigResponse(

--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -1301,31 +1301,22 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
                   }
 
                   // Session pill: count workouts (sections), not exercises.
-                  // A section counts as complete when every trackable exercise in
-                  // it has isCompleted === true; sections with no trackable
-                  // exercises are skipped from the "done" tally (plan-detail is
-                  // read-only — no separate sectionComplete flag).
+                  // Uses section.isCompleted from the backend (#260 fix) so
+                  // empty-exercise sections are counted correctly via
+                  // TrainingCompletion.CompletedSectionIds.
                   const totalWorkouts = sections.length
-                  const completedWorkouts = sections.filter((sec) => {
-                    const trackable = (sec.exercises ?? []).filter(
-                      (e) => e.exerciseExternalId != null,
-                    )
-                    if (trackable.length === 0) return false
-                    return trackable.every((e) => e.isCompleted === true)
-                  }).length
+                  const completedWorkouts = sections.filter(
+                    (sec) => sec.isCompleted === true,
+                  ).length
 
                   // Read-only session completion indicator for headerRight.
-                  // A session is complete when every trackable exercise in every
-                  // section has isCompleted === true.
-                  const allSessionExercises = sections.flatMap(
-                    (sec) => sec.exercises ?? [],
-                  )
-                  const trackableSessionExercises = allSessionExercises.filter(
-                    (e) => e.exerciseExternalId != null,
-                  )
+                  // A session is complete IFF every section (workout) within it
+                  // is complete. Empty-exercise sections are flagged complete by
+                  // the backend via TrainingCompletion.CompletedSectionIds
+                  // (#260 fix).
                   const isSessionComplete =
-                    trackableSessionExercises.length > 0 &&
-                    trackableSessionExercises.every((e) => e.isCompleted === true)
+                    sections.length > 0 &&
+                    sections.every((sec) => sec.isCompleted === true)
 
                   const sessionCheckIndicator = (
                     <View
@@ -1372,15 +1363,15 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
                         const isExpanded =
                           hasExercises && (sessionSectionExpanded[sectionKey] ?? true)
                         // Read-only completion indicator for the section header.
-                        // A section is "done" when every trackable exercise in it
-                        // is `isCompleted`. WOD-format sections without trackable
-                        // exercises don't show the indicator (left undefined).
-                        const trackableExercises = sectionExercises.filter(
-                          (e) => e.exerciseExternalId != null,
-                        )
-                        const isSectionComplete = trackableExercises.length > 0
-                          ? trackableExercises.every((e) => e.isCompleted === true)
-                          : undefined
+                        // Uses section.isCompleted from the backend (#260 fix)
+                        // so empty-exercise sections show the correct indicator.
+                        // undefined = no indicator (section never attempted).
+                        const isSectionComplete: boolean | undefined =
+                          section.isCompleted === true
+                            ? true
+                            : sectionExercises.some((e) => e.isCompleted === true)
+                              ? false
+                              : undefined
 
                         const isLastSection = sectionIdx === sections.length - 1
 

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -33,13 +33,19 @@ export type {
 };
 
 /**
- * Augmented SectionDto — adds `formatConfig` + `notes` that the backend now
- * emits but NSwag hasn't been re-run for. Drop the augmentation when the
- * generated client is regenerated.
+ * Augmented SectionDto — adds `formatConfig`, `notes`, and `isCompleted` that
+ * the backend now emits but NSwag hasn't been re-run for yet.
+ * Drop the augmentation fields once the generated client is regenerated
+ * and the fields appear on GeneratedSectionDto directly.
  */
 export type SectionDto = Omit<GeneratedSectionDto, 'exercises'> & {
   formatConfig?: WodConfig | null;
   notes?: string | null;
+  /** True when the backend considers this section fully complete.
+   * For sections with exercises: every exercise has IsCompleted=true.
+   * For sections without exercises: the section id is in
+   * TrainingCompletion.CompletedSectionIds (#260 fix). */
+  isCompleted?: boolean;
   exercises?: GeneratedSectionDto['exercises'];
 };
 

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1048,6 +1048,10 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
           ...(previous.completedSetsBySessionExercise ?? {}),
         }
 
+        const nextCompletedSectionIdsBySession: Record<string, string[]> = {
+          ...(previous.completedSectionIdsBySession ?? {}),
+        }
+
         for (const session of previous.sessions ?? []) {
           const sessionId = session.sessionId
           if (!sessionId) continue
@@ -1056,6 +1060,12 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
 
           const nextSessionSections: Record<string, string[]> = {}
           const plannedSetsByEx: Record<string, number[]> = {}
+
+          // Collect all section IDs for this session so empty-exercise sections
+          // immediately reflect as complete in the optimistic cache (#259 fix).
+          const allSectionIds: string[] = (session.sections ?? [])
+            .map((sec) => sec.sectionId)
+            .filter((id): id is string => id != null)
 
           for (const sec of session.sections ?? []) {
             if (!sec.sectionId) continue
@@ -1078,12 +1088,14 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
 
           nextBySectionAndSession[sessionId] = nextSessionSections
           nextSetsBySessionExercise[sessionId] = plannedSetsByEx
+          nextCompletedSectionIdsBySession[sessionId] = allSectionIds
         }
 
         queryClient.setQueryData<TodayTrainingResponse>(['today-training'], {
           ...previous,
           completedExerciseIdsBySectionAndSession: nextBySectionAndSession,
           completedSetsBySessionExercise: nextSetsBySessionExercise,
+          completedSectionIdsBySession: nextCompletedSectionIdsBySession,
         })
       }
       return { previous }


### PR DESCRIPTION
## Summary

Fixes two related mobile completion bugs sharing the same root cause —
workouts (sections) with zero exercises were invisible to the
"all-complete" check on both the Today screen and the plan-detail
screen.

### Bugs
- **#259**: marking the day finished left empty-exercise workouts
  incomplete, so a session with 4 workouts (one empty) showed "3/4".
- **#260**: the training plan detail session header showed the green
  check even though one of its child workouts (the empty one) was
  still incomplete.

### Fix

**Backend** (additive, non-breaking):
- `SectionDto` now has an `IsCompleted` flag in `GET /client/training/plans/{planId}`.
- For sections with exercises: aggregates `exercise.IsCompleted`.
- For empty sections: checks membership in
  `TrainingCompletion.CompletedSectionIds`.
- 4 new integration tests cover all error paths from the design-review
  approved scope (empty-complete, non-empty-complete, partial, no-row).

**Mobile**:
- `HasTrainerState.tsx markAllTrainingDoneMutation.onMutate` now also
  writes `completedSectionIdsBySession` in the optimistic cache, so
  empty sections reflect as finished instantly on tap (closes #259).
- `plans/[planId].tsx` session-header check uses `section.isCompleted`
  from the backend instead of derived-from-exercises (closes #260).
- `mobile/src/api/training.ts` augments `SectionDto.isCompleted` until
  the next `regen-api` consolidates it into `generated.ts` (same
  pattern already used for `formatConfig` and `notes`).

## Related issues
Closes #259
Closes #260

## Scope
backend + mobile (single branch, single PR — same-issue cross-package
work per rules/branch-and-pr.md#cross-package-prs-stay-on-one-branch).

## QA verdict (from qa-tester)
OVERALL ⚠️ PARTIAL — all 4 ACs met by code analysis; only the
interactive Playwright reproduction was blocked by a host-environment
issue (Docker disk full + recursive `bin/Debug` cascade), unrelated
to this branch. CI re-runs backend tests on clean infrastructure.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~GetFullTrainingPlanIntegrationTests"` — 4 new + 4 pre-existing pass (per backend-dotnet handoff).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx expo prebuild --no-install --check` — clean.
- [ ] Interactive Playwright reproduction blocked by host environment (Docker disk pressure + bin-cascade), unrelated to this branch — re-verify post-merge.

Acceptance criteria verified by qa-tester (handoff-qa-260.json):
- [x] #259: empty-exercise workouts close out on "mark day finished".
- [x] #259: zero-exercise workouts treated as trivially complete.
- [x] #259: completion count yields N/N after marking day done.
- [x] #260: session header check renders IFF every child workout finished (logical AND).

🤖 Generated with [Claude Code](https://claude.com/claude-code)