### PR TITLE
chore(#197): archive daily-researcher ecosystem surveys under docs/research/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,8 +92,10 @@ minio_data/
 # Docs (local design specs)
 # =========================
 docs/*
-# …except the testing reference docs that the e2e harness consumers cite.
+# …except the testing reference docs that the e2e harness consumers cite,
+# and the daily-researcher ecosystem-survey artifacts archived under docs/research/.
 !docs/testing/
+!docs/research/
 
 # =========================
 # OS Files

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,45 @@
+# Claude Code ecosystem surveys
+
+One-shot research artefacts produced by the `daily-researcher` skill
+between 2026-04-28 and 2026-05-19. Each file is an as-of-that-date scan of
+the Claude Code ecosystem — new skills, MCP servers, hooks, agents, and
+plugins — filtered through "would this slot into the GoodFellas
+fitness-platform stack?".
+
+## Reading order
+
+Chronological. Earlier entries (Apr 28 – May 05) are the longest and
+establish the catalogue baseline; later entries are diffs against the
+previous run, so they're shorter and assume context.
+
+| Date | File | Notes |
+|---|---|---|
+| 2026-04-28 | [`claude-code-ecosystem-additions-2026-04-28.md`](claude-code-ecosystem-additions-2026-04-28.md) | Baseline. Ranked P1 / P2 / P3 recommendation list. |
+| 2026-04-29 | [`claude-code-ecosystem-additions-2026-04-29.md`](claude-code-ecosystem-additions-2026-04-29.md) | Day-2 additions. |
+| 2026-04-30 | [`claude-code-ecosystem-additions-2026-04-30.md`](claude-code-ecosystem-additions-2026-04-30.md) | |
+| 2026-05-01 | [`claude-code-ecosystem-additions-2026-05-01.md`](claude-code-ecosystem-additions-2026-05-01.md) | Spawned tracking issues #190–#198. |
+| 2026-05-05 | [`claude-code-ecosystem-additions-2026-05-05.md`](claude-code-ecosystem-additions-2026-05-05.md) | |
+| 2026-05-11 | [`claude-code-ecosystem-additions-2026-05-11.md`](claude-code-ecosystem-additions-2026-05-11.md) | |
+| 2026-05-13 | [`claude-code-ecosystem-additions-2026-05-13.md`](claude-code-ecosystem-additions-2026-05-13.md) | Diff format — shorter. |
+| 2026-05-16 | [`claude-code-ecosystem-additions-2026-05-16.md`](claude-code-ecosystem-additions-2026-05-16.md) | |
+| 2026-05-19 | [`claude-code-ecosystem-additions-2026-05-19.md`](claude-code-ecosystem-additions-2026-05-19.md) | Most recent run. |
+
+## Source
+
+Produced by [`.claude/skills/daily-researcher/`](../../.claude/skills/daily-researcher/) —
+fan-out web search → curated registry sweep → adoption-readiness digest.
+
+## Retention policy
+
+**Historical artefacts.** These are not actively maintained. Items that
+graduated to action live elsewhere:
+
+- The P1 / P2 recommendations from 2026-04-28 → either landed as merged
+  PRs (Delightful Design System plugin, statusline, OWASP skill) or
+  became tracking issues [#190–#198](https://github.com/JanProkorat/fitness-platform/issues?q=is%3Aissue+author%3A%40me+%22ecosystem%22) with explicit triggers.
+- The current orchestration source-of-truth lives in
+  [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) and
+  [`.claude/rules/*.md`](../../.claude/rules/) — not here.
+
+If you want the latest ecosystem snapshot, invoke the
+`daily-researcher` skill — don't infer current state from these files.

--- a/docs/research/claude-code-ecosystem-additions-2026-04-28.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-04-28.md
@@ -1,0 +1,269 @@
+# Claude Code Ecosystem — Additions Worth Considering
+
+**Compiled:** 2026-04-28 (scheduled `daily-resercher` run)
+**Scope:** New skills, agents, hooks, MCP servers, and plugins released or matured by Apr 2026 that map to the GoodFellas fitness-platform stack (.NET 10 backend / React 19 web / Expo SDK 55 mobile) and its existing orchestration setup.
+**Filter applied:** anything that already overlaps with the project's `.claude/agents/`, `.claude/skills/`, or installed plugins is omitted. Each entry below names a concrete way it would slot into the *current* orchestration — not a generic pitch.
+
+---
+
+## 0. TL;DR — recommended adds, ranked
+
+| Priority | Addition | Why it fits *this* project |
+|---|---|---|
+| P1 | **Statusline plugin** (CCometixLine or ccstatusline) | Long orchestrator sessions; today there's no in-terminal signal for context %, token spend, or active branch. Pure visibility gain, zero workflow risk. |
+| P1 | **OWASP / Agentic AI security skill** + Anthropic's `claude-code-security-review` GH Action | Auth, invite, upload, and ownership endpoints are the riskiest surfaces. Formalises the `gc-sec-review` chainable mention into an automatic pre-merge gate. |
+| P1 | **i18n audit skill** (`i18n-expert` / `i18n-scan`) | cs/en/de parity is *already* an AC failure for `qa-tester`; a dedicated pre-QA scan would catch missing keys earlier and avoid round-trip churn. |
+| P2 | **Expo official remote MCP** | Adds Expo-SDK-aware doc/tool calls (current setup leans on `xcodebuildmcp` for the simulator path; Expo MCP would cover SDK 55 questions, native module guidance). |
+| P2 | **Testcontainers Claude skill** (`testcontainers/claude-skills`) | Backend tests already use Testcontainers — dedicated patterns would tighten `fe-endpoint`-generated test scaffolding around lifecycle, parallelism, and `.WithReuse()`. |
+| P2 | **Delightful Design System plugin** (token compliance scan) | Direct match for the project's hardcoded-color/spacing ban. Could become a `PreToolUse` hook on `web/**` and `mobile/**` Edits. |
+| P3 | **HTTP hooks** (Feb 2026 feature) | Replaces shell hooks with HTTP POSTs — opens the door to Slack/CI integrations without spawning processes per tool call. |
+| P3 | **`cclint`** (linter for `.claude/` files) | The repo's `.claude/` tree is now non-trivial (workflow agents, dev agents, ~13 skills). A lint pass on frontmatter + YAML would prevent silent agent-config bitrot. |
+| P3 | **`claude-mem` long-term memory** | Beyond the per-session `.remember/` buffer, `claude-mem` carries decisions across days/weeks. The project already keeps `today-*.md` daily logs — `claude-mem` would auto-promote durable preferences. |
+
+The deliberate **non-recommendations** (skills/plugins this project already has equivalents of) are listed at the bottom.
+
+---
+
+## 1. Statusline — context/budget visibility
+
+**What it is:** A custom statusline replaces the bottom bar in Claude Code with live data: model name, working directory, git branch + dirty state, context-window %, token usage, cost, and (with OAuth) subscription rate-limit headroom.
+
+The two leading 2026 implementations are:
+
+- **CCometixLine** (Rust) — model, dir, git status, context % with transcript-based tracking.
+- **ccstatusline** (Node) — modular widgets including separate counts for staged / unstaged / untracked files, deduped streaming token counts.
+
+**Where it slots in:** Pure overlay — no agent or hook impact. Configured via `~/.claude/settings.json` `statusLine` block (or `/statusline` natural-language config).
+
+**Why this project specifically:**
+- Orchestrator sessions on this repo regularly stack `ship-epic` → multiple parallel sub-issue dispatches → `qa-tester` → `pr-reviewer` rounds. Token spend is invisible today.
+- The epic-branch model means worktree branches change underfoot (`.worktrees/<N>-<short>/feature/<N>-<short>`). A branch widget removes "wait, which checkout am I in?" footguns.
+- Cost is a real concern with Opus 4.7 + 1M context; surfacing remaining budget per session feeds back into the "plan-then-execute for large tasks" rule (Working Principles §5).
+
+**Effort:** ~10 minutes. Low risk.
+
+---
+
+## 2. Security review — OWASP skill + GH Action
+
+**What it is:** Two complementary pieces:
+
+1. **`agamm/claude-code-owasp` skill** — bundles OWASP Top 10 (2025), ASVS 5.0, and the new **OWASP Agentic AI Top 10** (2026) as a Claude Code skill. Auto-activates on auth, upload, invitation, or AI-tool-call code-review prompts.
+2. **`anthropics/claude-code-security-review`** — official Anthropic GitHub Action that runs Claude as a security reviewer on every PR diff. Designed to find what static SAST tools miss: missing controls, business-logic flaws, attack-path chaining.
+
+Adjacent: `SecOpsAgentKit` ships 25+ skills including `secrets-gitleaks` for hardcoded-secret detection.
+
+**Where it slots in:**
+- The orchestrator's `.claude/CLAUDE.md` already references `gc-sec-review` as a chainable plugin skill, but it's optional today. Promoting it to **mandatory for any PR whose diff touches `Features/Auth/`, `Features/Client/Invites/`, `Features/Trainers/Clients/`, or any blob-upload path** would close a concrete gap.
+- `pr-reviewer` runs a two-pass review; the security skill would be invoked inside the first pass when scope-tags include `auth`, `invite`, `upload`, or `ownership`.
+- The GH Action is independent — it runs in CI alongside the existing review and surfaces findings on the PR. Backstops `pr-reviewer` for cases where the orchestrator skipped a sec-review chain.
+
+**Why this project specifically:**
+- The platform brokers trainer↔client relationships. Recent work (epic #67 photo-diary requests, PR #149 GuidSerializer, blob 403 fixes) all touched auth/ownership boundaries.
+- MinIO public-read is now the default for some assets (per `archive.md`). Anything touching ACL paths benefits from a structured audit.
+- The OWASP **Agentic** Top 10 specifically covers tool-calling agents — directly relevant since the trainer/client app uses SignalR + AI features.
+
+**Effort:** ~30 min for the skill, ~15 min for the GH Action workflow. The Action is gated on a Claude API key; project already has Anthropic creds via Claude Code so this is just env wiring in CI.
+
+---
+
+## 3. i18n audit — proactive translation parity
+
+**What it is:** A skill family for finding hardcoded strings, extracting them to locale files, and reporting parity gaps. Concrete options:
+
+- **`i18n-expert`** — runs `i18n_audit.py`, comparing `t('key')` usage against locale JSON files; reports missing/orphaned keys per locale.
+- **`i18n-scan`** — finds hardcoded JSX text, string literals in user-facing contexts, and placeholder text that should be `t()`-wrapped.
+- **`i18n-extract`** — actually rewrites the code to wrap and extract.
+
+**Where it slots in:**
+- Today the i18n parity check happens *inside* `qa-tester` per the AC gate — meaning a missing German key forces a full dev → qa round-trip.
+- A pre-QA `i18n-audit` invocation inside `web-react` and `mobile-expo` (right after their work, before they hand back) would catch parity gaps in-package.
+- For new web pages and mobile screens, this can chain inside `web-page` and `mobile-screen` skills as a final step.
+
+**Why this project specifically:**
+- cs/en/de is mandated across all three packages (`/web/src/i18n/`, `/mobile/src/i18n/`, backend FluentValidation messages where applicable).
+- Recent activity (`recent.md`) shows back-to-back i18n adds (auth flow, "FOTKY DNE", `common.delete*`); a parity scan would have caught the inevitable misses earlier.
+
+**Effort:** ~20 min. Low risk — the skill is read-only by default; only `i18n-extract` mode mutates.
+
+---
+
+## 4. Expo official MCP server
+
+**What it is:** A remote MCP server hosted by Expo (https://docs.expo.dev/eas/ai/mcp/) that exposes:
+
+- **Server capabilities** (no local server needed): `search_documentation` over the Expo SDK + EAS docs.
+- **Local capabilities** (requires `expo start`): interact with simulators, drive React Native DevTools, inspect network/components/state.
+
+**Where it slots in:**
+- The project's mobile work currently relies on `xcodebuildmcp` for the *iOS Simulator* and on memorised Expo SDK 55 conventions for everything else.
+- Adding the Expo MCP gives `mobile-expo` and `qa-tester` first-class access to up-to-date Expo SDK 55 docs (and any future SDK bump) without WebFetch detours.
+- Local-capability mode replicates parts of `xcodebuildmcp` (component inspection) but with cross-platform reach (Android emulator support).
+
+**Why this project specifically:**
+- SDK 55 is current; the project will inevitably need to evaluate SDK 56 / Expo Router v4 / new architecture migrations. Doc lookups via MCP > stale training data.
+- `xcodebuildmcp` is iOS-only by design. Android coverage is a known blind spot — Expo MCP closes part of it.
+
+**Effort:** ~5 min (remote MCP — just add the URL + token to `.mcp.json` or `~/.claude/mcp.json`).
+
+---
+
+## 5. Testcontainers Claude skill
+
+**What it is:** `testcontainers/claude-skills` — official skills for designing, running, and debugging Testcontainers-based integration tests. Covers lifecycle (`.WithReuse()`, container caching), parallel-friendly patterns, and the .NET-specific module pack (PostgreSQL, MongoDB, MinIO, Redis, Localstack — 65+ modules).
+
+**Where it slots in:**
+- `backend-dotnet` and the `fe-endpoint` skill already produce Testcontainers tests, but the patterns are baked into the skill's own template. Centralising them on the upstream skill (which tracks Testcontainers releases) means fewer drift bugs.
+- Could chain inside `fe-endpoint` as the test-scaffolding step.
+
+**Why this project specifically:**
+- `FitnessApiFactory.cs` is the central Testcontainers harness; it now has 884+ tests behind it. Any future change to that fixture has wide blast radius.
+- Recent work on PR #149 tripped over a `GuidSerializer` Mongo registration race that the official skill has documented patterns for ([ModuleInitializer] on bootstrap, exactly the fix that landed).
+
+**Effort:** ~10 min to install. Low risk — read-mostly.
+
+---
+
+## 6. Delightful Design System plugin (token compliance scan)
+
+**What it is:** `kylesnav/delightful-claude-plugin` — a design-system plugin with a *compliance scan* skill that detects:
+
+- Hardcoded color/spacing/font values when tokens exist.
+- Missing interaction states (hover/focus/active/disabled).
+- Accessibility gaps (contrast, touch-target, label).
+- Dark-mode breakage.
+
+**Where it slots in:**
+- The project explicitly bans hardcoded colors/spacing/fonts in `/web` and `/mobile` (see `CLAUDE.md` §"What NOT to Do" and §"Hardcoded-value bans").
+- Could be wired as a **`PreToolUse` hook** on `Edit`/`Write`/`MultiEdit` against `web/src/**` and `mobile/**` — analogous to the existing `block-generated-edits` hook on `generated.ts`.
+- Alternatively, run as a final-pass skill inside `web-react`/`mobile-expo` before they declare done.
+
+**Why this project specifically:**
+- The recent palette unification (`Brand.gold`, `Colors.shadow` consts, 31-file cleanup) was a manual sweep. A scan-on-edit hook would prevent re-introductions.
+- Mobile-side `useTheme()` discipline is enforced today only by code review — automated check is cheaper.
+
+**Effort:** ~30 min if installed as a skill; ~1 h if formalised as a hook with a scoped allowlist (e.g. allow hardcoded values inside `constants/colors.ts`, `tailwind.config.ts`, design-token files only).
+
+---
+
+## 7. HTTP hooks (Feb 2026 feature)
+
+**What it is:** A new hook transport that POSTs JSON to an HTTP endpoint and consumes the JSON response, in addition to the existing shell-command hooks. Lets you wire hooks to:
+
+- Internal CI / status APIs without spawning processes per tool call.
+- Slack incoming webhooks (the project already uses Slack OAuth for PR alerts).
+- Bespoke microservices (a self-hosted "review-gate" endpoint, for example).
+
+**Where it slots in:**
+- Replaces the shell-out from the (currently shell-based) SessionStart memory hook with an HTTP version that could pull live state from a central hub if the project ever centralises logs.
+- A `Stop` HTTP hook → Slack channel for "session ended on epic-branch <X> with N modified files" — handy for AFK orchestration days.
+
+**Why this project specifically:**
+- The existing Slack-OAuth → PR-alerts pipeline is documented in `archive.md`; HTTP hooks would let the orchestrator post turn-end summaries without a separate `mcp__slack_*` call.
+- Lower latency than the shell-fork model on long sessions.
+
+**Effort:** ~30 min for a Slack-end-of-turn webhook. Skip until there's a concrete handler to point at.
+
+---
+
+## 8. `cclint` — linter for `.claude/` files
+
+**What it is:** A standalone CLI (`carlrannaberg/cclint`) that lints Claude Code config files: agent frontmatter, skill YAML, MCP config, hook command syntax, `settings.json` schema. Catches typos in `subagent_type`, broken `Skill` references, malformed `permissions` blocks.
+
+**Where it slots in:**
+- Add as a `pre-commit` hook (the project already uses pre-commit hooks per `CLAUDE.md`).
+- Run in CI on PRs that touch `.claude/**`.
+
+**Why this project specifically:**
+- `.claude/` is no longer trivial: 3 dev sub-agents, 3 workflow sub-agents, ~13 project skills, the orchestrator CLAUDE.md, hooks, MCP config. A typo in any frontmatter today fails *silently* — the agent just isn't dispatched.
+- The recent epic dispatch model (`ship-epic`) hard-codes agent names; a lint catch on a renamed agent would prevent a confusing mid-epic failure.
+
+**Effort:** ~15 min. Low risk — read-only linter.
+
+---
+
+## 9. `claude-mem` — long-term cross-session memory
+
+**What it is:** A plugin that adds persistent long-term memory for Claude Code, beyond the per-session/per-day buffer. Memories survive context compaction and session boundaries; relevant ones are auto-injected on session start.
+
+**Where it slots in:**
+- Complements the existing `.remember/` daily/recent/archive buffers and the `~/.claude/projects/.../memory/` user-feedback memory store.
+- Where `.remember/` is *project state* and `memory/` is *user preferences*, `claude-mem` would carry **architectural decisions and ongoing context** (e.g. "epic #67 deferred Wave-3 web work to a follow-up — see `docs/notion`") across days without manual archive curation.
+
+**Why this project specifically:**
+- The current `today-*.md` daily logs are written by hand at session-end and grow stale fast (see `archive.md` — last entry is week of 2026-04-20).
+- Multi-day epics (#67 currently) span sessions; orchestrator state is currently re-derived from GitHub each new session.
+
+**Effort:** ~20 min. Some risk of context bloat — should be configured with a tight memory budget.
+
+**Caveat:** Overlaps philosophically with the project's existing memory system. Worth a *trial only*, not a default-on rollout.
+
+---
+
+## 10. Honourable mentions (lower-fit but worth noting)
+
+- **`context-mode` plugin** (98% context savings via sandboxed subprocess summarisation) — claims to dramatically extend session lifetime. Likely overlaps with the project's existing sub-agent isolation pattern; could conflict with `qa-tester` / `pr-reviewer` which intentionally consume large diffs. *Verdict: skip; the orchestration already factors heavy work into sub-agents.*
+- **`metro-mcp`** — third-party React Native MCP for component inspection without app-code changes. Useful but already partially covered by Expo MCP + xcodebuildmcp. *Verdict: revisit only if Expo MCP gaps emerge.*
+- **MongoDB official agent skills** — already wired in this project's installed plugins (`plugin:mongodb:mongodb`, `mongodb-query-optimizer`, `mongodb-schema-design`, etc.). *Verdict: already present; nothing to add.*
+- **Aaronontheweb/dotnet-skills** (30 .NET skills, 5 specialised agents) — the closest analogue to the project's `backend-dotnet` agent. *Verdict: cherry-pick patterns; don't install wholesale — would conflict with `fe-endpoint` and `mongo-document` skills already tuned to this codebase.*
+
+---
+
+## What NOT to add (to avoid duplication)
+
+- **`superpowers:brainstorming`, `:test-driven-development`, `:executing-plans`** — already in installed plugins; the orchestrator references them via the plan-then-execute rule.
+- **Generic ".NET expert" or "React expert" subagents** (VoltAgent / 0xfurai) — the project's `backend-dotnet`, `web-react`, `mobile-expo` are already package-tuned with the project's exact conventions.
+- **Generic "code-review" agents** — `pr-reviewer` + the `review` skill + `pr-review-toolkit:*` agents already cover this with the project's specific gate logic.
+- **Notion-doc skills (third-party)** — the project's `notion-docs` skill is already incremental-aware with bootstrap/update modes.
+- **Slack helper skills** (channel digest, draft announcement) — already in installed plugins.
+
+---
+
+## Suggested execution sequence
+
+If only one rollout window is available:
+
+1. **This week (low-effort, immediate value):**
+   Install a statusline (CCometixLine recommended for Rust speed) and `cclint`. Total time: <30 min.
+
+2. **Within the epic #67 cycle (defensive):**
+   Add the OWASP skill + the GitHub Action. Wire the OWASP skill into `pr-reviewer`'s first-pass for any PR with `scope:backend` + a touched file under `Features/Auth/` or any `Features/*/Photo*`.
+
+3. **Pre-merge of epic #67 (UX-quality):**
+   Install the i18n-expert skill and chain it into `web-page` and `mobile-screen`. Adds ~10s per scaffold; saves a `qa-tester` round-trip per missing-key.
+
+4. **Next quarter (infrastructure):**
+   Trial `claude-mem` on a single multi-day epic. Evaluate vs the existing `.remember/` setup. Keep only one source of truth for cross-session memory.
+
+5. **When a concrete handler exists:**
+   Migrate the SessionStart memory hook (and any future Slack-on-stop hook) to HTTP hooks.
+
+---
+
+## Sources
+
+- [GitHub – ComposioHQ/awesome-claude-plugins (registry of curated plugins)](https://github.com/ComposioHQ/awesome-claude-plugins)
+- [Top 10 Claude Code Plugins to Try in 2026 (Firecrawl blog)](https://www.firecrawl.dev/blog/best-claude-code-plugins)
+- [Claude Code Hooks: All 12 Events with Examples (Pixelmojo, 2026)](https://www.pixelmojo.io/blogs/claude-code-hooks-production-quality-ci-cd-patterns)
+- [Claude Code hooks — practical guide (eesel AI, 2026)](https://www.eesel.ai/blog/hooks-in-claude-code)
+- [Customize your status line — Claude Code Docs](https://code.claude.com/docs/en/statusline)
+- [GitHub – Haleclipse/CCometixLine (Rust statusline)](https://github.com/Haleclipse/CCometixLine)
+- [GitHub – sirmalloc/ccstatusline (Node statusline)](https://github.com/sirmalloc/ccstatusline)
+- [GitHub – agamm/claude-code-owasp (OWASP skill, includes Agentic AI Top 10)](https://github.com/agamm/claude-code-owasp)
+- [GitHub – anthropics/claude-code-security-review (official GH Action)](https://github.com/anthropics/claude-code-security-review)
+- [OWASP Agentic Skills Top 10 (2026)](https://owasp.org/www-project-agentic-skills-top-10/)
+- [GitHub – AgentSecOps/SecOpsAgentKit (25+ security skills incl. secrets-gitleaks)](https://github.com/AgentSecOps/SecOpsAgentKit)
+- [i18n-expert skill (explainx.ai)](https://explainx.ai/skills/daymade/claude-code-skills/i18n-expert)
+- [Claude Code Skills i18n 2026 (intlpull.com)](https://intlpull.com/blog/claude-code-skills-i18n-automation-2026)
+- [Create an i18n specialist with Claude Code subagents (Jökull Sólberg)](https://www.solberg.is/i18n-subagent)
+- [Using Model Context Protocol (MCP) with Expo — Expo Docs](https://docs.expo.dev/eas/ai/mcp/)
+- [GitHub – senaiverse/claude-code-reactnative-expo-agent-system](https://github.com/senaiverse/claude-code-reactnative-expo-agent-system)
+- [GitHub – testcontainers/claude-skills](https://github.com/testcontainers/claude-skills)
+- [GitHub – Aaronontheweb/dotnet-skills](https://github.com/Aaronontheweb/dotnet-skills)
+- [GitHub – kylesnav/delightful-claude-plugin (design-system compliance)](https://github.com/kylesnav/delightful-claude-plugin)
+- [GitHub – carlrannaberg/cclint (linter for `.claude/` files)](https://github.com/carlrannaberg/cclint)
+- [Claude Code Sub-Agent For .NET and Angular Development (Atomic Object)](https://spin.atomicobject.com/claude-code-sub-agent/)
+- [CLAUDE.md for .NET Developers (codewithmukesh)](https://codewithmukesh.com/blog/claude-md-mastery-dotnet/)
+- [Claude Code: Hooks, Subagents, and Skills — Complete Guide (ofox.ai)](https://ofox.ai/blog/claude-code-hooks-subagents-skills-complete-guide-2026/)
+- [Parallel Agentic Development With Git Worktrees (MindStudio)](https://www.mindstudio.ai/blog/parallel-agentic-development-git-worktrees)
+- [Claude Skills Marketplace (BrightCoding, 2026-04-26)](https://www.blog.brightcoding.dev/2026/04/26/claude-skills-marketplace-the-essential-plugin-hub-for-developers)

--- a/docs/research/claude-code-ecosystem-additions-2026-04-29.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-04-29.md
@@ -1,0 +1,228 @@
+# Claude Code Ecosystem — Follow-up Additions
+
+**Compiled:** 2026-04-29 (scheduled `daily-resercher` run)
+**Companion to:** [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+**Scope:** Items that yesterday's report didn't cover, or only mentioned in passing — focusing on official Anthropic features released in 2026 Q1 + a few fresh community pieces with concrete fit for the project.
+
+> Anything already analysed yesterday (statusline, OWASP skill + GH Action, i18n audit, Expo MCP, Testcontainers skill, Delightful Design System, HTTP hooks, `cclint`, `claude-mem`) is **not** repeated here. This is strictly the *delta*.
+
+---
+
+## 0. TL;DR — what's new today
+
+| Priority | Addition | Why it's worth re-evaluating |
+|---|---|---|
+| P1 | **Anthropic's "Code Review for Claude Code"** (parallel multi-agent PR reviewer, beta March 2026) | Could replace or complement the project's bespoke `pr-reviewer` two-pass — runs N parallel agents on Anthropic infra, ~84% finding rate on PRs >1k lines, ~$15–25/PR. |
+| P1 | **`dotnet-claude-kit` (codewithmukesh)** — 47 skills + **15 Roslyn MCP tools** | The Roslyn-MCP angle (proper AST queries, not regex) is genuinely new vs the existing `backend-dotnet` agent. Could power refactors and fix-ups that today rely on `grep`. |
+| P2 | **Anthropic "Agent Teams"** (experimental native multi-agent) | Built-in shared task list across team-lead + teammates; would test whether the custom `ship-epic` orchestration could be simplified by leaning on first-party scaffolding. |
+| P2 | **`lackeyjb/playwright-skill`** (skill, not MCP) | Lower context cost than the `playwright` MCP plugin currently used by `qa-tester`; explicit visual-regression patterns with `toHaveScreenshot()`. |
+| P3 | **`expo-mcp` + `xc-mcp` autonomous testing pattern** | Yesterday's report mentioned Expo MCP separately. The combined-with-xc-mcp testID-driven autonomous iOS testing pattern is the actual published workflow — worth considering as a replacement for `qa-tester`'s current XcodeBuildMCP-only loop. |
+| P3 | **`hesreallyhim/awesome-claude-code` registry** | Single-source curated index — useful as the shortlist for future scheduled `daily-resercher` runs (replaces ad-hoc googling). |
+
+---
+
+## 1. Anthropic's official Code Review feature (March 2026)
+
+**What it is:** Anthropic launched **Code Review for Claude Code** on 2026-03-10 — a parallel-agent system hosted on Anthropic infrastructure that scans pull requests for bugs, security vulnerabilities, and code-quality regressions. Multiple agents look for distinct issue classes simultaneously, then a verification step checks each candidate against actual code behaviour to filter false positives. Distinct from the older `claude-code-security-review` GitHub Action — this is general-purpose, not just security.
+
+Reported numbers from Anthropic's launch post:
+
+- PRs >1000 lines: **84% receive findings**, average **7.5 issues**.
+- PRs <50 lines: **31% receive findings**, average **0.5 issues**.
+- **<1% of findings marked incorrect** by reviewing engineers.
+- **$15–$25 per PR** typical, scales with diff size.
+- Beta on **Team and Enterprise plans only** (research preview).
+
+**Where it would slot in:**
+
+The project's `pr-reviewer` already runs a two-pass review (self-review via the `review` skill + a fresh-eyes sub-reviewer dispatched blind via the `Agent` tool). Anthropic's hosted system is structurally similar but:
+
+- Runs **in parallel on Anthropic infra**, not local — much faster turnaround on large PRs.
+- The **verification step** is what the current setup most explicitly lacks; the project's pr-reviewer can over-report on speculative findings and the orchestrator has to filter. Hosted verification would automate that.
+
+Concrete options:
+
+1. **Replace the second-pass sub-reviewer** with the hosted feature on PRs >500 lines. Keep the project-aware first-pass self-review intact (it's the only place project-specific gates like `regen-api` write-locks, design-token bans, and the `Migrations/**` exclusion live).
+2. **Run hosted in addition to** the existing two-pass on epic-level PRs only (where the diff cost matters most and the $15–25 spend is amortised over many sub-issues).
+3. **Skip for sub-issue PRs** (base = epic branch). The project's auto-merge model means sub-issues get heavy local review already; paying $15+ each would 5–10× the per-epic spend.
+
+**Why this project specifically:**
+
+- Recent epic PRs have run >1500 lines (#67 photo-diary epic, the photo-feature epic). 84% find-rate would have caught real issues earlier.
+- The project's hard-rule gate (auto-generated files, scope-tagged fix routing) is *orchestration logic*, not review heuristic — so layering the hosted review on top doesn't conflict; it lives in the second-pass slot.
+- Plan tier needs verification — the project owner is on a personal/team plan; if Enterprise-only blocks this, fall back to keeping the current setup.
+
+**Risk:** Hosted reviews submit the diff to Anthropic infra. Already true for any Claude Code call but worth flagging — the project has trainer/client PII flowing through some endpoints.
+
+**Effort:** ~15 min if eligible; the feature wires in via a setting in the Claude Code app or a single workflow file. Skip if not on Team/Enterprise plan.
+
+---
+
+## 2. `dotnet-claude-kit` — the Roslyn MCP angle
+
+**What it is:** A 2026 .NET 10 / C# 14 kit (codewithmukesh) bundling:
+
+- **47 skills** (CLAUDE.md templates, project-structure rules, FastEndpoints scaffolds, EF Core patterns, security/perf playbooks).
+- **10 specialist agents** (test-engineer for xUnit v3 + Testcontainers, security agent, perf agent, refactor agent, etc.).
+- **16 slash commands** (scaffold-feature, audit-deps, generate-test, fix-style, etc.).
+- **15 Roslyn MCP tools** — this is the bit yesterday's report missed.
+- **7 hooks** (PreToolUse safety, PostToolUse format/test, Stop summarisers).
+- **5 project templates**.
+
+The **Roslyn MCP tools** are the new thing. Today the `backend-dotnet` agent edits .NET code via `grep` + `Read` + `Edit`. Roslyn-MCP gives it actual semantic queries: "find all `IServiceCollection.AddScoped` registrations of types implementing `IClientNotifier`," "rename `IPhotoStore.GetAsync` and update every caller including override matrix," "list all `[Authorize]` endpoints with no role/policy attribute." Regex can't do those reliably; Roslyn can.
+
+**Where it would slot in:**
+
+- **Cherry-pick the Roslyn MCP** and add it to `~/.claude/mcp.json` for `backend-dotnet` only. Don't install the whole kit — yesterday's report correctly flagged that wholesale install conflicts with the project-specific `fe-endpoint` and `mongo-document` skills.
+- **Use it for refactor-class issues** specifically (`type:refactor` labelled work). Bug-fixes and feature work are well-served by current grep+edit; refactors that touch interface signatures are where today's setup gets brittle.
+
+**Why this project specifically:**
+
+- The backend has 22 EF entities, 23 Mongo documents, 11 service interfaces, ~116 endpoints. A signature change rippling through 116 endpoints is exactly where regex misses an override or implicit interface implementation.
+- Recent work (PR #149 GuidSerializer) involved a `ModuleInitializer` change that needed verifying-by-grep across the test surface; Roslyn would have answered directly.
+- xUnit v3 migration (if/when) — Roslyn-aware refactoring is much safer than regex sweeps.
+
+**Effort:** ~20 min to install Roslyn MCP standalone. **Don't** install the rest of the kit; cherry-pick patterns into existing project skills if useful, but the project's skills are tighter for its conventions.
+
+---
+
+## 3. Anthropic "Agent Teams" — native multi-agent (experimental)
+
+**What it is:** A native Claude Code feature that lets one session act as a "team lead," coordinating multiple "teammates" via a shared task list. Each teammate runs in its own context window. Communicate directly with each other, not just back through the lead.
+
+**Status:** Experimental, disabled by default.
+
+**Where it could slot in:**
+
+The project already has a sophisticated custom orchestration (`ship-epic` skill, parallel sub-agent dispatch, `.worktrees/<N>-<short>/` git-worktree isolation per sub-issue, the qa→review→merge gate). Agent Teams covers some of the same ground but:
+
+- **Shared task list** — the project today simulates this via the orchestrator's `TodoWrite` + the workflow agents' return summaries. A first-class shared list could reduce the orchestrator's "stitch return values back together" overhead.
+- **Direct teammate ↔ teammate communication** — the project's design is hub-and-spoke (orchestrator brokers everything). Direct communication could let, e.g., `web-react` ask `backend-dotnet` for a quick endpoint shape clarification without round-tripping through the orchestrator. But — direct communication breaks the project's invariant that each sub-agent's package boundary is enforced by the orchestrator. Trade-off worth thinking about.
+
+**Recommendation:** **Don't adopt** in the short term. The project's custom orchestration is mature, is documented in `.claude/CLAUDE.md`, and encodes invariants (epic-branch model, scope-tag routing, merge-exclusion list) that Agent Teams doesn't know about. **Do track** the feature — once it stabilises and supports custom routing rules, a port from custom orchestration to Agent Teams could simplify the codebase.
+
+**Effort to evaluate:** ~30 min spike on a non-critical issue. Don't migrate epic flow until the feature exits experimental.
+
+---
+
+## 4. `lackeyjb/playwright-skill` — Playwright as a Skill (not MCP)
+
+**What it is:** A Claude Code Skill (not an MCP server) for browser automation with Playwright. Auto-loads `API_REFERENCE.md` only when needed, advertised as "less context than `playwright-MCP`." Includes documented visual-regression patterns:
+
+- Animations disabled globally for screenshot stability.
+- `maxDiffPixelRatio: 0.01` for anti-aliasing tolerance.
+- Baseline-management workflow (`toHaveScreenshot()`, `--update-snapshots`).
+
+**Where it would slot in:**
+
+The project's `qa-tester` agent currently uses the `playwright` MCP plugin (per `.claude/CLAUDE.md`) for AC flows and prototype-fidelity diffs. The MCP loads its full API surface into context every session. The Skill version loads `API_REFERENCE.md` only when invoked — meaningful context savings on long QA loops.
+
+The visual-regression patterns are a more direct fit for the project's "prototype-fidelity diff" workflow than the current ad-hoc screenshot comparison. Today's diffs are visual but not pixel-exact; adopting `toHaveScreenshot()` baselines on key screens would catch real regressions automatically.
+
+**Why this project specifically:**
+
+- Mobile work especially benefits — animation/layout regression is the #1 cause of "the user said it doesn't work twice in a row" loops (the working principle that triggers the `ui-tradeoff` skill).
+- Web prototype scenes (`docs/prototypes/trainer/scenes/*.html`) are stable references — perfect baseline candidates.
+- Replacing MCP with Skill saves context budget on every `qa-tester` dispatch — small per-call but cumulative across an epic.
+
+**Trade-off:** MCP is bidirectional and live; the Skill model still needs Playwright running locally. Keep MCP for live-driven AC flows (form fills, click sequences); use the Skill specifically for screenshot-baseline workflows.
+
+**Effort:** ~30 min to install + bootstrap a baseline set for the top 5 web routes and top 5 mobile screens. Re-baseline on intentional UI changes.
+
+---
+
+## 5. `expo-mcp` + `xc-mcp` — autonomous iOS testing pattern
+
+**What it is:** A **published workflow** (Smithery's `claude-mobile-ios-testing`) combining two MCP servers:
+
+- **`expo-mcp`** — the Expo-hosted remote MCP. Drives React Native DevTools, queries components, interacts with the running app via testIDs.
+- **`xc-mcp`** — simulator lifecycle (boot, install, screenshot, log capture, teardown).
+
+The pattern: Claude **autonomously writes RN component tests by testID, runs them in the simulator, screenshots to verify UI, fixes issues it finds, re-runs.** No human in the loop for the inner test-iterate cycle.
+
+**Where it would slot in:**
+
+The project's `qa-tester` today uses **XcodeBuildMCP** for iOS Simulator (boot, install dev-client, screenshot). It does NOT currently have testID-aware component-level interaction — the simulator path is "boot the app, screenshot the screen, check the screenshot," which catches gross regressions but not, e.g., "this button is rendered but tapping it doesn't fire."
+
+Adding `expo-mcp` (already on yesterday's P2 list as a fit) **plus** the testID-driven testing pattern would let `qa-tester` actually drive the app like a real test runner — tap a button, wait for a state change, assert text content — instead of pixel-checking.
+
+**Why this project specifically:**
+
+- AC failures on mobile work most often come from interaction bugs, not layout (per recent epic #67 commits — overlay tokens, color tokens, message-textarea fixes — all interaction-adjacent).
+- The recent `mobile/test-results/` directory in the working tree status suggests interaction tests are at least partially in place locally; this pattern would integrate them into the QA gate.
+
+**Caveat:** This requires testIDs on every interactive component. Today the codebase has spotty testID coverage (mostly the SignalR-connected screens). Adopting this pattern means a one-time sweep to add testIDs across the mobile component tree — a real cost.
+
+**Effort:** ~2 h to install both MCPs + draft a testing playbook. **+ 4–8 h** for the testID coverage sweep on top mobile screens. Best done as its own scoped issue, not bundled into another PR.
+
+---
+
+## 6. `hesreallyhim/awesome-claude-code` — single-source registry
+
+**What it is:** A community-maintained curated list of skills, hooks, slash commands, agent orchestrators, applications, and plugins. Distinct from `ComposioHQ/awesome-claude-plugins` (focus on the plugin system specifically) and `travisvn/awesome-claude-skills` (skills only) — `hesreallyhim/` is the broadest registry.
+
+**Where it would slot in:**
+
+This is **infrastructure for the `daily-resercher` task itself** — not a runtime addition to the project's orchestration.
+
+Today this scheduled task does ad-hoc web searches across Google + DEV + Composio + various blogs. Most of those results re-cite a small handful of curated registries. Pinning the search to:
+
+1. `hesreallyhim/awesome-claude-code` (broadest)
+2. `ComposioHQ/awesome-claude-plugins` (plugin-system specifics)
+3. Anthropic's official `claude-code` repo's `plugins/` directory
+4. `claudemarketplace.com` (community directory, ~150+ entries)
+
+…would produce more focused, higher-quality results than the current general web search.
+
+**Recommendation:** Update the `daily-resercher` SKILL.md to direct the search at these registries first, with a fallback to web search only for items not present in the registries. Yesterday's report has nearly all the registry-listed items already covered — meaning future runs may find diminishing returns *unless* the search is repointed at the long tail.
+
+**Effort:** ~10 min to update `daily-resercher/SKILL.md`. Largest single ROI item in this report — improves every future scheduled run.
+
+---
+
+## What's NOT in this report (already in yesterday's)
+
+For continuity, yesterday's report covers these and they are **not re-evaluated here**:
+
+- Statusline (CCometixLine, ccstatusline)
+- OWASP skill + `claude-code-security-review` GH Action
+- i18n audit skills (`i18n-expert`, `i18n-scan`)
+- Expo official MCP (yesterday: doc-search angle; today: testing-pattern angle in §5)
+- Testcontainers Claude skill
+- Delightful Design System plugin
+- HTTP hooks
+- `cclint`
+- `claude-mem`
+- `Aaronontheweb/dotnet-skills` (yesterday's honourable mention; today §2 covers a *different* dotnet kit)
+
+---
+
+## Suggested execution sequence (delta vs yesterday's plan)
+
+1. **This week (cheapest, highest leverage):** Update `daily-resercher` SKILL.md to point at the curated registries (§6). Saves token spend on every future run.
+2. **Within next epic cycle (defensive):** Evaluate Anthropic's hosted Code Review feature (§1) — needs a plan-tier check first. If eligible, trial on the next epic-level PR only.
+3. **When the next major refactor lands:** Cherry-pick Roslyn MCP from `dotnet-claude-kit` (§2). Don't install the whole kit.
+4. **As a standalone scoped issue (not bundled):** TestID coverage sweep + `expo-mcp`/`xc-mcp` adoption (§5). Significant up-front cost; significant long-term QA value.
+5. **Track but don't adopt:** Anthropic Agent Teams (§3). Re-evaluate when it exits experimental.
+6. **Drop into `qa-tester` opportunistically:** `playwright-skill` for screenshot-baseline-driven tests (§4). Skill mode for visual regression; keep the existing MCP for live AC flows.
+
+---
+
+## Sources
+
+- [Code Review for Claude Code — Anthropic announcement (2026-03)](https://claude.com/blog/code-review)
+- [InfoQ — Anthropic Introduces Agent-Based Code Review for Claude Code (2026-04)](https://www.infoq.com/news/2026/04/claude-code-review/)
+- [Code Review — Claude Code Docs](https://code.claude.com/docs/en/code-review)
+- [`anthropics/claude-code` — `plugins/code-review/` README](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/README.md)
+- [`codewithmukesh/dotnet-claude-kit` (47 skills, 10 agents, 15 Roslyn MCP tools)](https://github.com/codewithmukesh/dotnet-claude-kit)
+- [.NET Claude Kit landing page](https://codewithmukesh.com/resources/dotnet-claude-kit/)
+- [Shipyard — Multi-agent orchestration for Claude Code in 2026 (Agent Teams)](https://shipyard.build/blog/claude-code-multi-agent/)
+- [Claude Code Agent Teams — Setup & Usage Guide 2026](https://claudefa.st/blog/guide/agents/agent-teams)
+- [`lackeyjb/playwright-skill` — Skill, not MCP](https://github.com/lackeyjb/playwright-skill)
+- [HN — Show HN: Playwright Skill for Claude Code (less context than playwright-MCP)](https://news.ycombinator.com/item?id=45642911)
+- [Smithery — `claude-mobile-ios-testing` (expo-mcp + xc-mcp)](https://smithery.ai/skills/krzemienski/claude-mobile-ios-testing)
+- [Expo MCP Server — Expo Docs](https://docs.expo.dev/eas/ai/mcp/)
+- [`hesreallyhim/awesome-claude-code` — broadest curated registry](https://github.com/hesreallyhim/awesome-claude-code)
+- [`ComposioHQ/awesome-claude-plugins` — plugin-system specifics](https://github.com/ComposioHQ/awesome-claude-plugins)
+- [`travisvn/awesome-claude-skills` — skills only](https://github.com/travisvn/awesome-claude-skills)
+- [Awesome Claude Skills marketplace](https://awesome-skills.com/)

--- a/docs/research/claude-code-ecosystem-additions-2026-04-30.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-04-30.md
@@ -1,0 +1,261 @@
+# Claude Code Ecosystem — Day-3 Additions
+
+**Compiled:** 2026-04-30 (scheduled `daily-resercher` run)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+
+**Scope:** Items neither prior report covered. Three days in, the obvious wins (statusline, OWASP scanner, i18n audit, Expo MCP, hosted Code Review, Roslyn MCP, playwright-skill) are documented — the long tail is where today's research went. Six items below, ordered by fit score.
+
+> Anything previously analysed (statusline tools, OWASP skill, i18n audit, Expo MCP, Testcontainers skill, Delightful Design System, HTTP hooks, `cclint`, `claude-mem`, hosted Code Review, `dotnet-claude-kit` / Roslyn MCP, Agent Teams, `playwright-skill`, `expo-mcp`+`xc-mcp`, awesome-claude-code registries) is **not** re-covered here.
+
+---
+
+## 0. TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P1 | **GitHub MCP server** (official, with `tail_lines`) | Direct replacement for the manual `gh run view <id>` step in `pr-reviewer`'s rule §8b CI-log diagnosis. |
+| P1 | **Pact (`pact-net` + `pact-js`)** consumer-driven contract testing | Catches backend ↔ web/mobile schema skew at PR time, not at `qa-tester` time. Fits the cross-package hand-off in routing rule 2. |
+| P2 | **`claude-a11y-skill` + axe-core MCP** | Plugs the missing accessibility gate before `qa-tester` PASS — currently spotty WCAG enforcement on `web-page` / `mobile-screen` outputs. |
+| P2 | **CocoIndex Code (Tree-sitter + vector index)** | Token-discipline play: shared semantic index across all sub-agents, replaces grep-bloat on cross-package lookups. |
+| P3 | **Git Worktree MCP** | Automates the `.worktrees/<N>-<short>/` lifecycle described in `.claude/CLAUDE.md` — including the sibling-rebase step after a sub-issue merge. |
+| P3 | **`claude-security-guardrails` hooks** | Makes the security baseline in `~/.claude/CLAUDE.md` machine-enforceable via PreToolUse instead of policy-text. |
+
+---
+
+## 1. Official GitHub MCP server — replaces manual CI-log diagnosis
+
+**What it is:** GitHub's first-party MCP server (`github/github-mcp-server`). Exposes Issues, PRs, Releases, Actions, and — relevant here — **workflow run logs with a `tail_lines` parameter** so an agent can pull the failing job's tail without dumping the whole log into context.
+
+**Source:** https://github.com/github/github-mcp-server
+
+**Where it slots in:**
+
+`pr-reviewer`'s rule §8b ("Pre-merge CI gate") already mandates `gh pr checks <N>` before any merge. When a check is `fail`, the orchestrator currently has to:
+
+1. Read `gh pr checks <N>` output, find the failing job ID.
+2. Run `gh run view <id> --log` (often hundreds of KB of context).
+3. Diagnose root cause manually.
+4. Route the fix to the owning dev sub-agent.
+
+The GitHub MCP collapses 1–2 into a single tool call with `tail_lines: 200`. Combined with the auto-memory rule "kill backend after short-lived runs," this also reduces context burn on every CI-failure round trip — typical `gh run view --log` output is 50–200 KB; a tail is <5 KB.
+
+**Why this project specifically:**
+
+- The merge gate is **the** highest-friction step in the orchestration today. Recent multi-package epics (epic #67) had multiple CI cycles per sub-issue PR; each manual diagnosis chewed Opus context.
+- The auto-memory entry `feedback_check_ci_before_merge.md` is precisely a workflow this MCP makes deterministic.
+- Side-benefit: `pr-reviewer` could read PR review comments/threads directly instead of manually re-fetching with `gh pr view`.
+
+**Risk:** Auth scope — GitHub MCP needs a PAT. Use a fine-grained token scoped to the `JanProkorat/fitness-platform` repo only, with `actions:read` + `pull-requests:write` + `issues:write`. Not the same blast radius as a classic PAT.
+
+**Effort:** ~15 min to install + provision a fine-grained PAT. Update `pr-reviewer`'s SKILL.md to prefer the MCP over `gh run view --log` when diagnosing CI failures.
+
+**Fit score:** 5/5 — direct replacement for an existing manual step.
+
+---
+
+## 2. Pact contract testing — catches schema drift before QA
+
+**What it is:** Consumer-driven contract testing across `pact-net` (backend producer) + `pact-js` (web/mobile consumers). Consumer writes an expectation against the API ("when I call `GET /trainer/clients/{id}`, the response has these fields with these types"); producer's CI verifies its actual responses match every consumer's expectation. Mismatches fail the producer build before merge.
+
+**Sources:**
+- https://pactflow.io / https://docs.pact.io
+- https://github.com/pact-foundation/pact-net (.NET producer side)
+- https://github.com/pact-foundation/pact-js (TS consumer side)
+
+**Where it slots in:**
+
+Today's `regen-api` skill regenerates `web/src/api/generated.ts` and `mobile/src/api/generated.ts` from the running backend's Swagger doc. That guarantees **type alignment**, but only for what NSwag projects from the OpenAPI document — it doesn't catch:
+
+- Response field renames where the type stayed the same (e.g. `clientId` → `userId`, both `string`).
+- Nullable changes the OpenAPI doc didn't reflect.
+- Default-value changes (e.g. `pageSize` default 50 → 25 — silent breaker for callers that relied on the default).
+- Behavioural changes that have no schema impact (e.g. a 200 turning into a 204 for empty results).
+
+Pact catches all four because the consumer encodes *expectations on real behaviour*, not just types. A `qa-tester` AC failure today often surfaces these as flaky integration test fallout — Pact catches them at PR time on the producer side.
+
+**Why this project specifically:**
+
+- 116 backend endpoints, 19 web API modules, 12 mobile API modules. The cross-package fan-out is exactly Pact's sweet spot.
+- The rule-2 hand-off ("backend finishes → web/mobile run regen-api → consume") would gain a hard contract gate. Sub-issue PRs that change a producer response shape would fail backend CI before web/mobile even starts.
+- xUnit + Testcontainers backend already has the harness Pact verification expects.
+
+**Trade-off:** Real upfront cost — every consumer endpoint needs a pact written (or auto-generated from existing test cases). Best done incrementally: start with the 5–10 endpoints that have changed shape most in 2026 (Today screen, dashboards, plan publish flow), extend over time.
+
+**Effort:** ~1 day for a pilot — pick 3 high-traffic endpoints, write consumer pacts in `web/`, wire `pact-net` verification into the existing xUnit Testcontainers run. Expand later as a scoped issue (`type:chore` + `scope:backend`).
+
+**Fit score:** 4/5 — high ceiling but real adoption cost.
+
+---
+
+## 3. `claude-a11y-skill` + axe-core MCP — accessibility gate
+
+**What it is:** A skill (`airowe/claude-a11y-skill`) bundling axe-core, jsx-a11y static rules, and WCAG 2.2 AA checks into a single invocation. Pairs with axe-core MCP servers that drive the audit live against a running browser session.
+
+**Source:** https://github.com/airowe/claude-a11y-skill
+
+**Where it slots in:**
+
+`qa-tester` today verifies AC and visual fidelity via Playwright MCP — but not accessibility. The project's CLAUDE.md notes Czech/English/German support and i18n parity gates, but no a11y gate. New scaffolds from `web-page` / `mobile-screen` ship without an automated WCAG check.
+
+Concrete chain:
+
+1. Web sub-agent finishes a new page or modifies an existing one.
+2. `qa-tester` runs Playwright AC flow as today.
+3. **New:** `qa-tester` also runs `claude-a11y-skill` against the same routes — reports WCAG violations (color contrast, missing labels, missing focus rings, keyboard traps).
+4. WCAG violations route back to `web-react` as scope-tagged fixes before AC PASS, same flow as routing rule 6c.
+
+**Why this project specifically:**
+
+- EU regulatory tail-wind — WCAG conformance is increasingly a compliance line for fitness/health products in EU markets where the app targets cs/en/de.
+- Trainer portal forms (plan editor, questionnaire builder, message bubbles) are exactly where keyboard navigation and screen-reader labels get missed.
+- Brand accent `#c9a84c` (gold) on dark backgrounds is contrast-sensitive — easy to miss a violation without an automated check.
+
+**Caveat:** This is web-side primarily. React Native a11y is harder to automate from the same skill — Expo has `accessibilityLabel`/`accessible` props but axe-core can't drive those. For mobile, rely on the `engineering:accessibility-review` skill the project already has installed (per the system-reminder skill list) — manual but informed.
+
+**Effort:** ~30 min install + write a `qa-tester` recipe to run the a11y skill on every web AC pass. ~2 h to clean up the initial findings on existing pages. Re-runs on every new page free thereafter.
+
+**Fit score:** 4/5 — closes a real gap, low adoption cost.
+
+---
+
+## 4. CocoIndex Code — semantic monorepo index
+
+**What it is:** AST-aware codebase indexer: Tree-sitter chunks code by symbol/scope, embeddings stored in a vector DB (Turbopuffer-backed by default, swappable). Available as CLI, MCP server, and Claude Code skill. Cited 70% token reduction per turn vs. raw grep, 80–90% cache hit rate on incremental re-indexing.
+
+**Source:** https://cocoindex.io / https://github.com/cocoindex-io/cocoindex
+
+**Where it slots in:**
+
+The project's monorepo is wide (3 packages + docs + infra) but each sub-agent's package boundary means cross-package lookups are common: web-react needs to know what response shape backend returned; mobile-expo needs to find every consumer of a SignalR event; backend-dotnet refactor needs to find every place that depends on a DTO.
+
+Today these searches happen via grep across the orchestrator's main context — token-expensive and sometimes wrong (regex doesn't know about TypeScript imports or C# `using` aliases).
+
+CocoIndex's semantic chunking would let each sub-agent ask "find every consumer of `ClientNutritionPlanPublished`" and get a structured answer (file + symbol + chunk text) without pulling 20 files into context. Especially valuable for the `feature-dev:code-explorer` agent already in the toolchain.
+
+**Why this project specifically:**
+
+- Token discipline is an explicit auto-memory line; this is a token-efficiency multiplier on every cross-package task.
+- The existing `Explore` sub-agent description says "reads excerpts rather than whole files" — that's literally what CocoIndex does, but with vector recall instead of grep precision. They complement: Explore for tight known queries, CocoIndex for fuzzy "find anything related to X" queries.
+
+**Trade-off vs. day-2 dotnet-claude-kit Roslyn MCP:** Roslyn is .NET-only and AST-precise (semantic queries on C# specifically). CocoIndex is whole-repo and AST-loose (Tree-sitter cross-language). Different jobs — Roslyn for correct C# refactors, CocoIndex for cross-package discovery. Not redundant.
+
+**Effort:** ~1 h to install + index the repo (one-time index ~10 min for this codebase size). Re-indexing is incremental and auto-trigger-able via PostToolUse hook on file write.
+
+**Fit score:** 4/5 — strong token-discipline ROI; soft adoption (sub-agents fall back to grep gracefully).
+
+---
+
+## 5. Git Worktree MCP — automates the epic-branch worktree lifecycle
+
+**What it is:** MCP server (`kingkillery/git-worktree-mcp`) that exposes worktree create/list/rebase/remove as tool calls. Pairs with GitButler if visual branch management is wanted; the MCP itself is CLI-deep.
+
+**Source:** https://github.com/kingkillery/git-worktree-mcp
+
+**Where it slots in:**
+
+`.claude/CLAUDE.md` has explicit rules around `.worktrees/<N>-<short>/`:
+
+- Created off the **epic branch** for sub-issues.
+- After a sub-issue merges to the epic branch (rule §8a), all in-flight sibling sub-issue worktrees must be rebased onto the new epic-branch tip.
+- After full merge, the worktree must be removed (`git worktree remove`).
+
+Today these steps are bash one-liners the orchestrator runs by hand. The Git Worktree MCP wraps them as structured tool calls with consistent error handling — esp. valuable for the rebase-siblings step (currently no automated check that rebases actually completed cleanly across all siblings).
+
+**Why this project specifically:**
+
+- The epic-branch model is already in `.claude/CLAUDE.md` as the project's distinguishing orchestration choice; tightening its mechanics is high-ROI.
+- Recent epics (#65 photo feature, #66, #67 photo-diary) had 5–13 sub-issues each. Sibling-rebase failures on epic #67 caused at least one stale-diff QA round-trip.
+- A PostToolUse hook on `gh pr merge` (or pr-reviewer's MERGED return) could auto-trigger sibling rebase via the MCP — turns rule §8a's manual sibling-rebase clause into a hands-off step.
+
+**Effort:** ~30 min to install + write a rebase-siblings recipe. Update `pr-reviewer.md` (sub-issue mode) to call the MCP instead of bash worktree commands.
+
+**Fit score:** 3.5/5 — high-quality hardening of an existing convention, but only worth the install if epics keep coming at the current cadence.
+
+---
+
+## 6. `claude-security-guardrails` — turn the policy-text security baseline into hooks
+
+**What it is:** A community hooks bundle (`mafiaguy/claude-security-guardrails`) of PreToolUse and PostToolUse hooks that block risky operations: force-push variants, `rm -rf` with absolute paths, edits to `.env*` / `appsettings.*.json` / `secrets.json` / `*.pfx`. Includes a small React dashboard for visualising blocked operations.
+
+**Source:** https://github.com/mafiaguy/claude-security-guardrails
+
+**Where it slots in:**
+
+The global `~/.claude/CLAUDE.md` Security Baseline lists exactly the same set of bans:
+
+- `git push --force` / `--force-with-lease` / `-f`
+- `git reset --hard`
+- `rm -rf` (esp. with absolute paths)
+- `dotnet ef database drop`
+- Edits to `.env*`, `appsettings.*.json`, `secrets.json`, `*.pfx`, `*.key`
+
+Today these are policy-text. They're respected because Opus reads CLAUDE.md every session, but a sub-agent with a stripped-down prompt or a Haiku scout might miss them. Hooks make them deterministic regardless of which model runs the tool.
+
+**Why this project specifically:**
+
+- The auto-memory line `feedback_kill_be_after_regen.md` shows tool discipline is already a managed concern; a hook layer formalises it.
+- The project already has one custom guardrail (`block-generated-edits` PreToolUse on `src/api/generated.ts`) — adding a security-baseline bundle on top is the same pattern.
+- Parallel sub-agent dispatch (rule §parallel-sub-agents) is where this matters most: orchestrator can't step in mid-tool-call to remind a sub-agent of the security baseline.
+
+**Trade-off:** Day-2 report's §7 covered HTTP hooks (Anthropic's Feb 2026 feature). This is the *content* of useful hooks, not the hook system itself. Compatible with HTTP hooks if/when those are adopted.
+
+**Effort:** ~20 min to install + cherry-pick the relevant hooks (drop the dashboard component if not wanted). Configure deny lists in `.claude/settings.json` to inherit instead of duplicating.
+
+**Fit score:** 3/5 — good hardening, low cost, but the existing policy-text already works for a single-user setup. Higher value when delegation breadth increases.
+
+---
+
+## What's NOT in this report
+
+Already covered in the prior two:
+
+- Statusline tools (CCometixLine, ccstatusline) — day 1 §1
+- OWASP / `claude-code-security-review` GH Action — day 1 §2
+- i18n audit skills — day 1 §3
+- Expo MCP — day 1 §4 + day 2 §5
+- Testcontainers skill — day 1 §5
+- Delightful Design System — day 1 §6
+- HTTP hooks — day 1 §7
+- `cclint` — day 1 §8
+- `claude-mem` — day 1 §9
+- Hosted Code Review for Claude Code — day 2 §1
+- `dotnet-claude-kit` / Roslyn MCP — day 2 §2
+- Anthropic Agent Teams — day 2 §3
+- `lackeyjb/playwright-skill` — day 2 §4
+- `expo-mcp` + `xc-mcp` testID-driven testing — day 2 §5
+- `hesreallyhim/awesome-claude-code` registry — day 2 §6
+
+Considered but rejected today:
+
+- **Playwright AI Healer (auto-repair visual regressions)** — slim differentiation vs. `playwright-skill`'s `toHaveScreenshot()` patterns from day 2 §4. Re-evaluate if the project adopts visual baselines first.
+- **`rohitg00/awesome-claude-code-toolkit`** — overlaps with day 2's coverage of `hesreallyhim/awesome-claude-code` and `ComposioHQ/awesome-claude-plugins`. Different curation slice but not enough new material to justify its own section.
+
+---
+
+## Suggested execution sequence (delta vs days 1–2)
+
+1. **This week:** Install GitHub MCP server (§1) — direct replacement for an existing manual step in `pr-reviewer`'s merge gate. Update the agent's SKILL.md to prefer the MCP. Lowest risk, highest immediate ROI.
+2. **Within next epic cycle:** Pilot a11y skill (§3) on the trainer portal's top 5 routes. Treat findings as a backlog, not as a single big PR.
+3. **As a scoped chore issue:** Pact pilot (§2) on 3 high-churn endpoints. If the producer-side gate proves useful, expand on each new endpoint.
+4. **Token-discipline experiment:** Spike CocoIndex Code (§4) on the next cross-package issue. If `feature-dev:code-explorer` shows measurable token reduction, adopt project-wide.
+5. **Quality-of-life:** Git Worktree MCP (§5) — install when the next epic kicks off. Avoid mid-flight conversion.
+6. **Optional hardening:** `claude-security-guardrails` (§6) — install as a second safety net, not a primary defence. Day-1 HTTP hooks remain the canonical hook system.
+
+---
+
+## Sources
+
+- [GitHub MCP server (official)](https://github.com/github/github-mcp-server)
+- [GitHub MCP — `tail_lines` parameter (changelog)](https://github.com/github/github-mcp-server/releases)
+- [Pact — consumer-driven contract testing](https://docs.pact.io)
+- [`pact-foundation/pact-net`](https://github.com/pact-foundation/pact-net)
+- [`pact-foundation/pact-js`](https://github.com/pact-foundation/pact-js)
+- [`airowe/claude-a11y-skill`](https://github.com/airowe/claude-a11y-skill)
+- [axe-core (Deque) — accessibility engine](https://github.com/dequelabs/axe-core)
+- [CocoIndex Code](https://cocoindex.io/cocoindex-code/)
+- [`cocoindex-io/cocoindex` — repo](https://github.com/cocoindex-io/cocoindex)
+- [`kingkillery/git-worktree-mcp`](https://github.com/kingkillery/git-worktree-mcp)
+- [`mafiaguy/claude-security-guardrails`](https://github.com/mafiaguy/claude-security-guardrails)
+- [Claude Code hooks reference](https://docs.claude.com/en/docs/claude-code/hooks)

--- a/docs/research/claude-code-ecosystem-additions-2026-05-01.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-05-01.md
@@ -1,0 +1,260 @@
+# Claude Code Ecosystem — Day-4 Additions
+
+**Compiled:** 2026-05-01 (scheduled `daily-resercher` run)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+- [`claude-code-ecosystem-additions-2026-04-30.md`](./claude-code-ecosystem-additions-2026-04-30.md)
+
+**Scope:** Items the prior three reports did not cover. Day 4 leans into the runtime-orchestration layer — async hooks, dynamic context injection, dependency-aware orchestration, formal AC syntax — areas where the surrounding ecosystem has matured into shippable patterns rather than just docs. Six items below, ordered by fit.
+
+> Anything previously analysed (statusline tools, OWASP skill, i18n audit, Expo MCP, Testcontainers skill, Delightful Design System, HTTP hooks, `cclint`, `claude-mem`, hosted Code Review, `dotnet-claude-kit` / Roslyn MCP, Agent Teams, `playwright-skill`, `expo-mcp`+`xc-mcp`, awesome-claude-code registries, GitHub MCP, Pact, axe-core / a11y skill, CocoIndex, Git Worktree MCP, `claude-security-guardrails`) is **not** re-covered here.
+
+---
+
+## 0. TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P1 | **Async hooks (`async: true`)** — Jan 2026 Claude Code 2.1+ feature | Lets us bolt telemetry / Slack notify / Notion-changelog drafts onto `gate-check.sh` (SubagentStop) without blocking the validation gate. Pure win — current gate is the slowest path on every dev-handoff. |
+| P1 | **`barkain/claude-code-workflow-orchestration`** — dependency-aware parallel orchestrator | The first community plugin that codifies what `ship-epic` currently does manually: explicit dependency-analysis phase, adaptive-nudge enforcement (instead of silent contract), wave sequencing. Strong reference even if we don't adopt it wholesale. |
+| P2 | **Dynamic context injection** — `` !`command` `` syntax inside skills | Replaces the bespoke SessionStart `reinject-state.sh` for several skills. A skill can run a shell command at load-time and embed the output into its own prompt — lighter, in-tree alternative to a hook. |
+| P2 | **EARS / `Axiom` skill** — formal acceptance-criteria syntax | Makes AC machine-parseable for `qa-tester`. Currently the gate is prose ("✅ When client navigates to X, then Y") — formalising lets the agent generate test stubs from the AC itself. |
+| P3 | **ER Flow Database Architect MCP** — live PostgreSQL schema → EF Core migrations | Replaces the manual `dotnet ef migrations add` scaffolding step in `backend-dotnet`'s migration flow. Useful when migrations are non-trivial (multi-table FK chain, partial indexes). |
+| P3 | **XcodeBuildMCP v1.x LLDB tools** — breakpoints + variable inspection from the agent | Net-new since we adopted XcodeBuildMCP. Lets `qa-tester` actually debug a failing native-only AC instead of guessing from screenshots. |
+
+---
+
+## 1. Async hooks — non-blocking telemetry on `gate-check.sh`
+
+**What it is:** Claude Code 2.1.0+ (rolled out late January 2026) adds an `async: true` flag on hook entries. The hook fires, but the agent does not wait for it to finish — output is discarded, no blocking, no exit-code check. The synchronous variant remains the default.
+
+**Source:** [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks) · [JP Caparas: Async hooks and when to use them](https://reading.sh/claude-code-async-hooks-what-they-are-and-when-to-use-them-61b21cd71aad)
+
+**Where it slots in:**
+
+`.claude/hooks/gate-check.sh` runs on every SubagentStop and JSON-validates the dev-handoff before control returns. Today it's a single synchronous step — fast in the happy path, but it owns the entire critical path between "dev sub-agent finishes" and "orchestrator can dispatch `qa-tester`."
+
+What we'd add **alongside** (not replacing) it:
+
+```jsonc
+// .claude/settings.json
+{
+  "hooks": {
+    "SubagentStop": [
+      { "command": ".claude/hooks/gate-check.sh" },                    // sync — must block
+      { "command": ".claude/hooks/log-handoff.sh", "async": true },    // async — telemetry
+      { "command": ".claude/hooks/notify-slack.sh", "async": true }    // async — only when AFK
+    ]
+  }
+}
+```
+
+`log-handoff.sh` could append a one-line JSON record per handoff to `.claude/state/handoff-log.ndjson` (sub-agent name, issue #, files-touched count, verification.passed, ms-elapsed). That's the data we currently *don't* have for analysing why a `ship-epic` run took N minutes — it'd answer "which sub-agent type is the slowest" without context cost.
+
+`notify-slack.sh` could wrap the `ask-user-async` flow more cheaply — instead of the orchestrator explicitly invoking the skill at a blocker, the hook fires on every `qa-tester` ❌ FAIL handoff and pings #fitness-platform-dev. Off by default; flip on when the user is AFK.
+
+**Why this project specifically:**
+
+- The auto-memory entry `feedback_check_ci_before_merge.md` and the verification rules already produce structured signals. Logging them is currently manual.
+- Notion-docs mode currently runs *after* the merge — async post-merge hooks could pre-stage a Notion draft entry as soon as `pr-reviewer` returns READY FOR MERGE, so the post-merge run is just a publish.
+
+**Risk:** Async failures are silent. Don't async anything in the critical path (validation, permission checks). The matrix in JP Caparas's post is the rule of thumb: logging, notifications, cleanup, backups → safe; PreToolUse, security gates → must block.
+
+**Effort:** ~30 min — one new shell script, one settings.json edit, one telemetry schema decision (where the NDJSON file lives, rotation policy).
+
+**Fit score:** 5/5 — direct upgrade to existing infrastructure, zero risk to the validation gate.
+
+---
+
+## 2. `barkain/claude-code-workflow-orchestration` — dependency-aware orchestration
+
+**What it is:** A community plugin that formalises multi-agent orchestration into three explicit phases: **task decomposition → dependency analysis → wave sequencing**. Phases that genuinely don't depend on each other run in parallel; the rest run serially. Sub-agents get adaptive-nudge feedback (silent → hint → warning → strong reminder) when they bypass the planned routing instead of being silently wrong.
+
+**Source:** [barkain/claude-code-workflow-orchestration](https://github.com/barkain/claude-code-workflow-orchestration) · [claudefa.st: Agent Teams & Execution Modes (Q1 2026)](https://claudefa.st/blog/guide/agents/agent-teams)
+
+**Where it slots in:**
+
+`ship-epic` already fan-outs sub-issues in parallel, but **within** an issue (cross-package work) we go strictly sequential per [`rules/scope-boundaries.md#cross-package-coordination`](../.claude/rules/scope-boundaries.md): backend → web → mobile. That's correct when the web/mobile work needs the regenerated `generated.ts`. But it's not always required — a docs-only adjustment in `web/` and a pure-mobile token tweak don't depend on each other.
+
+The `barkain` pattern would let `ship-epic` ask: "for issue #N, which of the touched packages have *no* shared schema dependency?" and run those sub-agents truly concurrently.
+
+The other half — adaptive-nudge enforcement — fits a long-standing soft-spot: `pr-reviewer` enforces the boundary rule at PR time (a `backend-dotnet` PR touching `/web/**` is a BLOCKING finding), but the dev sub-agent doesn't get earlier feedback. An adaptive-nudge PreToolUse hook could intercept the first cross-boundary Edit, prompt the sub-agent to return to the orchestrator, and only escalate to a hard block if the agent ignores the nudge.
+
+**Why this project specifically:**
+
+- Recent epics (#67 diary-request, #65 photo feature) had cases where sequential dispatch was overkill — the cost of a stricter design analysis could have been recovered in shorter wall-clock.
+- The two-tier merge model already needs a dependency graph implicitly (which sub-issues block the epic merge). Making it explicit means `ship-epic` can show the user a graph at kickoff and at sibling-rebase time.
+
+**Risk:** Adopting the whole plugin means introducing competing orchestration logic to `ship-epic`. Better path: read the source, lift the dependency-analysis phase into a new `epic-deps` helper skill, and leave `ship-epic` in charge.
+
+**Effort:** ~4 hours — read the plugin source, decide which patterns to lift, write a `dispatch-plan.md` artefact that `ship-epic` produces at kickoff (issue list, dependency edges, recommended waves), one round of evaluation against last week's epics.
+
+**Fit score:** 4/5 — strong conceptual fit; bigger lift than P1 because of the integration with existing `ship-epic` state.
+
+---
+
+## 3. Dynamic context injection — `` !`command` `` syntax in skills
+
+**What it is:** Skills (and slash-command markdown files) can now embed shell command output at load time. Inside SKILL.md, writing `` !`git rev-parse --short HEAD` `` causes Claude Code to execute that command before the skill content reaches the model — so the *current* git SHA is in the skill, not the SHA from when the skill was authored.
+
+**Source:** [claudefa.st: Complete Guide to All 12 Lifecycle Events](https://claudefa.st/blog/tools/hooks/hooks-guide) · [ofox.ai: Hooks, Subagents, and Skills 2026](https://ofox.ai/blog/claude-code-hooks-subagents-skills-complete-guide-2026/)
+
+**Where it slots in:**
+
+We currently have `.claude/hooks/reinject-state.sh` (SessionStart) re-hydrating `state/handoff-*.json` references after a `/clear` or compact. That's the right pattern for *cross-skill* state. But there are several places where a single skill has its own ephemeral context need:
+
+- `regen-api` — needs to know if the dev API is currently up on `:5001`. Today the skill prose says "check if the API is running first." With dynamic injection: `` !`lsof -ti:5001 || echo none` `` — the skill *starts* knowing the answer.
+- `mobile-screen` — needs the current Expo SDK version to suggest the right deprecation. `` !`jq -r .expo.sdkVersion mobile/app.json` ``.
+- `mongo-document` — needs the existing collection list to avoid name collisions. `` !`docker exec mongo mongosh --quiet --eval "db.adminCommand('listDatabases').databases.map(d=>d.name).join(',')"` ``.
+
+The point isn't to replace the SessionStart hook — that handles cross-cutting state. It's that dynamic injection is **in-tree** (lives in the skill file), so the skill is self-contained and doesn't depend on an external shell script the user might forget to wire up.
+
+**Why this project specifically:**
+
+- Skills like `regen-api` and `signalr-event` are most often invoked mid-session, not at session start — the SessionStart hook is the wrong layer for their state.
+- Reduces total hook count: today three of the five PreToolUse / SessionStart / SubagentStop hooks exist purely to inject project state. Some of that can move into the skills themselves.
+
+**Risk:** Shell expansion in skill content is a security surface. The skills run with the user's shell — `` !`...` `` can read arbitrary files. Not new risk for an authenticated CLI session, but be sceptical of skills installed from random plugin marketplaces.
+
+**Effort:** ~1 hour per skill — pick three skills with clearest state needs, replace the prose check with a dynamic-injection one-liner, smoke-test, document in CLAUDE.md.
+
+**Fit score:** 4/5 — small per-skill change, compound benefit across the skill catalogue.
+
+---
+
+## 4. EARS / `Axiom` — machine-parseable acceptance criteria
+
+**What it is:** EARS (*Easy Approach to Requirements Syntax*) is a five-template grammar for acceptance criteria — every AC bullet conforms to one of: ubiquitous (`The system shall ...`), event-driven (`When <trigger>, the system shall ...`), state-driven (`While <state>, the system shall ...`), unwanted-behaviour (`If <condition>, then the system shall ...`), or optional-feature. The `Axiom` community skill builds review pipelines on top: the spec is structured, so the QA agent can match each bullet to a specific test case.
+
+**Source:** [rohitg00/awesome-claude-code-toolkit (Axiom skill)](https://github.com/rohitg00/awesome-claude-code-toolkit)
+
+**Where it slots in:**
+
+`qa-tester` currently reads the issue's `## ✅ Acceptance criteria` section as prose. The handoff JSON it writes (`state/handoff-qa-<N>.json`) records pass/fail per bullet, but the matching is human-driven — the agent decides "this bullet maps to this test."
+
+If the AC is in EARS form, that mapping becomes algorithmic:
+
+- `When user submits the diary-request form, the banner appears on the Today screen.`
+  → trigger = `submit form`; postcondition = `banner appears`; QA generates: render Today, simulate form submit, assert banner.
+- `If trainer is missing, the Today screen shows the No-Trainer state instead.`
+  → guard = `trainer missing`; postcondition = `No-Trainer state`; QA generates: clear trainer, render, assert state.
+
+The flip side: `github-issues` would need to emit AC in EARS form. We'd want a `github-issues` mode that converts a draft AC list into EARS before the issue lands.
+
+**Why this project specifically:**
+
+- The auto-memory entry `feedback_interrogate_deferred_acs.md` exists because we've had churn around prose AC ambiguity. EARS removes the ambiguity at the source.
+- `qa-tester`'s Playwright + Simulator runs already follow a setup → action → assert shape. EARS encodes exactly that.
+
+**Risk:** Adoption cost. Issues we already wrote in prose stay in prose; EARS would only apply to new issues. Worse: a strict EARS lint at `github-issues` time would push back on humans writing the issue, which is friction even if technically right.
+
+**Effort:** Big. ~1 day to write a `github-issues` EARS-conversion mode, ~2 hours to teach `qa-tester` to consume EARS, ongoing tax to enforce on new issues. Only worth doing if the next 3+ epics are similarly large to #67 / #65.
+
+**Fit score:** 3/5 — strong concept, real adoption cost. Park as a follow-up; revisit after the next epic if QA churn surfaces.
+
+---
+
+## 5. ER Flow Database Architect MCP — live schema → migrations
+
+**What it is:** An MCP server that connects to a live PostgreSQL instance, reads the current schema (tables, FKs, indexes, partitioning), and produces EF Core / Prisma / SQLAlchemy migrations from natural-language requests. Claims to handle multi-table FK chains, partial-index design, and migration safety analysis (ALTER TABLE on a 50M-row table flagged as unsafe).
+
+**Source:** [ER Flow: Claude as Database Architect](https://erflow.io/en/blog/claude-mcp-database-architect)
+
+**Where it slots in:**
+
+`backend-dotnet`'s migration flow today: human asks for a schema change → agent edits the entity / configuration → `dotnet ef migrations add` → agent reads the generated up/down → orchestrator inspects the diff. The weak spot is *step zero* — neither the agent nor the human always knows the current schema state in detail. We rely on the entity classes being the source of truth, which is *usually* fine, but mismatches happen (especially after a manual hot-fix in a non-prod DB).
+
+The MCP would let `backend-dotnet` start from "what's actually there right now" rather than "what the entity classes say." For a project with the merge-exclusion list rule (`backend/**/Migrations/**` is human-merged), getting the migration *correct on the first pass* is high-value — every migration round trip costs a manual merge.
+
+**Why this project specifically:**
+
+- We're past the easy migration phase. Recent migrations (PhotoDiaryRequest entity, plan-photos backfill) touched multiple tables and indexes. The next denormalisation pass (likely on `Conversations` / `WorkoutLogs` for read performance) will need exactly this kind of analysis.
+- Combines well with the existing `mongo-document` skill — MongoDB migrations are easier (no schema), but the relational side is where surgical migrations matter.
+
+**Risk:** The MCP needs DB credentials. Use a read-only role for schema inspection; never give it write access to production. Local dev DB is fine for development; CI/prod stays out of scope.
+
+**Effort:** ~30 min to install + provision a read-only role on the local dev DB. Zero changes to existing skills (the MCP is invoked ad-hoc by the agent during a migration request).
+
+**Fit score:** 3/5 — useful when migrations get complex; marginal for routine entity additions.
+
+---
+
+## 6. XcodeBuildMCP v1.x — LLDB tools (genuinely new)
+
+**What it is:** XcodeBuildMCP shipped v1.0 in February 2026 with 59 tools, including a new LLDB integration: set breakpoints, step through Swift/Obj-C, inspect variables, run arbitrary LLDB commands against a running simulator app — all from the agent.
+
+**Source:** [XcodeBuildMCP Docs](https://www.xcodebuildmcp.com/) · [getsentry/XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) · [blake_crosley: Two MCP Servers as iOS Build System](https://blakecrosley.com/blog/xcode-mcp-claude-code)
+
+> Note vs prior reports: 04-29 covered XcodeBuildMCP for *autonomous testing* paired with `expo-mcp`. The angle here is different — debugging a failing AC, not running a green test path.
+
+**Where it slots in:**
+
+`qa-tester` today, on a native-only AC failure (MMKV state, haptics, camera, native nav transition), captures a screenshot and falls back to "ask the user." The screenshot tells you *what's wrong* but not *why*. With LLDB tools, when an AC asserts that "after dismissing the camera modal, the back-stack pops to Today," the agent can:
+
+1. Set a breakpoint on the `popToTop` call in the navigation handler.
+2. Trigger the camera flow.
+3. Inspect whether the call fires at all, and with what arguments.
+
+For a project that recently shipped per-meal photo + plan-photo gallery with native pickers, the difference between "screenshot says wrong screen" and "LLDB shows `popToTop` was called with the wrong root" is the difference between a 3-hour native-bug round-trip and a 20-minute one.
+
+**Why this project specifically:**
+
+- Mobile epics #65 and #67 both had native-state bugs that ended in `ui-tradeoff` skill invocations because the screenshot evidence wasn't enough to root-cause. LLDB would have shortened those to root-cause in one step.
+- The `root-cause-swarm` skill explicitly looks for multi-layer bugs — LLDB gives the mobile layer the same observability the backend layer has via logs.
+
+**Risk:** Adds a new failure mode — LLDB session can hang the simulator. Cheap to mitigate (kill simulator, restart) but worth a guardrail in `qa-tester` (cap LLDB session at 5 min, then abort and report).
+
+**Effort:** ~1 hour to update the `qa-tester` agent description with the new LLDB tools and add a "when to use LLDB vs screenshot" decision rule. Zero install (XcodeBuildMCP is already wired in).
+
+**Fit score:** 4/5 — already-paid integration cost, net-new capability against an existing pain point.
+
+---
+
+## What's NOT in this report
+
+Surfaced in research but skipped:
+
+- **`great_cto` skill (7-agent SDLC)** — interesting reference, but our `ship-epic` + workflow agents already cover the same shape with project-specific knowledge. Adopting `great_cto` would mean rewriting our orchestration to fit a generic template.
+- **`moyu` anti-overengineering skill** — claims 66% code reduction, but the metric is unverified and the project's concern isn't over-engineering volume — it's the working-principles compliance (root-cause, scope discipline, two-attempt rule), which is human judgment, not a skill.
+- **`nv:context` MCP-discovery skill** — useful for greenfield setup; we're past that phase.
+- **Virtual Monorepo pattern** — single-monorepo project, doesn't apply.
+- **React Native enterprise MCP** — heavy overlap with `mobile-expo`; would only add value if mobile scope expanded into bare React Native.
+- **.NET MCP via NuGet 10** — only relevant if we ship custom MCPs to other consumers; not the current need.
+- **Forked subagents (Feb 2026 experimental)** — explicitly experimental; the current SubagentStop + handoff schema model is more proven. Re-evaluate when stable.
+- **Native Agent Teams** — same reasoning, already covered in the 04-29 report; no new movement.
+
+---
+
+## Suggested execution sequence (delta vs days 1–3)
+
+If days 1–3 produce a `.claude/`-tooling cleanup PR (statusline, OWASP, i18n audit, GitHub MCP, axe-core, Worktree MCP, security guardrails), day 4 fits as a **runtime-orchestration tightening** PR:
+
+1. **Async hooks** — add `log-handoff.sh` (NDJSON telemetry) async on SubagentStop. **Ship first** — pure additive, no risk to existing gates.
+2. **XcodeBuildMCP LLDB rules** — update `qa-tester` agent description with native-debug decision rule. ~1 hour.
+3. **Dynamic context injection** — pilot on `regen-api` and `mobile-screen` skills (smallest blast radius). If smooth after a week, extend to `mongo-document` and `signalr-event`.
+4. **`barkain` dependency-analysis phase** — read source, propose a `dispatch-plan.md` artefact for `ship-epic`. Ship behind a flag; only flip on for the next ≥3-sub-issue epic.
+5. **ER Flow MCP** — install when the next non-trivial migration lands. Don't pre-install; tools you don't use rot.
+6. **EARS / `Axiom`** — defer. Revisit if the next epic shows AC-ambiguity churn.
+
+---
+
+## Sources
+
+- [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks)
+- [JP Caparas — Async hooks: what they are and when to use them](https://reading.sh/claude-code-async-hooks-what-they-are-and-when-to-use-them-61b21cd71aad)
+- [blake_crosley — 95 Hooks: Why They Exist](https://blakecrosley.com/blog/claude-code-hooks)
+- [claudefa.st — Complete Guide to All 12 Lifecycle Events](https://claudefa.st/blog/tools/hooks/hooks-guide)
+- [claudefa.st — Agent Teams & Execution Modes (Q1 2026)](https://claudefa.st/blog/guide/agents/agent-teams)
+- [ofox.ai — Hooks, Subagents, and Skills (2026 Guide)](https://ofox.ai/blog/claude-code-hooks-subagents-skills-complete-guide-2026/)
+- [smartscope — Claude Code Hooks Guide (March 2026 edition)](https://smartscope.blog/en/generative-ai/claude/claude-code-hooks-guide/)
+- [barkain/claude-code-workflow-orchestration](https://github.com/barkain/claude-code-workflow-orchestration)
+- [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit)
+- [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills)
+- [Owen Zanzal — The Virtual Monorepo Pattern](https://medium.com/devops-ai/the-virtual-monorepo-pattern-how-i-gave-claude-code-full-system-context-across-35-repos-43b310c97db8)
+- [ER Flow — Claude as Database Architect](https://erflow.io/en/blog/claude-mcp-database-architect)
+- [XcodeBuildMCP Docs](https://www.xcodebuildmcp.com/)
+- [getsentry/XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP)
+- [blake_crosley — Two MCP Servers as iOS Build System](https://blakecrosley.com/blog/xcode-mcp-claude-code)
+- [Shipyard — Multi-agent Orchestration for Claude Code](https://shipyard.build/blog/claude-code-multi-agent/)
+- [MindStudio — 5 Claude Code Workflow Patterns](https://www.mindstudio.io/blog/claude-code-agentic-workflow-patterns)

--- a/docs/research/claude-code-ecosystem-additions-2026-05-05.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-05-05.md
@@ -1,0 +1,263 @@
+# Claude Code Ecosystem — Day-5 Additions
+
+**Compiled:** 2026-05-05 (scheduled `daily-resercher` run)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+- [`claude-code-ecosystem-additions-2026-04-30.md`](./claude-code-ecosystem-additions-2026-04-30.md)
+- [`claude-code-ecosystem-additions-2026-05-01.md`](./claude-code-ecosystem-additions-2026-05-01.md)
+
+**Scope:** Items the prior four reports did not cover. Day 5 leans into Anthropic's first-party `plugins/` directory in the `anthropics/claude-code` repo — a quiet shift in late April where several patterns we built bespoke (hook authoring, plugin scaffolding, autonomous loops, structured feature workflow) now ship as official plugins. Plus two community registries that are large enough to mine for individual agents rather than adopt wholesale. Seven items below, ordered by fit.
+
+> Anything previously analysed (statusline tools, OWASP skill, i18n audit, Expo MCP, Testcontainers skill, Delightful Design System, HTTP hooks, `cclint`, `claude-mem`, hosted Code Review, `dotnet-claude-kit` / Roslyn MCP, Agent Teams, `playwright-skill`, `expo-mcp`+`xc-mcp`, awesome-claude-code registries, GitHub MCP, Pact, axe-core / a11y skill, CocoIndex, Git Worktree MCP, `claude-security-guardrails`, async hooks, `barkain/claude-code-workflow-orchestration`, dynamic context injection `` !`cmd` ``, EARS / Axiom, ER Flow Database Architect, XcodeBuildMCP LLDB) is **not** re-covered here.
+
+---
+
+## 0. TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P1 | **Anthropic first-party `feature-dev` plugin** — 7-phase explore→architect→implement→test→refactor→review→ship | Codifies what `ship-epic` does manually for *single* issues. Worth A/B-ing against our orchestration on the next non-epic feature to see whether our bespoke design-reviewer + qa-tester + pr-reviewer chain wins on quality, or whether we're just re-implementing the official path. |
+| P1 | **Anthropic first-party `hookify` plugin** — slash-command authoring for hooks | Generates conversation-pattern guards via `/hookify`, `/hookify:list`, `/hookify:configure`. Several of our `.claude/hooks/*.sh` are exactly this shape (`block-generated-edits`, `deny-subagent-merge`, `agent-bash-allowlist`). Future hooks could be authored interactively instead of hand-written shell. |
+| P1 | **`wshobson/agents`** — registry of 185 agents + 80 plugins + 153 skills (34.8k stars) | The largest and best-maintained community pattern-library. Not "install all of it" — it's a reference for patterns we haven't yet codified (parallel sub-agent dispatch with state persistence, cross-package coordination contracts, workflow orchestrators). |
+| P2 | **`VoltAgent/awesome-claude-code-subagents`** — 131 specialized subagents (19.1k stars) | Mine individually, don't adopt wholesale. Specific agents (accessibility-tester, qa-expert, type-checker, performance-profiler) are usable as direct upgrades to our `qa-tester` + `pr-reviewer` two-pass pipeline. |
+| P2 | **Anthropic first-party `plugin-dev` plugin** — 7-skill toolkit + 8-phase scaffolding for plugin authoring | Relevant if we want to package our internal toolkit (`fe-endpoint`, `mongo-document`, `signalr-event`, `regen-api`, `web-page`, `mobile-screen`, `prototype-scene`, `ship-epic`) into a shareable plugin instead of keeping them in `.claude/skills/`. |
+| P3 | **Anthropic first-party `ralph-wiggum` plugin** — `/ralph-loop` autonomous self-iterating tasks | Direct equivalent of our `superpowers:loop` skill. Read it, compare. If the official version handles error-state better, swap the references in `daily-resercher` and other scheduled tasks. |
+| P3 | **`wshaddix/dotnet-skills`** — 167 .NET skills + 16 agents focused on ASP.NET Core, EF Core, testing | Small project (19 stars) but tight scope match with `backend-dotnet`. Worth scanning for skills we don't have — likely adds value around EF migrations, FastEndpoints idioms, xUnit + Testcontainers patterns. |
+
+---
+
+## 1. Anthropic first-party `feature-dev` plugin — A/B against `ship-epic`
+
+**What it is:** A plugin shipped in `anthropics/claude-code/plugins/feature-dev/` that codifies a 7-phase feature workflow: **explore → architect → implement → test → refactor → review → ship**. Each phase has explicit gates and produces an artefact the next phase consumes.
+
+**Source:** [anthropics/claude-code → plugins/feature-dev](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) · invokable via `feature-dev:feature-dev` once the plugin is installed (it already shows in our skills list under that exact name).
+
+**Where it slots in:**
+
+We already orchestrate this shape, but split across artefacts: `design-reviewer` covers explore + architect (handoff JSON via `state/handoff-design-<issue>.json`), the dev sub-agents cover implement + test, `qa-tester` covers verify, `pr-reviewer` covers review, and the merge gate covers ship. The official plugin bundles these into one slash-command that an unfamiliar Claude Code instance could pick up cold.
+
+What this is good for in our environment is **not** replacing `ship-epic` — that handles multi-issue epic orchestration which `feature-dev` doesn't. It's good for **single-issue work that doesn't justify epic machinery**:
+
+- Standalone bug fixes (e.g. PR #229 register flow).
+- Small refactors with no sub-issues.
+- The "one quick endpoint" tasks that today launch the full design-reviewer → backend-dotnet → qa-tester → pr-reviewer pipeline.
+
+The bet is that for low-coordination tasks, the official plugin's lighter-touch flow ships faster than our bespoke chain.
+
+**Why this project specifically:**
+
+- Our `design-reviewer` gate adds ~1 round-trip of latency for every issue, even trivial ones. The `feature-dev` "explore" phase is leaner.
+- Provides an external benchmark for "does our orchestration actually produce better outcomes" — currently we have no honest comparison.
+- If it loses the A/B, we drop it; if it wins on small-scope work, we route by issue size at dispatch time.
+
+**Risk:** Adopting the plugin while keeping our chain risks two parallel ladders. Mitigation: hard rule that `feature-dev` is only invoked for issues without a `scope:*` cross-cut (single-package, ≤3 files in the dispatch brief's expected diff).
+
+**Effort:** ~1 hour to read the plugin source + write the routing rule into `.claude/CLAUDE.md`. Then 2-3 small standalone issues over the next week to A/B.
+
+**Fit score:** 4/5 — direct overlap with existing infra, but a real opportunity to test our assumptions.
+
+---
+
+## 2. Anthropic first-party `hookify` plugin — interactive hook authoring
+
+**What it is:** A plugin shipped in `anthropics/claude-code/plugins/hookify/` that exposes `/hookify`, `/hookify:list`, `/hookify:configure` slash commands. Authoring a hook becomes a conversation: describe the trigger, describe the guard, the plugin generates the shell script + the `settings.json` entry.
+
+**Source:** [anthropics/claude-code → plugins/hookify](https://github.com/anthropics/claude-code/tree/main/plugins/hookify) — install via plugin marketplace.
+
+**Where it slots in:**
+
+We currently maintain six bespoke hooks in `.claude/hooks/`:
+
+- `block-generated-edits.sh` — blocks Edit/Write on `{web,mobile}/src/api/generated.ts`.
+- `deny-subagent-merge.sh` — blocks `gh pr merge` and `git push --force` from sub-agents.
+- `agent-bash-allowlist.sh` — per-agent bash command curation.
+- `gate-check.sh` — JSON-schema validation of dev-handoff payloads.
+- `reinject-state.sh` — re-hydrate `state/*.json` after `/clear` or compact.
+- `split-compound-commands.sh` — splits `cmd1 && cmd2` for permission validation.
+
+`hookify` doesn't replace these — they're already authored. It targets the *next* hook the orchestrator reaches for. Examples we've considered but not written:
+
+- Block `notion-docs` from running between sub-issue and epic merges (already in [feedback memory](../.claude/projects/-Users-jan-Projects-fitness-platform/memory/feedback_post_merge_notion_docs.md), enforced by prose).
+- Auto-kill stale `dotnet run` processes after `regen-api` (also feedback memory).
+- Force-rebase sibling sub-issue branches after a sibling merge to the epic branch.
+
+Each of those is a 30-line shell hook today. With `hookify` they become a 2-minute conversation. The win is the *next 5 hooks*, not the 6 we have.
+
+**Why this project specifically:**
+
+- Several of our auto-memory `feedback_*` entries are exactly the kind of thing a hook should enforce, not a prose memory to remember.
+- Hookify generates `settings.json` entries that are correctly scoped (PreToolUse vs SubagentStop vs SessionStart) — we've hand-written this twice, gotten it wrong twice, fixed it twice.
+
+**Risk:** Generated hook scripts may be naïve (no idempotency, no error handling). Treat hookify output as a draft, then handle the long-tail manually — same as scaffolding tools always require.
+
+**Effort:** ~30 min to install + try on one hook (suggest: kill-backend-after-regen). If it produces a sane skeleton, adopt. If not, drop quietly.
+
+**Fit score:** 4/5 — low risk, removes a manual chore, scales to the next-N hooks not the current ones.
+
+---
+
+## 3. `wshobson/agents` — community orchestration registry (34.8k stars)
+
+**What it is:** The largest active Claude Code agent collection — 185 specialized agents, 80 plugins, 153 skills, 16 workflow orchestrators. Updated for Opus 4.7 / Sonnet 4.6 / Haiku 4.5. Not a single tool, but a meta-library of patterns.
+
+**Source:** [wshobson/agents](https://github.com/wshobson/agents) — 34.8k GitHub stars (verified).
+
+**Where it slots in:**
+
+Not "install all of it" — that would be an actual nightmare for our context budget (153 skills × description-line overhead = significant tokens at session start). The right model is **read it as a reference**, lift specific patterns we haven't implemented:
+
+- **Workflow orchestrators** are the closest analogue to our `ship-epic`. The repo has 16; ours has 1. Worth comparing for state-handoff conventions, dependency-resolution patterns, retry semantics on dev-agent failure, and how they handle partial-PR rollback.
+- **Specialized review agents** beyond what `pr-reviewer` covers. Today our two-pass review is generalist; the repo has agents for type-design, security-by-default, performance-profiling, dead-code-detection. Each is invokable individually, so we could chain them as additional sub-passes when the diff matches a heuristic (e.g. a backend diff with `await` keywords → run the concurrency-review agent).
+- **State persistence patterns** — they have multiple approaches to long-running task state (NDJSON event log, JSON snapshot, SQLite). We use `.claude/state/*.json`; their patterns may handle compaction and recovery better.
+
+**Why this project specifically:**
+
+- Our `pr-reviewer` two-pass gate is good but generalist. Specific review agents are likely cheaper (Haiku-able) and catch domain-specific issues better.
+- `ship-epic` was written from scratch — we've never validated our orchestration shape against a 34.8k-star reference implementation. Even if we don't change anything, the comparison is cheap insurance.
+- We routinely struggle with dev-handoff schema evolution. They've solved this once before; reading their schema patterns will save us a refactor.
+
+**Risk:** Reading 153 skills end-to-end is a token sink. Mitigation: clone locally, grep for the patterns we care about (`workflow-orchestrator`, `state-handoff`, `review-agent`), read only those.
+
+**Effort:** ~3 hours of focused reading + one pass to extract findings into a follow-up issue. Fan out from there.
+
+**Fit score:** 4/5 — high informational value, low risk, but takes a deliberate session not a drive-by.
+
+---
+
+## 4. `VoltAgent/awesome-claude-code-subagents` — mine individual agents
+
+**What it is:** A curated list of 131 specialized Claude Code subagents organized into 10 categories (security, accessibility, QA, performance, frontend, backend, devops, docs, AI/ML, productivity). 19.1k stars, 2.2k forks.
+
+**Source:** [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) — verified.
+
+**Where it slots in:**
+
+This is **not** a registry to install — it's a list of vetted individual agents, each linked to its own repo. The way to use it is to scan the categories, identify gaps in our pipeline, and adopt one agent at a time:
+
+- **Accessibility-tester** — direct upgrade for our `design:accessibility-review` skill. Currently we run a11y as a one-off skill; the agent is a sub-pass that fires on every PR with UI changes.
+- **Qa-expert** — comparison for our `qa-tester`. The categories overlap (AC verification, regression detection); the implementation differences are worth diffing.
+- **Type-checker / performance-profiler** — additional `pr-reviewer` sub-passes for diffs matching specific heuristics (TS files for type-checker, useEffect-heavy diffs for perf).
+- **Code-archaeologist** — git-history aware refactor suggestions; useful for `refactor:*` issues.
+
+**Why this project specifically:**
+
+- Our pipeline today is one-size-fits-all: the same `qa-tester` runs whether the change is a CSS tweak or a SignalR hub overhaul. Specialized agents matched to diff shape would be cheaper (Haiku-tier) and catch issues our generalist misses.
+- The accessibility category is large and deep — we already have `a11y-accessibility` and `design:accessibility-review` installed but neither is wired into the AC gate. A specialist sub-agent would close that gap.
+
+**Risk:** Sprawl. Adding agents without retiring the generalist makes every PR slower. Rule: each new specialist agent must have a heuristic that gates it on (only fires when the diff matches), not blanket-applied to every PR.
+
+**Effort:** ~2 hours per agent adopted (read source, integrate into `pr-reviewer` second-pass). Start with one, evaluate after a week before adding the next.
+
+**Fit score:** 3/5 — high quality material, but adopting individual agents is a slow drip rather than a one-shot upgrade.
+
+---
+
+## 5. Anthropic first-party `plugin-dev` plugin — package our toolkit
+
+**What it is:** A plugin in `anthropics/claude-code/plugins/plugin-dev/` providing 7 skills + an 8-phase scaffolding workflow for authoring Claude Code plugins. Output: a `.plugin` file that can be shared, versioned, distributed via marketplace.
+
+**Source:** [anthropics/claude-code → plugins/plugin-dev](https://github.com/anthropics/claude-code/tree/main/plugins/plugin-dev) — verified.
+
+**Where it slots in:**
+
+We have ~12 internal skills under `.claude/skills/`: `fe-endpoint`, `mongo-document`, `signalr-event`, `regen-api`, `web-page`, `mobile-screen`, `prototype-scene`, `notion-docs`, `root-cause-swarm`, `ui-tradeoff`, `ship-epic`, `daily-resercher`. They live in the project tree, which means:
+
+- Every fresh checkout (CI sandbox, new contributor) gets them automatically — good.
+- They're not versioned independently of project code — bad for skills like `signalr-event` that have stable contracts independent of the rest of the monorepo.
+- They can't be reused across projects (other repos in `~/Projects/` would have to copy-paste).
+- They can't be shared with the team via the plugin marketplace.
+
+`plugin-dev` is the path from "skills in `.claude/`" to "shareable, versioned plugin." Whether that's worth doing depends on whether we want a second project to reuse our skills (we do — Green Code projects could benefit from `fe-endpoint`, `mongo-document`).
+
+**Why this project specifically:**
+
+- Our `fe-endpoint` and `mongo-document` skills encode FastEndpoints + Mongo conventions that other Green Code projects use too.
+- Maintaining 12 skills in one folder is starting to be its own project; tooling for plugin-dev has versioning, CHANGELOG, lint, test that our `.claude/skills/` directory doesn't.
+
+**Risk:** Premature abstraction. If we never actually share these, packaging adds overhead with no payoff. Decision rule: only adopt if we've identified at least one concrete second-project consumer.
+
+**Effort:** ~1 day to package the first 3 skills end-to-end. Iterates from there.
+
+**Fit score:** 3/5 — useful but not urgent. Defer until we have a concrete cross-project need.
+
+---
+
+## 6. Anthropic first-party `ralph-wiggum` plugin — official autonomous loop
+
+**What it is:** A plugin shipping `/ralph-loop` for autonomous self-iterating tasks until completion. Direct equivalent of the `superpowers:loop` skill we already have installed.
+
+**Source:** [anthropics/claude-code → plugins/ralph-wiggum](https://github.com/anthropics/claude-code/tree/main/plugins/ralph-wiggum) — verified.
+
+**Where it slots in:**
+
+`daily-resercher` (the skill that produced this very document) runs via `ScheduleWakeup` in dynamic mode plus the `superpowers:loop` skill for repeating tasks. That works, but `superpowers` is a third-party plugin family — if Anthropic's official `ralph-wiggum` handles the same loop semantics with better state-recovery, error-bounded retry, or cleaner stop conditions, swapping is cheap.
+
+**Why this project specifically:**
+
+- The `superpowers:loop` documentation is sparse on what happens when an iteration fails partway. `ralph-wiggum` being first-party means it'll evolve with Claude Code's lifecycle event model.
+- Several scheduled tasks would benefit from autonomous self-iteration (e.g. `notion-docs` post-merge, currently fire-once).
+
+**Risk:** Migrating mid-stream loops would lose state. Mitigation: only use `ralph-wiggum` for *new* loops, leave existing `superpowers:loop` invocations alone.
+
+**Effort:** ~30 min to read the plugin source + try one loop. Compare on the next scheduled task that needs autonomous iteration.
+
+**Fit score:** 2/5 — likely a wash with what we have, but worth the half-hour to know.
+
+---
+
+## 7. `wshaddix/dotnet-skills` — focused .NET skill collection
+
+**What it is:** 167 skills + 16 agents narrowly scoped to .NET ecosystem: ASP.NET Core, EF Core, testing (xUnit + Testcontainers), security, CI/CD. Small repo (~19 stars verified) but tight match.
+
+**Source:** [wshaddix/dotnet-skills](https://github.com/wshaddix/dotnet-skills) — verified, 67 commits.
+
+**Where it slots in:**
+
+Our `backend-dotnet` sub-agent currently leans on three skills: `fe-endpoint` (FastEndpoints scaffolding), `mongo-document` (Mongo aggregate scaffolding), `signalr-event` (cross-package realtime). That's three skills against a backend with 22 EF entities, 23 Mongo documents, 116 endpoints, 88 test files. The gaps:
+
+- EF Core migrations — we have **zero** migration-helper skills, despite migrations being on the merge exclusion list (i.e. exactly the high-risk surface that would benefit from rigour).
+- Testcontainers test scaffolding — we have the `testcontainers:testcontainers-dotnet` skill from a plugin, but no project-specific glue (our fixtures, our base test class conventions).
+- xUnit theory data builders — repeated boilerplate across the 88 test files.
+- FluentValidation pattern enforcement.
+
+`wshaddix/dotnet-skills` likely covers some of these; worth a 30-min skim of its skill list to see which are direct lifts.
+
+**Why this project specifically:**
+
+- Our backend is the largest single package by file count (LoC). It has the fewest project-specific skills relative to its size.
+- The merge-exclusion list (migrations, Mongo data scripts) flags exactly the surfaces where ad-hoc handwritten changes are riskiest. Skills for those surfaces are the highest-value gap.
+
+**Risk:** A 19-star project may be one-person-maintained and could go stale. Adopt skills as one-time copy-ins, not as a live dependency.
+
+**Effort:** ~30 min to scan + ~1 hour per skill we lift. Conservative target: 2 skills (migration-helper + xUnit theory builder).
+
+**Fit score:** 3/5 — small project but the scope match is unusually tight.
+
+---
+
+## Skipped — already covered, duplicate, or low fit
+
+For audit transparency:
+
+- **`claude-code-owasp`** — duplicates `owasp-security` plugin we already have installed.
+- **`senaiverse/claude-code-reactnative-expo-agent-system`** — 20 agents for Expo, but small (115 stars, October 2025); doesn't beat our `mobile-expo` sub-agent + `mobile-screen` skill on day-1 fit. Re-evaluate if it gets to ~500 stars.
+- **`ruvnet/ruflo`** — swarm-intelligence orchestration platform; an order of magnitude more complex than we need. Track if our orchestration outgrows `ship-epic`.
+- **`composio/test-writer-fixer`, `security-sweep`, `bug-fix`, `audit-project`, `senior-frontend`** — Composio plugin family, surfaced by scout but not independently verified in this run. Re-check next week with direct WebFetch on `awesome-claude-plugins`.
+- **GitHub Projects MCP** — we use GitHub issues directly via `gh` CLI; no Projects board adoption planned, so no incremental value.
+
+---
+
+## Recommended next action
+
+Three concrete moves, smallest first:
+
+1. **30 min — install `hookify`** and use it to author the kill-backend-after-regen hook (the one in [feedback memory](../.claude/projects/-Users-jan-Projects-fitness-platform/memory/feedback_kill_be_after_regen.md)). If the generated script is sane, adopt; if not, drop the plugin.
+2. **1 hour — read `feature-dev` source** and decide: do we route small standalone issues through it as an A/B against our chain, or does our `design-reviewer + qa-tester + pr-reviewer` already win on quality? Document the decision in `.claude/CLAUDE.md` either way.
+3. **3 hours — clone `wshobson/agents`** and read the 16 workflow-orchestrators side-by-side with `ship-epic`. Extract the dependency-resolution and state-handoff patterns we don't have. File one follow-up issue per pattern.
+
+Skip the rest until those three settle.
+
+---
+
+**Word count: ~2200. Compiled by `daily-resercher` skill (Haiku scouts + Opus synthesis). Verifications cross-checked against repo READMEs; star counts and last-commit dates as of 2026-05-05.**

--- a/docs/research/claude-code-ecosystem-additions-2026-05-11.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-05-11.md
@@ -1,0 +1,244 @@
+# Claude Code Ecosystem — Day-6 Additions
+
+**Compiled:** 2026-05-11 (scheduled `daily-resercher` run, 6 days after prior digest)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+- [`claude-code-ecosystem-additions-2026-04-30.md`](./claude-code-ecosystem-additions-2026-04-30.md)
+- [`claude-code-ecosystem-additions-2026-05-01.md`](./claude-code-ecosystem-additions-2026-05-01.md)
+- [`claude-code-ecosystem-additions-2026-05-05.md`](./claude-code-ecosystem-additions-2026-05-05.md)
+
+**Scope:** Items the prior five reports did not cover. The 6-day gap since 2026-05-05 turned out to be **harness-heavy, plugin-light**: Anthropic shipped eleven point-releases of the CLI (v2.1.128 → v2.1.138, mostly bug-fix tier) and two new first-party plugins. The community-side movement is concentrated in **context durability and agent-action governance** — exactly the surface our orchestrator hits hardest. Six items below, ordered by fit.
+
+> Anything previously analysed (feature-dev, hookify, plugin-dev, ralph-wiggum, wshobson/agents, VoltAgent/awesome-claude-code-subagents, wshaddix/dotnet-skills, statusline tools, OWASP skill, i18n audit, Expo MCP, Testcontainers skill, Delightful Design System, HTTP hooks, cclint, claude-mem, hosted Code Review, dotnet-claude-kit, Roslyn MCP, Agent Teams, playwright-skill, axe-core / a11y skill, CocoIndex, Git Worktree MCP, claude-security-guardrails, async hooks, EARS / Axiom, ER Flow Database Architect, XcodeBuildMCP LLDB) is **not** re-covered here.
+
+---
+
+## 0. TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P1 | **`mksglu/context-mode`** — MCP server for sandboxed tool output + SQLite event tracking (14.3k stars, updated 2026-05-11) | Formalises what our `reinject-state.sh` + `.claude/state/ship-epic.json` does by hand. The boot-sentinel for this very session was "ship-epic state malformed" — that's the failure mode this MCP exists to fix. |
+| P1 | **`alexgreensh/token-optimizer`** — context-bloat auditor for skills, hooks, memory files (952 stars, updated 2026-05-10) | Our session-start surface now loads ~60 KB of CLAUDE.md + rules + memory + skill descriptors. Worth a single audit pass to see what we're paying for but never use. |
+| P2 | **Anthropic first-party `learning-output-style` plugin** — new in `anthropics/claude-code/plugins/` since 2026-05-05 | Configurable output mode that emphasises *why* over *what* in agent responses. Worth a look for new-contributor onboarding into our orchestration tree. |
+| P2 | **`pegasi-ai/reins`** — deterministic policy framework for agent action governance (412 stars, updated 2026-05-08) | Richer policy model than our two custom hooks (`deny-subagent-merge`, `agent-bash-allowlist`). Lets us promote prose rules from `.claude/CLAUDE.md` to enforced policies — but the bar is "does this catch something our current hooks miss?" |
+| P3 | **Harness releases v2.1.128 → v2.1.138** — eleven bug-fix releases between 2026-05-04 and 2026-05-09 | Auto-upgrade path; nothing to install. The OAuth MCP refresh fix is the headline — mid-session MongoDB / Playwright / GitHub MCP auth drops should be gone. |
+| P3 | **Anthropic first-party `claude-opus-4-5-migration` plugin** — codemod for projects still on Opus 4.5 | We're already on 4.7 (and Sonnet 4.6 for impl work). Tracking-only — useful only if we adopt a sibling repo that's lagging. |
+
+---
+
+## 1. `mksglu/context-mode` — sandboxed-output MCP, plug-and-play for our state model
+
+**What it is:** An MCP server that wraps every tool call's stdout in a sandbox, stores the full output in a local SQLite store, and only returns a short reference token to the model context. The model can later "open" the reference if it actually needs the full payload. The same SQLite store also tracks file edits, git operations, and user decisions across the session — survivable across `/clear`, `/compact`, and token-limit truncations.
+
+**Source:** [mksglu/context-mode](https://github.com/mksglu/context-mode) — 14.3k stars verified, last updated 2026-05-11. Works with Claude Code, Gemini CLI, Cursor, OpenCode (one MCP server, multiple front-ends).
+
+**Where it slots in:**
+
+We already have a hand-rolled version of half of this:
+
+- `.claude/state/ship-epic.json` is our long-running orchestration state.
+- `reinject-state.sh` (a SessionStart hook) re-hydrates it after `/clear` or compact.
+- The very first system reminder on **this** conversation said *"ship-epic state malformed — see .claude/hooks/log/2026-05-11.log"*. So our hand-rolled state-tracker has at least one bug surface right now.
+
+`context-mode` would replace the JSON-file approach with a SQLite store the model talks to via MCP. Benefits:
+
+- Schema validation handled by the MCP (today our `gate-check.sh` validates dev-handoff payloads against a manually-maintained JSON Schema).
+- Sandboxed stdout means we stop paying full-page costs for `gh pr view`, `git log`, `dotnet build` output we only need a snippet of — those become reference tokens.
+- Cross-tool state — the file-edit log alone would close a gap our orchestrator has: today the orchestrator doesn't know exactly *which* files a sub-agent touched without re-running `git status`.
+
+**Why this project specifically:**
+
+- The `ship-epic` orchestrator is exactly the long-running, multi-handoff, state-heavy workload this MCP targets. Five days of sub-issue PRs + epic rebases is the average load.
+- We've already accepted the cost of an MCP server (Playwright, MongoDB, GitHub MCPs all running). Adding one more is incremental.
+- The failure surface we hit on this session (`state malformed`) is one of the explicit pitches.
+
+**Risk:** Replacing a working hand-rolled system with a 14.3k-star community project means we lose direct control of the state shape. Mitigation: install in **observer mode** first (let it track alongside our own JSON), compare for a week, then decide whether to retire the manual hooks.
+
+**Effort:** ~1 hour to install + configure the MCP, ~2 hours over a week to compare outputs.
+
+**Fit score:** 5/5 — direct match for a current operational pain point.
+
+---
+
+## 2. `alexgreensh/token-optimizer` — single-pass session-cost audit
+
+**What it is:** A static analyser that scans a Claude Code workspace (`.claude/` tree, MEMORY.md, hooks, skill descriptors, plugin manifests) and reports what's eating tokens at session-start vs. what's actually used. Detects: unused skills (loaded by description but never invoked), stale memory entries, redundant hooks, oversized CLAUDE.md sections.
+
+**Source:** [alexgreensh/token-optimizer](https://github.com/alexgreensh/token-optimizer) — 952 stars verified, last updated 2026-05-10. CLI tool, runs against any Claude Code project root. (Note: the previous scout claimed "98% context reduction" — the README is more conservative; the headline number applies to specific high-bloat starting points, not blanket every project.)
+
+**Where it slots in:**
+
+Our session-start payload has grown organically over five months. Today it includes:
+
+- Root `CLAUDE.md` (~5 KB)
+- `.claude/CLAUDE.md` (~9 KB orchestration playbook)
+- Six `rules/*.md` files (~7 KB)
+- `~/.claude/CLAUDE.md` global (~5 KB)
+- `MEMORY.md` index + 9 memory files (~3 KB combined just for the descriptions)
+- ~70 skill descriptors in the catalogue (each one a line of context)
+- 13+ MCP servers, each loading its tool schemas
+
+We've never audited which of those actually fire in the average session. There's almost certainly fat — for example, our memory file `feedback_mobile_dev_https.md` (saved this morning) is now duplicated information with `feedback_kill_be_after_regen.md` from last week.
+
+**Why this project specifically:**
+
+- Working Principles §6 explicitly calls out token discipline as a recurring failure mode.
+- We're already paying ~20% of context window on session-start *before any user message*. Half that and we'd extend the 5h working window measurably.
+- One-shot tool — no integration cost.
+
+**Risk:** Tool may flag valid items as "unused" because their trigger is rare-but-important (e.g. `pps-mongo-connect` only fires when the user explicitly asks). Treat the report as *advisory*, not a hit list.
+
+**Effort:** ~15 min to install + run. ~1 hour to triage the report.
+
+**Fit score:** 4/5 — concrete and low-risk; the win is finite but real.
+
+---
+
+## 3. Anthropic first-party `learning-output-style` plugin
+
+**What it is:** A new first-party plugin under [`anthropics/claude-code/plugins/learning-output-style/`](https://github.com/anthropics/claude-code/tree/main/plugins/learning-output-style), landed since the 2026-05-05 digest. Configures Claude to emphasise the **reasoning** behind decisions over the *what was done* — useful for sessions where a human is learning by observing.
+
+**Source:** Verified in the anthropics/claude-code plugins directory; one of two new entries since Day 5 (the other is `claude-opus-4-5-migration`, see §6).
+
+**Where it slots in:**
+
+Our orchestrator's default voice is terse, post-hoc reporting ("merged PR #254, dispatched notion-docs"). That's correct for the trained operator (you) but high friction for:
+
+- A new contributor reading session transcripts to understand how `ship-epic` flows.
+- The Notion changelog generator (`notion-docs`) — currently it has to reverse-engineer the *why* from `git log` + dev-handoff JSONs.
+- Future-you, six months from now, opening an old transcript to remember "why did we route the SignalR work through backend-dotnet *before* mobile-expo?"
+
+The plugin doesn't change orchestration shape; it changes the narration. Activating it on `daily-resercher`, `notion-docs`, and `ship-epic` could yield artefacts that read more like documentation than execution logs.
+
+**Why this project specifically:**
+
+- The Notion Changelog page is already known to be too large to patch in-place (saved as a project memory). Better, more-explanatory commit-time narration would make the dated sub-pages easier to skim retroactively.
+- Onboarding documentation for the orchestration model is currently zero — the system is the whole runbook. Better narrated transcripts are a low-effort substitute until proper onboarding docs exist.
+
+**Risk:** Verbose output costs tokens. Activate per-task, not globally — the orchestrator stays terse.
+
+**Effort:** ~15 min to install + try on one `daily-resercher` run. Compare side-by-side with this very document for verbosity tradeoff.
+
+**Fit score:** 3/5 — useful niche, not transformative.
+
+---
+
+## 4. `pegasi-ai/reins` — declarative policy framework for agent actions
+
+**What it is:** An MCP-friendly policy engine that defines *deterministic*, *fail-closed* rules for what agents may and may not do. Looks like Open Policy Agent for the Claude Code tool-call layer. Examples from its README: "no `git push --force` on `main` or `develop`", "no `rm -rf` with absolute paths", "approval required before `gh pr merge` against `main`".
+
+**Source:** [pegasi-ai/reins](https://github.com/pegasi-ai/reins) — 412 stars verified, last updated 2026-05-08.
+
+**Where it slots in:**
+
+We have **two custom hooks** doing exactly this:
+
+- `deny-subagent-merge.sh` — blocks `gh pr merge` + `git push --force` from sub-agents.
+- `agent-bash-allowlist.sh` — per-agent bash-command curation (`qa-tester` cannot `git commit`, etc.).
+
+Both are bash scripts with hand-rolled string matching. `reins` would let us express these as declarative policies:
+
+```yaml
+policy: subagent_merge_ban
+agents: [backend-dotnet, web-react, mobile-expo, qa-tester]
+deny:
+  - tool: Bash
+    matches: "gh pr merge"
+  - tool: Bash
+    matches: "git push --force"
+```
+
+Plus richer rules we don't have today:
+
+- "Block `dotnet ef database drop` from any agent, period." (Currently in `.claude/CLAUDE.md` as prose.)
+- "Block direct edits to `appsettings.*.json` and `.env*` files." (Also prose-only.)
+- "Require explicit user authorisation in same turn for `gh pr merge` against `develop` or `main`." (Today enforced by `pr-reviewer` instructions, not a hard hook.)
+
+**Why this project specifically:**
+
+- Several of our `.claude/CLAUDE.md` *prose* rules are exactly the shape that should be a *policy*: easy to express, easy to bypass by accident, costly when bypassed.
+- Sub-agents have repeatedly tried to merge or force-push in past sessions — caught by the hooks today, but the bash-string matching is fragile (e.g. someone runs `gh pr merge --auto`, our hook may not catch a future variant).
+
+**Risk:** Replacing working hooks with a new framework just because it's prettier is yak-shaving. Adopt only if `reins` catches a real gap our current hooks miss — file an issue listing the gaps first.
+
+**Effort:** ~30 min to install + write the first 3 policies. Run alongside existing hooks for a week.
+
+**Fit score:** 3/5 — solid match but not urgent; current hooks are working.
+
+---
+
+## 5. CLI harness releases v2.1.128 → v2.1.138
+
+**What it is:** Eleven bug-fix releases shipped between 2026-05-04 and 2026-05-09. Anthropic's release notes are sparse ("Internal fixes"), but secondary sources (the first scout's WebFetch) flag two concrete improvements:
+
+- **OAuth MCP refresh** — long-running sessions no longer lose auth to MongoDB / Playwright / GitHub MCPs mid-flight. Previously this caused daily re-auth friction on `qa-tester` runs that took >30 min.
+- **Worktree HEAD selection** — `EnterWorktree` now reliably lands on the local HEAD; eliminates a subtle branch-tracking bug that hit epic rebases.
+
+**Source:** [anthropics/claude-code releases](https://github.com/anthropics/claude-code/releases). Note: release notes are minimal — specific feature claims are inferred from the secondary scout, not directly verifiable from the release page text.
+
+**Where it slots in:**
+
+Zero install effort; auto-applies on next CLI update. The OAuth fix in particular matters for our `qa-tester` workflows that run packaged-backend curl probes + Playwright simulator drives against `:5101` for tens of minutes. Same for `notion-docs` writing 6 sub-pages over multiple GitHub MCP calls.
+
+**Why this project specifically:**
+
+- Three of our integrated MCPs (MongoDB, Playwright, GitHub) were affected by the pre-fix OAuth drop behaviour.
+- Epic-branch sub-issue dispatch (the worktree-heavy path) is exactly where the HEAD-selection bug bit.
+
+**Risk:** Pure upgrade. Risk = whatever else changed in 11 untagged bug-fix releases. Low.
+
+**Effort:** Run `claude --update` or whatever the CLI's self-update is. Verify version with `claude --version`.
+
+**Fit score:** 4/5 — free win, immediate.
+
+---
+
+## 6. Anthropic first-party `claude-opus-4-5-migration` plugin
+
+**What it is:** A first-party plugin under [`anthropics/claude-code/plugins/claude-opus-4-5-migration/`](https://github.com/anthropics/claude-code/tree/main/plugins/claude-opus-4-5-migration). Codemod / orchestration toolkit for projects still pinned to Opus 4.5 that want to roll forward to 4.6 / 4.7.
+
+**Source:** Verified in the plugins directory; landed since the 2026-05-05 digest.
+
+**Where it slots in:**
+
+We're already on Opus 4.7 (for design, review, planning) and Sonnet 4.6 (for impl work) per the model-selection matrix in `~/.claude/CLAUDE.md`. So we have **no migration need** for this project.
+
+**Why this project specifically — almost not at all:**
+
+The only scenario it'd fire is a sibling repo that hasn't kept up. Green Code projects (`capacity-planning`, `manufactory`, `migration-management`) might still have stale model pins in their `.claude/CLAUDE.md` files. If so, this plugin is the right tool for that cleanup — but it's not a fitness-platform task.
+
+**Risk:** None — non-applicable plugin.
+
+**Effort:** Zero.
+
+**Fit score:** 1/5 — tracking-only. Useful as a *reference for the eventual 4.7 → 4.8 migration* when that lands; the pattern is reusable.
+
+---
+
+## Skipped — already covered, duplicate, or low fit
+
+For audit transparency:
+
+- **`getzikra/Zikra` (7 stars, PostgreSQL + pgvector team memory)** — overlaps our existing MEMORY.md + auto-memory pipeline. Cross-project memory is interesting in principle but we have no concrete second-project consumer yet. Track if a Green Code project asks for shared memory access.
+- **`DeepSeek-V4-Claude-Code` MCP (5 stars)** — fallback model for cost-sensitive tasks. Our model-selection matrix already covers tiered routing (Haiku for scouts, Sonnet for impl, Opus for design/review). Adding a non-Anthropic model adds a quality variable we don't need.
+- **Continuing community noise around context optimisation skills (numerous 50–200-star repos)** — `context-mode` and `token-optimizer` are the credible heads of this category. The rest re-implement the same ideas with smaller user bases. Re-evaluate in 30 days if any cross 1k stars.
+- **Anthropic newsroom posts** — no Claude Code-branded announcement in the last 14 days. The harness releases are the only signal.
+
+---
+
+## Recommended next action
+
+Three concrete moves, in priority order. The first one addresses an *actively-failing* surface (this session opened with a `ship-epic` state corruption notice), so it leads.
+
+1. **1 hour — install `context-mode` MCP in observer mode.** Configure it alongside our current `state/ship-epic.json` for the next epic. Compare the SQLite-backed event log against our manual state file for one full epic cycle. If it captures the state-corruption case we hit this morning (the `state/ship-epic.json` malformed sentinel), retire `reinject-state.sh` + the hand-rolled JSON store.
+
+2. **15 min + 1 hour triage — run `token-optimizer`** against this repo's `.claude/` tree. Read the report, dismiss false positives, retire what's genuinely unused. The win is durable — every future session benefits.
+
+3. **30 min — install Anthropic's `learning-output-style` plugin** and trial it on the next `notion-docs` run. If the narrated output makes the changelog sub-pages more useful, keep it active for `daily-resercher` + `notion-docs`. If it just bloats responses, drop it.
+
+Skip the rest until those three settle. `reins` waits for a real gap our hooks missed. `claude-opus-4-5-migration` waits forever (or until a sibling repo needs it). Harness releases auto-apply.
+
+---
+
+**Word count: ~2400. Compiled by `daily-resercher` skill (Haiku scouts + Opus synthesis). Findings verified via direct WebFetch of GitHub repo pages on 2026-05-11; star counts and last-commit dates as of that date. Two corrections vs. raw scout output: `token-optimizer`'s headline claim is bloat-elimination (not "98% context reduction" blanket-applied), `context-mode`'s core value is sandboxed tool output with event-log continuity (not just session persistence).**

--- a/docs/research/claude-code-ecosystem-additions-2026-05-13.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-05-13.md
@@ -1,0 +1,75 @@
+# Claude Code Ecosystem — Day-2 Check-in
+
+**Compiled:** 2026-05-13 (scheduled `daily-resercher` run, 2 days after prior digest)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+- [`claude-code-ecosystem-additions-2026-04-30.md`](./claude-code-ecosystem-additions-2026-04-30.md)
+- [`claude-code-ecosystem-additions-2026-05-01.md`](./claude-code-ecosystem-additions-2026-05-01.md)
+- [`claude-code-ecosystem-additions-2026-05-05.md`](./claude-code-ecosystem-additions-2026-05-05.md)
+- [`claude-code-ecosystem-additions-2026-05-11.md`](./claude-code-ecosystem-additions-2026-05-11.md)
+
+**Scope:** The 2-day window since the 2026-05-11 digest. Short interval, narrow surface — the registry survey came back almost empty. Anything previously covered (full list in the 2026-05-11 digest's preamble) is **not** re-covered here.
+
+---
+
+## Summary
+
+- **Surveyed:** `hesreallyhim/awesome-claude-code` (no commits since 2026-04-27), `ComposioHQ/awesome-claude-plugins` (no additions post-2026-05-11), `anthropics/claude-code/plugins/` (no new folders), `anthropic.com/news` (no Code posts since 2026-04-17). `claudemarketplace.com` was unreachable during this scout (connection refused) — flagged for retry next run.
+- **Findings:** 1 total (1 drop-in / 0 wire-up / 0 tracking).
+- **Recommended next action:** Auto-upgrade the CLI when convenient and rerun the scout on 2026-05-18+ when community cadence typically resumes after the weekend lull.
+
+---
+
+## TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P3 | **Claude Code CLI v2.1.140** — maintenance release (2026-05-13) | One concrete win for our `.claude/` setup: settings hot-reload fix for **symlinked files**. Several of our `.claude/settings.json` entries and hook paths resolve through symlinks during local testing; this regression-bin was real. Plus case-insensitive agent tool matching and a `/goal` hang fix. |
+
+Everything else: silent. No new plugins, no new MCPs, no new skills, no new Anthropic blog posts in the window.
+
+---
+
+## docs-infra
+
+### Claude Code CLI v2.1.140
+
+- **Source:** [Releasebot — Claude Code updates](https://releasebot.io/updates/anthropic/claude-code) (canonical changelog also at the Claude Code release page).
+- **Status:** **drop-in** — auto-upgrades on next CLI bump; nothing to wire.
+- **Take:**
+  - *Line 1:* Maintenance release: case-insensitive agent tool matching, `/goal` hang fix, settings hot-reload fix for symlinked files, background service startup hardening.
+  - *Line 2:* The symlinked-settings hot-reload fix is the bit that touches us — when `~/.claude/settings.json` or the project `.claude/settings.json` is symlinked (we do this for the cross-project hooks layer), prior versions could miss reloads after edits. Nothing else in the release rewrites our workflow.
+- **Action:** **skip filing an issue** — auto-upgrade on next CLI refresh. If anyone hits a hot-reload misfire on `.claude/settings.json` in the next few days, refer them to this version.
+
+---
+
+## Nothing for backend / web / mobile this cycle
+
+No movement on:
+
+- `wshaddix/dotnet-skills`, `dotnet-claude-kit`, Roslyn MCP — all unchanged.
+- Expo MCP, XcodeBuildMCP — no new releases.
+- `playwright-skill`, axe-core / a11y MCP, Delightful Design System — no new releases.
+
+The 2026-05-11 P1 candidates (`mksglu/context-mode`, `alexgreensh/token-optimizer`) are still the unfinished business worth attention from that digest if anyone has spare cycles — neither has been actioned yet and both target real pain points (state-file durability, session-start token bloat).
+
+---
+
+## Honest assessment of this run
+
+A 2-day cadence is too tight for ecosystem surveys — most registries don't see daily churn. The schedule was set to "daily" but the realistic signal cadence is more like every 5–7 days. **Suggestion for the user:** consider relaxing the `daily-resercher` cron to ~weekly (Monday + Thursday, or weekly Monday). Current run found 1 minor item over 2 days; the 2026-05-11 run found 6 items over 6 days. The hit-rate per run improves dramatically with the longer interval, and the total tokens spent per week drops.
+
+A second consideration: `claudemarketplace.com` failed to load during this scout — if it's still down on the next run, the survey should fall back to its mirror on `claudemarketplace.com/sitemap.xml` or skip that source entirely with a noted exclusion.
+
+---
+
+## Open carryovers from prior digests
+
+These remain unfiled / un-actioned:
+
+1. **`mksglu/context-mode`** (2026-05-11 P1) — direct fit for our `ship-epic.json` state-tracking. The SessionStart sentinel on 2026-05-13 ("ship-epic state malformed") confirmed the failure surface is still live. Worth a 1-hour install-in-observer-mode spike.
+2. **`alexgreensh/token-optimizer`** (2026-05-11 P1) — single-pass audit of what's eating session-start tokens. Our `.claude/` tree grew again this week (training-sections sub-issues, fresh hook additions). One audit run + prune pass is a high-ROI 30-minute task.
+3. **`pegasi-ai/reins`** (2026-05-11 P2) — only worth it if our two custom Bash hooks (`deny-subagent-merge`, `agent-bash-allowlist`) start missing real violations. They haven't. **Tracking-only.**
+
+If any of (1) or (2) come up next time the user is between epics, they're worth surfacing.

--- a/docs/research/claude-code-ecosystem-additions-2026-05-16.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-05-16.md
@@ -1,0 +1,82 @@
+# Claude Code Ecosystem — Day-3 Check-in
+
+**Compiled:** 2026-05-16 (scheduled `daily-resercher` run, 3 days after prior digest)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+- [`claude-code-ecosystem-additions-2026-04-30.md`](./claude-code-ecosystem-additions-2026-04-30.md)
+- [`claude-code-ecosystem-additions-2026-05-01.md`](./claude-code-ecosystem-additions-2026-05-01.md)
+- [`claude-code-ecosystem-additions-2026-05-05.md`](./claude-code-ecosystem-additions-2026-05-05.md)
+- [`claude-code-ecosystem-additions-2026-05-11.md`](./claude-code-ecosystem-additions-2026-05-11.md)
+- [`claude-code-ecosystem-additions-2026-05-13.md`](./claude-code-ecosystem-additions-2026-05-13.md)
+
+**Scope:** The 3-day window since the 2026-05-13 digest. Carryovers from older digests are not re-covered (see prior digest preambles for full lists). Scout work delegated to a Haiku-backed `general-purpose` sub-agent per Working Principles §6.
+
+---
+
+## Summary
+
+- **Surveyed:** `hesreallyhim/awesome-claude-code` (last commit 2026-04-27, no movement), `ComposioHQ/awesome-claude-plugins` (no May merges), `anthropics/claude-code` releases (three new CLI patches: v2.1.141 → v2.1.143), `claudemarketplace.com` (still unreachable — `ECONNREFUSED`, **second consecutive failure**), `anthropic.com/news` (no Code posts in window).
+- **Findings:** 1 total (1 drop-in / 0 wire-up / 0 tracking).
+- **Recommended next action:** Auto-upgrade the CLI on next refresh. Drop `claudemarketplace.com` from the survey procedure until it's confirmed back up — two failed runs in a row.
+
+---
+
+## TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P3 | **Claude Code CLI v2.1.141 → v2.1.143** — three patch releases (2026-05-13 → 2026-05-15) | Two items touch our setup: **plugin dependency enforcement** (transitive enable/disable chains across the 8+ plugins we have wired) and **projected context-cost display in the marketplace** (visibility into which installed plugins are eating session-start tokens — directly addresses the unresolved `token-optimizer` carryover). Plus ~20 bug fixes including credential-corruption hang, `/loop` wakeup, agent-view spawn storms, and background-session file capture. |
+
+Everything else: silent. No new plugins, no new MCPs, no new skills, no new Anthropic blog posts in the window.
+
+---
+
+## docs-infra
+
+### Claude Code CLI v2.1.141–143
+
+- **Source:** [`anthropics/claude-code` releases](https://github.com/anthropics/claude-code/releases)
+- **Last updated:** 2026-05-15 (v2.1.143)
+- **Status:** **drop-in** — auto-upgrades on next CLI bump; nothing to wire.
+- **Take:**
+  - *Line 1:* Three patch releases delivering plugin dependency enforcement (transitive enable/disable), projected context-cost display in the plugin marketplace, the new `worktree.bgIsolation` mode (direct working-copy edits without spinning `EnterWorktree`), and ~20 stability fixes (credential corruption, PowerShell exec-policy, `/loop` wakeup, agent-view spawn storms, background-session file capture, macOS Full Disk Access).
+  - *Line 2:* The two relevant bits for this project: (a) dependency enforcement matters because we have 8+ plugins wired (`superpowers`, `Notion`, `slack`, `atlassian`, `pdf-viewer`, `mongodb`, `playwright-skill`, etc.) and the transitive chain is easy to mis-configure; (b) cost projection in the marketplace finally gives us the **session-start token visibility** the open `alexgreensh/token-optimizer` carryover was meant to address — we may not need a third-party plugin for that audit anymore. `worktree.bgIsolation` is niche — we use worktrees correctly per the epic-branch model, so low immediate value.
+- **Action:** **skip filing an issue** — auto-upgrade on next CLI refresh. Worth a 5-minute look at the new plugin-cost panel after the upgrade to confirm it covers what `token-optimizer` would have done; if it does, the carryover can be dropped from the deferred list.
+
+---
+
+## Nothing for backend / web / mobile this cycle
+
+No movement on the surfaces that intersect with our code:
+
+- `wshaddix/dotnet-skills`, `dotnet-claude-kit`, Roslyn MCP — unchanged.
+- Expo MCP, XcodeBuildMCP — no new releases.
+- `playwright-skill`, axe-core / a11y MCP, Delightful Design System — no new releases.
+- No new React 19 / TanStack Query / Tailwind 4 skills hit the curated registries.
+
+---
+
+## Honest assessment of this run
+
+Third consecutive run that came back with one CLI release and nothing else. The 2026-05-13 digest's recommendation — relax `daily-resercher` to a weekly cadence (Monday, or Monday + Thursday) — still stands. Three daily runs over the 2026-05-13 → 2026-05-16 window produced one cumulative finding that would have surfaced just as well in a single weekly run.
+
+`claudemarketplace.com` has now failed two runs in a row. Recommend removing it from the survey procedure in `daily-resercher/SKILL.md` until it's confirmed back online, otherwise we keep paying the WebFetch round-trip for a guaranteed timeout.
+
+---
+
+## Open carryovers from prior digests
+
+These remain unfiled / un-actioned:
+
+1. **`mksglu/context-mode`** (2026-05-11 P1) — direct fit for our `ship-epic.json` state-tracking. The SessionStart sentinel today still flagged `ship-epic state malformed` — the failure surface is **still live three days later**. This is increasingly worth a 1-hour install-in-observer-mode spike.
+2. **`alexgreensh/token-optimizer`** (2026-05-11 P1) — **may be obsoleted by** the new CLI v2.1.143 plugin-cost panel. Re-evaluate after the CLI upgrade lands; if the built-in panel breaks the spending down by plugin/skill, this third-party tool no longer adds value.
+3. **`pegasi-ai/reins`** (2026-05-11 P2) — **tracking-only**, no change.
+
+The `ship-epic` state issue (carryover #1) deserves a real fix soon — it's now been flagged in three consecutive SessionStart hooks. Either install `context-mode` for resilience or have the orchestrator add an automatic `state/ship-epic.json` repair pass when malformed JSON is detected.
+
+---
+
+## Suggested cron change
+
+Move `daily-resercher` from daily to **weekly (Monday)**. Three consecutive daily runs have produced one cumulative actionable finding — the per-run signal density is roughly 1/3 of what a 7-day window would produce, and the token cost per week would drop ~5×.

--- a/docs/research/claude-code-ecosystem-additions-2026-05-19.md
+++ b/docs/research/claude-code-ecosystem-additions-2026-05-19.md
@@ -1,0 +1,91 @@
+# Claude Code Ecosystem — Day-3 Check-in
+
+**Compiled:** 2026-05-19 (scheduled `daily-researcher` run, 3 days after prior digest)
+**Companions:**
+- [`claude-code-ecosystem-additions-2026-04-28.md`](./claude-code-ecosystem-additions-2026-04-28.md)
+- [`claude-code-ecosystem-additions-2026-04-29.md`](./claude-code-ecosystem-additions-2026-04-29.md)
+- [`claude-code-ecosystem-additions-2026-04-30.md`](./claude-code-ecosystem-additions-2026-04-30.md)
+- [`claude-code-ecosystem-additions-2026-05-01.md`](./claude-code-ecosystem-additions-2026-05-01.md)
+- [`claude-code-ecosystem-additions-2026-05-05.md`](./claude-code-ecosystem-additions-2026-05-05.md)
+- [`claude-code-ecosystem-additions-2026-05-11.md`](./claude-code-ecosystem-additions-2026-05-11.md)
+- [`claude-code-ecosystem-additions-2026-05-13.md`](./claude-code-ecosystem-additions-2026-05-13.md)
+- [`claude-code-ecosystem-additions-2026-05-16.md`](./claude-code-ecosystem-additions-2026-05-16.md)
+
+**Scope:** The 3-day window since the 2026-05-16 digest. Carryovers from older digests are not re-covered (see prior digest preambles for full lists). `claudemarketplace.com` dropped from the survey procedure per the 2026-05-16 recommendation — two prior consecutive failures.
+
+---
+
+## Summary
+
+- **Surveyed:** `hesreallyhim/awesome-claude-code` (last commit 2026-04-27, **no movement** in window), `ComposioHQ/awesome-claude-plugins` (last commit 2026-05-01, no May-13-onward merges), `anthropics/claude-code` releases (one new CLI patch: v2.1.144), `anthropics/claude-code/plugins/` tree (last commit 2026-03-12, no movement), `anthropic.com/news` (no Code posts in window — only enterprise partnership announcements). `claudemarketplace.com` skipped.
+- **Findings:** 1 total (1 drop-in / 0 wire-up / 0 tracking).
+- **Recommended next action:** Auto-upgrade the CLI on next refresh. **Confirm the move to weekly cadence** — fourth consecutive run with 1 cumulative finding.
+
+---
+
+## TL;DR — what's new today
+
+| Priority | Addition | Why it matters here |
+|---|---|---|
+| P2 | **Claude Code CLI v2.1.144** (released 2026-05-19) | Three items intersect our orchestrator setup: **(1) `/resume` now lists background sessions** (we routinely fan out `ship-epic` background agents — historically those vanished from the resume picker), **(2) elapsed duration in background subagent completion notifications** (visibility into how long a `qa-tester` or `pr-reviewer` actually took without re-opening the agent view), **(3) `/plugin` panes show "last updated"** — directly enables the plugin-staleness audit we've been deferring. Plus the startup-hang-on-captive-portal fix, which has bitten me twice in cafés. |
+
+Everything else: silent. No new plugins, no new MCPs, no new skills, no new Anthropic blog posts in the window. Same as the 2026-05-13 and 2026-05-16 digests.
+
+---
+
+## docs-infra
+
+### Claude Code CLI v2.1.144
+
+- **Source:** [`anthropics/claude-code` releases](https://github.com/anthropics/claude-code/releases)
+- **Last updated:** 2026-05-19
+- **Status:** **drop-in** — auto-upgrades on next CLI bump; nothing to wire.
+- **Take:**
+  - *Line 1:* CLI patch delivering `/resume` support for background sessions, elapsed-time stamps on background subagent completion notifications, a "last updated" column in `/plugin` browse/discover panes, `/model` session-only-by-default (press `d` to set global), the `/extra-usage` → `/usage-credits` rename, and a fix for startup hanging up to 75s behind a captive portal / VPN.
+  - *Line 2:* The three relevant bits for this project: (a) **background-session `/resume`** is a real ergonomics improvement — `ship-epic` fan-outs spawn background agents and historically lost them after a `/clear`; now they're indexed alongside interactive sessions; (b) **elapsed duration on background completion notifications** lets the orchestrator log per-agent wall-clock cost without re-attaching, which feeds back into our cost discipline (`CLAUDE.md §Working Principles §6`); (c) **`/plugin` "last updated"** is the missing piece for the plugin-staleness audit — we have 8+ wired plugins (`superpowers`, `Notion`, `slack`, `atlassian`, `pdf-viewer`, `mongodb`, `playwright-skill`, `delightful-design-system`, `feature-dev`, etc.) and "is this still maintained?" was previously a per-plugin GitHub round-trip. The captive-portal startup fix is a quality-of-life win for working off-network.
+- **Action:** **skip filing an issue** — auto-upgrade on next CLI refresh. After the upgrade, spend 10 minutes walking the `/plugin` browse pane to find plugins with `last updated` older than 90 days; flag any candidates for `/clear`-and-disable.
+
+---
+
+## Nothing for backend / web / mobile this cycle
+
+No movement on the surfaces that intersect with our code:
+
+- `wshaddix/dotnet-skills`, `dotnet-claude-kit`, Roslyn MCP — unchanged.
+- Expo MCP, XcodeBuildMCP — no new releases since the prior survey.
+- `playwright-skill`, axe-core / a11y MCP, Delightful Design System — no new releases.
+- No new React 19 / TanStack Query / Tailwind 4 skills hit the curated registries.
+
+The four consecutive low-signal runs (2026-05-11 → 2026-05-13 → 2026-05-16 → 2026-05-19) all surfaced exactly one CLI patch and nothing else. The ecosystem has clearly entered a steady state since the April surge.
+
+---
+
+## Honest assessment of this run
+
+Fourth consecutive run that came back with one CLI release and nothing else. The 2026-05-13 and 2026-05-16 digests both recommended moving `daily-researcher` to **weekly cadence (Monday)**; that recommendation now has a clear empirical base — 4 runs × 1 cumulative finding = ~0.25 findings per run. A single weekly run would cover the same surface at ~1/4 the cost.
+
+The schedule rename also surfaced again: the directory is now `daily-researcher` (was `daily-resercher`), but the scheduled task in `~/.claude/scheduled-tasks/` still references the old typo'd name. Worth fixing when the cadence change lands.
+
+---
+
+## Open carryovers from prior digests
+
+These remain unfiled / un-actioned:
+
+1. **`mksglu/context-mode`** (2026-05-11 P1) — direct fit for `ship-epic.json` state-tracking resilience. SessionStart's state-reinjection block today rendered cleanly (28 handoff files listed, no "malformed" warning), so the urgency dropped slightly vs the 2026-05-16 digest — but the underlying brittleness hasn't been fixed, just hasn't fired today. **Still worth a 1-hour spike** when state damage next surfaces.
+2. **`alexgreensh/token-optimizer`** (2026-05-11 P1) — **likely obsoleted by** the v2.1.143 plugin-cost panel + v2.1.144 "last updated" column. After the next CLI refresh, walk both panels for 10 minutes; if they jointly cover "which plugin is expensive" + "which plugin is dead," **drop the carryover entirely**.
+3. **`pegasi-ai/reins`** (2026-05-11 P2) — **tracking-only**, no change.
+
+---
+
+## Suggested cron change (re-stated)
+
+Move `daily-researcher` from daily to **weekly (Monday)** in
+`~/.claude/scheduled-tasks/`. While doing it, fix the directory rename
+mismatch — the scheduled task still references the old typo'd
+`daily-resercher` name even though the skill folder is now
+`daily-researcher`.
+
+Four consecutive daily runs over the 2026-05-11 → 2026-05-19 window have
+produced one cumulative actionable finding per ~3-day delta. The
+signal-to-cost ratio favors weekly by a factor of ~3-5×.


### PR DESCRIPTION
## Summary

- Promotes 9 daily-researcher ecosystem survey docs (2026-04-28 → 2026-05-19) from untracked `docs/*.md` to first-class committed `docs/research/*.md`. No editorial changes to bodies — verbatim from the source artefacts.
- Adds `docs/research/README.md` with a reading-order table, source link to `.claude/skills/daily-researcher/`, and a retention policy clarifying these are historical (not actively maintained).
- Minimal `.gitignore` tweak (one comment line + one `!docs/research/` exemption) mirroring the existing `!docs/testing/` precedent.

**AC count discrepancy noted:** issue body cites three April docs (2026-04-28/-29/-30); actual count is nine because the `daily-researcher` skill kept running through 2026-05-19. design-reviewer's spirit read of the AC approved processing all nine — flagged in the dispatch handoff (`.claude/state/handoff-design-197.json` round 1, MINOR `ac-coverage`).

## Related issue

Fixes #197

## Scope

`docs-infra` — `.gitignore` + `docs/research/**` only. Scope-leak grep confirms zero files outside scope:

```
$ git diff --name-only origin/develop..HEAD | grep -v -E '^(\.gitignore|docs/research/)'
(no output)
```

## QA verdict (from qa-tester)

OVERALL ✅ PASS — both ACs `met: true` with concrete evidence. See `.claude/state/handoff-qa-197.json`:

- AC1 (fork (a) chosen): 9 surveys committed under `docs/research/` (75–269 lines each), README index added.
- AC2 (no scope creep): one commit (`d61e1b0`), zero off-scope file diffs.

i18n + prototype-fidelity not applicable (no UI strings, no prototype scenes).

## Test plan

- [x] All survey markdown files are committed under `docs/research/` and parse as markdown (light editorial pass = added README index, bodies unchanged).
- [x] No other changes are made to the repo as part of this issue (`.gitignore` exemption + new `docs/research/` directory only).
- [x] `.gitignore` exemption mirrors the existing `!docs/testing/` precedent (line 97 already exempts testing; new line 98 exempts research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
