### PR TITLE
fix(#282): delete cargo-cult IHostedService removal in FitnessApiFactory; document #296 closure for ServiceResolver race

### DIFF
--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactory.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using MongoDB.Driver;
 using Testcontainers.MongoDb;
 using Testcontainers.PostgreSql;
@@ -112,40 +111,12 @@ public class FitnessApiFactory : WebApplicationFactory<Program>, IAsyncLifetime
             services.AddSingleton<IPushNotificationService>(
                 sp => sp.GetRequiredService<FakePushNotificationService>());
 
-            // Candidate A — test isolation: remove all IHostedService registrations for
-            // PhotoDiaryReminderScheduler so it does not run autonomously during tests and
-            // cannot race with the real-time clock at the :00 boundary on Linux CI.
-            //
-            // Three descriptor shapes are matched defensively because the production
-            // registration in Program.cs uses the factory overload:
-            //
-            //   builder.Services.AddSingleton<PhotoDiaryReminderScheduler>();          // line 199
-            //   builder.Services.AddHostedService(sp =>                                // line 200
-            //       sp.GetRequiredService<PhotoDiaryReminderScheduler>());
-            //
-            // The second call produces a ServiceDescriptor whose ImplementationType is null
-            // (factory-registered) and whose ImplementationFactory is a Func<IServiceProvider, object>
-            // whose MethodInfo.ReturnType is PhotoDiaryReminderScheduler (covariant delegate
-            // conversion).  Matching only ImplementationType == typeof(...) is a no-op against
-            // this shape — the ImplementationType check is always false for factory descriptors.
-            //
-            // All three variants are checked so the removal is robust against future
-            // registration-style changes without requiring another test-isolation fixup.
-            //
-            // The scheduler remains resolvable as a singleton via
-            //   factory.Services.GetRequiredService<PhotoDiaryReminderScheduler>()
-            // so existing tests that drive TickAsync directly are unaffected.
-            var toRemove = services
-                .Where(d => d.ServiceType == typeof(IHostedService))
-                .Where(d =>
-                    d.ImplementationType == typeof(PhotoDiaryReminderScheduler) ||
-                    d.ImplementationInstance is PhotoDiaryReminderScheduler ||
-                    (d.ImplementationFactory is not null &&
-                     d.ImplementationFactory.Method.ReturnType == typeof(PhotoDiaryReminderScheduler)))
-                .ToList();
-
-            foreach (var d in toRemove)
-                services.Remove(d);
+            // Issue #282: the IHostedService-removal predicate for PhotoDiaryReminderScheduler
+            // (added in #279) was a CI runtime no-op — both schedulers still fired ExecuteAsync
+            // on every Backend CI run (verified on run 26187846524, sha ee01787: 8 PhotoDiary
+            // first-tick log lines, 9 WeeklyCheckIn first-tick log lines). Cascade prevention
+            // is carried by the per-candidate IServiceScope inside each scheduler's ExecuteAsync
+            // (introduced in #278/#279/#280/#281) and remains intact.
         });
 
         builder.UseEnvironment("Development");

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactoryTests.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactoryTests.cs
@@ -1,44 +1,18 @@
 using FluentAssertions;
 using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace FitnessPlatform.Tests.Infrastructure;
 
 /// <summary>
 /// Smoke tests for <see cref="FitnessApiFactory"/> configuration correctness.
-/// These are the "would have caught the QA regression" tests that verify the
-/// hosted-service descriptor removal predicate actually works against the
-/// factory-registered shape used in Program.cs lines 199-200.
 /// </summary>
 [Collection(TestCollection.Name)]
 public class FitnessApiFactoryTests(FitnessApiFactory factory)
 {
     /// <summary>
-    /// Verifies that the <see cref="PhotoDiaryReminderScheduler"/> is NOT exposed as
-    /// an <see cref="IHostedService"/> in the test host.
-    ///
-    /// Regression guard for the factory-registered descriptor shape:
-    ///   AddHostedService(sp => sp.GetRequiredService&lt;PhotoDiaryReminderScheduler&gt;())
-    /// produces a ServiceDescriptor with ImplementationType == null (ImplementationFactory != null),
-    /// so a predicate that only checks ImplementationType is a no-op and the scheduler
-    /// continues to run autonomously, racing the clock on the :00 boundary in CI.
-    /// </summary>
-    [Fact]
-    public void PhotoDiaryReminderScheduler_IsNotRegisteredAsHostedService()
-    {
-        var hostedServices = factory.Services.GetServices<IHostedService>();
-
-        hostedServices
-            .Should().NotContain(
-                s => s is PhotoDiaryReminderScheduler,
-                "the scheduler must be removed from IHostedService registrations " +
-                "so it cannot race the real clock during integration tests");
-    }
-
-    /// <summary>
     /// Verifies that the <see cref="PhotoDiaryReminderScheduler"/> singleton is still
-    /// resolvable from DI after the IHostedService descriptor is removed.
+    /// resolvable from DI in the test host.
     /// Tests that drive the scheduler directly via TickAsync must be able to call
     /// factory.Services.GetRequiredService&lt;PhotoDiaryReminderScheduler&gt;().
     /// </summary>

--- a/backend/FitnessPlatform.Tests/TestAssemblyConfig.cs
+++ b/backend/FitnessPlatform.Tests/TestAssemblyConfig.cs
@@ -23,4 +23,8 @@
 // xunit.runner.json covers dotnet-test / VSTest adapter runs.
 //
 // See also: FitnessApiFactory.cs (PhotoDiaryReminderScheduler suppression, #278 precedent).
+//
+// Issue #282 Finding 2 (ObjectDisposedException on FastEndpoints.ServiceResolver under parallel test load)
+// empirically addressed by this configuration + #296 (skip base.DisposeAsync to preserve
+// ServiceResolver.Provider lifetime). Verified 2026-05-25.
 [assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary

Closes #282. Two-finding test-isolation cleanup:

- **Finding 1 (IHostedService removal silently no-ops in CI):** chose **Path A2** — delete the three-variant descriptor-removal predicate in `FitnessApiFactory.ConfigureWebHost` (introduced in #279) and delete the false-positive smoke test `PhotoDiaryReminderScheduler_IsNotRegisteredAsHostedService`. CI evidence: Backend run **26187846524** (sha `ee01787` on `develop`) shows **8 `PhotoDiaryReminderScheduler: first tick` + 9 `WeeklyCheckInScheduler: first tick`** log lines, proving the predicate was a CI runtime no-op. Cascade prevention is carried by the per-candidate `IServiceScope` pattern inside each scheduler's `ExecuteAsync` (introduced in #278/#279/#280/#281) — preserved intact, no production code touched.
- **Finding 2 (FastEndpoints static `ServiceResolver` race under parallel test load):** closed by **comment-only** addendum in `TestAssemblyConfig.cs` referencing **#296**'s structural fix (skip `base.DisposeAsync()` in both `FitnessApiFactory.DisposeAsync` and `ResetEndpointFactoryBase.DisposeAsync` to preserve `ServiceResolver.Provider` lifetime). Same CI run shows **zero** `ObjectDisposedException` / `ServiceResolver` matches — empirical closure data point #1; PR CI is data point #2 (this PR's Backend CI must reproduce zero matches before merge per design contract `error_paths #6`).

Net diff: **-62 / +11** across 3 files. No production code changed.

## Related issue
Fixes #282

## Scope
backend

## QA verdict (from qa-tester)
OVERALL ✅ PASS — full 1066-test sweep green in 3m02s under `DisableTestParallelization=true`. Zero `ObjectDisposedException` failures, zero scheduler-test regressions, Docker (Testcontainers) available.

## Test plan
- [x] Finding 1: predicate deleted; `Candidate B` per-candidate `IServiceScope` cascade prevention stays intact in both schedulers.
- [x] Finding 1: false-positive smoke test `PhotoDiaryReminderScheduler_IsNotRegisteredAsHostedService` removed; legit `PhotoDiaryReminderScheduler_IsStillResolvableAsSingleton` kept (verifies DI resolvability for `TickAsync`-driven tests).
- [x] Finding 2: `TestAssemblyConfig.cs` documents closure via #296 + xunit collection-parallelism disable, with verification date 2026-05-25.
- [x] **Pre-merge CI gate (design contract `error_paths #6`):** PR's own Backend CI logs grepped for `ObjectDisposedException` AND `ServiceResolver` matches. If non-zero → STOP, do not merge, re-open Finding 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)