### PR TITLE
fix: WeeklyCheckInTab enabled toggle missing aria-pressed / aria-label

### DIFF
--- a/web/src/components/profile/WeeklyCheckInTab.tsx
+++ b/web/src/components/profile/WeeklyCheckInTab.tsx
@@ -216,6 +216,8 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
                   type="button"
                   className={`toggle${field.value ? ' on' : ''}`}
                   onClick={() => field.onChange(!field.value)}
+                  aria-pressed={field.value}
+                  aria-label={t('weeklyCheckIn.config.enabled')}
                 >
                   <span className="toggle-thumb" />
                 </button>


### PR DESCRIPTION
## Summary
- Adds `aria-pressed={field.value}` and `aria-label={t('weeklyCheckIn.config.enabled')}` to the per-profession enabled-toggle button inside `ProfessionBlock` (web profile → Weekly check-ins tab).
- Mirrors the precedent in `RolesSection.tsx:186-187` (the same `.toggle.on` visual pattern; accessibility attrs were not carried over during the PR #263 migration).
- Reuses the existing `weeklyCheckIn.config.enabled` i18n key (already in cs/en/de) — no new copy, no visual change.

## Related issue
Fixes #264

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — both ACs met; `npm run build` clean on `fix/264-toggle-aria-pressed-label`; no banned tokens in diff.

## Test plan
- [x] Screen readers announce the toggle's pressed state (`aria-pressed={field.value}` bound to the RHF `Controller` for `enabled`).
- [x] The toggle exposes an accessible name matching its visible label (`aria-label` reuses the same i18n key as the visible `.toggle-lbl` at line 209, so accessible name == visible label across cs/en/de).

🤖 Generated with [Claude Code](https://claude.com/claude-code)