### PR TITLE
refactor(#270): hide decorative caret in RecentActivitySection month picker from a11y tree

### DIFF
--- a/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
+++ b/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
@@ -219,7 +219,7 @@ export function RecentActivitySection({
                     ))}
                   </select>
                   {/* Caret overlay — purely decorative */}
-                  <span className="pointer-events-none absolute right-1.5 text-accent text-[10px]">
+                  <span aria-hidden="true" className="pointer-events-none absolute right-1.5 text-accent text-[10px]">
                     ▾
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Adds `aria-hidden="true"` to the decorative `▾` caret span in the RecentActivitySection month-picker chrome.
- The native `<select>` already exposes expansion state to assistive tech; the caret glyph is purely visual and was creating a duplicate signal in the a11y tree.
- Follow-up NIT from the two-pass PR review on #261 / #267.

## Related issue
Fixes #270

## Scope
web (single-file refactor — `web/src/components/domain/RecentActivity/RecentActivitySection.tsx:222`)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all three ACs verified. Branch diff is exactly 1 insertion + 1 deletion on the targeted line; `npm run build` clean (`tsc -b && vite build` → exit 0, built in 6.96s, no new warnings).

## Test plan
- [x] `aria-hidden="true"` added to the decorative caret span.
- [x] No layout or visual change (only one attribute added; no className/style/structure delta).
- [x] `npm run build` passes with no TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)