### PR TITLE
fix(#295): two-pass xcodebuild to eliminate cold-cache modulemap race

### DIFF
--- a/mobile/scripts/qa-build-dev-client.sh
+++ b/mobile/scripts/qa-build-dev-client.sh
@@ -25,6 +25,16 @@
 #    stub bundle (only Expo.plist + Frameworks/__preview.dylib, no main
 #    executable, no Info.plist). The validation gate catches this before
 #    caching garbage to disk and installs downstream tooling (simctl install).
+#
+# 5. -parallelizeTargets NO: eliminates the remaining cold-cache modulemap race
+#    (#295). Even after pod install, xcodebuild's default parallel target
+#    scheduling can start the main target's Swift compilation (AppDelegate.swift)
+#    before CocoaPods dependency targets (Expo, Nitro, SwiftUIIntrospect, etc.)
+#    have emitted their modulemaps, producing 30+ "module map file not found"
+#    errors. Disabling target parallelism forces dependency targets to complete —
+#    and emit their modulemaps — before the main target's Swift compilation
+#    begins. Build time increases by ~10–20s on cold runs; cache hits are
+#    unaffected.
 
 set -euo pipefail
 
@@ -81,6 +91,12 @@ fi
 
 derived="$cache_dir/.derived-$sha"
 echo "[qa-build] Building scheme=$scheme workspace=$workspace (sha=$sha)" >&2
+# -parallelizeTargets NO: prevents the cold-cache modulemap race (#295) where
+# xcodebuild starts the main target's Swift compilation before CocoaPods
+# dependency targets (Expo / Nitro / SwiftUIIntrospect) have emitted their
+# modulemaps, producing 30+ "module map file not found" errors. With serial
+# target execution, dependency targets fully complete before the main target's
+# Swift phase begins.
 xcodebuild \
   -workspace "$workspace" \
   -scheme "$scheme" \
@@ -89,6 +105,7 @@ xcodebuild \
   -destination 'generic/platform=iOS Simulator' \
   -derivedDataPath "$derived" \
   -onlyUsePackageVersionsFromResolvedFile \
+  -parallelizeTargets NO \
   build >&2
 
 built_app="$(find "$derived/Build/Products/Debug-iphonesimulator" -maxdepth 2 -name "*.app" -print -quit)"

--- a/mobile/scripts/qa-build-dev-client.sh
+++ b/mobile/scripts/qa-build-dev-client.sh
@@ -26,15 +26,19 @@
 #    executable, no Info.plist). The validation gate catches this before
 #    caching garbage to disk and installs downstream tooling (simctl install).
 #
-# 5. -parallelizeTargets NO: eliminates the remaining cold-cache modulemap race
-#    (#295). Even after pod install, xcodebuild's default parallel target
-#    scheduling can start the main target's Swift compilation (AppDelegate.swift)
-#    before CocoaPods dependency targets (Expo, Nitro, SwiftUIIntrospect, etc.)
-#    have emitted their modulemaps, producing 30+ "module map file not found"
-#    errors. Disabling target parallelism forces dependency targets to complete —
-#    and emit their modulemaps — before the main target's Swift compilation
-#    begins. Build time increases by ~10–20s on cold runs; cache hits are
-#    unaffected.
+# 5. Two-pass build to break the cold-cache modulemap race (#295): even after
+#    pod install, xcodebuild's default parallel target scheduling can start the
+#    main target's Swift compilation (AppDelegate.swift) before CocoaPods
+#    dependency targets (Expo, Nitro, SwiftUIIntrospect, etc.) have emitted
+#    their modulemaps, producing 30+ "module map file not found" errors. The
+#    fix is a pre-pass that builds only the Pods-<AppName> aggregate scheme
+#    (which compiles every CocoaPods dependency and emits all their modulemaps
+#    into derivedDataPath) BEFORE the main scheme build begins. Both passes
+#    share the same -derivedDataPath so the second pass picks up the already-
+#    emitted modulemaps from the cache and skips recompiling them.
+#    NOTE: -parallelizeTargets is a boolean switch (enables parallelism; no
+#    argument accepted); there is no CLI flag to disable it — confirmed via
+#    xcrun xcodebuild --help. The two-pass approach is the correct solution.
 
 set -euo pipefail
 
@@ -79,10 +83,12 @@ if [[ -z "$workspace" ]]; then
   exit 1
 fi
 
-# Read the iOS scheme from the project. Expo prebuild names it after
-# expo.name -> sanitized; this picks the first scheme in the workspace.
-scheme="$(xcodebuild -workspace "$workspace" -list -json 2>/dev/null \
-  | python3 -c 'import json,sys;d=json.load(sys.stdin);print(d["workspace"]["schemes"][0])')"
+# Derive the app scheme name from the workspace file name. Expo prebuild names
+# the workspace (and app scheme) after expo.name -> sanitized (e.g.
+# "GFPlatform.xcworkspace" → scheme "GFPlatform"). Using the workspace basename
+# is more reliable than picking schemes[0] from -list, which returns schemes in
+# alphabetical order (CocoaPods schemes like EXApplication sort before the app).
+scheme="$(basename "$workspace" .xcworkspace)"
 
 if [[ -z "$scheme" ]]; then
   echo "[qa-build] FATAL: could not determine xcodebuild scheme" >&2
@@ -90,14 +96,28 @@ if [[ -z "$scheme" ]]; then
 fi
 
 derived="$cache_dir/.derived-$sha"
-echo "[qa-build] Building scheme=$scheme workspace=$workspace (sha=$sha)" >&2
-# -parallelizeTargets NO: prevents the cold-cache modulemap race (#295) where
-# xcodebuild starts the main target's Swift compilation before CocoaPods
-# dependency targets (Expo / Nitro / SwiftUIIntrospect) have emitted their
-# modulemaps, producing 30+ "module map file not found" errors. With serial
-# target execution, dependency targets fully complete before the main target's
-# Swift phase begins.
-xcodebuild \
+
+# Pre-pass: build Pods-<AppName> aggregate scheme first so every CocoaPods
+# dependency target emits its modulemaps into $derived before the main scheme
+# Swift compilation starts. This is the two-pass fix for the cold-cache
+# modulemap race (#295): parallel target scheduling in xcodebuild can otherwise
+# start AppDelegate.swift before Expo/Nitro/SwiftUIIntrospect modulemaps land.
+# Both passes share -derivedDataPath so the second pass picks up the
+# already-compiled Pods and skips recompiling them.
+pods_scheme="Pods-${scheme}"
+echo "[qa-build] Pre-emitting Pods modulemaps to break cold-cache race (scheme=$pods_scheme)" >&2
+xcrun xcodebuild \
+  -workspace "$workspace" \
+  -scheme "$pods_scheme" \
+  -configuration Debug \
+  -sdk iphonesimulator \
+  -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath "$derived" \
+  -onlyUsePackageVersionsFromResolvedFile \
+  build >&2
+
+echo "[qa-build] Building main scheme=$scheme workspace=$workspace (sha=$sha)" >&2
+xcrun xcodebuild \
   -workspace "$workspace" \
   -scheme "$scheme" \
   -configuration Debug \
@@ -105,7 +125,6 @@ xcodebuild \
   -destination 'generic/platform=iOS Simulator' \
   -derivedDataPath "$derived" \
   -onlyUsePackageVersionsFromResolvedFile \
-  -parallelizeTargets NO \
   build >&2
 
 built_app="$(find "$derived/Build/Products/Debug-iphonesimulator" -maxdepth 2 -name "*.app" -print -quit)"

--- a/mobile/scripts/qa-build-dev-client.sh
+++ b/mobile/scripts/qa-build-dev-client.sh
@@ -39,6 +39,14 @@
 #    NOTE: -parallelizeTargets is a boolean switch (enables parallelism; no
 #    argument accepted); there is no CLI flag to disable it — confirmed via
 #    xcrun xcodebuild --help. The two-pass approach is the correct solution.
+#    The workspace lookup uses -maxdepth 1 so find returns the CocoaPods-
+#    augmented GFPlatform.xcworkspace (depth 1) and never the Xcode-generated
+#    project.xcworkspace nested inside GFPlatform.xcodeproj/ (depth 2).
+#
+# 6. Scheme-existence assertion: after deriving pods_scheme from the workspace
+#    basename, the script verifies that scheme is actually listed in the
+#    workspace before launching the pre-pass. This converts a wrong-scheme
+#    silent exit-65 into a loud FATAL with the available scheme names.
 
 set -euo pipefail
 
@@ -77,7 +85,7 @@ if [[ ! -f "$pods_manifest" ]] || ! diff -q "$pods_manifest" "$podfile_lock" > /
   (cd "$mobile_dir/ios" && pod install) >&2
 fi
 
-workspace="$(find "$mobile_dir/ios" -maxdepth 2 -name "*.xcworkspace" -print -quit)"
+workspace="$(find "$mobile_dir/ios" -maxdepth 1 -name "*.xcworkspace" -print -quit)"
 if [[ -z "$workspace" ]]; then
   echo "[qa-build] FATAL: no .xcworkspace under mobile/ios/" >&2
   exit 1
@@ -105,6 +113,18 @@ derived="$cache_dir/.derived-$sha"
 # Both passes share -derivedDataPath so the second pass picks up the
 # already-compiled Pods and skips recompiling them.
 pods_scheme="Pods-${scheme}"
+
+# Assert that pods_scheme exists in the workspace before attempting the pre-pass.
+# A wrong scheme causes xcodebuild to exit 65 with a cryptic "does not contain a
+# scheme" error. This guard catches it early and prints the schemes that ARE present.
+if ! xcrun xcodebuild -workspace "$workspace" -list -json 2>/dev/null \
+     | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if '$pods_scheme' in d['workspace']['schemes'] else 1)"; then
+  echo "[qa-build] FATAL: expected scheme '$pods_scheme' not found in workspace. Schemes present:" >&2
+  xcrun xcodebuild -workspace "$workspace" -list -json 2>/dev/null \
+    | python3 -c "import json,sys; print('\n'.join(json.load(sys.stdin)['workspace']['schemes']))" >&2
+  exit 1
+fi
+
 echo "[qa-build] Pre-emitting Pods modulemaps to break cold-cache race (scheme=$pods_scheme)" >&2
 xcrun xcodebuild \
   -workspace "$workspace" \


### PR DESCRIPTION
## Summary

Replaces the cold-cache `xcodebuild` modulemap race in `mobile/scripts/qa-build-dev-client.sh` with a deterministic two-pass build.

- **Pre-pass** builds the `Pods-GFPlatform` aggregate scheme against the workspace with a shared `-derivedDataPath`, emitting every CocoaPods dependency modulemap (Expo, Nitro, SwiftUIIntrospect, …) before the main scheme's Swift compilation can start.
- **Main pass** then builds `GFPlatform` against the same derived data — the modulemaps are already on disk, so `AppDelegate.swift`'s `import Expo` resolves cleanly.
- **Defensive scheme-existence assertion** fails fast with a readable diagnostic if the workspace ever stops exposing `Pods-GFPlatform`, instead of letting `xcodebuild` exit 65 with a cryptic "does not contain a scheme" error.
- **Workspace finder** tightened to `-maxdepth 1` so `find` can't accidentally pick `<App>.xcodeproj/project.xcworkspace` (the depth-2 auto-generated nested workspace) over the sibling CocoaPods-augmented workspace at depth 1.
- All `xcodebuild` invocations standardised to `xcrun xcodebuild`.
- Scheme name now derived from the workspace basename (`basename "$workspace" .xcworkspace`) instead of `schemes[0]` to avoid alphabetical surprises (`EXApplication` would otherwise sort before `GFPlatform`).
- WHY comment block (points 5 + 6) updated to document the new mechanism and the constraints behind it.

Three commits on the branch — the first attempt (`bb73170`) used an invalid `-parallelizeTargets NO` flag; the rework (`68df746`) introduced the two-pass mechanism but a workspace-find depth bug surfaced; the final commit (`2bd544d`) tightened `find` to `-maxdepth 1` and added the scheme-existence assertion. Per the `type:bug` strategy in `rules/merge-strategy.md`, the three commits squash-merge to a single commit on `develop`.

## Related issue

Closes #295

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all 3 acceptance criteria met:

- Cold-build smoke produced exit 0 + valid `.app` (Info.plist + main binary) at `mobile/.qa-cache/7ce2ae6cbec82403d85f83205af4e4cc56678eb0.app`, zero "module map file not found" errors.
- Two-pass mechanism exercised end-to-end: pre-pass `** BUILD SUCCEEDED **` for `Pods-GFPlatform`, then main pass `** BUILD SUCCEEDED **` for `GFPlatform`. Both passes shared `-derivedDataPath`.
- No retry / loop primitives introduced — straight-line script.

Evidence: `/tmp/qa-295-run4-stderr.log`, cached `.app` path above.

## Test plan

- [x] `mobile/scripts/qa-build-dev-client.sh` reliably produces a valid `.app` from a cold worktree without manual intervention.
- [x] Verified by: `git worktree add` a throwaway branch off develop, run the script, confirm exit 0 + `Info.plist` + main executable present in the cached `.app`.
- [x] No new "fail twice, succeed third time" loops in the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)