### PR TITLE
fix(#280): per-candidate IServiceScope in WeeklyCheckInScheduler.ProcessTickAsync

### DIFF
--- a/backend/FitnessPlatform.Application/Infrastructure/Services/WeeklyCheckInScheduler.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/WeeklyCheckInScheduler.cs
@@ -32,6 +32,27 @@ public class WeeklyCheckInScheduler(
     private bool _cursorInitialized;
 
     /// <summary>
+    /// Resets the scheduler's cursor state so the next <see cref="TickAsync"/> call
+    /// re-seeds from the DB. Use between tests that share the same singleton instance.
+    /// </summary>
+    internal void ResetCursor()
+    {
+        _cursorInitialized = false;
+        _lastTickAt = default;
+    }
+
+    /// <summary>
+    /// Force-sets the last-tick cursor to a specific point in time WITHOUT re-seeding from DB.
+    /// Use in tests that need to position the window precisely without resetting
+    /// <see cref="_cursorInitialized"/>.
+    /// </summary>
+    internal void SetLastTickAt(DateTime lastTickAt)
+    {
+        _cursorInitialized = true;
+        _lastTickAt = lastTickAt;
+    }
+
+    /// <summary>
     /// Entry point used by tests: execute one scheduler cycle treating <paramref name="now"/>
     /// as the current UTC time.  The internal cursor is seeded on first call.
     /// </summary>
@@ -144,6 +165,7 @@ public class WeeklyCheckInScheduler(
     {
         // Load all enabled settings with their associated professional users
         // and optional per-client overrides.
+        // Use AsNoTracking — the candidate list is read-only; writes happen in per-candidate scopes.
         var settings = await db.WeeklyCheckInSettings
             .AsNoTracking()
             .Where(s => s.Enabled)
@@ -211,6 +233,16 @@ public class WeeklyCheckInScheduler(
                 // WeekStartDate = Monday of the ISO week AFTER the fire moment.
                 var weekStartDate = NextIsoMonday(nextFireAt);
 
+                // ── Candidate: per-candidate scope ────────────────────────────
+                // Each candidate gets its own IApplicationDbContext scope so that a 23505
+                // unique-violation (or any other DbUpdateException) on one candidate's
+                // SaveChanges cannot corrupt the change tracker and cascade to the next
+                // candidate's inserts.  This is the architecturally correct fix: after
+                // a failed SaveChanges the EF change tracker is in an undefined state;
+                // disposing the scope is the only safe recovery.
+                using var candidateScope = scopeFactory.CreateScope();
+                var candidateDb = candidateScope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+
                 var checkIn = new WeeklyCheckIn
                 {
                     ClientUserId = clientUserId,
@@ -222,23 +254,23 @@ public class WeeklyCheckInScheduler(
                     DateModified = now
                 };
 
-                db.WeeklyCheckIns.Add(checkIn);
+                candidateDb.WeeklyCheckIns.Add(checkIn);
 
                 try
                 {
-                    await db.SaveChangesAsync(ct);
+                    await candidateDb.SaveChangesAsync(ct);
                 }
                 catch (DbUpdateException ex)
                     when (IsUniqueViolation(ex))
                 {
+                    // Duplicate — check-in already exists for this (ClientUserId, ProfessionalUserId,
+                    // Profession, WeekStartDate). The candidateScope is disposed at end-of-block;
+                    // no tracker cleanup needed.
                     logger.LogWarning(
                         "WeeklyCheckInScheduler: duplicate check-in skipped for " +
                         "client={ClientUserId} professional={ProfessionalUserId} " +
                         "profession={Profession} week={WeekStartDate}.",
                         clientUserId, setting.UserId, setting.Profession, weekStartDate);
-
-                    // Remove the tracked entity so the context remains usable.
-                    db.WeeklyCheckIns.Remove(checkIn);
                     continue;
                 }
 
@@ -262,8 +294,19 @@ public class WeeklyCheckInScheduler(
                     Data = notificationData
                 };
 
-                db.Notifications.Add(notification);
-                await db.SaveChangesAsync(ct);
+                // ── Persist in-app notification (best-effort) ────────────────
+                try
+                {
+                    candidateDb.Notifications.Add(notification);
+                    await candidateDb.SaveChangesAsync(ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "WeeklyCheckInScheduler: failed to persist notification for client {ClientUserId}.",
+                        clientUserId);
+                    continue;
+                }
 
                 // Send push notification.
                 try

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/WeeklyCheckInSchedulerTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/WeeklyCheckInSchedulerTests.cs
@@ -238,4 +238,205 @@ public class WeeklyCheckInSchedulerTests(FitnessApiFactory factory)
         newNotificationCalls.Should().HaveCount(1,
             "scheduler must broadcast exactly one newnotification to the client");
     }
+
+    /// <summary>
+    /// Regression test for the EF Core change-tracker cascade (issue #280).
+    ///
+    /// When two candidates (clients A and B linked to the same trainer) are processed
+    /// in the same tick and the FIRST candidate's WeeklyCheckIn insert violates the
+    /// unique constraint (Postgres 23505), the SECOND candidate must still receive its
+    /// check-in row, in-app notification, and push notification.
+    ///
+    /// Before the fix: the catch block called db.WeeklyCheckIns.Remove(checkIn) on a
+    /// never-persisted entity, leaving the shared DbContext's change tracker in a
+    /// corrupted state.  The second candidate's SaveChanges would then fail with a
+    /// cascade exception.
+    ///
+    /// After the fix: each candidate runs inside its own IServiceScope / IApplicationDbContext,
+    /// so a failed SaveChanges disposes that scope and the next candidate starts clean.
+    /// </summary>
+    [Fact]
+    public async Task Tick_UniqueViolationOnFirstCandidate_DoesNotCascadeToSecondCandidate()
+    {
+        // Arrange: one trainer with two clients, both fire at the same UTC time (Friday 14:00 UTC).
+        var utcNow = DateTime.UtcNow;
+        var daysToLastFriday = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Friday + 7) % 7;
+        var lastFriday = utcNow.Date.AddDays(-daysToLastFriday).AddHours(14);
+        if (lastFriday >= utcNow) lastFriday = lastFriday.AddDays(-7);
+
+        var weekStartDate = WeeklyCheckInScheduler.NextIsoMonday(lastFriday);
+
+        // Register trainer
+        var trainerEmail = UniqueEmail("cascade-trainer");
+        var trainerHttp = factory.CreateClient();
+        await TestHelpers.RegisterAsync(trainerHttp, trainerEmail, "TestPass1!", "Cascade", "Trainer", "Trainer");
+
+        // Register client A
+        var clientAEmail = UniqueEmail("cascade-clientA");
+        var clientAHttp = factory.CreateClient();
+        await TestHelpers.RegisterAsync(clientAHttp, clientAEmail, "TestPass1!", "Cascade", "ClientA", "Client");
+
+        // Register client B
+        var clientBEmail = UniqueEmail("cascade-clientB");
+        var clientBHttp = factory.CreateClient();
+        await TestHelpers.RegisterAsync(clientBHttp, clientBEmail, "TestPass1!", "Cascade", "ClientB", "Client");
+
+        Guid trainerUserId, clientAId, clientBId;
+
+        using (var setupScope = factory.Services.CreateScope())
+        {
+            var setupDb = setupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var trainerUser = await setupDb.Users.FirstAsync(
+                u => u.Email == trainerEmail, TestContext.Current.CancellationToken);
+            var clientAUser = await setupDb.Users.FirstAsync(
+                u => u.Email == clientAEmail, TestContext.Current.CancellationToken);
+            var clientBUser = await setupDb.Users.FirstAsync(
+                u => u.Email == clientBEmail, TestContext.Current.CancellationToken);
+
+            trainerUserId = trainerUser.Id;
+            clientAId = clientAUser.Id;
+            clientBId = clientBUser.Id;
+
+            // Set timezone to UTC so fire time = 14:00 UTC directly.
+            trainerUser.TimeZone = "UTC";
+
+            var profProfile = await setupDb.ProfessionalProfiles.FirstAsync(
+                p => p.UserId == trainerUserId, TestContext.Current.CancellationToken);
+
+            var clientAProfile = await setupDb.ClientProfiles.FirstAsync(
+                cp => cp.UserId == clientAId, TestContext.Current.CancellationToken);
+            var clientBProfile = await setupDb.ClientProfiles.FirstAsync(
+                cp => cp.UserId == clientBId, TestContext.Current.CancellationToken);
+
+            // Link both clients to trainer.
+            setupDb.ClientProfessionalLinks.Add(new ClientProfessionalLink
+            {
+                PublicId = Guid.NewGuid(),
+                ProfessionalProfileId = profProfile.Id,
+                ClientProfileId = clientAProfile.Id,
+                ProfessionalRole = UserRole.Trainer,
+                IsActive = true,
+                CanViewTrainingPlans = true,
+                CanViewNutritionPlans = false,
+                DateCreated = DateTime.UtcNow
+            });
+            setupDb.ClientProfessionalLinks.Add(new ClientProfessionalLink
+            {
+                PublicId = Guid.NewGuid(),
+                ProfessionalProfileId = profProfile.Id,
+                ClientProfileId = clientBProfile.Id,
+                ProfessionalRole = UserRole.Trainer,
+                IsActive = true,
+                CanViewTrainingPlans = true,
+                CanViewNutritionPlans = false,
+                DateCreated = DateTime.UtcNow
+            });
+
+            // One setting fires every Friday at 14:00 UTC.
+            setupDb.WeeklyCheckInSettings.Add(new WeeklyCheckInSetting
+            {
+                UserId = trainerUserId,
+                Profession = Profession.Training,
+                DayOfWeek = DayOfWeek.Friday,
+                TimeOfDay = TimeSpan.FromHours(14),
+                Enabled = true,
+                DateCreated = DateTime.UtcNow,
+                DateModified = DateTime.UtcNow
+            });
+
+            await setupDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Pre-seed a WeeklyCheckIn row for client A's (ClientUserId, ProfessionalUserId, Profession,
+        // WeekStartDate) so that A's insert will hit the 23505 unique violation.
+        using (var seedScope = factory.Services.CreateScope())
+        {
+            var seedDb = seedScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            seedDb.WeeklyCheckIns.Add(new WeeklyCheckIn
+            {
+                ClientUserId = clientAId,
+                ProfessionalUserId = trainerUserId,
+                Profession = Profession.Training,
+                WeekStartDate = weekStartDate,
+                SentAt = lastFriday.AddHours(-1),   // pre-existing row for this week
+                DateCreated = lastFriday.AddHours(-1),
+                DateModified = lastFriday.AddHours(-1)
+            });
+            await seedDb.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var push = factory.Services.GetRequiredService<FakePushNotificationService>();
+        push.Reset();
+
+        var notifier = factory.Services.GetRequiredService<FakeRealtimeNotifier>();
+        notifier.Reset();
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+        scheduler.ResetCursor();
+
+        // Position cursor one hour before fire time so Friday 14:00 UTC is in the window.
+        scheduler.SetLastTickAt(lastFriday.AddHours(-1));
+        scheduler.OverrideNow = lastFriday.AddMinutes(30);
+
+        // Act — one tick processes both candidates (A hits 23505, B must succeed).
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Assert
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        // Candidate A: only the pre-seeded row remains — duplicate was rejected cleanly.
+        var checkInsForA = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientAId
+                        && c.ProfessionalUserId == trainerUserId
+                        && c.WeekStartDate == weekStartDate)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        checkInsForA.Should().HaveCount(1,
+            "candidate A had a pre-existing row — the unique violation must be swallowed, " +
+            "not crash the scheduler, and the existing row must not be deleted");
+
+        // Candidate B: check-in row must be inserted (no cascade from A's failure).
+        var checkInsForB = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientBId
+                        && c.ProfessionalUserId == trainerUserId
+                        && c.WeekStartDate == weekStartDate)
+            .ToListAsync(TestContext.Current.CancellationToken);
+        checkInsForB.Should().HaveCount(1,
+            "candidate B's check-in insert must succeed despite A's 23505 violation");
+
+        // Candidate B: in-app notification must be created.
+        var notificationForB = await db.Notifications
+            .Where(n => n.RecipientUserId == clientBId
+                        && n.Type == NotificationType.WeeklyCheckInRequested)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        notificationForB.Should().NotBeNull(
+            "candidate B's in-app notification must be persisted — it must not be affected by A's failure");
+
+        // Candidate A: no new in-app notification (check-in was skipped as duplicate).
+        var notificationForA = await db.Notifications
+            .Where(n => n.RecipientUserId == clientAId
+                        && n.Type == NotificationType.WeeklyCheckInRequested)
+            .FirstOrDefaultAsync(TestContext.Current.CancellationToken);
+        notificationForA.Should().BeNull(
+            "candidate A's notification must NOT be created — the check-in was a duplicate and was skipped");
+
+        // Push must be invoked exactly once (for candidate B only).
+        var cascadePushCalls = push.Calls
+            .Where(c => c.UserId == clientAId || c.UserId == clientBId)
+            .ToList();
+        cascadePushCalls.Should().HaveCount(1,
+            "push must be sent for candidate B only — candidate A's check-in was a duplicate");
+        cascadePushCalls[0].UserId.Should().Be(clientBId,
+            "the push must target candidate B's client");
+
+        // SignalR broadcast must fire exactly once (for candidate B's newnotification).
+        var newNotificationCalls = notifier.Calls
+            .Where(c => (c.UserId == clientAId || c.UserId == clientBId)
+                        && c.EventType == "newnotification")
+            .ToList();
+        newNotificationCalls.Should().HaveCount(1,
+            "newnotification must be broadcast once (for candidate B) — candidate A was skipped");
+        newNotificationCalls[0].UserId.Should().Be(clientBId);
+    }
 }

--- a/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactoryTests.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/FitnessApiFactoryTests.cs
@@ -24,4 +24,19 @@ public class FitnessApiFactoryTests(FitnessApiFactory factory)
         scheduler.Should().NotBeNull(
             "the singleton must remain resolvable so tests can drive TickAsync directly");
     }
+
+    /// <summary>
+    /// Verifies that the <see cref="WeeklyCheckInScheduler"/> singleton is still
+    /// resolvable from DI in the test host after the per-candidate-scope refactor (#280).
+    /// Tests that drive the scheduler directly via TickAsync must be able to call
+    /// factory.Services.GetRequiredService&lt;WeeklyCheckInScheduler&gt;().
+    /// </summary>
+    [Fact]
+    public void WeeklyCheckInScheduler_IsStillResolvableAsSingleton()
+    {
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        scheduler.Should().NotBeNull(
+            "the singleton must remain resolvable so tests can drive TickAsync directly");
+    }
 }


### PR DESCRIPTION
## Summary

- Root cause: `WeeklyCheckInScheduler.ProcessTickAsync` shared a single `IApplicationDbContext` across every candidate in its per-tick `foreach`. When candidate A's `WeeklyCheckIns` insert hit a Postgres `23505` unique-constraint, the buggy `db.WeeklyCheckIns.Remove(checkIn)` recovery acted on a never-persisted entity and left the EF change tracker corrupted — cascading the next candidate's `SaveChangesAsync` (and the in-app notification insert) into a hard failure.
- Fix mirrors `PhotoDiaryReminderScheduler.cs:262-329` (the pattern shipped in PR #279): each candidate that passes the cursor/dedup filter opens its own `IServiceScope` via the injected `IServiceScopeFactory` and resolves a fresh `IApplicationDbContext` (`candidateDb`). The outer `db` (created in `TickAsync` from the scheduler's own scope) is retained only for the pre-foreach `AsNoTracking()` reads (`settings`, `professionalProfiles`, `overrides`). The buggy `db.WeeklyCheckIns.Remove(checkIn)` recovery is deleted — scope disposal handles tracker cleanup. `Notifications.SaveChangesAsync` is wrapped in a defensive `try/catch + continue` so a transient notification failure logs and proceeds to the next candidate (also mirrors PhotoDiaryReminderScheduler).
- Adds two `internal` test-helper methods on the scheduler (`ResetCursor()` and `SetLastTickAt()`) mirroring `PhotoDiaryReminderScheduler` so the regression test can position the tick window precisely.

## Related issue

Fixes #280

## Scope

backend

## QA verdict (from qa-tester)

OVERALL: ✅ PASS — 4 ACs green, full integration suite 1068/0/0 in 3m 44s, zero `ObjectDisposedException` / `ServiceResolver` matches in test output (clean against the historic #281 flake gate). Handoff: `state/handoff-qa-280.json`.

## Test plan

- [x] `WeeklyCheckInScheduler.ProcessTickAsync` gives each candidate its own `IServiceScope` / `IApplicationDbContext`; the buggy `db.WeeklyCheckIns.Remove(checkIn)` recovery is removed.
- [x] Regression: `Tick_UniqueViolationOnFirstCandidate_DoesNotCascadeToSecondCandidate` (Testcontainers — pre-seeds a duplicate row for candidate A, asserts candidate B's check-in row, in-app notification, push, and `newnotification` SignalR broadcast all land cleanly).
- [x] DI smoke: `WeeklyCheckInScheduler_IsStillResolvableAsSingleton` mirrors the `PhotoDiaryReminderScheduler` smoke from #279.
- [x] No regression: existing `WeeklyCheckInSchedulerTests` and `WeeklyCheckInSchedulerUnitTests` stay green (full suite 1068/0/0).

## Notes

- The previous attempt at this fix (PR #281) was closed on 2026-05-19 because adding per-candidate scope to a second scheduler tipped a latent FastEndpoints `ServiceResolver` race into non-deterministic flake (5/91/41 failures across three full-suite runs). PR #299 (merged today, sha `aead751`) structurally fixed that race by skipping `base.DisposeAsync()` in `TestAssemblyConfig` to preserve `ServiceResolver.Provider` lifetime and disabling xUnit collection parallelism. This PR re-applies the per-candidate-scope refactor on top of #299's clean base; the qa-tester's full-suite grep confirms the historic flake signature is no longer present.
- Out of scope: any change to scheduler domain behaviour (fire-time math, override-precedence, time-zone handling), indexes, or migrations.