### PR TITLE
fix: block Admin from public /auth/register allow-list (#230)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Auth/Register/RegisterValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/Register/RegisterValidator.cs
@@ -10,6 +10,18 @@ namespace FitnessPlatform.Application.Features.Auth.Register;
 public class RegisterValidator : Validator<RegisterRequest>
 {
     /// <summary>
+    /// Roles that may be self-assigned via the public registration endpoint.
+    /// <see cref="UserRole.Admin"/> is intentionally excluded — it can only be
+    /// granted out-of-band by a platform administrator.
+    /// </summary>
+    private static readonly HashSet<string> PubliclyRegistrableRoles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        nameof(UserRole.Trainer),
+        nameof(UserRole.Nutritionist),
+        nameof(UserRole.Client),
+    };
+
+    /// <summary>
     /// Initializes validation rules for user registration.
     /// </summary>
     public RegisterValidator()
@@ -46,8 +58,8 @@ public class RegisterValidator : Validator<RegisterRequest>
             .WithMessage("Cannot combine Client role with Trainer or Nutritionist.");
 
         RuleForEach(x => x.Roles)
-            .Must(r => Enum.TryParse<UserRole>(r, ignoreCase: true, out _))
-            .WithMessage("Role must be one of: Admin, Trainer, Nutritionist, Client.");
+            .Must(r => PubliclyRegistrableRoles.Contains(r))
+            .WithMessage("Role must be one of: Trainer, Nutritionist, Client.");
 
         RuleFor(x => x.GdprConsent)
             .Equal(true)

--- a/backend/FitnessPlatform.Tests/Validators/RegisterValidatorTests.cs
+++ b/backend/FitnessPlatform.Tests/Validators/RegisterValidatorTests.cs
@@ -130,12 +130,35 @@ public class RegisterValidatorTests
     [InlineData("Client")]
     [InlineData("Trainer")]
     [InlineData("Nutritionist")]
-    [InlineData("Admin")]
     public void Roles_SingleValidRole_Passes(string role)
     {
         var req = ValidRequest();
         req.Roles = new List<string> { role };
         _validator.TestValidate(req).ShouldNotHaveValidationErrorFor(x => x.Roles);
+    }
+
+    [Theory]
+    [InlineData("Admin")]
+    [InlineData("admin")]
+    public void Roles_ContainsAdmin_Fails_SingleRole(string adminRole)
+    {
+        var req = ValidRequest();
+        req.Roles = new List<string> { adminRole };
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Role must be one of: Trainer, Nutritionist, Client.");
+    }
+
+    [Theory]
+    [InlineData("Trainer", "Admin")]
+    [InlineData("Admin", "Client")]
+    public void Roles_ContainsAdmin_Fails_MixedWithValidRole(string role1, string role2)
+    {
+        var req = ValidRequest();
+        req.Roles = new List<string> { role1, role2 };
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Role must be one of: Trainer, Nutritionist, Client.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Public `POST /auth/register` previously accepted any `UserRole` enum value (including `Admin`) because `RegisterValidator` used `Enum.TryParse<UserRole>(ignoreCase: true)` as the membership check. A caller could submit `roles: ["Admin"]` and receive HTTP 201 with a JWT carrying the `Admin` claim. This is a P1 security gap.
- The validator now uses an explicit allow-list (`PubliclyRegistrableRoles` — a `HashSet<string>` with `StringComparer.OrdinalIgnoreCase`) restricted to `Trainer`, `Nutritionist`, and `Client`. `Admin` is intentionally excluded and may only be granted out-of-band by a platform administrator. The case-insensitive comparer preserves the prior `Enum.TryParse(ignoreCase: true)` semantics, so `"admin"` (lowercase) — equally exploitable before — is also blocked.
- User-facing error message updated from `"Role must be one of: Admin, Trainer, Nutritionist, Client."` to `"Role must be one of: Trainer, Nutritionist, Client."` so the API no longer advertises `Admin` as a valid input.
- Test coverage: removed `[InlineData("Admin")]` from `Roles_SingleValidRole_Passes` and added `Roles_ContainsAdmin_Fails_SingleRole` (`"Admin"`, `"admin"`) and `Roles_ContainsAdmin_Fails_MixedWithValidRole` (`["Trainer","Admin"]`, `["Admin","Client"]`). Both assert `IsValid == false` and the exact error message. Full backend suite passes 1071/1071.

## Related issue

Fixes #230

Defense-in-depth follow-up surfaced during review: #308 (AddRoleEndpoint is also guarded only by its validator — single point of failure).

## Scope

backend

## QA verdict (from qa-tester)

OVERALL ✅ PASS — 4 of 5 code ACs verified via unit tests (FastEndpoints maps FluentValidation failures to HTTP 400 ProblemDetails as a framework guarantee). AC5 audit ran against local dev — see `## Audit (AC5)` below.

`dotnet build` — clean. `dotnet test` — 1071/1071 passed in 2m27s.

## Test plan

- [x] `POST /auth/register` with `roles` containing `"Admin"` returns HTTP 400 with a validation error.
- [x] `RegisterValidator` explicitly excludes `Admin` from the allowed-public-registration set (allow only `Trainer`, `Nutritionist`, `Client`).
- [x] Backend tests assert the 400 response when `roles` contains `Admin` (mixed roles too — `["Trainer", "Admin"]` must also reject).
- [x] Validator user-facing error message reads `"Role must be one of: Trainer, Nutritionist, Client."` (no `Admin` reference).
- [x] Audit existing user accounts on dev to confirm no unauthorized Admin grants (see `## Audit (AC5)` below).

## Audit (AC5)

Schema note: this codebase uses EF Core NamingConventions (snake_case), not the default Identity casing. The corrected query is below.

```sql
-- AC5: Audit existing user accounts on dev/staging Postgres for any
-- pre-fix Admin role grants.
SELECT u.email, u.normalized_user_name, r.name AS role
FROM users u
JOIN user_roles ur ON ur.user_id = u.id
JOIN roles r ON r.id = ur.role_id
WHERE r.normalized_name = 'ADMIN'
ORDER BY u.email;
```

### Result — local dev (`fitness-postgres`, db `fitness_dev`, 2026-05-28)

```
 email | normalized_user_name | role
-------+----------------------+------
(0 rows)
```

**Zero Admin grants** — no exploit traces in the local dev environment.

⚠️ Staging / cloud Postgres audit is still on the user to run (or confirm "no staging exists yet"). The same query applies; paste the result into a PR comment before authorizing merge if staging is in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
