### PR TITLE
feat(#266): show unsaved-changes pill on weekly-checkins tab

### DIFF
--- a/web/src/components/profile/WeeklyCheckInTab.tsx
+++ b/web/src/components/profile/WeeklyCheckInTab.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -107,6 +107,7 @@ function resolveEffective(
 
 interface ProfessionBlockHandle {
   submit: () => Promise<void>;
+  resetDirty: () => void;
 }
 
 /* ─────────────────────── Per-profession block ─────────────────────── */
@@ -114,10 +115,11 @@ interface ProfessionBlockHandle {
 interface ProfessionBlockProps {
   profession: Profession;
   setting: CheckInSettingDto | undefined;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
-  function ProfessionBlock({ profession, setting }, ref) {
+  function ProfessionBlock({ profession, setting, onDirtyChange }, ref) {
     const { t } = useTranslation();
     const queryClient = useQueryClient();
     const addToast = useToastStore((s) => s.addToast);
@@ -134,7 +136,8 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
       handleSubmit,
       control,
       watch,
-      formState: { errors },
+      reset,
+      formState: { errors, isDirty },
     } = useForm<SettingForm>({
       resolver: zodResolver(settingSchema),
       defaultValues,
@@ -142,6 +145,11 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
 
     const enabled = watch('enabled');
     const addendum = watch('defaultAddendum') ?? '';
+
+    // Propagate dirty state to parent
+    useEffect(() => {
+      onDirtyChange?.(isDirty);
+    }, [isDirty, onDirtyChange]);
 
     const onSubmit = async (data: SettingForm) => {
       try {
@@ -152,6 +160,10 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
           enabled: data.enabled,
           defaultAddendum: data.defaultAddendum || null,
         });
+        // Reset RHF defaults to submitted values so isDirty flips false.
+        // Do NOT reset on the error branch — the form stays dirty so the user
+        // knows they still have unsaved edits.
+        reset(data);
         void queryClient.invalidateQueries({ queryKey: ['weekly-checkin-settings'] });
         addToast(t('weeklyCheckIn.config.saved'), 'success');
       } catch {
@@ -161,7 +173,19 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
 
     useImperativeHandle(ref, () => ({
       submit: () => handleSubmit(onSubmit)(),
-    }), [handleSubmit]);
+      // Clears isDirty without altering displayed values. Used by the
+      // leave-without-saving flow in ProfilePage so the dirty useEffect
+      // doesn't re-fire after the parent has set checkInDirty=false.
+      resetDirty: () => {
+        const currentValues = {
+          enabled: watch('enabled'),
+          dayOfWeek: watch('dayOfWeek'),
+          timeOfDay: watch('timeOfDay'),
+          defaultAddendum: watch('defaultAddendum'),
+        };
+        reset(currentValues, { keepValues: true });
+      },
+    }), [handleSubmit, reset, watch]);
 
     const professionLabel =
       profession === 'Training'
@@ -378,6 +402,7 @@ function OverrideRow({ override, onClick, settings }: OverrideRowProps) {
 
 export interface WeeklyCheckInTabHandle {
   save: () => Promise<void>;
+  resetDirty: () => void;
 }
 
 /* ─────────────────────── Main tab ─────────────────────── */
@@ -386,10 +411,11 @@ interface WeeklyCheckInTabProps {
   /** The trainer's role array from the auth store */
   roles: string[];
   onSavingChange?: (saving: boolean) => void;
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 export const WeeklyCheckInTab = forwardRef<WeeklyCheckInTabHandle, WeeklyCheckInTabProps>(
-  function WeeklyCheckInTab({ roles, onSavingChange }, ref) {
+  function WeeklyCheckInTab({ roles, onSavingChange, onDirtyChange }, ref) {
     const { t } = useTranslation();
     const [selectedOverride, setSelectedOverride] = useState<CheckInOverrideDto | null>(null);
 
@@ -398,6 +424,16 @@ export const WeeklyCheckInTab = forwardRef<WeeklyCheckInTabHandle, WeeklyCheckIn
 
     const isTrainer = roles.includes('Trainer');
     const isNutritionist = roles.includes('Nutritionist');
+
+    // Per-block dirty tracking. Mirror the conditional render guards so an
+    // unmounted block contributes false to the aggregate.
+    const [trainingDirty, setTrainingDirty] = useState(false);
+    const [nutritionDirty, setNutritionDirty] = useState(false);
+    const anyDirty = (isTrainer && trainingDirty) || (isNutritionist && nutritionDirty);
+
+    useEffect(() => {
+      onDirtyChange?.(anyDirty);
+    }, [anyDirty, onDirtyChange]);
 
     const { data: settingsResponse, isLoading: settingsLoading } = useQuery({
       queryKey: ['weekly-checkin-settings'],
@@ -420,6 +456,12 @@ export const WeeklyCheckInTab = forwardRef<WeeklyCheckInTabHandle, WeeklyCheckIn
         } finally {
           onSavingChange?.(false);
         }
+      },
+      // Clears RHF isDirty on each visible block so the parent's onDirtyChange
+      // useEffect doesn't re-fire true after confirmLeave sets checkInDirty=false.
+      resetDirty: () => {
+        if (isTrainer) trainingRef.current?.resetDirty();
+        if (isNutritionist) nutritionRef.current?.resetDirty();
       },
     }), [isTrainer, isNutritionist, onSavingChange]);
 
@@ -461,6 +503,7 @@ export const WeeklyCheckInTab = forwardRef<WeeklyCheckInTabHandle, WeeklyCheckIn
             ref={trainingRef}
             profession="Training"
             setting={trainingSetting}
+            onDirtyChange={setTrainingDirty}
           />
         )}
         {isNutritionist && (
@@ -468,6 +511,7 @@ export const WeeklyCheckInTab = forwardRef<WeeklyCheckInTabHandle, WeeklyCheckIn
             ref={nutritionRef}
             profession="Nutrition"
             setting={nutritionSetting}
+            onDirtyChange={setNutritionDirty}
           />
         )}
 

--- a/web/src/pages/ProfilePage.tsx
+++ b/web/src/pages/ProfilePage.tsx
@@ -46,6 +46,7 @@ export default function ProfilePage() {
   // Weekly check-ins ref + state
   const weeklyCheckInRef = useRef<WeeklyCheckInTabHandle>(null);
   const [checkInSaving, setCheckInSaving] = useState(false);
+  const [checkInDirty, setCheckInDirty] = useState(false);
 
   // Personal fields (API-backed)
   const [saving, setSaving] = useState(false);
@@ -195,9 +196,7 @@ export default function ProfilePage() {
   const isDirty = loaded && getCurrentSnapshot() !== initialState.current;
 
   // Combined dirty state for navigation guard
-  // Note: weekly check-ins tab state is owned inside WeeklyCheckInTab (per-profession RHF forms);
-  // we do not track its dirty state centrally — only its saving state to disable the button.
-  const anyDirty = isDirty || questionnaireDirty;
+  const anyDirty = isDirty || questionnaireDirty || checkInDirty;
 
   // ── Warn before browser refresh/close ──
   useEffect(() => {
@@ -244,6 +243,10 @@ export default function ProfilePage() {
     // Reset dirty states to allow navigation
     initialState.current = getCurrentSnapshot();
     setQuestionnaireDirty(false);
+    // resetDirty on the handle is required (not just setCheckInDirty(false)):
+    // without it, ProfessionBlock's isDirty useEffect re-fires onDirtyChange(true)
+    // on the next render because RHF still considers the form dirty.
+    weeklyCheckInRef.current?.resetDirty();
     if (target === '__back__') {
       window.history.back();
     } else if (target) {
@@ -303,7 +306,9 @@ export default function ProfilePage() {
         subtitle={t('profile.subtitle')}
         actions={
           <div className="flex items-center gap-2">
-            {((activeTab === 'personal' && isDirty) || (activeTab === 'questionnaires' && questionnaireDirty)) && (
+            {((activeTab === 'personal' && isDirty)
+              || (activeTab === 'questionnaires' && questionnaireDirty)
+              || (activeTab === 'weekly-checkins' && checkInDirty)) && (
               <span style={{ fontSize: 11, color: 'var(--orange)', display: 'flex', alignItems: 'center', gap: 4 }}>
                 <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--orange)' }} />
                 {t('profile.unsavedChanges')}
@@ -324,7 +329,7 @@ export default function ProfilePage() {
                 activeTab === 'personal'
                   ? saving
                   : activeTab === 'weekly-checkins'
-                    ? checkInSaving
+                    ? checkInSaving || !checkInDirty
                     : questionnaireSaving || !questionnaireDirty
               }
               className="rounded-md bg-text px-5 py-2 text-[13px] font-medium text-bg transition-opacity hover:opacity-90 disabled:opacity-50"
@@ -479,6 +484,7 @@ export default function ProfilePage() {
             ref={weeklyCheckInRef}
             roles={user?.roles ?? []}
             onSavingChange={setCheckInSaving}
+            onDirtyChange={setCheckInDirty}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Wires `WeeklyCheckInTab` dirty state up to `ProfilePage` via a new `onDirtyChange` callback chain (mirrors the existing `onSavingChange` pattern).
- `ProfessionBlock` watches RHF `formState.isDirty` and propagates upward; `WeeklyCheckInTab` aggregates across the role-gated Training / Nutrition blocks; `ProfilePage` feeds the result into the existing `anyDirty` chain (already drives `beforeunload`, in-app nav guard, and the unsaved-changes pill).
- After a successful `upsertCheckInSetting`, `ProfessionBlock.onSubmit` calls `reset(data)` to clear `isDirty`; the catch branch deliberately leaves the form dirty.
- Adds an imperative `resetDirty()` handle so `confirmLeave` can flip RHF's `isDirty` without triggering a state-loop where the dirty `useEffect` would re-fire `onDirtyChange(true)` after the parent had already set `checkInDirty = false`.
- Save button now disables on `weekly-checkins` when `!checkInDirty`, matching the questionnaire-tab behaviour.
- No new copy — reuses `profile.unsavedChanges` (already in cs/en/de). No visual change beyond the pill extending into the `weekly-checkins` branch.

## Related issue
Fixes #266

Follow-up from PR #263 / issue #262 — the in-card save button was unified into the page-level button there, leaving the dirty signal missing on this tab only.

## Scope
web

## Implementation note — why `resetDirty()` is imperative

The questionnaire tab uses a snapshot-based dirty pattern, so `setQuestionnaireDirty(false)` in `confirmLeave` sticks. Weekly check-ins uses RHF's `isDirty`, so plain `setCheckInDirty(false)` would be overwritten on the next render when the dirty `useEffect` re-fires with the still-dirty form. `resetDirty()` calls `reset(currentValues, { keepValues: true })` on each visible block to flip RHF's marker without altering displayed values, breaking the loop. qa-tester specifically called this out as good craft.

## QA verdict (from qa-tester)
OVERALL ✅ PASS — web build clean (2.28s), 2 files +60/-10, all 6 ACs verified statically (`.claude/state/handoff-qa-266.json`).

## Test plan
- [ ] Wire `WeeklyCheckInTab` dirty state up to `ProfilePage` via the existing imperative-ref pattern or a new `onDirtyChange` callback prop — whichever is less invasive given the current ref interface.
- [ ] Show the same dirty-state dot on the `weekly-checkins` tab label as on `personal` / `questionnaires`.
- [ ] Dot clears after a successful save.
- [ ] If `ProfilePage` already has a `beforeunload` guard covering `personal` / `questionnaires`, extend it to cover `weekly-checkins` dirty state too.
- [ ] No new copy (no new i18n keys required).
- [ ] No visual change beyond the dot itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)