### PR TITLE
chore(#171): add Mobile CI workflow — typecheck + Expo prebuild check

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -38,6 +38,6 @@ jobs:
         run: npx tsc --noEmit
         working-directory: mobile
 
-      - name: Expo prebuild check
-        run: npx expo prebuild --no-install --check
+      - name: Expo project doctor
+        run: npx expo-doctor
         working-directory: mobile

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,43 @@
+name: Mobile CI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'mobile/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/mobile-ci.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'mobile/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/mobile-ci.yml'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: mobile
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+        working-directory: mobile
+
+      - name: Expo prebuild check
+        run: npx expo prebuild --no-install --check
+        working-directory: mobile

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -38,6 +38,6 @@ jobs:
         run: npx tsc --noEmit
         working-directory: mobile
 
-      - name: Expo project doctor
-        run: npx expo-doctor
+      - name: Expo config + plugin chain check
+        run: npx expo config --type prebuild >/dev/null
         working-directory: mobile


### PR DESCRIPTION
## Summary

Adds `.github/workflows/mobile-ci.yml` so the `/mobile` package gets the same automated CI safety net as `/web` and `/backend`: runs `npx tsc --noEmit` and an Expo plugin-chain check on every push / PR that touches mobile code. Closes the long-running gap where mobile typecheck regressions only surfaced on developer machines.

## Related issue

Closes #171

## Scope

docs-infra (orchestrator-owned `.github/workflows/**`)

## Convention decisions

- **Branches list `[main, develop]`** — issue body specified `develop` only, but `web.yml` and `backend.yml` both trigger on the same superset and the QA dispatch brief explicitly accepted superset parity. Keeping all three workflows uniform avoids a surprise gap should anyone push directly to a release branch later.
- **Path filter includes root `package.json` / `package-lock.json` + the workflow file itself** — broader than `web.yml`'s `web/**`-only filter. Intentional: root manifest edits (dep version bumps) and workflow self-edits should re-trigger the check.
- **Per-step `working-directory: mobile`** — matches `web.yml`'s style (rather than `backend.yml`'s `defaults: run:` block). Explicit and unsurprising at the cost of three extra lines.
- **Step 5 validator: `npx expo config --type prebuild >/dev/null`** — final landing after iteration. The original AC2 incantation (`expo prebuild --no-install --check`) used a `--check` flag that does not exist on Expo SDK 55. `expo-doctor` was tried next but exited 1 on pre-existing repo drift (metro.config.js base + 22 dep-pin mismatches) unrelated to this PR. `expo config --type prebuild` is the SDK-55 validator that exercises the full plugin chain (matching AC2 step 5's intent) without gating on dep pins. Output piped to /dev/null because exit code is what gates CI.

## Out-of-band follow-ups

- **#314** — `chore(docs): correct rules/verification.md mobile-prebuild invocation`. Updates `.claude/rules/verification.md` + two agent files that still cite the stale `expo prebuild --check`.
- **#315** — `chore(mobile): resolve Expo SDK 55 dependency drift surfaced by expo-doctor`. The 22 dep bumps + metro.config.js base. Once #315 lands, this workflow can be tightened from `expo config --type prebuild` to `expo-doctor` in its own follow-up PR.
- **AC3 — branch protection.** Marking this workflow as a required check on the `develop` branch protection rule is a repo-admin UI action; it lands after this PR merges and the workflow produces at least one green run.
- **AC4 — Notion DevOps page.** The post-merge `notion-docs` (update mode) dispatch will append the one-line note acknowledging mobile CI now runs the same way web/backend CI does.

## QA verdict (from qa-tester)

OVERALL ✅ PASS — AC1 and AC2 verified via js-yaml parse of the workflow file. AC3 (branch protection) and AC4 (Notion update) deferred as documented above; not verification failures.

## Test plan

- [x] CI run against this PR shows the new `Mobile CI / typecheck` job triggered and passing. Run 26590799663 (job 78348764210) — typecheck pass in 46s.
- [x] Workflow steps execute in order: checkout → setup-node (20) → npm ci → tsc --noEmit → expo config --type prebuild.
- [x] `actions/setup-node` cache key resolves against `mobile/package-lock.json` (visible in job logs).
- [ ] Re-running with an edit to a non-mobile file (e.g. `web/src/**`) does NOT trigger this workflow. (Verifiable post-merge.)
- [ ] After merge: repo admin enables the workflow as a required status check on `develop` (out-of-band, AC3).
- [ ] After merge: `notion-docs` update appends the DevOps line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)