### PR TITLE
chore: QA harness polish + qa-tester scripts/test-env allowlist + QA_SEED_KIND

### DIFF
--- a/.claude/hooks/agent-bash-allowlist.sh
+++ b/.claude/hooks/agent-bash-allowlist.sh
@@ -80,8 +80,8 @@ case "$AGENT_TYPE" in
         # `npm install <pkg>`, no `npm publish`, etc.) — defence-in-depth preserved.
         # `cd` itself is allowed so the workflow patterns documented in qa-tester.md
         # just work.
-        ALLOW_REGEX="^(dotnet (test|build|run))|^npm( --prefix \\S+)? (run|ci|ls)( |$)|^npx( --prefix \\S+)? (--no-install|expo|tsc|playwright)( |$)|^(node )|^(xcrun |osascript)|^cd( |$)|${GIT_READ}|${FS_READ}|${GH_READ}|^pkill( -| $)|^docker (compose|ps|logs)|^bash |^python3 |^curl |^open |^brew "
-        DENY_HINT="qa-tester is read-only at source level. Allowed: dotnet test/build/run, npm (run/ci/ls) and npx (--no-install/expo/tsc/playwright) — both accept --prefix <path>, node, expo, xcrun, osascript, cd, git read-only (incl. -C <path>), gh read-only, find/grep/cat/etc., pkill, docker compose, curl, open, brew. Forbidden: npm install / npm publish, git commit/push (write ops), gh pr create/merge, code edits."
+        ALLOW_REGEX="^(dotnet (test|build|run))|^npm( --prefix \\S+)? (run|ci|ls)( |$)|^npx( --prefix \\S+)? (--no-install|expo|tsc|playwright)( |$)|^(node )|^(xcrun |osascript)|^cd( |$)|${GIT_READ}|${FS_READ}|${GH_READ}|^pkill( -| $)|^docker (compose|ps|logs)|^bash |^python3 |^curl |^open |^brew |^\\.?/?scripts/test-env( |$)"
+        DENY_HINT="qa-tester is read-only at source level. Allowed: dotnet test/build/run, npm (run/ci/ls) and npx (--no-install/expo/tsc/playwright) — both accept --prefix <path>, node, expo, xcrun, osascript, cd, git read-only (incl. -C <path>), gh read-only, find/grep/cat/etc., pkill, docker compose, curl, open, brew, scripts/test-env (the QA harness CLI). Forbidden: npm install / npm publish, git commit/push (write ops), gh pr create/merge, code edits."
         ;;
     pr-reviewer)
         ALLOW_REGEX="^(gh pr |gh issue |gh api|gh run|gh label)|${GIT_READ}|${FS_READ}|^bash |^python3 "

--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -93,6 +93,39 @@ public static class QaSeedRunner
             ?? throw new InvalidOperationException(
                 "QA_SEED_PASSWORD is not set. Copy .env.test.example to .env.test and fill it in.");
 
+    /// <summary>
+    /// Selects how much of the fixture to seed.
+    /// <list type="bullet">
+    ///   <item><term>Rich</term><description>(default when QA_SEED_KIND is unset or "rich") — full fixture: users + profiles + link + training plan + foods + recipes + nutrition plan + image blobs.</description></item>
+    ///   <item><term>Minimal</term><description>(QA_SEED_KIND=minimal) — users + profiles + trainer↔client link only. No plans, no foods, no blobs. Useful when a test only needs auth/profile and the additional rows just add noise.</description></item>
+    /// </list>
+    /// Switched via the QA_SEED_KIND env var so callers (compose `seed` service,
+    /// `scripts/test-env seed --kind=…`) can opt in to a leaner reset without
+    /// recompiling.
+    /// </summary>
+    public enum SeedKind { Minimal, Rich }
+
+    /// <summary>
+    /// Resolves <see cref="SeedKind"/> from the QA_SEED_KIND env var. Unset or
+    /// empty → <see cref="SeedKind.Rich"/> (backwards-compatible default —
+    /// the prior behaviour was always-rich). Unknown values fail fast so a
+    /// typo in `--kind=ritch` doesn't silently fall through to rich.
+    /// </summary>
+    public static SeedKind ResolveKind()
+    {
+        var raw = Environment.GetEnvironmentVariable("QA_SEED_KIND");
+        if (string.IsNullOrWhiteSpace(raw))
+            return SeedKind.Rich;
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "minimal" => SeedKind.Minimal,
+            "rich"    => SeedKind.Rich,
+            _ => throw new InvalidOperationException(
+                $"QA_SEED_KIND='{raw}' is not a valid value. Expected 'minimal' or 'rich' (unset = rich).")
+        };
+    }
+
     public static async Task SeedAsync(IServiceProvider serviceProvider)
     {
         using var scope = serviceProvider.CreateScope();
@@ -120,20 +153,30 @@ public static class QaSeedRunner
         // empty client list and Playwright's getByText('QA Client') never resolves.
         await EnsureTrainerClientLinkAsync(db, trainerProfile, clientProfile, logger);
 
-        // Training plan — ForTime + 0-exercise fixture for #258 non-regression.
-        await EnsureTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
+        // Resolve seed kind once so the log line below reports it consistently.
+        var kind = ResolveKind();
 
-        // Foods + Recipes + NutritionPlan (Phase 3 additions).
-        await EnsureFoodsAsync(mongo, nutriProfile.PublicId, logger);
-        await EnsureRecipesAsync(mongo, nutriProfile.PublicId, logger);
-        await EnsureNutritionPlanAsync(mongo, clientProfile.PublicId, nutriProfile.PublicId, logger);
+        if (kind == SeedKind.Rich)
+        {
+            // Training plan — ForTime + 0-exercise fixture for #258 non-regression.
+            await EnsureTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
 
-        // Image blobs in MinIO — idempotent, bucket created if absent.
-        await EnsureAvatarAsync(sp, logger);
-        await EnsureFoodImageAsync(sp, logger);
+            // Foods + Recipes + NutritionPlan.
+            await EnsureFoodsAsync(mongo, nutriProfile.PublicId, logger);
+            await EnsureRecipesAsync(mongo, nutriProfile.PublicId, logger);
+            await EnsureNutritionPlanAsync(mongo, clientProfile.PublicId, nutriProfile.PublicId, logger);
 
-        logger.LogInformation("QA seed complete — client={Client} trainer={Trainer} nutri={Nutri}",
-            ClientEmail, TrainerEmail, NutriEmail);
+            // Image blobs in MinIO — idempotent, bucket created if absent.
+            await EnsureAvatarAsync(sp, logger);
+            await EnsureFoodImageAsync(sp, logger);
+        }
+        else
+        {
+            logger.LogInformation("QA seed kind=minimal — skipping training plan, foods, recipes, nutrition plan, and blobs.");
+        }
+
+        logger.LogInformation("QA seed complete (kind={Kind}) — client={Client} trainer={Trainer} nutri={Nutri}",
+            kind, ClientEmail, TrainerEmail, NutriEmail);
     }
 
     private static async Task EnsureUserAsync(

--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -128,6 +128,12 @@ public static class QaSeedRunner
 
     public static async Task SeedAsync(IServiceProvider serviceProvider)
     {
+        // Resolve the seed kind BEFORE touching the database. A typo in
+        // QA_SEED_KIND throws here, so no users / profiles get created on
+        // a bad invocation — preserves the "fail-fast on unknown" contract
+        // documented on ResolveKind.
+        var kind = ResolveKind();
+
         using var scope = serviceProvider.CreateScope();
         var sp = scope.ServiceProvider;
         var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("QaSeed");
@@ -152,9 +158,6 @@ public static class QaSeedRunner
         // Trainer↔client link — without this the trainer dashboard returns an
         // empty client list and Playwright's getByText('QA Client') never resolves.
         await EnsureTrainerClientLinkAsync(db, trainerProfile, clientProfile, logger);
-
-        // Resolve seed kind once so the log line below reports it consistently.
-        var kind = ResolveKind();
 
         if (kind == SeedKind.Rich)
         {

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -323,12 +323,14 @@ public class QaSeedRunnerTests : IAsyncLifetime
 
     /// <summary>
     /// QA_SEED_KIND with a value other than "minimal" or "rich" must throw at
-    /// resolve-time, so a typo like `--kind=ritch` fails fast instead of silently
-    /// falling through to rich.
+    /// resolve-time — before any database row gets created — so a typo like
+    /// `--kind=ritch` doesn't leave behind a half-seeded fixture.
     /// </summary>
     [Fact]
     public async Task SeedAsync_UnknownKind_ThrowsInvalidOperation()
     {
+        var ct = TestContext.Current.CancellationToken;
+
         Environment.SetEnvironmentVariable("QA_SEED_KIND", "ritch");
         try
         {
@@ -340,6 +342,18 @@ public class QaSeedRunnerTests : IAsyncLifetime
         {
             Environment.SetEnvironmentVariable("QA_SEED_KIND", null);
         }
+
+        // No users should have been created — ResolveKind runs at the very top of
+        // SeedAsync, before MigrateAsync + EnsureUserAsync. The typo's blast
+        // radius is zero. (Asserts the contract documented on ResolveKind.)
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var userCount = await db.Users.CountAsync(
+            u => u.Email == QaSeedRunner.ClientEmail
+                 || u.Email == QaSeedRunner.TrainerEmail
+                 || u.Email == QaSeedRunner.NutriEmail,
+            ct);
+        userCount.Should().Be(0, "ResolveKind must run before any database write");
     }
 
     /// <summary>

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -263,6 +263,86 @@ public class QaSeedRunnerTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// QA_SEED_KIND=minimal must seed users + profiles + trainer↔client link only.
+    /// All "rich" fixtures (training plan, foods, recipes, nutrition plan, blobs)
+    /// must be absent.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_MinimalKind_SkipsRichFixtures()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Arrange — switch to minimal mode for this seed run.
+        Environment.SetEnvironmentVariable("QA_SEED_KIND", "minimal");
+        try
+        {
+            await QaSeedRunner.SeedAsync(_factory.Services);
+        }
+        finally
+        {
+            // Clear so other tests run with the default (rich).
+            Environment.SetEnvironmentVariable("QA_SEED_KIND", null);
+        }
+
+        using var scope = _factory.Services.CreateScope();
+        var sp    = scope.ServiceProvider;
+        var db    = sp.GetRequiredService<ApplicationDbContext>();
+        var mongo = sp.GetRequiredService<IMongoContext>();
+
+        // Users + profiles + link must all exist.
+        (await db.Users.CountAsync(u => u.Email == QaSeedRunner.ClientEmail, ct))
+            .Should().Be(1);
+        (await db.Users.CountAsync(u => u.Email == QaSeedRunner.TrainerEmail, ct))
+            .Should().Be(1);
+        (await db.Users.CountAsync(u => u.Email == QaSeedRunner.NutriEmail, ct))
+            .Should().Be(1);
+        (await db.ClientProfessionalLinks.CountAsync(ct))
+            .Should().Be(1, "trainer↔client link is part of the minimal fixture");
+
+        // Rich fixtures must be absent.
+        (await mongo.TrainingPlans.CountDocumentsAsync(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaTrainingPlanExternalId),
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips the training plan");
+        (await mongo.Foods.CountDocumentsAsync(
+            Builders<Food>.Filter.Empty,
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips all foods");
+        (await mongo.Recipes.CountDocumentsAsync(
+            Builders<Recipe>.Filter.Empty,
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips all recipes");
+        (await mongo.NutritionPlans.CountDocumentsAsync(
+            Builders<NutritionPlan>.Filter.Empty,
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips the nutrition plan");
+
+        // No blob uploads in minimal mode.
+        _factory.BlobStorage.UploadCalls.Should().BeEmpty("minimal seed skips both image blobs");
+    }
+
+    /// <summary>
+    /// QA_SEED_KIND with a value other than "minimal" or "rich" must throw at
+    /// resolve-time, so a typo like `--kind=ritch` fails fast instead of silently
+    /// falling through to rich.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_UnknownKind_ThrowsInvalidOperation()
+    {
+        Environment.SetEnvironmentVariable("QA_SEED_KIND", "ritch");
+        try
+        {
+            var act = async () => await QaSeedRunner.SeedAsync(_factory.Services);
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .Where(ex => ex.Message.Contains("QA_SEED_KIND"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("QA_SEED_KIND", null);
+        }
+    }
+
+    /// <summary>
     /// The nutrition plan seeded by <see cref="QaSeedRunner"/> must have Status=Active
     /// and exactly one Published week with three meals (Breakfast, Lunch, Dinner).
     /// </summary>

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,7 +46,12 @@ services:
       retries: 30
 
   minio-test:
-    image: minio/minio
+    # Pinned to a specific MinIO release so the harness behaves identically
+    # across CI runs + dev workstations. Rolling `latest` exposed us to surprise
+    # upstream changes that could flip CI red across all branches at once.
+    # When bumping: rebuild the image (`docker compose -f docker-compose.test.yml
+    # build minio-test`) and re-verify the `mc ready local` healthcheck.
+    image: minio/minio:RELEASE.2024-10-13T13-34-11Z
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minio_test_password

--- a/qa-playwright/named-flow-runner.sh
+++ b/qa-playwright/named-flow-runner.sh
@@ -22,7 +22,7 @@ list_flows() {
     jq -r 'to_entries[] | "  \(.key)  —  \(.value.description // "")"' "$FLOWS_JSON" 2>/dev/null \
       || echo "  (flows.json present but unreadable)"
   else
-    echo "  (flows.json not yet populated — lands in Phase 4)"
+    echo "  (flows.json not present — qa-playwright image may need a rebuild)"
   fi
 }
 

--- a/scripts/test-env
+++ b/scripts/test-env
@@ -243,16 +243,22 @@ cmd_run() {
   env_file="$(env_file_for "$project")"
   [[ -f "$env_file" ]] || die "No compose project found for current branch — run 'scripts/test-env up' first."
 
-  # Phase 2 wires the playwright service; Phase 4 wires qa-playwright/flows.json
-  # and the named-flow runner. For now this subcommand is a stub that surfaces
-  # the correct error path until Phase 4 lands.
+  # Defensive guard: the playwright service must exist in the compose file
+  # for `run` to be meaningful. If a future contributor strips the service
+  # without updating this CLI, fail with a clear envelope instead of `exec`-ing
+  # into nothing.
   if ! compose "$project" ps --services 2>/dev/null | grep -q '^playwright$'; then
-    err "playwright service not yet present in $COMPOSE_FILE (lands in Phase 2)."
+    err "playwright service not present in $COMPOSE_FILE — `run` requires the qa-playwright runner."
     printf '{"ok":false,"reason":"playwright service not deployed","flow":"%s"}\n' "$flow"
     exit 1
   fi
 
-  # Wait for api + web healthchecks before running.
+  # Gate on the api healthcheck. web + mobile-web don't need an explicit wait
+  # here because the playwright service `depends_on` them with
+  # `condition: service_healthy` in docker-compose.test.yml — compose won't
+  # start the runner until they're up. api is the only service we still need
+  # to gate on directly because the playwright container can be exec'd into
+  # at any point (compose's depends_on only blocks initial start).
   if ! wait_for_healthy "$project" api 90; then
     local logs
     logs="$(compose "$project" logs --tail=50 api 2>&1 | tail -c 4096)"

--- a/scripts/test-env
+++ b/scripts/test-env
@@ -225,8 +225,11 @@ cmd_seed() {
 
   err "Re-running seed (kind=$kind) against project '$project'…"
   # The seed container is one-shot. Re-running requires recreating it.
-  # `--kind` is currently accepted but ignored by QaSeedRunner — left in place
-  # so callers can opt in once the seed runner honours QA_SEED_KIND.
+  # QA_SEED_KIND is honoured by QaSeedRunner.ResolveKind:
+  #   unset / 'rich'  → full fixture (users + profiles + link + training plan
+  #                     + foods + recipes + nutrition plan + image blobs).
+  #   'minimal'       → users + profiles + trainer↔client link only.
+  #   anything else   → InvalidOperationException at resolve-time (fail-fast on typos).
   # stdout → stderr so the final JSON envelope is the only thing on stdout.
   compose "$project" run --rm -e QA_SEED_KIND="$kind" seed --qa-seed >&2
   printf '{"project":"%s","kind":"%s","status":"seeded"}\n' "$project" "$kind"

--- a/web/tests/e2e/nutritionist/food-admin-upload.spec.ts
+++ b/web/tests/e2e/nutritionist/food-admin-upload.spec.ts
@@ -60,14 +60,15 @@ test('food-admin-upload — nutritionist uploads food image and it renders in di
   // (only wired when isNutritionist is true, which it is for qa.nutri).
   await chickenRow.first().click();
 
-  // Wait for the dialog to open. FoodDialog renders in a modal overlay; wait
-  // for the dialog role or the image section heading to appear.
-  // The FoodImageSection renders a heading "foods.image.mainHeading" — the
-  // Czech translation. Use a loose locator that matches the visible label text.
-  const imageSection = page.locator('[aria-hidden="true"]').or(
+  // Wait for the dialog to open. FoodDialog renders inside a `role="dialog"`
+  // shadcn container; target that explicitly so we don't accidentally match a
+  // random aria-hidden element on the page (e.g. a modal backdrop, a hidden
+  // tooltip). Fall back to the localised image-section heading if the dialog
+  // role isn't wired on this page version.
+  const dialog = page.getByRole('dialog').or(
     page.getByText(/Hlavní foto|Main image|Hauptbild/i),
   );
-  await expect(imageSection.first()).toBeVisible({ timeout: 15_000 });
+  await expect(dialog.first()).toBeVisible({ timeout: 15_000 });
 
   // ── 4. Locate the SlotPicker input and set the file ──────────────────────────
   // FoodImageSection / SlotPicker renders:

--- a/web/tests/e2e/nutritionist/food-admin-upload.spec.ts
+++ b/web/tests/e2e/nutritionist/food-admin-upload.spec.ts
@@ -63,10 +63,13 @@ test('food-admin-upload — nutritionist uploads food image and it renders in di
   // Wait for the dialog to open. FoodDialog renders inside a `role="dialog"`
   // shadcn container; target that explicitly so we don't accidentally match a
   // random aria-hidden element on the page (e.g. a modal backdrop, a hidden
-  // tooltip). Fall back to the localised image-section heading if the dialog
-  // role isn't wired on this page version.
+  // tooltip). The image-section heading is included as a secondary check
+  // because it lives inside the dialog body — the .or() resolves to whichever
+  // is found first, but in practice both co-occur so the second clause is a
+  // safety net for shadcn version drift, NOT a fallback for "dialog wasn't
+  // wired" (the heading-outside-dialog case is not supported by this spec).
   const dialog = page.getByRole('dialog').or(
-    page.getByText(/Hlavní foto|Main image|Hauptbild/i),
+    page.getByText(/Hlavní fotka|Main image|Hauptbild/i),
   );
   await expect(dialog.first()).toBeVisible({ timeout: 15_000 });
 


### PR DESCRIPTION
## Summary

Follow-ups from PR #321 (#120 dockerised QA harness). Four independent micro-tasks, landing as a single chore PR:

- **Pin minio/minio** to `RELEASE.2024-10-13T13-34-11Z` in `docker-compose.test.yml` (no more surprise rolling-`latest` upgrades flipping CI red across all branches at once).
- **Extend qa-tester bash allowlist** with `scripts/test-env` so the QA harness CLI is invocable from sub-agent dispatches (allowlist still blocks `git commit` / `gh pr merge` / `npm install`).
- **Honour `QA_SEED_KIND=minimal|rich` in `QaSeedRunner`** — `minimal` seeds only users + profiles + trainer↔client link; `rich` (default) keeps the full fixture; unknown values throw `InvalidOperationException` so typos fail fast.
- **Polish from fresh-eyes review** — stale "Phase N lands" comments rewritten in `scripts/test-env` + `qa-playwright/named-flow-runner.sh`; `food-admin-upload.spec.ts` dialog locator tightened from `[aria-hidden="true"]` to `getByRole('dialog')`.

## Related issue

Fixes #324

## Scope

`docs-infra` — four small surgical changes across compose, hook allowlist, the QA harness CLI, the seed runner, the Playwright e2e spec, and the named-flow runner. No prod code paths touched.

## What's in this PR

- **`0d5ba5c` — minio pin.** Image bumped from `minio/minio` to `minio/minio:RELEASE.2024-10-13T13-34-11Z`. New compose-level comment explains the rationale + bump procedure.
- **`2a29c45` — qa-tester allowlist.** Allow regex extended with `^\.?/?scripts/test-env( |$)` (matches `scripts/test-env`, `./scripts/test-env`, and `/scripts/test-env`). `DENY_HINT` text updated for clarity. `git commit` / `gh pr merge` / `npm install` remain blocked.
- **`18e23a2` — `QA_SEED_KIND`.** New `SeedKind { Minimal, Rich }` enum + `ResolveKind()` reads `QA_SEED_KIND`. Unknown values throw at resolve-time so `--kind=ritch` doesn't silently fall through. Tests cover the minimal branch (`SeedAsync_MinimalKind_SkipsRichFixtures`) and unknown-kind branch (`SeedAsync_UnknownKind_ThrowsInvalidOperation`). The existing `SeedAsync_RunTwice_IsIdempotent` still covers the rich path.
- **`67bf5fa` — polish.** Stale phase-references rewritten in terms of behaviour (no more "lands in Phase 2/4"). `cmd_run`'s comment updated to reflect that only `api` is gated directly; web + mobile-web rely on compose `depends_on:condition:service_healthy`. `food-admin-upload.spec.ts` dialog locator tightened. `recipe-gallery-upload.spec.ts` already used specific locators so was untouched.

## AC coverage (Fixes #324)

11/11 ACs met per qa-tester `.claude/state/handoff-qa-324.json`. Highlights:

- **AC #1** minio pin → `grep minio/minio docker-compose.test.yml` shows the pinned tag.
- **AC #2** allowlist → hook denies `git commit` + `gh pr merge`; allows `./scripts/test-env up`.
- **AC #3** `QA_SEED_KIND` → all four `QaSeedRunnerTests` pass (idempotency + nutrition-plan-shape + minimal-mode + unknown-kind).
- **AC #4** polish → file-level evidence: no "Phase N lands" comments remain; `[aria-hidden="true"]` selector gone from `food-admin-upload.spec.ts`.

## Out of scope

- Selector iteration on the three canonical flow specs to make them actually green against the live SPA — tracked in #325 (deferred, user-driven). The `continue-on-error: true` markers on those CI steps stay until #325 lands.

## Test plan

- [ ] CI workflow `E2E` green on this branch.
- [ ] `dotnet test --filter "FullyQualifiedName~QaSeedRunnerTests"` green locally.
- [ ] `npm run build` in `/web` green (typecheck included).
- [ ] Two-pass code review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)