### PR TITLE
fix(#258): suppress duplicate WodTimerHero overlay on zero-exercise WOD section

### DIFF
--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -3860,6 +3860,10 @@ export default function WorkoutLogScreen() {
           ? resolveSection(activeSection, sessionFormat, sessionFormatConfig)
           : null
         if (!resolved || !isWodFormat(resolved.format) || !resolved.formatConfig) return null
+        // When the section has no exercises, site #2 (the inline exercise-free
+        // WOD render at line ~3506) already owns the timer. Returning null here
+        // prevents a duplicate WodTimerHero overlay (fix for #258).
+        if ((activeSection?.exercises?.length ?? 0) === 0) return null
         const sectionId = activeSection?.sectionId ?? `section-${activeSectionIdx}`
         const sectionLabel = activeSection?.name ?? sessionDisplayName
         return (


### PR DESCRIPTION
## Summary
- ForTime workout with zero exercises was rendering two overlapping timer cards because two independent render sites both fired: the inline exercise-free render (site #2, `[id].tsx:3506`) and the absoluteFill section-level `WodTimerHero` overlay (site #3, `[id].tsx:3856`).
- Added a 4-line guard at site #3 that short-circuits to `null` when `activeSection.exercises.length === 0`, leaving site #2 as the sole timer for zero-exercise WOD sections.
- Site #1 (inline currentExercise WodTimerHero around `[id].tsx:3060`) was already gated on `currentExercise` so it does not fire when the section has no exercises.

## Related issue
Fixes #258

## Scope
mobile

## Root cause (one line)
Site #2 (inline) and site #3 (overlay) both fire on ForTime with zero exercises because `showWodHero` is set true on mount and the `{}` fallback at `[id].tsx:3514` keeps site #3's `!resolved.formatConfig` guard inactive; the new guard at line 3866 short-circuits site #3 when `exercises.length === 0`, so only site #2 renders.

## QA verdict (from qa-tester)
OVERALL: PARTIAL — ACs 3 + 4 statically PASS (non-regression for AMRAP/EMOM/Tabata + Standard branch). ACs 1, 2, 5 statically PASS via 5 independent static traces converging on the same verdict but are not interactively verified due to two known dispatch-environment limitations: (a) the qa-tester sub-agent's callable function schema does not currently load `mcp__xcodebuildmcp__*` UI-automation tools (tap/snapshot_ui/etc.) — same gap across runs 2/3/4/5; (b) the compose-harness `QaSeedRunner.cs` has zero WOD-format references, so the seeded fixture cannot reach a ForTime+0-exercise plan without a backend fixture extension. Run 6 (post-#288) confirms the auth-bypass mechanism reaches the iOS "Open in App?" deep-link prompt — screenshot at `.qa-artifacts/258/run6-sim-after-deeplink.png`. The interactive verification gap is a tooling/fixture follow-up, not a defect in this 4-line guard.

## Test plan
- [x] `npx tsc --noEmit` clean (run 4)
- [x] 5 independent static traces converge on PASS for ACs 1, 2, 5
- [x] AC3 — AMRAP/EMOM/Tabata + ≥1 exercise still renders site #3 overlay (guard returns false → falls through to `Animated.View`)
- [x] AC4 — Standard (non-WOD) section delegates to `LiveExerciseFocus` unchanged (`isWodFormat` returns false at line 3862 before the new guard at 3866)
- [ ] Interactive AC1/AC2/AC5 verification — deferred to follow-up (`QaSeedRunner` WOD fixture + XcodeBuildMCP UI-automation tool surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)