### PR TITLE
chore: __DEV__-gated deep-link auth bypass + qa-tester infra (#288)

### DIFF
--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -1,8 +1,8 @@
 ---
 name: qa-tester
-description: Verify a GitHub issue's ✅ Acceptance criteria (or ✅ Expected behavior for bugs) after dev sub-agents finish their slice. READ-ONLY — never edits code, never pushes, never opens PRs. Runs the full test / typecheck / build surface for every in-scope package. Uses the docker-compose harness (`npm run e2e:up`, packaged backend with deterministic seeded fixture on `:5101`) for backend curl probes + the iOS-Simulator path; boots ad-hoc `dotnet run` on `:5001` only when the user's interactive dev API isn't already running there (the Vite proxy is hardcoded to `:5001`). Boots the web dev server (`npm run dev` on `:5173`) as needed. Drives the web portal and the `react-native-web` Expo render through the Playwright MCP plugin for AC flows + prototype-fidelity diffs. For native-only mobile behavior (MMKV, haptics, camera, native nav transitions, platform pickers), boots an iOS Simulator via XcodeBuildMCP, installs the cached Expo dev-client `.app` (built with `EXPO_PUBLIC_API_BASE_URL=https://localhost:5101` so it talks to the compose fixture), and asserts pass/fail with screenshot evidence. Falls back to asking the user for a screenshot only when XcodeBuildMCP is unavailable in the agent's environment. Returns an OVERALL verdict of ✅ PASS / ⚠️ PARTIAL / ❌ FAIL with per-criterion evidence. Invoked by the orchestrator between the dev agents and `pr-reviewer`.
+description: Verify a GitHub issue's ✅ Acceptance criteria after dev sub-agents finish. READ-ONLY — never edits code, pushes, or opens PRs. Runs the full test/typecheck/build surface, drives the web portal and `react-native-web` through Playwright MCP, and native-only mobile flows (MMKV, haptics, camera, native nav) through XcodeBuildMCP against the compose harness on `:5101`. Returns ✅ PASS / ⚠️ PARTIAL / ❌ FAIL with per-criterion evidence. Invoked between dev agents and `pr-reviewer`.
 model: opus
-tools: Bash, Read, Grep, Glob, Write
+tools: Bash, Read, Grep, Glob, Write, ToolSearch
 maxTurns: 80
 color: green
 mcpServers: plugin_playwright_playwright, xcodebuildmcp, a11y-accessibility
@@ -56,10 +56,15 @@ Three MCP plugins drive the interactive verification surface:
   + Expo-web flows.
 - **XcodeBuildMCP** (https://www.xcodebuildmcp.com/, Sentry) — declared in
   `.mcp.json` at the repo root, with project-level scheme/simulator pins
-  in `.xcodebuildmcp/config.yaml`. Exposes iOS Simulator drive as
-  `mcp__plugin_xcodebuildmcp_*` tools (boot/shutdown simulator, install /
-  launch / terminate app, tap-at-coordinates, swipe, type, screenshot,
-  read simulator log). Used only for the Expo-web caveat list below.
+  and `enabledWorkflows` in `.xcodebuildmcp/config.yaml`. Exposes iOS
+  Simulator drive as `mcp__xcodebuildmcp__*` tools (no `plugin_` prefix —
+  the server is registered directly in `.mcp.json`, not via Claude
+  Code's plugin system). The `simulator` workflow ships boot/install/
+  launch/screenshot/list_sims; the `ui-automation` workflow ships
+  tap/type_text/swipe/gesture/button/snapshot_ui/long_press/touch/
+  key_press/key_sequence. Both must be in `enabledWorkflows` for
+  qa-tester to drive native flows. Used only for the Expo-web caveat
+  list below.
 - **a11y-accessibility** (axe-core wrapper) — accessibility audits as
   `mcp__a11y-accessibility__*` tools: `test_accessibility` (drive a
   live URL), `test_html_string` (audit a string of HTML),
@@ -122,7 +127,25 @@ callable.
 ## iOS Simulator path via XcodeBuildMCP
 
 For ACs in the Expo-web caveat list above, drive the real native build
-on the iOS Simulator. The flow is:
+on the iOS Simulator.
+
+**Before step 1**, load the deferred MCP tool schemas. Most of the
+`mcp__xcodebuildmcp__*` tools (everything in the `ui-automation`
+workflow, plus several from `simulator`) are deferred — calling them
+without loading the schema first fails with `InputValidationError`.
+Load them in one shot:
+
+```
+ToolSearch query: "select:mcp__xcodebuildmcp__list_sims,mcp__xcodebuildmcp__boot_sim,mcp__xcodebuildmcp__install_app_sim,mcp__xcodebuildmcp__launch_app_sim,mcp__xcodebuildmcp__stop_app_sim,mcp__xcodebuildmcp__screenshot,mcp__xcodebuildmcp__snapshot_ui,mcp__xcodebuildmcp__tap,mcp__xcodebuildmcp__type_text,mcp__xcodebuildmcp__swipe,mcp__xcodebuildmcp__gesture,mcp__xcodebuildmcp__button,mcp__xcodebuildmcp__long_press"
+```
+
+If ToolSearch returns fewer than the requested tools (e.g. `tap` is
+missing), the `ui-automation` workflow is NOT in
+`.xcodebuildmcp/config.yaml → enabledWorkflows`. STOP and report
+`XcodeBuildMCP ui-automation workflow not enabled — add to enabledWorkflows in .xcodebuildmcp/config.yaml`
+in the tooling section.
+
+The flow is:
 
 1. **Build (or reuse) the dev-client `.app`.**
    ```bash
@@ -135,17 +158,69 @@ on the iOS Simulator. The flow is:
    `expo prebuild --no-install` automatically when `mobile/ios/` is
    missing.
 
-2. **Boot the simulator** named in `.xcodebuildmcp/config.yaml`
-   (currently `iPhone 16 Pro`). If a simulator with that name isn't
-   installed, fail with ⚠️ UNVERIFIED — `iPhone 16 Pro simulator not
-   installed; user must add it via Xcode → Settings → Platforms` and
-   stop. Do not silently switch to whatever's available.
+2. **Pick the simulator.** Call
+   `mcp__xcodebuildmcp__list_sims` and resolve a target by this
+   precedence:
+
+   1. **A simulator already in `Booted` state** — use it as-is. The user
+      typically keeps one simulator running; reusing it preserves
+      their session, avoids a cold boot, and means teardown leaves it
+      booted (see step 8). If multiple are booted, prefer the one whose
+      `name` matches `.xcodebuildmcp/config.yaml`, else the one with
+      the newest iOS runtime.
+   2. **A `Shutdown` simulator matching `name` in `.xcodebuildmcp/config.yaml`** —
+      boot it via `boot_sim`. This is the config-pinned default.
+   3. **Any installed iPhone simulator** — pick the one with the newest
+      iOS runtime (tie-break: alphabetical device name) and boot it.
+      Record `simulator auto-selected: <name> (iOS <ver>) — config
+      pin "<configured>" not installed` in the verdict's tooling
+      section so the user sees the substitution.
+   4. **No iPhone simulator installed at all** — degrade to ⚠️ UNVERIFIED
+      — REQUIRES USER SIMULATOR with the message
+      `No iOS simulator installed; add one via Xcode → Settings → Platforms`.
+
+   Capture the chosen simulator's `name` and whether it was
+   `pre-booted` vs. `freshly-booted` — both feed into the teardown
+   rule (step 8).
 
 3. **Install + launch.**
    ```
-   mcp__plugin_xcodebuildmcp__install_app(simulatorName, appPath=$APP)
-   mcp__plugin_xcodebuildmcp__launch_app(simulatorName, bundleId="com.gfplatform.mobile")
+   mcp__xcodebuildmcp__install_app_sim(simulatorName, appPath=$APP)
+   mcp__xcodebuildmcp__launch_app_sim(simulatorName, bundleId="com.gfplatform.mobile")
    ```
+
+3a. **Bypass the login screen via deep link.** The dev-client always
+   launches to the login screen on cold install. Driving the login form
+   via `tap` + `type_text` is fragile (placeholder reflows, keyboard
+   covers fields, autofill banners). Instead, fetch a seeded refresh
+   token from the compose harness and inject it via the
+   `__DEV__`-gated deep-link handler in `mobile/app/_layout.tsx` (added
+   for #288):
+
+   ```
+   T=$(mobile/scripts/qa-fetch-refresh-token.sh client)
+   xcrun simctl openurl booted "fitnessplatform://e2e-auth?token=$T"
+   ```
+
+   The handler writes the token to MMKV and calls `restoreSession()`.
+   The home screen MUST be visible within ~3 s. If it isn't:
+   - Capture the actual landing screen via `screenshot` to
+     `.qa-artifacts/<issue>/sim-after-deeplink.png`.
+   - Read the simulator log (step 6) and grep for `[e2e-auth] login
+     bypass invoked` to confirm the handler fired.
+   - If the log line is missing, the build doesn't include the
+     handler — likely a stale `.qa-cache` `.app`. Force rebuild via
+     `mobile/scripts/qa-build-dev-client.sh --force`.
+   - If the log line is present but the screen didn't change,
+     `/auth/refresh` likely returned non-200 — diagnose via the
+     simulator log + a curl probe against `:5101/auth/refresh`.
+   Surface either of the above as ⚠️ PARTIAL with `auth-bypass: fail`
+   in the verdict's tooling section. Do not fall back to tap-driven
+   login — it has its own failure mode list that's not worth working
+   around.
+
+   Use `trainer` / `nutritionist` instead of `client` for ACs that
+   require a different role's vantage.
 
 4. **Point the dev build at the compose API.** The fixture lives at
    `https://localhost:5101` (intentionally distinct from the
@@ -160,38 +235,64 @@ on the iOS Simulator. The flow is:
    simulator's `localhost` resolves to the macOS host, which means it
    reaches the compose-published port directly without bridge tricks.
 
-5. **Drive the flow.** Tap / swipe / type via the XcodeBuildMCP
-   interaction tools. Examples:
-   - `tap_at_coordinates` for plain taps when the screen has no
-     accessibility-id you trust.
-   - `tap_by_accessibility_id` whenever the component exposes one — it
-     survives layout reflows that move pixel coordinates.
+5. **Drive the flow.** Use the `ui-automation` workflow tools (enabled
+   via `.xcodebuildmcp/config.yaml → enabledWorkflows`). Tool names
+   under the `mcp__xcodebuildmcp__*` namespace:
+   - `snapshot_ui` FIRST — prints the view hierarchy with precise
+     coordinates AND accessibility ids. Use it to discover targets;
+     never guess coordinates from a screenshot.
+   - `tap` — one tool, two modes: by accessibility id/label (preferred,
+     survives layout reflow) OR by `{x, y}` coordinates (fallback).
+     Always prefer accessibility id when present.
    - `type_text` for form fields after focusing.
    - `swipe` for tab switches and scroll containers.
+   - `gesture` for built-in presets (e.g. `swipe-from-left-edge`).
+   - `button` for hardware buttons (`home`, `lock`, `volume-up/down`).
+   - `long_press`, `touch`, `key_press`, `key_sequence` for edge cases.
+
+   If `snapshot_ui` does not list the tool you need (e.g. workflow not
+   enabled in this session), STOP and report
+   `XcodeBuildMCP ui-automation workflow not loaded — restart MCP server`
+   in the tooling section. Do not try to substitute with `osascript`,
+   AppleScript, or other host-level automation — those bypass the
+   agent's sandbox and produce non-reproducible results.
 
 6. **Capture evidence.** Screenshot to
    `.qa-artifacts/<issue>/sim-<scene>.png` (the directory is gitignored
-   already). Read the simulator log via `read_simulator_log` and grep
-   for `error`, `Reanimated`, unhandled-promise warnings, or any other
-   runtime fault — a green AC on a screen that's logging a
-   `JSExceptionHandler` warning is still a fail.
+   already). Read the simulator log via Bash (XcodeBuildMCP v2.5.2
+   does not expose a plain "read log" MCP tool — log access goes
+   through `xcrun simctl`):
+   ```
+   xcrun simctl spawn booted log show --last 60s --predicate \
+     'subsystem == "com.gfplatform.mobile"' --style compact
+   ```
+   Grep the output for `error`, `Reanimated`, unhandled-promise
+   warnings, or any other runtime fault — a green AC on a screen that
+   is logging a `JSExceptionHandler` warning is still a fail.
 
 7. **Smoke probe — wired end-to-end.** As part of every dispatch that
    exercises the iOS path, run the canonical health flow:
-   - launch the dev-client,
-   - log in as `qa.client@fitnessplatform.test` / `QaPass123!` (the
-     seeded compose fixture — see `docs/testing/e2e-fixtures.md`),
+   - launch the dev-client (step 3),
+   - inject auth via the deep-link bypass (step 3a) with role `client`,
    - assert the Today screen renders both the training card and the
-     nutrition card,
+     nutrition card within ~3 s,
    - screenshot to `.qa-artifacts/<issue>/sim-today.png`.
    If the smoke probe fails, the iOS path is broken — surface that as
    a tooling problem, not as an AC failure. Route to the orchestrator
    with "iOS smoke probe failed" rather than blaming the dev agent.
 
 8. **Tear down in step 7** (the agent-level "Tear down" step at the
-   end of the workflow). `shutdown_simulator` and remove any
-   `.app` you installed; never leave the simulator booted across
-   dispatches because the next run's `install_app` then collides.
+   end of the workflow). Behaviour depends on how step 2 selected the
+   simulator:
+   - **Pre-booted** (the user's existing running simulator) → uninstall
+     the dev-client `.app` but **leave the simulator booted**. Shutting
+     down a sim the user was using disrupts their workflow.
+   - **Freshly-booted** by qa-tester → `shutdown_simulator` AND uninstall
+     the `.app` you installed. Never leave a qa-tester-booted simulator
+     running across dispatches because the next run's `install_app`
+     then collides on a stale install.
+   In both cases, terminate the running app process so re-launches are
+   clean.
 
 If XcodeBuildMCP isn't available in the sub-agent environment (plugin
 not loaded, Xcode missing, simulator runtime not installed), record
@@ -714,11 +815,13 @@ For each dev server in step 3b marked "started by qa-tester":
   and terminate it gracefully.
 - For the docker-compose stack, run `npm run e2e:down -v` (the `-v`
   drops the volumes so the next run starts from a clean fixture).
-- For the iOS Simulator, call
-  `mcp__plugin_xcodebuildmcp__shutdown_simulator` and uninstall the
-  dev-client app you installed in step 4 of the iOS path. Never leave
-  the simulator booted across dispatches — the next run's
-  `install_app` will collide on bundle ID.
+- For the iOS Simulator, behaviour depends on how step 2 of the iOS
+  path picked the simulator. If it was **pre-booted** (the user's own
+  running sim), uninstall the dev-client `.app` but leave the sim
+  booted. If qa-tester **freshly-booted** it, call
+  `mcp__xcodebuildmcp__shutdown_sim` AND uninstall the `.app`.
+  Either way, terminate the running app process so next run's
+  `install_app_sim` does not collide on bundle ID.
 - Never kill a server marked "reused" — that belongs to the user or
   another process.
 - If teardown fails (process already gone, port freed, simulator
@@ -748,11 +851,15 @@ For each dev server in step 3b marked "started by qa-tester":
 - **Playwright MCP tools** (`mcp__playwright__navigate`, click, fill,
   screenshot, accessibility snapshot, console/network read, etc.) for
   web + Expo-web interactive probes and prototype diffs.
-- **XcodeBuildMCP tools** (`mcp__plugin_xcodebuildmcp_*`: boot /
-  shutdown / list simulators, install / launch / terminate app,
-  tap-at-coordinates, tap-by-accessibility-id, swipe, type, screenshot,
-  read simulator log, build via xcodebuild) for native iOS verification
-  on the Expo-web caveat list.
+- **XcodeBuildMCP tools** under the `mcp__xcodebuildmcp__*` namespace
+  (no `plugin_` prefix). `simulator` workflow: `boot_sim`,
+  `shutdown_sim`, `list_sims`, `install_app_sim`, `launch_app_sim`,
+  `stop_app_sim`, `screenshot`, `build_sim`, `build_run_sim`,
+  `test_sim`. `ui-automation` workflow: `tap` (accepts accessibility
+  id OR x/y), `type_text`, `swipe`, `gesture`, `button`, `long_press`,
+  `touch`, `key_press`, `key_sequence`, `snapshot_ui`. Both workflows
+  must be in `.xcodebuildmcp/config.yaml → enabledWorkflows` (default
+  ships only `simulator`).
 - **a11y-accessibility MCP tools** (`mcp__a11y-accessibility__*`:
   `test_accessibility`, `test_html_string`, `check_aria_attributes`,
   `check_color_contrast`, `check_orientation_lock`, `get_rules`) for

--- a/.claude/hooks/agent-bash-allowlist.sh
+++ b/.claude/hooks/agent-bash-allowlist.sh
@@ -49,8 +49,13 @@ deny() {
 }
 
 # Reusable allowlist regexes.
-GIT_READ='^(git status|git diff|git log|git show|git branch|git rev-parse|git ls-files|git fetch|git remote)( |$)'
-GIT_WRITE='^(git add|git commit|git checkout|git switch|git stash|git restore|git reset(?! --hard)|git rm|git mv|git push|git pull|git rebase|git merge|git worktree|git fetch)( |$)'
+# GIT_READ / GIT_WRITE match both the bare form (`git status`) and the
+# worktree-targeted form (`git -C <path> status`, `git --git-dir=<path> status`,
+# `git --work-tree=<path> status`) so that sub-agents can inspect and modify
+# state inside `.worktrees/<issue>/` without needing `cd` (which is itself
+# blocked by the FS_READ regex below).
+GIT_READ='^git( -C \S+| --git-dir=\S+| --work-tree=\S+)? (status|diff|log|show|branch|rev-parse|ls-files|fetch|remote)( |$)'
+GIT_WRITE='^git( -C \S+| --git-dir=\S+| --work-tree=\S+)? (add|commit|checkout|switch|stash|restore|reset(?! --hard)|rm|mv|push|pull|rebase|merge|worktree|fetch)( |$)'
 FS_READ='^(find|grep|cat|head|tail|less|more|ls|wc|awk|sed( -n)?|jq|xargs|sort|uniq|cut|tr|tee|file|stat|du|tree|which|type|env)( |$)'
 GH_READ='^gh (issue view|issue list|pr view|pr list|pr checks|pr diff|api( |$)|run view|run list|workflow view|label list|repo view)( |$)'
 

--- a/.xcodebuildmcp/config.yaml
+++ b/.xcodebuildmcp/config.yaml
@@ -4,14 +4,31 @@
 # qa-tester reads this file to discover defaults; humans use it as a single
 # source of truth so manual `xcodebuild` invocations match what the agent runs.
 
+schemaVersion: 1
+
+# Enable both the simulator workflow (build/boot/install/launch/screenshot)
+# AND the ui-automation workflow (tap/type/swipe/snapshot_ui). Without
+# ui-automation, qa-tester can launch the dev-client but cannot drive the
+# UI to exercise acceptance criteria. Restart the MCP server after changing
+# this list (Claude Code: /mcp restart, or restart the session).
+enabledWorkflows: ["simulator", "ui-automation"]
+
 workspace: mobile/ios/GFPlatform.xcworkspace
 scheme: GFPlatform
 configuration: Debug
 sdk: iphonesimulator
 
-# Latest stable iOS Simulator the user's Xcode supports. Update alongside
-# Xcode upgrades — qa-tester errors loudly if the named simulator isn't
-# installed rather than silently picking another.
+# Preferred iOS Simulator. qa-tester uses this as a *hint*, not a hard pin:
+#   1. If any simulator is currently `Booted`, qa-tester uses that one
+#      (so the user's existing running sim is preserved across dispatches
+#      and not shut down at teardown).
+#   2. Otherwise, if a simulator matching `name` is installed, that's the
+#      one it boots.
+#   3. Otherwise, qa-tester boots whatever iPhone simulator is installed
+#      with the latest iOS runtime (deterministic tie-break: highest iOS
+#      version, then alphabetical device name).
+#   4. Only if no iPhone simulator is installed at all does qa-tester
+#      degrade to ⚠️ UNVERIFIED — REQUIRES USER SIMULATOR.
 simulator:
-  name: "iPhone 16 Pro"
+  name: "iPhone 16e"
   os: latest

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { Slot, useRouter, useSegments } from 'expo-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { href } from '@/lib/navigation';
 import * as SplashScreen from 'expo-splash-screen';
+import * as Linking from 'expo-linking';
 import {
   useFonts,
   Inter_400Regular,
@@ -12,7 +13,7 @@ import {
   Inter_600SemiBold,
   Inter_700Bold,
 } from '@expo-google-fonts/inter';
-import { useAuthStore } from '@/stores/auth';
+import { useAuthStore, storage } from '@/stores/auth';
 import { useOfflineMutations } from '@/hooks/useOfflineMutations';
 import { OfflineBanner } from '@/components/OfflineBanner';
 import { ToastProvider } from '@/components/ui/Toast';
@@ -42,6 +43,34 @@ function AuthGate() {
   });
 
   useOfflineMutations();
+
+  // __DEV__-only: QA auto-login bypass via deep link.
+  // Fires on every inbound deep link; silently ignores anything that is not
+  // fitnessplatform://e2e-auth?token=<refreshToken>.  Never runs in production
+  // builds (__DEV__ is tree-shaken to false by Metro for release builds).
+  useEffect(() => {
+    if (!__DEV__) return;
+
+    const handleUrl = (url: string | null) => {
+      if (!url) return;
+      const parsed = Linking.parse(url);
+      if (parsed.hostname !== 'e2e-auth') return;
+      const token =
+        typeof parsed.queryParams?.token === 'string'
+          ? parsed.queryParams.token
+          : null;
+      if (!token) return;
+      console.log('[e2e-auth] login bypass invoked');
+      storage.set('refreshToken', token);
+      useAuthStore.getState().restoreSession();
+    };
+
+    // Cold-start: app was not running when the deep link was tapped.
+    Linking.getInitialURL().then(handleUrl);
+    // Warm: app was already running when the deep link arrived.
+    const sub = Linking.addEventListener('url', ({ url }) => handleUrl(url));
+    return () => sub.remove();
+  }, []);
 
   useEffect(() => {
     restoreSession();

--- a/mobile/scripts/qa-fetch-refresh-token.sh
+++ b/mobile/scripts/qa-fetch-refresh-token.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Fetch a QA refresh token from the compose harness (:5101) by logging in as one
+# of the seeded fixture users.  Prints the token to stdout so callers can pipe
+# it directly into `xcrun simctl openurl`.
+#
+# Usage:
+#   mobile/scripts/qa-fetch-refresh-token.sh [client|trainer|nutritionist]
+#
+# Default role: client
+#
+# Prerequisites:
+#   - .env.test at the repo root with QA_SEED_PASSWORD set.
+#   - Compose harness running: npm run e2e:up
+#   - jq installed.
+#
+# See docs/testing/e2e-fixtures.md for fixture details.
+
+set -euo pipefail
+
+role="${1:-client}"
+
+# ── Resolve email for the requested role ───────────────────────────────────
+case "$role" in
+  client)       email="qa.client@fitnessplatform.test" ;;
+  trainer)      email="qa.trainer@fitnessplatform.test" ;;
+  nutritionist) email="qa.nutri@fitnessplatform.test" ;;
+  *)
+    echo "Usage: $0 [client|trainer|nutritionist]" >&2
+    exit 1
+    ;;
+esac
+
+# ── Load QA_SEED_PASSWORD from .env.test ───────────────────────────────────
+repo_root="$(dirname "$0")/../.."
+env_file="$repo_root/.env.test"
+
+if [[ ! -f "$env_file" ]]; then
+  echo "error: .env.test not found at $env_file" >&2
+  echo "       Copy .env.test.example to .env.test and set QA_SEED_PASSWORD." >&2
+  echo "       See docs/testing/e2e-fixtures.md for details." >&2
+  exit 1
+fi
+
+# Source only the QA_SEED_PASSWORD line to avoid polluting the environment
+# with other variables that may have shell-unsafe values.
+QA_SEED_PASSWORD="$(grep -E '^QA_SEED_PASSWORD=' "$env_file" | head -1 | cut -d= -f2-)"
+
+if [[ -z "$QA_SEED_PASSWORD" ]]; then
+  echo "error: QA_SEED_PASSWORD is not set in $env_file" >&2
+  echo "       See docs/testing/e2e-fixtures.md for details." >&2
+  exit 1
+fi
+
+# ── POST to /auth/login on the compose harness ─────────────────────────────
+harness_url="https://localhost:5101"
+
+# Capture body + HTTP status code in one curl call.
+# The status code is appended after a newline separator.
+response="$(
+  curl -k -sS \
+    -w '\n%{http_code}' \
+    -X POST "$harness_url/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$email\",\"password\":\"$QA_SEED_PASSWORD\"}" \
+  2>&1
+)" || {
+  echo "error: harness unreachable on :5101 — run \`npm run e2e:up\`" >&2
+  exit 1
+}
+
+# Split body and status code (last line).
+status_code="$(printf '%s' "$response" | tail -1)"
+body="$(printf '%s' "$response" | head -n -1)"
+
+# ── Handle HTTP error codes ────────────────────────────────────────────────
+case "$status_code" in
+  200)
+    : # success — handled below
+    ;;
+  401)
+    echo "error: auth failed (HTTP 401) — check QA_SEED_PASSWORD against \`.env.test.example\`" >&2
+    exit 1
+    ;;
+  404)
+    echo "error: /auth/login not found on harness :5101 (HTTP 404) — is the harness running? (\`npm run e2e:up\`)" >&2
+    exit 1
+    ;;
+  5*)
+    excerpt="${body:0:200}"
+    echo "error: harness 5xx: $status_code — body excerpt: $excerpt" >&2
+    exit 1
+    ;;
+  *)
+    echo "error: unexpected HTTP $status_code from harness" >&2
+    exit 1
+    ;;
+esac
+
+# ── Extract refreshToken via jq ────────────────────────────────────────────
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is not installed — install it to parse the login response" >&2
+  exit 1
+fi
+
+refresh_token="$(printf '%s' "$body" | jq -r '.refreshToken // empty')"
+
+if [[ -z "$refresh_token" ]]; then
+  echo "error: login succeeded but response missing refreshToken — schema mismatch?" >&2
+  exit 1
+fi
+
+# Token to stdout only — never to a log file.
+printf '%s\n' "$refresh_token"


### PR DESCRIPTION
## Summary

- Adds a `__DEV__`-only deep-link handler in `mobile/app/_layout.tsx` that accepts `fitnessplatform://e2e-auth?token=<refreshToken>`, writes the token to MMKV, and calls `restoreSession()` — letting `qa-tester` land the simulator on the home screen without driving the login form.
- Ships `mobile/scripts/qa-fetch-refresh-token.sh` (executable, strict-mode bash) which logs in as a seeded fixture user against the compose harness on `:5101` and prints the refresh token to stdout, ready to pipe into `xcrun simctl openurl`.
- Updates `.claude/agents/qa-tester.md` with the new step 3a auth-prep flow, fixes the XcodeBuildMCP tool-name namespace (`mcp__plugin_xcodebuildmcp_*` → `mcp__xcodebuildmcp__*`), documents the `simulator` + `ui-automation` workflow set, codifies simulator-selection precedence (pre-booted wins) and a matching teardown rule.
- Pins `.xcodebuildmcp/config.yaml` with `schemaVersion: 1`, `enabledWorkflows: [simulator, ui-automation]`, and a default of `iPhone 16e`.
- Widens `.claude/hooks/agent-bash-allowlist.sh` GIT_READ/GIT_WRITE regexes to accept the worktree-targeted forms (`git -C <path>`, `--git-dir=`, `--work-tree=`) so sub-agents can operate inside `.worktrees/<issue>/` without `cd`.

## Related issue

Fixes #288

## Scope

mobile (handler + helper script) + docs-infra (agent definition, hook regex, mcp config)

## Security posture

- `if (!__DEV__) return;` is the **first statement** inside the new `useEffect` body — Metro tree-shakes `__DEV__` to `false` in release builds, so the entire handler becomes dead code in production.
- The URL handler is strictly scoped: `parsed.hostname === 'e2e-auth'` AND `typeof parsed.queryParams?.token === 'string'` — anything else silently passes through (no token write, no `restoreSession()`).
- The `fitnessplatform://` scheme is registered app-only in `mobile/app.json` (no universal-link entitlement), so even in `__DEV__` builds the handler is only reachable from `xcrun simctl openurl` or a deliberate paste — not from arbitrary web pages.
- `qa-fetch-refresh-token.sh` reads `QA_SEED_PASSWORD` from `.env.test` (gitignored), pipes only the refresh token to stdout, never logs the password, and handles 401 / 404 / 5xx / connection-refused / missing env-file / missing var / missing `refreshToken` in the response with non-zero exits and clear stderr.

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all 5 ACs met via static diff inspection + harness smoke (`POST /auth/login` returned 200 with `refreshToken`). On-simulator deep-link drive was deferred (dev-client cold build not cached for this SHA); fallback to static was authorized in the brief.

## Test plan

- [x] `npx tsc --noEmit` on `mobile/` — clean
- [x] `bash -n mobile/scripts/qa-fetch-refresh-token.sh` — syntax OK
- [x] `git ls-files -s mobile/scripts/qa-fetch-refresh-token.sh` reports mode 100755
- [x] Error paths covered: 401 / 404 / 5xx / connection-refused / missing `.env.test` / missing `QA_SEED_PASSWORD` / missing `refreshToken`
- [x] `qa-tester.md` step 3a documents the deep-link auth-prep with the log-line assertion and PARTIAL fallback
- [ ] On a freshly-built dev-client `.app`, `xcrun simctl openurl booted "fitnessplatform://e2e-auth?token=<T>"` lands the simulator on the home screen within ~3 s with `[e2e-auth] login bypass invoked` in the simulator log (deferred — interactive simulator run once the dev-client `.app` is cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)