### PR TITLE
chore: include onSubmit in useImperativeHandle deps via useCallback (#265)

### DIFF
--- a/web/src/components/profile/WeeklyCheckInTab.tsx
+++ b/web/src/components/profile/WeeklyCheckInTab.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -151,7 +151,7 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
       onDirtyChange?.(isDirty);
     }, [isDirty, onDirtyChange]);
 
-    const onSubmit = async (data: SettingForm) => {
+    const onSubmit = useCallback(async (data: SettingForm) => {
       try {
         await upsertCheckInSetting({
           profession,
@@ -169,7 +169,7 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
       } catch {
         addToast(t('weeklyCheckIn.config.saveError'), 'error');
       }
-    };
+    }, [profession, reset, queryClient, addToast, t]);
 
     useImperativeHandle(ref, () => ({
       submit: () => handleSubmit(onSubmit)(),
@@ -185,7 +185,7 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
         };
         reset(currentValues, { keepValues: true });
       },
-    }), [handleSubmit, reset, watch]);
+    }), [handleSubmit, onSubmit, reset, watch]);
 
     const professionLabel =
       profession === 'Training'


### PR DESCRIPTION
## Summary
- Wrap `ProfessionBlock.onSubmit` in `useCallback` so its identity is stable across renders.
- Add `onSubmit` to the inner `useImperativeHandle` dep array, closing the `react-hooks/exhaustive-deps` lint gap surfaced by the fresh-eyes review of PR #263 / issue #262.
- Pure lint-correctness fix — no behavior change to the Týdenní check-iny tab save flow.

## Related issue
Fixes #265

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — `npm run build` clean (typecheck + Vite production build), no lint regression on touched file, page-level save continues to trigger per-profession upserts. See `.claude/state/handoff-qa-265.json`.

## Test plan
- [x] Either include `onSubmit` in the dep array (wrapping in `useCallback`) or suppress the rule with a `// eslint-disable-next-line` comment explaining the omission.
- [x] `npm run build` exits clean with no new lint regressions.
- [x] No behavior change — page-level save continues to trigger per-profession upserts for the Týdenní check-iny tab.

Follow-up from PR #263 / issue #262 (fresh-eyes code review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)