### PR TITLE
refactor(#269): associate month-picker select with a label (a11y)

### DIFF
--- a/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
+++ b/web/src/components/domain/RecentActivity/RecentActivitySection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/cn';
 import type { ClientTimelineItem } from '@/api/timeline';
@@ -52,6 +52,7 @@ export function RecentActivitySection({
   locale,
 }: RecentActivitySectionProps) {
   const { t } = useTranslation();
+  const monthSelectId = useId();
   const [activeFilter, setActiveFilter] = useState<FilterType>('all');
   const [selectedMonthKey, setSelectedMonthKey] = useState<string>(currentMonthKey);
 
@@ -199,11 +200,12 @@ export function RecentActivitySection({
 
               {/* Month picker chip — client-side filter */}
               <div className="flex items-center gap-1 relative">
-                <span className="text-[13px] text-text2">
+                <label htmlFor={monthSelectId} className="text-[13px] text-text2">
                   {t('clients.recentActivity.monthPickerPrefix')}
-                </span>
+                </label>
                 <div className="relative inline-flex items-center">
                   <select
+                    id={monthSelectId}
                     value={effectiveMonthKey}
                     onChange={(e) => setSelectedMonthKey(e.target.value)}
                     className={cn(


### PR DESCRIPTION
## Summary
- Converts the visible prefix `<span>` next to the month-picker `<select>` into a `<label htmlFor>` so screen readers announce the combobox with its `clients.recentActivity.monthPickerPrefix` accessible name.
- Generates a stable element id via React `useId()` and wires the label/select pair on `RecentActivitySection.tsx`.
- Design-reviewer recommended option (a) — `<label htmlFor>` — over option (b) `aria-label` so the existing visible prefix text becomes the AT-associated label, preserving the inline visual hint with no duplication.

## Related issue
Fixes #269

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS. All four ACs met (label-htmlFor wiring, i18n key present in cs/en/de, byte-identical layout, `npm run build` clean in 2.23s). No regressions, `i18n_check: pass`.

## Test plan
- [x] Either convert the prefix span to a label with `htmlFor` pointing at the select id, OR add `aria-label` using the `clients.recentActivity.monthPickerPrefix` translation key directly on the select element.
- [x] All three locale files (cs/en/de) carry the `monthPickerPrefix` key; if the key is absent in any locale, add it in the same PR.
- [x] No visible layout change (a visually-hidden label is acceptable if the design does not call for an inline text label alongside the calendar icon).
- [x] `npm run build` passes with no TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)