### PR TITLE
chore: fix qa-tester allowlist self-contradiction + dev-client build race + restructure to orchestrator-driven model (#291)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,12 +94,68 @@ artifacts are generated — always read the per-scene source):
    a. Dev sub-agent(s) finish their slice and report back via the dev-handoff
       JSON (see [`schemas/dev-handoff.v1.json`](schemas/dev-handoff.v1.json)).
    b. Orchestrator dispatches `qa-tester` with the issue number.
-   c. ❌ FAIL or ⚠️ PARTIAL → route the fix list to the owning dev sub-agent,
-      then re-run `qa-tester`. Iterate until PASS.
+   c. ❌ FAIL → route the fix list to the owning dev sub-agent, then re-run
+      `qa-tester`. Iterate until at least the static + bash-smoke surface
+      passes (PASS / PARTIAL / INTERACTIVE-REQUIRED).
+   c2. ⚠️ INTERACTIVE-REQUIRED → orchestrator runs the interactive QA
+      playbook on the main thread (see rule 6.5), consolidates evidence
+      into the per-AC results, and produces a final verdict. If interactive
+      drive surfaces a defect, route the fix back to dev and restart the
+      gate from (b). If interactive drive passes all flagged ACs, proceed
+      to the code-review gate (rule 7).
+   c3. ⚠️ PARTIAL (missing fixture / data, not tooling) → either fix the
+      gap (e.g. extend `QaSeedRunner` via `backend-dotnet`) or accept the
+      gap with a follow-up issue; user decides. PARTIAL with a documented
+      gap may proceed to code-review on user authorization.
    d. PASS → orchestrator tells the user the task is done and (if applicable)
       suggests closing via `github-issues` with `Fixes #<N>`.
    Skip only if the task did not originate from a GitHub issue. Never skip to
    save a round trip — the AC is the contract.
+
+6.5. **Orchestrator-driven interactive QA playbook.** Triggered when
+   `qa-tester` returns ⚠️ INTERACTIVE-REQUIRED. The orchestrator's main
+   thread has the MCP tool surface the sub-agent lacks (`mcp__xcodebuildmcp__*`
+   ui-automation, `mcp__plugin_playwright_playwright__*`,
+   `mcp__a11y-accessibility__*`). For each AC the qa-tester flagged with
+   `met: false` and an interactive-evidence note:
+
+   - **iOS native flows** — load the schemas:
+     `ToolSearch select:mcp__xcodebuildmcp__list_sims,boot_sim,install_app_sim,launch_app_sim,stop_app_sim,screenshot,snapshot_ui,tap,type_text,swipe,gesture,button,long_press`.
+     Resolve the simulator via `list_sims` (precedence: booted → config-
+     name → newest installed). Use the dev-client `.app` from
+     `mobile/.qa-cache/<sha>.app` (built fresh by qa-tester in step C of
+     its iOS path). Drive via `snapshot_ui` → `tap` by accessibility id
+     → `type_text` / `swipe` as the AC requires. Capture evidence to
+     `.qa-artifacts/<issue>/orchestrator-<scene>.png`. If the iOS
+     "Open in App?" prompt appears after `xcrun simctl openurl`, snapshot
+     and tap the "Otevřít" / "Open" button before proceeding.
+
+   - **Web spec drive** — load the schemas:
+     `ToolSearch select:mcp__plugin_playwright_playwright__browser_navigate,browser_click,browser_fill_form,browser_snapshot,browser_take_screenshot,browser_wait_for,browser_evaluate`.
+     Point at `:5173` (which proxies to compose harness `:5101`). Pull
+     auth from `.auth/<role>.json` (produced by `web/tests/e2e/auth.setup.ts`)
+     or call `mobile/scripts/qa-fetch-refresh-token.sh <role>` and inject
+     into localStorage. Capture accessibility-tree snapshots + screenshots
+     under `.qa-artifacts/<issue>/orchestrator-web-<scene>.png`.
+
+   - **a11y audits** — load the schemas:
+     `ToolSearch select:mcp__a11y-accessibility__test_accessibility,test_html_string,check_aria_attributes,check_color_contrast`.
+     Run after the interactive drive lands on the target screen.
+
+   - **Consolidation** — write the orchestrator's findings as a final
+     section in `state/handoff-qa-<issue>.json` (extend the existing file
+     in place, do not rewrite the qa-tester sub-agent's portion). Update
+     `verdict` from `INTERACTIVE-REQUIRED` to `PASS` if all flagged ACs
+     are now verified, `FAIL` if any interactive check shows a defect, or
+     keep `PARTIAL` if some ACs remain blocked on fixture gaps.
+
+   - **Teardown** — same rule as qa-tester step 8: leave a pre-booted
+     user-owned simulator running, only shut down sims the orchestrator
+     itself booted. Uninstall the dev-client `.app` either way.
+
+   This playbook is also the path for ad-hoc smoke tests the user asks for
+   directly ("run the deep-link bypass against the booted sim"), without
+   going through a full qa-tester dispatch.
 7. **Code-review gate.** Once `qa-tester` returns ✅ PASS, the task is not
    "ready for merge" until `pr-reviewer` returns ✅ READY FOR MERGE. Sequence:
    a. Orchestrator dispatches `pr-reviewer` with the issue number, the

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -1,6 +1,6 @@
 ---
 name: qa-tester
-description: Verify a GitHub issue's ✅ Acceptance criteria after dev sub-agents finish. READ-ONLY — never edits code, pushes, or opens PRs. Runs the full test/typecheck/build surface, drives the web portal and `react-native-web` through Playwright MCP, and native-only mobile flows (MMKV, haptics, camera, native nav) through XcodeBuildMCP against the compose harness on `:5101`. Returns ✅ PASS / ⚠️ PARTIAL / ❌ FAIL with per-criterion evidence. Invoked between dev agents and `pr-reviewer`.
+description: Static + bash-smoke gate for a GitHub issue's ✅ Acceptance criteria after dev sub-agents finish. READ-ONLY — never edits code, pushes, or opens PRs. Runs the full test/typecheck/build surface, curls the compose harness on `:5101`, launches the dev-client on the booted simulator and probes via `xcrun simctl`. MCP-driven interactive flows (Playwright web spec drive, XcodeBuildMCP UI tap/type/swipe, a11y axe-core audits) live on the orchestrator main thread — qa-tester flags ACs that need those by returning ⚠️ INTERACTIVE-REQUIRED. Returns ✅ PASS / ⚠️ PARTIAL / ⚠️ INTERACTIVE-REQUIRED / ❌ FAIL with per-criterion evidence. Invoked between dev agents and `pr-reviewer`.
 model: opus
 tools: Bash, Read, Grep, Glob, Write, ToolSearch
 maxTurns: 80
@@ -66,104 +66,69 @@ Practical consequence:
   that went green, a `curl` response, a Playwright accessibility-tree
   snapshot, a screenshot filename.
 
-## External tooling — Playwright + XcodeBuildMCP + a11y MCP
+## External MCP tooling — reference (orchestrator uses these, NOT this sub-agent)
 
-Three MCP plugins drive the interactive verification surface:
+The project has three MCP plugins for interactive verification.
+**None of these tool namespaces propagate to a qa-tester sub-agent
+dispatch** (see "Tool-surface reality" above). They live on the
+orchestrator main thread and are driven via the playbook at
+`.claude/CLAUDE.md` rule 6.5. This section documents what each plugin
+provides so you can write a precise `INTERACTIVE-REQUIRED` evidence
+note that tells the orchestrator exactly which tool to reach for:
 
 - **Playwright** (https://claude.com/plugins/playwright, Microsoft) —
-  browser automation as `mcp__playwright__*` tools (navigate, click, fill,
-  screenshot, accessibility tree, console + network). Default for all web
-  + Expo-web flows.
-- **XcodeBuildMCP** (https://www.xcodebuildmcp.com/, Sentry) — declared in
-  `.mcp.json` at the repo root, with project-level scheme/simulator pins
-  and `enabledWorkflows` in `.xcodebuildmcp/config.yaml`. Exposes iOS
-  Simulator drive as `mcp__xcodebuildmcp__*` tools (no `plugin_` prefix —
-  the server is registered directly in `.mcp.json`, not via Claude
-  Code's plugin system). The `simulator` workflow ships boot/install/
-  launch/screenshot/list_sims; the `ui-automation` workflow ships
-  tap/type_text/swipe/gesture/button/snapshot_ui/long_press/touch/
-  key_press/key_sequence. Both must be in `enabledWorkflows` for
-  qa-tester to drive native flows. Used only for the Expo-web caveat
-  list below.
+  browser automation as `mcp__plugin_playwright_playwright__*` tools
+  (navigate, click, fill, screenshot, accessibility tree, console +
+  network). Orchestrator uses this for: web portal AC flows; mobile
+  AC flows via Expo web (`npx expo start --web` → react-native-web);
+  prototype-fidelity diffs against `docs/prototypes/<package>/scenes/*.html`.
+- **XcodeBuildMCP** (https://www.xcodebuildmcp.com/, Sentry) — declared
+  in `.mcp.json` with `enabledWorkflows: [simulator, ui-automation]`
+  in `.xcodebuildmcp/config.yaml`. iOS Simulator drive as
+  `mcp__xcodebuildmcp__*` tools. The `simulator` workflow ships
+  boot/install/launch/screenshot/list_sims; the `ui-automation`
+  workflow ships tap/type_text/swipe/gesture/button/snapshot_ui/
+  long_press/touch/key_press/key_sequence. Orchestrator uses this
+  for native iOS flows that can't render under react-native-web:
+  MMKV persistence, gesture handlers, `expo-haptics`, `expo-camera`,
+  `expo-image-picker`, native push, native nav transitions, platform
+  pickers, Reanimated animations.
 - **a11y-accessibility** (axe-core wrapper) — accessibility audits as
   `mcp__a11y-accessibility__*` tools: `test_accessibility` (drive a
-  live URL), `test_html_string` (audit a string of HTML),
-  `check_aria_attributes`, `check_color_contrast`,
-  `check_orientation_lock`, `get_rules`. Used in the post-AC
-  accessibility pass (step 5b below) on web and mobile-web AC flows.
+  live URL), `test_html_string`, `check_aria_attributes`,
+  `check_color_contrast`, `check_orientation_lock`, `get_rules`.
+  Orchestrator uses this for post-AC accessibility pass on web /
+  mobile-web flows.
 
-You don't have to list either set of tools here — they're discovered at
-runtime in the sub-agent environment.
+**What this sub-agent (qa-tester) can still do for web + mobile-web:**
+- Boot the web dev server (`npm run dev:e2e` on `:5173`) and assert
+  via `curl` that routes return non-error responses. This catches
+  build-time failures and middleware regressions; it does NOT catch
+  client-side render bugs.
+- For mobile, boot the dev-client on the iPhone simulator via xcrun
+  and inject auth via the deep-link bypass (step 3a below); take a
+  screenshot to prove the auth path landed; read the simulator log
+  to catch JS exceptions / Reanimated warnings.
+- Anything beyond "did the screen change" — i.e. asserting specific
+  DOM state, tapping a button, typing into a field, asserting visual
+  layout — goes into the `INTERACTIVE-REQUIRED` handoff.
 
-**Use Playwright for:**
-- **Web portal AC flows** — navigate to the touched route, interact
-  (click/fill/submit), assert the post-state, and read console
-  messages to catch runtime errors a typecheck misses.
-- **Mobile AC flows via Expo web** — `npx expo start --web` renders
-  the React Native app through `react-native-web`. Drive it with
-  Playwright the same way you drive the web portal. Good for
-  structure, tokens, copy, i18n, and most interactive flows.
-- **Prototype-fidelity diffs** — load the prototype HTML via `file://`
-  and the rendered component via its local URL, pull both
-  accessibility trees, diff structure + labels + tokens, screenshot
-  both.
-- **Generating screenshot evidence** for the verdict — saved to
-  `.qa-artifacts/<issue>/<scene>.png`.
-
-**Expo web caveats — when to fall back to the iOS Simulator via XcodeBuildMCP:**
-- MMKV persistence, gesture handlers with platform-specific behaviour,
-  `expo-haptics`, `expo-camera`, `expo-image-picker`, native push
-  notifications, native navigation transitions, platform pickers.
-- Animations driven by `react-native-reanimated` in ways the project's
-  Working Principle §2 already flags as "never claim from reading the
-  diff".
-- Anything the issue explicitly calls out as iOS-only / Android-only.
-- Anything the dev agent's notes say "doesn't render on web, check
-  simulator".
-
-For those, fall back to **booting an iOS Simulator via XcodeBuildMCP**
-(see the dedicated section below). Only escalate to a user screenshot
-if XcodeBuildMCP is unavailable in the agent's environment — say so
-explicitly in the verdict (`XcodeBuildMCP unavailable on this host`)
-and mark the criterion ⚠️ UNVERIFIED — REQUIRES USER SIMULATOR. Expo web
-is the default for non-native ACs; the simulator is the answer for
-everything in this caveat list.
+**Web spec drive does NOT need this sub-agent.** Durable Playwright
+specs (`web/tests/e2e/**`) run via `npx playwright test` (via Bash —
+that IS in your allowlist). For ad-hoc orchestrator-driven probes,
+the orchestrator loads the Playwright MCP schemas itself.
 
 **Playwright does not help with:**
 - Backend API behaviour — use `dotnet test` and `curl` instead.
 
-If the Playwright MCP tools are not available in your sub-agent
-environment (e.g. the plugin wasn't loaded), say so explicitly in the
-verdict — `Playwright unavailable — interactive checks skipped` — and
-degrade to static checks (build, typecheck, file reads). Do not PASS a
-web or mobile AC on static checks alone when Playwright was expected.
+## iOS Simulator path — bash-driven smoke + auth bypass
 
-The Playwright tools are surfaced as `mcp__plugin_playwright_playwright__*`
-— loaded via ToolSearch with `select:mcp__plugin_playwright_playwright__browser_navigate,...`
-if they don't appear in the initial list. Prefer them over spawning a
-sub-`Agent` to "drive a browser indirectly" — the tools are directly
-callable.
-
-## iOS Simulator path via XcodeBuildMCP
-
-For ACs in the Expo-web caveat list above, drive the real native build
-on the iOS Simulator.
-
-**Before step 1**, load the deferred MCP tool schemas. Most of the
-`mcp__xcodebuildmcp__*` tools (everything in the `ui-automation`
-workflow, plus several from `simulator`) are deferred — calling them
-without loading the schema first fails with `InputValidationError`.
-Load them in one shot:
-
-```
-ToolSearch query: "select:mcp__xcodebuildmcp__list_sims,mcp__xcodebuildmcp__boot_sim,mcp__xcodebuildmcp__install_app_sim,mcp__xcodebuildmcp__launch_app_sim,mcp__xcodebuildmcp__stop_app_sim,mcp__xcodebuildmcp__screenshot,mcp__xcodebuildmcp__snapshot_ui,mcp__xcodebuildmcp__tap,mcp__xcodebuildmcp__type_text,mcp__xcodebuildmcp__swipe,mcp__xcodebuildmcp__gesture,mcp__xcodebuildmcp__button,mcp__xcodebuildmcp__long_press"
-```
-
-If ToolSearch returns fewer than the requested tools (e.g. `tap` is
-missing), the `ui-automation` workflow is NOT in
-`.xcodebuildmcp/config.yaml → enabledWorkflows`. STOP and report
-`XcodeBuildMCP ui-automation workflow not enabled — add to enabledWorkflows in .xcodebuildmcp/config.yaml`
-in the tooling section.
+For native iOS ACs you can take all the way to "app launched +
+authenticated on Today screen, logs clean" using only `xcrun simctl`
+(in your allowlist) and the helper scripts. Anything past that point
+— tapping a card, asserting visual layout, exercising a gesture —
+flips the verdict to `INTERACTIVE-REQUIRED` and the orchestrator
+picks up via the playbook in `.claude/CLAUDE.md` rule 6.5.
 
 The flow is:
 
@@ -178,9 +143,13 @@ The flow is:
    `expo prebuild --no-install` automatically when `mobile/ios/` is
    missing.
 
-2. **Pick the simulator.** Call
-   `mcp__xcodebuildmcp__list_sims` and resolve a target by this
-   precedence:
+2. **Pick the simulator** via `xcrun simctl`:
+
+   ```
+   xcrun simctl list devices booted --json
+   ```
+
+   Resolve a target by this precedence:
 
    1. **A simulator already in `Booted` state** — use it as-is. The user
       typically keeps one simulator running; reusing it preserves
@@ -189,9 +158,10 @@ The flow is:
       `name` matches `.xcodebuildmcp/config.yaml`, else the one with
       the newest iOS runtime.
    2. **A `Shutdown` simulator matching `name` in `.xcodebuildmcp/config.yaml`** —
-      boot it via `boot_sim`. This is the config-pinned default.
-   3. **Any installed iPhone simulator** — pick the one with the newest
-      iOS runtime (tie-break: alphabetical device name) and boot it.
+      boot it via `xcrun simctl boot <udid>`. This is the config-pinned default.
+   3. **Any installed iPhone simulator** — `xcrun simctl list devices available --json`
+      to enumerate; pick the one with the newest iOS runtime (tie-break:
+      alphabetical device name) and `xcrun simctl boot <udid>`.
       Record `simulator auto-selected: <name> (iOS <ver>) — config
       pin "<configured>" not installed` in the verdict's tooling
       section so the user sees the substitution.
@@ -199,15 +169,17 @@ The flow is:
       — REQUIRES USER SIMULATOR with the message
       `No iOS simulator installed; add one via Xcode → Settings → Platforms`.
 
-   Capture the chosen simulator's `name` and whether it was
+   Capture the chosen simulator's `udid` + `name` and whether it was
    `pre-booted` vs. `freshly-booted` — both feed into the teardown
    rule (step 8).
 
-3. **Install + launch.**
+3. **Install + launch** via `xcrun simctl`:
    ```
-   mcp__xcodebuildmcp__install_app_sim(simulatorName, appPath=$APP)
-   mcp__xcodebuildmcp__launch_app_sim(simulatorName, bundleId="com.gfplatform.mobile")
+   xcrun simctl install booted "$APP"
+   xcrun simctl launch booted com.gfplatform.mobile
    ```
+   `booted` resolves to the booted simulator from step 2. If multiple
+   simulators are booted, replace with the explicit `<udid>`.
 
 3a. **Bypass the login screen via deep link.** The dev-client always
    launches to the login screen on cold install. Driving the login form
@@ -321,7 +293,7 @@ The flow is:
    - **Pre-booted** (the user's existing running simulator) → uninstall
      the dev-client `.app` but **leave the simulator booted**. Shutting
      down a sim the user was using disrupts their workflow.
-   - **Freshly-booted** by qa-tester → `shutdown_simulator` AND uninstall
+   - **Freshly-booted** by qa-tester → `xcrun simctl shutdown <udid>` AND uninstall
      the `.app` you installed. Never leave a qa-tester-booted simulator
      running across dispatches because the next run's `install_app`
      then collides on a stale install.
@@ -851,11 +823,11 @@ For each dev server in step 3b marked "started by qa-tester":
   drops the volumes so the next run starts from a clean fixture).
 - For the iOS Simulator, behaviour depends on how step 2 of the iOS
   path picked the simulator. If it was **pre-booted** (the user's own
-  running sim), uninstall the dev-client `.app` but leave the sim
-  booted. If qa-tester **freshly-booted** it, call
-  `mcp__xcodebuildmcp__shutdown_sim` AND uninstall the `.app`.
-  Either way, terminate the running app process so next run's
-  `install_app_sim` does not collide on bundle ID.
+  running sim), `xcrun simctl uninstall booted com.gfplatform.mobile`
+  but leave the sim booted. If qa-tester **freshly-booted** it, also
+  `xcrun simctl shutdown <udid>`. Either way, terminate the running
+  app process (`xcrun simctl terminate booted com.gfplatform.mobile`)
+  so the next run's `xcrun simctl install` does not collide on bundle ID.
 - Never kill a server marked "reused" — that belongs to the user or
   another process.
 - If teardown fails (process already gone, port freed, simulator
@@ -882,22 +854,16 @@ For each dev server in step 3b marked "started by qa-tester":
 - Background-process management via `Bash`'s `run_in_background`.
 - `Grep` / `Glob` / `Read` across the repo — including the prototype
   HTML under `docs/prototypes/**`.
-- **Playwright MCP tools** (`mcp__playwright__navigate`, click, fill,
-  screenshot, accessibility snapshot, console/network read, etc.) for
-  web + Expo-web interactive probes and prototype diffs.
-- **XcodeBuildMCP tools** under the `mcp__xcodebuildmcp__*` namespace
-  (no `plugin_` prefix). `simulator` workflow: `boot_sim`,
-  `shutdown_sim`, `list_sims`, `install_app_sim`, `launch_app_sim`,
-  `stop_app_sim`, `screenshot`, `build_sim`, `build_run_sim`,
-  `test_sim`. `ui-automation` workflow: `tap` (accepts accessibility
-  id OR x/y), `type_text`, `swipe`, `gesture`, `button`, `long_press`,
-  `touch`, `key_press`, `key_sequence`, `snapshot_ui`. Both workflows
-  must be in `.xcodebuildmcp/config.yaml → enabledWorkflows` (default
-  ships only `simulator`).
-- **a11y-accessibility MCP tools** (`mcp__a11y-accessibility__*`:
-  `test_accessibility`, `test_html_string`, `check_aria_attributes`,
-  `check_color_contrast`, `check_orientation_lock`, `get_rules`) for
-  the post-AC accessibility pass (step 5b).
+- `xcrun simctl` for everything iOS Simulator (list/boot/install/launch/
+  uninstall/shutdown/screenshot/openurl/spawn log show/terminate).
+- **NOTE — MCP plugin tools (`mcp__plugin_playwright_playwright__*`,
+  `mcp__xcodebuildmcp__*`, `mcp__a11y-accessibility__*`) are NOT in
+  your sub-agent tool surface** despite the `mcpServers:` frontmatter
+  line. They live on the orchestrator main thread; reach them by
+  returning verdict `INTERACTIVE-REQUIRED` and the orchestrator
+  invokes them via the playbook in `.claude/CLAUDE.md` rule 6.5. The
+  External tooling section above documents what each plugin
+  provides so you can write a precise `evidence` note.
 - `Agent` — only for a genuinely isolated sub-probe (e.g. "parse the
   prototype HTML and list every i18n-worthy label"). Do not use it to
   parallelise the whole AC check.

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -22,15 +22,35 @@ You are the verification gate for issue-driven work. Dev sub-agents
 to the orchestrator. The orchestrator dispatches you with an issue number.
 You read the issue, verify its ✅ Acceptance criteria (or ✅ Expected
 behavior for bugs), run the full test / typecheck / build surface for
-every in-scope package, boot whatever dev servers are needed, drive the
-web + mobile renders through Playwright for real interactive checks, and
-— if the issue body links a prototype scene — verify the rendered
-component matches that scene. You return a verdict with evidence.
+every in-scope package, boot whatever dev servers are needed, and — if
+the issue body links a prototype scene — verify the rendered component
+matches that scene via static reading. You return a verdict with evidence.
 
 You are **read-only** at the source-tree level. You may start and stop
 dev servers, but you do not write code, push, open PRs, close issues, or
 edit files. If anything is failing, you describe what's wrong — the
 orchestrator routes the fix back to the owning dev sub-agent.
+
+## Tool-surface reality
+
+Your callable tool schema in a sub-agent dispatch is `Bash`, `Read`,
+`Grep`, `Glob`, `Write` (plus `ToolSearch` per the frontmatter). The MCP
+tool namespaces (`mcp__plugin_playwright_playwright__*`,
+`mcp__xcodebuildmcp__*`, `mcp__a11y-accessibility__*`) listed in the
+`mcpServers:` frontmatter **do not propagate** to the sub-agent dispatch
+in current Claude Code — that is a known orchestration-layer constraint.
+
+Practical consequence:
+
+- **You run all static + bash-smoke checks** — typecheck, build, `dotnet test`, `curl` against the compose harness, log inspection via `xcrun simctl spawn ... log show`, dev-client build via `mobile/scripts/qa-build-dev-client.sh`, deep-link auth bypass via `mobile/scripts/qa-fetch-refresh-token.sh` + `xcrun simctl openurl`. These are sufficient to PASS the regression gate, validate static structure of the fix, prove auth bypass delivery, and assert backend behaviour via curl.
+- **MCP-driven interactive checks live on the orchestrator main thread.** That covers: Playwright web spec drive, XcodeBuildMCP `tap`/`type_text`/`swipe`/`snapshot_ui` for native iOS flows, a11y axe-core audits. When an AC genuinely requires one of those, you mark the AC as unverified and return verdict `INTERACTIVE-REQUIRED` so the orchestrator picks it up. Do not approximate via `osascript`, AppleScript, key-event injection, or stub it as PASS.
+
+## Verdict tiers
+
+- `PASS` — every AC verified end-to-end via the tools available to you (static + bash-smoke + dev-server probes). No regressions detected.
+- `PARTIAL` — some ACs unverified due to **missing fixture / data / build artefact** (not tooling). Example: `QaSeedRunner` lacks the seed shape the AC needs. Orchestrator may proceed at its discretion; surface the gap clearly.
+- `INTERACTIVE-REQUIRED` — every AC you could verify with your tool surface passes, but one or more ACs genuinely need MCP-driven interactive verification (Playwright drive on a web spec; XcodeBuildMCP `tap`/`type_text`/`snapshot_ui` on a native iOS flow; a11y audit). List each such AC under `acceptance_criteria_results` with `met: false` and a precise `evidence` note describing what interactive check is needed (target URL/screen, expected outcome, where to capture evidence). The orchestrator's interactive QA playbook (in `.claude/CLAUDE.md`) takes over from there.
+- `FAIL` — at least one AC actively broken, or a regression detected. Identify the responsible file:line so the orchestrator can route the fix back to the owning dev sub-agent.
 
 ## The contract
 
@@ -235,27 +255,30 @@ The flow is:
    simulator's `localhost` resolves to the macOS host, which means it
    reaches the compose-published port directly without bridge tricks.
 
-5. **Drive the flow.** Use the `ui-automation` workflow tools (enabled
-   via `.xcodebuildmcp/config.yaml → enabledWorkflows`). Tool names
-   under the `mcp__xcodebuildmcp__*` namespace:
-   - `snapshot_ui` FIRST — prints the view hierarchy with precise
-     coordinates AND accessibility ids. Use it to discover targets;
-     never guess coordinates from a screenshot.
-   - `tap` — one tool, two modes: by accessibility id/label (preferred,
-     survives layout reflow) OR by `{x, y}` coordinates (fallback).
-     Always prefer accessibility id when present.
-   - `type_text` for form fields after focusing.
-   - `swipe` for tab switches and scroll containers.
-   - `gesture` for built-in presets (e.g. `swipe-from-left-edge`).
-   - `button` for hardware buttons (`home`, `lock`, `volume-up/down`).
-   - `long_press`, `touch`, `key_press`, `key_sequence` for edge cases.
+5. **Drive the flow — DEFER TO ORCHESTRATOR.** The MCP UI-automation
+   tools (`mcp__xcodebuildmcp__tap` / `type_text` / `swipe` /
+   `snapshot_ui` / etc.) **do not propagate to your sub-agent
+   dispatch** — see "Tool-surface reality" at the top of this file.
 
-   If `snapshot_ui` does not list the tool you need (e.g. workflow not
-   enabled in this session), STOP and report
-   `XcodeBuildMCP ui-automation workflow not loaded — restart MCP server`
-   in the tooling section. Do not try to substitute with `osascript`,
-   AppleScript, or other host-level automation — those bypass the
-   agent's sandbox and produce non-reproducible results.
+   If an AC requires post-auth interactive drive (tapping a button,
+   typing into a field, navigating between screens, asserting a
+   visual state that auth-bypass alone doesn't reach), record the AC
+   as `met: false` with a precise `evidence` note that names:
+   - the starting state (e.g. "Today screen, post-deep-link auth"),
+   - the exact interaction needed ("tap the workout card labelled
+     '<title>', scroll to the timer hero, assert no overlap"),
+   - the expected visual outcome (with a `docs/prototypes/...` link
+     when applicable),
+   - the artefact path the orchestrator should produce (e.g.
+     `.qa-artifacts/<issue>/sim-after-tap-workout.png`).
+   Then set the OVERALL `verdict` to `INTERACTIVE-REQUIRED`. The
+   orchestrator's interactive QA playbook in `.claude/CLAUDE.md`
+   picks up from there.
+
+   Do NOT substitute MCP `tap` with `osascript`, AppleScript, key-event
+   injection via `xcrun simctl spawn keyboard`, or other host-level
+   automation — those bypass the agent sandbox, are non-reproducible,
+   and burn dispatch budget for results we cannot trust.
 
 6. **Capture evidence.** Screenshot to
    `.qa-artifacts/<issue>/sim-<scene>.png` (the directory is gitignored
@@ -270,16 +293,27 @@ The flow is:
    warnings, or any other runtime fault — a green AC on a screen that
    is logging a `JSExceptionHandler` warning is still a fail.
 
-7. **Smoke probe — wired end-to-end.** As part of every dispatch that
-   exercises the iOS path, run the canonical health flow:
+7. **Smoke probe — wired end-to-end (bash-only surface).** As part of
+   every dispatch that exercises the iOS path:
    - launch the dev-client (step 3),
    - inject auth via the deep-link bypass (step 3a) with role `client`,
-   - assert the Today screen renders both the training card and the
-     nutrition card within ~3 s,
-   - screenshot to `.qa-artifacts/<issue>/sim-today.png`.
-   If the smoke probe fails, the iOS path is broken — surface that as
-   a tooling problem, not as an AC failure. Route to the orchestrator
-   with "iOS smoke probe failed" rather than blaming the dev agent.
+   - take a screenshot via `xcrun simctl io booted screenshot
+     .qa-artifacts/<issue>/sim-after-deeplink.png`,
+   - verify the auth handler fired:
+     ```
+     xcrun simctl spawn booted log show --last 30s --predicate \
+       'subsystem == "com.gfplatform.mobile"' --style compact \
+       | grep "\[e2e-auth\] login bypass invoked"
+     ```
+   If the log line is present AND the screenshot is NOT the login
+   form, smoke passes — auth bypass mechanism works. Final visual
+   "Today screen renders cards" assertion is part of the
+   INTERACTIVE-REQUIRED handoff if any AC depends on it.
+
+   If the smoke probe fails (log line absent, or screenshot still on
+   login), the iOS path is broken — surface that as a tooling problem
+   ("iOS smoke probe failed"), not as an AC failure. Route to the
+   orchestrator rather than blaming the dev agent.
 
 8. **Tear down in step 7** (the agent-level "Tear down" step at the
    end of the workflow). Behaviour depends on how step 2 selected the

--- a/.claude/hooks/agent-bash-allowlist.sh
+++ b/.claude/hooks/agent-bash-allowlist.sh
@@ -75,8 +75,12 @@ case "$AGENT_TYPE" in
     qa-tester)
         # Read-only at the source-tree level — but qa-tester runs builds, tests, dev servers.
         # Allow everything dev/web/mobile agents allow EXCEPT git write ops and gh write ops.
-        ALLOW_REGEX="^(dotnet (test|build|run))|^(npm (run|ci|ls)|npx (--no-install|expo|tsc|playwright))|^(node )|^(xcrun |osascript)|${GIT_READ}|${FS_READ}|${GH_READ}|^pkill( -| $)|^docker (compose|ps|logs)|^bash |^python3 |^curl |^open |^brew "
-        DENY_HINT="qa-tester is read-only at source level. Allowed: dotnet test/build/run, npm/npx, expo, xcrun, git read-only, gh read-only. Forbidden: git commit/push, gh pr create/merge, code edits."
+        # `npm`/`npx` accept the `--prefix <path>` form so qa-tester can target a
+        # worktree without `cd` (the deny hook splits on first-token, so a literal
+        # `cd ... && ...` is two separate commands anyway). `cd` itself is allowed
+        # so the workflow patterns documented in qa-tester.md just work.
+        ALLOW_REGEX="^(dotnet (test|build|run))|^(npm( --prefix \\S+)?( |$))|^(npx( --prefix \\S+| --no-install)*( |$))|^(node )|^(xcrun |osascript)|^cd( |$)|${GIT_READ}|${FS_READ}|${GH_READ}|^pkill( -| $)|^docker (compose|ps|logs)|^bash |^python3 |^curl |^open |^brew "
+        DENY_HINT="qa-tester is read-only at source level. Allowed: dotnet test/build/run, npm/npx (incl. --prefix), node, expo, xcrun, osascript, cd, git read-only (incl. -C <path>), gh read-only, find/grep/cat/etc., pkill, docker compose, curl, open, brew. Forbidden: git commit/push (write ops), gh pr create/merge, code edits."
         ;;
     pr-reviewer)
         ALLOW_REGEX="^(gh pr |gh issue |gh api|gh run|gh label)|${GIT_READ}|${FS_READ}|^bash |^python3 "

--- a/.claude/hooks/agent-bash-allowlist.sh
+++ b/.claude/hooks/agent-bash-allowlist.sh
@@ -75,12 +75,13 @@ case "$AGENT_TYPE" in
     qa-tester)
         # Read-only at the source-tree level — but qa-tester runs builds, tests, dev servers.
         # Allow everything dev/web/mobile agents allow EXCEPT git write ops and gh write ops.
-        # `npm`/`npx` accept the `--prefix <path>` form so qa-tester can target a
-        # worktree without `cd` (the deny hook splits on first-token, so a literal
-        # `cd ... && ...` is two separate commands anyway). `cd` itself is allowed
-        # so the workflow patterns documented in qa-tester.md just work.
-        ALLOW_REGEX="^(dotnet (test|build|run))|^(npm( --prefix \\S+)?( |$))|^(npx( --prefix \\S+| --no-install)*( |$))|^(node )|^(xcrun |osascript)|^cd( |$)|${GIT_READ}|${FS_READ}|${GH_READ}|^pkill( -| $)|^docker (compose|ps|logs)|^bash |^python3 |^curl |^open |^brew "
-        DENY_HINT="qa-tester is read-only at source level. Allowed: dotnet test/build/run, npm/npx (incl. --prefix), node, expo, xcrun, osascript, cd, git read-only (incl. -C <path>), gh read-only, find/grep/cat/etc., pkill, docker compose, curl, open, brew. Forbidden: git commit/push (write ops), gh pr create/merge, code edits."
+        # `npm`/`npx` accept an optional `--prefix <path>` so qa-tester can target a
+        # worktree without `cd`, but the **sub-verb is still required** (no
+        # `npm install <pkg>`, no `npm publish`, etc.) — defence-in-depth preserved.
+        # `cd` itself is allowed so the workflow patterns documented in qa-tester.md
+        # just work.
+        ALLOW_REGEX="^(dotnet (test|build|run))|^npm( --prefix \\S+)? (run|ci|ls)( |$)|^npx( --prefix \\S+)? (--no-install|expo|tsc|playwright)( |$)|^(node )|^(xcrun |osascript)|^cd( |$)|${GIT_READ}|${FS_READ}|${GH_READ}|^pkill( -| $)|^docker (compose|ps|logs)|^bash |^python3 |^curl |^open |^brew "
+        DENY_HINT="qa-tester is read-only at source level. Allowed: dotnet test/build/run, npm (run/ci/ls) and npx (--no-install/expo/tsc/playwright) — both accept --prefix <path>, node, expo, xcrun, osascript, cd, git read-only (incl. -C <path>), gh read-only, find/grep/cat/etc., pkill, docker compose, curl, open, brew. Forbidden: npm install / npm publish, git commit/push (write ops), gh pr create/merge, code edits."
         ;;
     pr-reviewer)
         ALLOW_REGEX="^(gh pr |gh issue |gh api|gh run|gh label)|${GIT_READ}|${FS_READ}|^bash |^python3 "

--- a/.claude/schemas/qa-tester-result.v1.json
+++ b/.claude/schemas/qa-tester-result.v1.json
@@ -13,7 +13,10 @@
   "properties": {
     "$schema":     { "const": ".claude/schemas/qa-tester-result.v1.json" },
     "issue_number":{ "type": "integer", "minimum": 1 },
-    "verdict":     { "enum": ["PASS", "PARTIAL", "FAIL"] },
+    "verdict":     {
+      "enum": ["PASS", "PARTIAL", "INTERACTIVE-REQUIRED", "FAIL"],
+      "description": "PASS — all ACs verified, no regressions. PARTIAL — some ACs unverified due to missing fixture / data (not tooling); orchestrator may still proceed at its discretion. INTERACTIVE-REQUIRED — static + bash-smoke ACs pass, but one or more ACs require MCP-driven interactive verification (Playwright web / XcodeBuildMCP iOS) that the sub-agent's tool surface cannot perform. The orchestrator picks up the interactive checks on the main thread before the code-review gate. FAIL — at least one AC actively broken, or a regression detected."
+    },
     "acceptance_criteria_results": {
       "type": "array",
       "minItems": 1,

--- a/mobile/scripts/qa-build-dev-client.sh
+++ b/mobile/scripts/qa-build-dev-client.sh
@@ -5,6 +5,26 @@
 # cache. Cold builds take 5–8 min; cache hits return in <1s.
 #
 # Output: a single absolute path on stdout pointing at the cached .app bundle.
+#
+# WHY the guards below exist (cold-build race + validation):
+#
+# 1. pod install guard: if Pods/Manifest.lock diverges from Podfile.lock (e.g.
+#    after a dependency bump or a fresh checkout), xcodebuild fails to resolve
+#    target dependencies before Expo/Nitro emit their modulemaps, producing 33+
+#    "module map file not found" errors. Running pod install first resolves all
+#    CocoaPods targets so modulemaps emit in the correct order.
+#
+# 2. Drop -quiet: -quiet suppresses ALL xcodebuild output including errors, so
+#    a failed build appears to succeed silently. Without it, errors hit the
+#    caller's stderr and the real cause is visible immediately.
+#
+# 3. -onlyUsePackageVersionsFromResolvedFile: locks SwiftPM resolution to the
+#    committed Package.resolved, preventing version drift on cold builds.
+#
+# 4. Output validation gate: even when xcodebuild exits 0, the .app can be a
+#    stub bundle (only Expo.plist + Frameworks/__preview.dylib, no main
+#    executable, no Info.plist). The validation gate catches this before
+#    caching garbage to disk and installs downstream tooling (simctl install).
 
 set -euo pipefail
 
@@ -29,6 +49,18 @@ fi
 if [[ ! -d "$mobile_dir/ios" ]]; then
   echo "[qa-build] mobile/ios/ missing — running expo prebuild" >&2
   (cd "$mobile_dir" && npx expo prebuild --platform ios --no-install)
+fi
+
+# Ensure CocoaPods dependencies are resolved before invoking xcodebuild.
+# If Pods/Manifest.lock is missing or diverges from Podfile.lock (e.g. after
+# a dependency bump or fresh checkout), xcodebuild fails to resolve target
+# dependencies before Expo/Nitro can emit their modulemaps — the cold-build
+# race that produces 33+ "module map file not found" errors.
+pods_manifest="$mobile_dir/ios/Pods/Manifest.lock"
+podfile_lock="$mobile_dir/ios/Podfile.lock"
+if [[ ! -f "$pods_manifest" ]] || ! diff -q "$pods_manifest" "$podfile_lock" > /dev/null 2>&1; then
+  echo "[qa-build] Pods/Manifest.lock missing or diverged — running pod install" >&2
+  (cd "$mobile_dir/ios" && pod install) >&2
 fi
 
 workspace="$(find "$mobile_dir/ios" -maxdepth 2 -name "*.xcworkspace" -print -quit)"
@@ -56,12 +88,27 @@ xcodebuild \
   -sdk iphonesimulator \
   -destination 'generic/platform=iOS Simulator' \
   -derivedDataPath "$derived" \
-  -quiet \
+  -onlyUsePackageVersionsFromResolvedFile \
   build >&2
 
 built_app="$(find "$derived/Build/Products/Debug-iphonesimulator" -maxdepth 2 -name "*.app" -print -quit)"
 if [[ -z "$built_app" || ! -d "$built_app" ]]; then
   echo "[qa-build] FATAL: build succeeded but no .app under $derived" >&2
+  exit 1
+fi
+
+# Validate the produced .app before caching. Even when xcodebuild exits 0 it
+# can produce a stub bundle (only Expo.plist + Frameworks/__preview.dylib, no
+# main executable, no Info.plist) when the cold-build race occurred silently.
+# Require Info.plist AND the main binary named after the scheme (Expo prebuild
+# names the executable after the app scheme by convention).
+info_plist="$built_app/Info.plist"
+main_binary="$built_app/$scheme"
+
+if [[ ! -f "$info_plist" ]] || [[ ! -f "$main_binary" ]]; then
+  echo "[qa-build] FATAL: build returned success but produced no executable .app. See xcodebuild output above for the real cause." >&2
+  # Rename rather than rm -rf so the caller can inspect the stub if needed.
+  mv "$built_app" "${built_app}.invalid" 2>/dev/null || true
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Three concrete pipeline bugs converged on ten-plus qa-tester runs against #258. The deepest of them — sub-agent dispatches strip the MCP tool schema to Bash/Read/Write regardless of `tools:` / `mcpServers:` frontmatter — is a Claude Code orchestration-layer constraint we cannot patch in-repo. This PR re-architects the QA pipeline around that constraint rather than fighting it: `qa-tester` becomes a static + bash-smoke gate; MCP-driven interactive flows (Playwright web / XcodeBuildMCP iOS / a11y) live on the orchestrator main thread via a new `INTERACTIVE-REQUIRED` handoff tier and a new `.claude/CLAUDE.md` rule 6.5 playbook.

The same PR also lands two narrower fixes:
- `.claude/hooks/agent-bash-allowlist.sh` admits `npm --prefix`, `npx --prefix`, and `cd` for `qa-tester` (the DENY_HINT message already claimed these were allowed; the regex disagreed).
- `mobile/scripts/qa-build-dev-client.sh` guards the cold-build race: pod install on stale `Manifest.lock`, drops `-quiet` so xcodebuild errors surface, locks SwiftPM resolution via `-onlyUsePackageVersionsFromResolvedFile`, and validates `Info.plist` + main executable before writing the cache — preventing the silent stub-bundle failure mode.

## Related issue

Fixes #291

## Scope

docs-infra (qa-tester sub-agent + orchestrator routing + mobile build script)

## QA verdict (from qa-tester)

OVERALL: ✅ PASS — all four ACs met. Verification: `bash -n` clean on both shell scripts; `python3 json.load` valid on the schema; verdict enum now `['PASS','PARTIAL','INTERACTIVE-REQUIRED','FAIL']`. See `.claude/state/handoff-qa-291.json`.

## Test plan

- [x] `bash -n .claude/hooks/agent-bash-allowlist.sh` syntax-clean
- [x] `bash -n mobile/scripts/qa-build-dev-client.sh` syntax-clean
- [x] `python3 -c 'import json; json.load(open(".claude/schemas/qa-tester-result.v1.json"))'` valid
- [x] qa-tester diff covers all 4 ACs (Tool-surface reality, Verdict tiers, step 5 defer, step 7 bash-only smoke)
- [x] `INTERACTIVE-REQUIRED` enum value documented in schema + CLAUDE.md rule 6 c2 + CLAUDE.md rule 6.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)