### PR TITLE
fix(#257): lock sibling session CTAs when a live session is active

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -55,7 +55,7 @@ import { useTodayStore } from '@/stores/todayStore'
 import { PlanBanner } from '@/components/today/PlanBanner'
 import { ResumeTrainingBanner } from '@/components/training/ResumeTrainingBanner'
 import { useLiveSessionStore } from '@/stores/liveSessionStore'
-import { deriveSessionCtaState, type SessionCtaState } from '@/components/training/trainingCardHelpers'
+import { deriveSessionCtaState, computeLockedSessionIds, type SessionCtaState } from '@/components/training/trainingCardHelpers'
 
 // ─── NoDayNutritionCard ───────────────────────────────────────────────────────
 // Shown when the user has an active nutrition plan but today is not covered by
@@ -707,6 +707,14 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
     return result
   }, [todaySessions, completedIdsBySectionAndSession, completedSectionIdsFor, hasActiveSession, liveSessionId])
 
+  // ── Locked sibling session IDs ────────────────────────────────────────────
+  // When a live session is running, every OTHER session for today shows a
+  // locked CTA ("Session already in progress") to prevent accidental parallel starts.
+  const lockedSessionIds = useMemo(
+    () => computeLockedSessionIds(todaySessions, hasActiveSession, liveSessionId),
+    [todaySessions, hasActiveSession, liveSessionId],
+  )
+
   const handleToggleExercise = useCallback(
     (sessionId: string, sectionId: string, exerciseExternalId: string) => {
       const ids = completedIdsForSection(sessionId, sectionId)
@@ -1260,6 +1268,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               onToggleSession={handleToggleSession}
               sessionCtaStateBySession={sessionCtaStateBySession}
               onSessionCta={handleSessionCta}
+              lockedSessionIds={lockedSessionIds}
               exerciseMuscleGroups={training?.exerciseMuscleGroups ?? {}}
               completedSetsBySessionExercise={trainingQuery.data?.completedSetsBySessionExercise ?? {}}
               onMarkAllTrainingDone={handleMarkAllTrainingDone}

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -109,6 +109,12 @@ interface TrainingCardProps {
   /** Returns true when the startWorkout mutation for the given sessionId is pending. */
   isSessionCtaPending?: (sessionId: string) => boolean
   /**
+   * Set of sessionIds whose Start CTA should be locked because another session
+   * is currently live. Computed by `computeLockedSessionIds` in HasTrainerState.
+   * Defaults to an empty set when omitted — no sessions are locked.
+   */
+  lockedSessionIds?: ReadonlySet<string>
+  /**
    * Map from exerciseExternalId to its muscle groups, sourced from the backend's
    * `GetTodaySessionResponse.exerciseMuscleGroups` field. Used to render colored
    * muscle-group chips in the hero and a per-exercise dot in each exercise row.
@@ -153,33 +159,51 @@ interface SessionCtaFooterProps {
   state: SessionCtaState
   isPending: boolean
   onPress: (session: TrainingSession, state: SessionCtaState) => void
+  /**
+   * When true, another session is currently live. The CTA is rendered
+   * disabled with a "Session already in progress" label. The not-locked
+   * code path is not affected.
+   */
+  locked?: boolean
 }
 
-function SessionCtaFooter({ session, state, isPending, onPress }: SessionCtaFooterProps) {
+function SessionCtaFooter({ session, state, isPending, onPress, locked = false }: SessionCtaFooterProps) {
   const colors = useTheme()
   const { t } = useTranslation()
+
+  const isDisabled = isPending || locked
 
   return (
     <View style={[ctaStyles.footerButton, { borderTopColor: colors.sep2 }]}>
       <Pressable
         onPress={() => {
-          if (!isPending) onPress(session, state)
+          if (!isDisabled) onPress(session, state)
         }}
-        disabled={isPending}
+        disabled={isDisabled}
         accessibilityRole="button"
-        accessibilityState={{ disabled: isPending }}
+        accessibilityState={{ disabled: isDisabled }}
+        accessibilityLabel={locked ? t('today.trainingCta.sessionInProgress') : undefined}
         style={({ pressed }) => [
           ctaStyles.primaryButton,
-          { backgroundColor: colors.gold, opacity: pressed ? 0.8 : 1 },
+          locked
+            ? { backgroundColor: colors.bg3, opacity: 0.7 }
+            : { backgroundColor: colors.gold, opacity: pressed ? 0.8 : 1 },
         ]}
       >
-        {isPending ? (
+        {isPending && !locked ? (
           <ActivityIndicator size="small" color={colors.onAccent} />
         ) : (
-          <Text style={[ctaStyles.primaryLabel, { color: colors.onAccent }]}>
-            {state === 'in-progress'
-              ? t('today.trainingCta.continue')
-              : t('today.trainingCta.start')}
+          <Text
+            style={[
+              ctaStyles.primaryLabel,
+              locked ? { color: colors.label3 } : { color: colors.onAccent },
+            ]}
+          >
+            {locked
+              ? t('today.trainingCta.sessionInProgress')
+              : state === 'in-progress'
+                ? t('today.trainingCta.continue')
+                : t('today.trainingCta.start')}
           </Text>
         )}
       </Pressable>
@@ -227,6 +251,7 @@ export function TrainingCard({
   sessionCtaStateBySession,
   onSessionCta,
   isSessionCtaPending,
+  lockedSessionIds = new Set<string>(),
   exerciseMuscleGroups = {},
   completedSetsBySessionExercise = {},
   onMarkAllTrainingDone,
@@ -367,6 +392,8 @@ export function TrainingCard({
           const showCta =
             ctaState != null && ctaState !== 'finished' && onSessionCta != null
           const ctaPending = isSessionCtaPending?.(sessionId) ?? false
+          // When another session is live, lock this session's CTA.
+          const ctaLocked = session.sessionId != null && lockedSessionIds.has(session.sessionId)
 
           // Session-level checkbox injected into the session card header.
           // Uses the View+inner-icon pattern from MealRow's CheckButton so the
@@ -414,6 +441,7 @@ export function TrainingCard({
               showCta={showCta}
               ctaState={ctaState}
               ctaPending={ctaPending}
+              ctaLocked={ctaLocked}
               session={session}
               exerciseMuscleGroups={exerciseMuscleGroups}
               completedSetsBySessionExercise={completedSetsBySessionExercise[sessionId] ?? {}}
@@ -480,6 +508,8 @@ interface SessionSectionListProps {
   showCta: boolean
   ctaState: SessionCtaState | undefined
   ctaPending: boolean
+  /** When true, another session is live — this session's CTA is locked. */
+  ctaLocked: boolean
   session: TrainingSession
   exerciseMuscleGroups: Record<string, MuscleGroup[]>
   completedSetsBySessionExercise: Record<string, number[]>
@@ -506,6 +536,7 @@ function SessionSectionList({
   showCta,
   ctaState,
   ctaPending,
+  ctaLocked,
   session,
   exerciseMuscleGroups,
   completedSetsBySessionExercise,
@@ -775,6 +806,7 @@ function SessionSectionList({
                   session={session}
                   state={ctaState}
                   isPending={ctaPending}
+                  locked={ctaLocked}
                   onPress={onSessionCta}
                 />
               )}

--- a/mobile/src/components/training/__tests__/trainingCardHelpers.test.ts
+++ b/mobile/src/components/training/__tests__/trainingCardHelpers.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for trainingCardHelpers — pure functions, no RN dependencies.
  */
 
-import { deriveSessionCtaState } from '../trainingCardHelpers'
+import { deriveSessionCtaState, computeLockedSessionIds } from '../trainingCardHelpers'
 import type { TrainingSession } from '@/api/training'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -306,5 +306,71 @@ describe('deriveSessionCtaState', () => {
       )
       expect(result).toBe('in-progress')
     })
+  })
+})
+
+// ─── computeLockedSessionIds ──────────────────────────────────────────────────
+
+describe('computeLockedSessionIds', () => {
+  function makeSessionWithId(id: string): TrainingSession {
+    return {
+      sessionId: id,
+      name: `Session ${id}`,
+      sections: [],
+      exercises: [],
+    }
+  }
+
+  const sessions = [
+    makeSessionWithId('s1'),
+    makeSessionWithId('s2'),
+    makeSessionWithId('s3'),
+  ]
+
+  it('returns empty set when hasActiveSession is false', () => {
+    const result = computeLockedSessionIds(sessions, false, 's1')
+    expect(result.size).toBe(0)
+  })
+
+  it('returns empty set when activeSessionId is null', () => {
+    const result = computeLockedSessionIds(sessions, true, null)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns empty set when hasActiveSession is false and activeSessionId is null', () => {
+    const result = computeLockedSessionIds(sessions, false, null)
+    expect(result.size).toBe(0)
+  })
+
+  it('returns the other session IDs excluding the active one', () => {
+    const result = computeLockedSessionIds(sessions, true, 's1')
+    expect(result.size).toBe(2)
+    expect(result.has('s2')).toBe(true)
+    expect(result.has('s3')).toBe(true)
+    expect(result.has('s1')).toBe(false)
+  })
+
+  it('returns correct locked set when the middle session is active', () => {
+    const result = computeLockedSessionIds(sessions, true, 's2')
+    expect(result.has('s1')).toBe(true)
+    expect(result.has('s3')).toBe(true)
+    expect(result.has('s2')).toBe(false)
+  })
+
+  it('filters out sessions with null sessionId cleanly', () => {
+    const sessionsWithNull: TrainingSession[] = [
+      makeSessionWithId('s1'),
+      { sessionId: undefined, name: 'No-id session', sections: [], exercises: [] },
+      makeSessionWithId('s3'),
+    ]
+    const result = computeLockedSessionIds(sessionsWithNull, true, 's1')
+    expect(result.has('s3')).toBe(true)
+    // The undefined-id session must not appear in the locked set
+    expect(result.size).toBe(1)
+  })
+
+  it('returns empty set when sessions array is empty', () => {
+    const result = computeLockedSessionIds([], true, 's1')
+    expect(result.size).toBe(0)
   })
 })

--- a/mobile/src/components/training/trainingCardHelpers.ts
+++ b/mobile/src/components/training/trainingCardHelpers.ts
@@ -136,3 +136,38 @@ export function deriveSessionCtaState(
 
   return 'not-started'
 }
+
+// ─── computeLockedSessionIds ──────────────────────────────────────────────────
+
+/**
+ * Returns a set of sessionIds that should show a locked CTA because another
+ * session in the same day is currently live (active).
+ *
+ * - If `hasActiveSession` is false or `activeSessionId` is null, returns an
+ *   empty set (nothing to lock).
+ * - Otherwise returns the sessionIds of all sessions whose `sessionId` is
+ *   non-null AND is not the currently active session.
+ *
+ * This is a pure helper — no React, no store imports. It mirrors the same
+ * style as `deriveSessionCtaState` so it can be unit-tested without React Native.
+ *
+ * @param sessions         Today's training sessions.
+ * @param hasActiveSession Whether a live session is currently in-flight.
+ * @param activeSessionId  The sessionId of the live session (from liveSessionStore).
+ */
+export function computeLockedSessionIds(
+  sessions: readonly TrainingSession[],
+  hasActiveSession: boolean,
+  activeSessionId: string | null,
+): ReadonlySet<string> {
+  if (!hasActiveSession || activeSessionId == null) {
+    return new Set<string>()
+  }
+  const locked = new Set<string>()
+  for (const session of sessions) {
+    if (session.sessionId != null && session.sessionId !== activeSessionId) {
+      locked.add(session.sessionId)
+    }
+  }
+  return locked
+}

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -341,7 +341,8 @@
       "start": "Začít trénink",
       "continue": "Pokračovat v tréninku",
       "finished": "Dokončeno",
-      "startError": "Trénink se nepodařilo spustit. Zkus to znovu."
+      "startError": "Trénink se nepodařilo spustit. Zkus to znovu.",
+      "sessionInProgress": "Jiný trénink už běží"
     },
     "noNutritionPlanForToday": "Na dnes nemáte naplánovaný jídelníček",
     "noTrainingForToday": "Na dnes nemáte naplánovaný trénink"

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -336,7 +336,8 @@
       "start": "Training starten",
       "continue": "Training fortsetzen",
       "finished": "Abgeschlossen",
-      "startError": "Training konnte nicht gestartet werden. Bitte versuche es erneut."
+      "startError": "Training konnte nicht gestartet werden. Bitte versuche es erneut.",
+      "sessionInProgress": "Trainingseinheit läuft bereits"
     },
     "noNutritionPlanForToday": "Heute ist kein Ernährungsplan geplant",
     "noTrainingForToday": "Heute ist kein Training geplant"

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -336,7 +336,8 @@
       "start": "Start training",
       "continue": "Continue training",
       "finished": "Completed",
-      "startError": "Could not start training. Please try again."
+      "startError": "Could not start training. Please try again.",
+      "sessionInProgress": "Session already in progress"
     },
     "noNutritionPlanForToday": "No nutrition plan for today",
     "noTrainingForToday": "No training planned for today"


### PR DESCRIPTION
## Summary
- When `liveSessionStore.hasActiveSession` is true, sibling training sessions on the Today screen now render their CTA disabled with the "Jiný trénink už běží" / "Session already in progress" / "Trainingseinheit läuft bereits" label.
- Lock derivation lives in a new pure helper `computeLockedSessionIds` (mobile-only, no React/store imports), unit-tested with 7 jest cases covering every branch.
- ~50 LOC across one helper + one prop wire-through + one `useMemo` derivation in HasTrainerState + three i18n entries.

## Related issue
Fixes #257

## Scope
mobile

## QA verdict (from qa-tester)
PARTIAL — static surface PASS (typecheck + 30 jest tests including 7 new `computeLockedSessionIds` cases; i18n parity cs/en/de; token compliance). Interactive iOS drive confirmed Today renders 2 sibling Thursday sessions correctly in the baseline; the final Start-button tap to flip the live store could not be driven because of Expo dev-client log overlay + deep-link auth race — infrastructure friction unrelated to the fix (filed separately as #309). The lockout derivation itself is exhaustively unit-tested.

## Test plan
- [ ] While any training session is in the `running` state, the start buttons on all other sessions of the day must be hidden or disabled with a clear "Session already in progress" indicator.
- [ ] The user cannot accidentally start a second parallel session on the same day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)