### PR TITLE
chore(#314): replace expo prebuild --check with expo-doctor in .claude/

### DIFF
--- a/.claude/agents/mobile-expo.md
+++ b/.claude/agents/mobile-expo.md
@@ -40,7 +40,7 @@ it to run design-review first (Rule 5.5).
 - [`rules/code-quality.md#no-any-in-typescript`](../rules/code-quality.md#no-any-in-typescript) — strict-mode TS.
 - [`rules/code-quality.md#generated-files-are-write-locked`](../rules/code-quality.md#generated-files-are-write-locked) — `mobile/src/api/generated.ts` is write-locked; use `regen-api`.
 - [`rules/i18n.md#supported-languages`](../rules/i18n.md#supported-languages) — cs/en/de in same PR.
-- [`rules/verification.md#mobile`](../rules/verification.md#mobile) — `npx tsc --noEmit` + `expo prebuild --check`.
+- [`rules/verification.md#mobile`](../rules/verification.md#mobile) — `npx tsc --noEmit` + `npx expo-doctor`.
 
 ## Stack
 - React Native 0.83, Expo SDK 55, Expo Router (file-based, grouped routes)
@@ -157,7 +157,9 @@ Before returning control to the orchestrator, write
 ```
 
 Use `verification.tool: "mobile-typecheck"` for `npx tsc --noEmit` or
-`"mobile-prebuild-check"` for `npx expo prebuild --no-install --check`.
+`"mobile-prebuild-check"` for `npx expo-doctor` (the schema enum value
+is kept stable post-#314 so archived handoffs still validate; the
+literal command it represents is now `expo-doctor`).
 The `gate-check.sh` SubagentStop hook validates before control returns;
 a malformed handoff exits non-zero so you can self-correct.
 

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -14,7 +14,7 @@ mcpServers: plugin_playwright_playwright, xcodebuildmcp, a11y-accessibility
 
 - [`rules/verification.md#backend`](../rules/verification.md#backend) — `dotnet build` + `dotnet test` against Testcontainers.
 - [`rules/verification.md#web`](../rules/verification.md#web) — `npm run build` + Playwright on touched routes.
-- [`rules/verification.md#mobile`](../rules/verification.md#mobile) — `npx tsc --noEmit` + `expo prebuild --check` + iOS Simulator for native ACs.
+- [`rules/verification.md#mobile`](../rules/verification.md#mobile) — `npx tsc --noEmit` + `npx expo-doctor` + iOS Simulator for native ACs.
 - [`rules/i18n.md#supported-languages`](../rules/i18n.md#supported-languages) — cs/en/de keys must all exist for new copy; missing → fail.
 
 You are the verification gate for issue-driven work. Dev sub-agents
@@ -504,7 +504,7 @@ scope appears on the issue — don't cherry-pick.
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `backend`   | `cd backend && dotnet build` then `dotnet test`. Testcontainers require Docker — if Docker isn't available, mark ⚠️ UNVERIFIED with the reason; do not PASS. |
 | `web`       | `cd web && npm ci` (only if `node_modules` is missing or `package-lock.json` changed) then `npm run build` (typecheck lives in the build). If `npm test` ever appears, run it. |
-| `mobile`    | `cd mobile && npm ci` (same condition) then `npx tsc --noEmit` and `npx expo prebuild --no-install --check`. No test suite exists yet — if one appears, run it. |
+| `mobile`    | `cd mobile && npm ci` (same condition) then `npx tsc --noEmit` and `npx expo-doctor`. No test suite exists yet — if one appears, run it. |
 | `docs-infra`| File-level diff review, `gh workflow view <file>` or `yamllint` for any changed `.github/workflows/*.yml`, scene-anchor existence for prototype changes.     |
 
 A non-zero exit from any of these is an automatic FAIL, regardless of
@@ -769,7 +769,7 @@ Dev servers:
 Full-surface results (regression gate):
   backend: ✅ dotnet build PASS, dotnet test PASS (148/148)
   web:     ✅ npm run build PASS (12.3s)
-  mobile:  ✅ npx tsc --noEmit PASS, expo prebuild --check PASS
+  mobile:  ✅ npx tsc --noEmit PASS, npx expo-doctor PASS
 
 Per-criterion results:
   1. <criterion text>
@@ -842,7 +842,7 @@ For each dev server in step 3b marked "started by qa-tester":
   read-only).
 - `dotnet build`, `dotnet test`, `dotnet run` (for boot in step 3b).
 - `npm ci`, `npm run build`, `npm run dev`, `npm test` (if it exists),
-  `npx tsc --noEmit`, `npx expo prebuild --check`,
+  `npx tsc --noEmit`, `npx expo-doctor`,
   `npx expo start --web`.
 - `npm run e2e:up`, `npm run e2e:down`, `npm run e2e:health`,
   `npm run e2e:logs` and the underlying

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -48,8 +48,9 @@ worth keeping.
 
 - `npm ci` when the lockfile changed.
 - `npx tsc --noEmit` — typecheck.
-- `npx expo prebuild --no-install --check` — verifies the Expo config
-  + plugin chain don't drift.
+- `npx expo-doctor` — verifies SDK compatibility, project config
+  drift, plugin chain health, and package version mismatches against
+  the SDK's expected pins.
 
 For interactive AC checks `qa-tester` boots `npx expo start --web` and
 drives the `react-native-web` render through Playwright. **Same rule
@@ -72,7 +73,9 @@ JSON's `verification` field — see
 shape is constrained:
 
 - `tool` — one of `dotnet-build`, `dotnet-test`, `web-build`,
-  `web-typecheck`, `mobile-typecheck`, `mobile-prebuild-check`.
+  `web-typecheck`, `mobile-typecheck`, `mobile-prebuild-check` (now
+  maps to `npx expo-doctor` after #314; schema enum value kept stable
+  so archived handoffs still validate).
 - `filter` — optional, regex-validated FQN fragment for `dotnet-test`
   (no quotes/whitespace/shell metacharacters).
 - `passed` — boolean.


### PR DESCRIPTION
## Summary

Sweep `.claude/` rule and agent files to replace the invalid `npx expo prebuild --no-install --check` invocation with the canonical `npx expo-doctor`. PR #313 already corrected the CI workflow; this PR closes the loop on the agent and rule references so future runs don't re-introduce the same bug.

Touched files (3, `.claude/`-only):
- `.claude/rules/verification.md` — replaces the `## Mobile` bullet and rewrites the sentence to describe what `expo-doctor` actually verifies (SDK compatibility, project config drift, plugin chain health, package version mismatches).
- `.claude/agents/qa-tester.md` — 4 occurrences updated (verification citation line 17, step-table row line 507, full-surface results template line 772, allowed-commands list line 845). Note: `qa-tester.md:143` is deliberately preserved — it describes a different code path (`mobile/scripts/qa-build-dev-client.sh` invoking Expo's auto-prebuild during `npm ci` when `mobile/ios/` is missing), not the validator.
- `.claude/agents/mobile-expo.md` — 2 occurrences updated (verification citation line 43, tool-name description line 160).

### Schema-enum stability

The `"mobile-prebuild-check"` enum value in `.claude/schemas/dev-handoff.v1.json` is **deliberately not modified** so archived handoffs in `.claude/state/archive/` continue to validate. Both `verification.md` and `mobile-expo.md` carry an inline annotation explaining the value now maps to `npx expo-doctor` post-#314.

## Related issue

Fixes #314

## Scope

docs-infra (`.claude/` only; no `/backend`, `/web`, `/mobile`, no schemas, no state/archive, no hook logs)

## Process note

No dev-handoff JSON for this PR — the change is `.claude/`-only docs-infra and was driven directly by the orchestrator, not via a dev sub-agent.

## QA verdict (from qa-tester)

OVERALL ✅ PASS — `.claude/state/handoff-qa-314.json`. All 5 acceptance criteria met:

- Primary grep gate (`grep -RIn 'expo prebuild --.*check' .claude/ docs/ CLAUDE.md README.md`) returns empty.
- Secondary grep (`grep -RIn 'expo prebuild' .claude/rules/ .claude/agents/`) returns exactly one match — the intentionally-preserved `qa-tester.md:143`.
- `verification.md` sentence describes all four `expo-doctor` dimensions from the AC.
- `mobile-expo.md` and `verification.md` annotate the schema-enum preservation.
- No edits to `.claude/schemas/*.json`, `.claude/state/**`, or `.claude/hooks/log/**`.

## Test plan

- [x] Replace `npx expo prebuild --no-install --check` in `rules/verification.md` and rewrite the surrounding sentence.
- [x] Replace all 3+ occurrences in `agents/qa-tester.md` (actual count: 4).
- [x] Replace both occurrences in `agents/mobile-expo.md`.
- [x] Annotate `"mobile-prebuild-check"` enum to clarify it now maps to `expo-doctor`.
- [x] Grep gate empty across `.claude/`, `docs/`, root markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)