### PR TITLE
chore(#336): widen Testcontainers startup deadline to 180s for PhotoDescriptionBackfillServiceTests

### DIFF
--- a/backend/FitnessPlatform.Tests/Services/PhotoDescriptionBackfillServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/PhotoDescriptionBackfillServiceTests.cs
@@ -23,6 +23,18 @@ namespace FitnessPlatform.Tests.Services;
 /// </summary>
 public class PhotoDescriptionBackfillServiceTests : IAsyncLifetime
 {
+    // Bumped from the Testcontainers default of 60s to 180s because this test's
+    // PostgreSQL + MongoDB containers regularly contend with a developer- (or
+    // qa-tester-) started compose harness on the same host. The harness's
+    // `postgres-test` / `mongo-test` services and these test containers share
+    // the docker socket, the image-pull bandwidth, and the kernel-level network
+    // stack, so a parallel boot can push the test container's readiness probe
+    // past the 60s default and surface as
+    // `DockerContainer.ThrowIfContainerNotRunningAsync` during InitializeAsync.
+    // 180s gives headroom without making genuine container-boot failures hang
+    // too long. See #336.
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(180);
+
     private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16").Build();
     private readonly MongoDbContainer   _mongo    = new MongoDbBuilder("mongo:7").Build();
 
@@ -33,7 +45,14 @@ public class PhotoDescriptionBackfillServiceTests : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await Task.WhenAll(_postgres.StartAsync(), _mongo.StartAsync());
+        // Pass an extended-deadline cancellation token to StartAsync so the
+        // default Testcontainers wait-strategy gets up to StartupTimeout to
+        // observe the container becoming healthy. The IWaitStrategy
+        // implementation respects the CT, so this is the canonical
+        // single-call way to widen the readiness window without replacing
+        // the default strategy entirely.
+        using var cts = new CancellationTokenSource(StartupTimeout);
+        await Task.WhenAll(_postgres.StartAsync(cts.Token), _mongo.StartAsync(cts.Token));
 
         _db = BuildDbContext(_postgres.GetConnectionString());
 


### PR DESCRIPTION
## Summary

Extends the Testcontainers `StartAsync` cancellation-token deadline from the default 60s to 180s for both the PostgreSQL and MongoDB containers in `PhotoDescriptionBackfillServiceTests`. Stops the flake observed when `dotnet test` runs concurrently with `scripts/test-env up` (both stacks contending for the docker socket + image-pull bandwidth).

## What's in this PR

Single file: `backend/FitnessPlatform.Tests/Services/PhotoDescriptionBackfillServiceTests.cs`. Adds `static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(180)` and threads a single `CancellationTokenSource` into both `StartAsync(cts.Token)` calls. Default wait-strategies preserved (port reachability + Mongo command readiness).

## AC coverage (Fixes #336)

qa-tester verified: full `dotnet test` suite ran end-to-end while the compose harness was concurrently active on the host. All 1093 tests passed in 5m 33s, including the three `[Fact]`s in this file. The previously-flaking `BackfillAsync_MealPhoto_WithNullNote_SkipsRow` is in that green set.

## Test plan

- [ ] CI backend job green.
- [ ] Two-pass code review clean.

Fixes #336

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
