### PR TITLE
chore(#335): document MTP --filter-class as the canonical dotnet test filter syntax

### DIFF
--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -76,8 +76,19 @@ shape is constrained:
   `web-typecheck`, `mobile-typecheck`, `mobile-prebuild-check` (now
   maps to `npx expo-doctor` after #314; schema enum value kept stable
   so archived handoffs still validate).
-- `filter` — optional, regex-validated FQN fragment for `dotnet-test`
-  (no quotes/whitespace/shell metacharacters).
+- `filter` — optional, regex-validated **fully-qualified class name**
+  for `dotnet-test` (no quotes/whitespace/shell metacharacters). Used
+  with xUnit v3 + Microsoft.Testing.Platform's `--filter-class`
+  option, which requires the FQN (`FitnessPlatform.Tests.Services.PhotoDescriptionBackfillServiceTests`
+  — NOT the short form `PhotoDescriptionBackfillServiceTests`, which
+  silently matches zero tests). Substituted into the canonical
+  invocation `dotnet test -- --filter-class <filter>`; the leading
+  `--` separator is required by `dotnet test` to forward the option
+  to MTP rather than swallowing it. The legacy `--filter
+  "FullyQualifiedName~..."` VSTest syntax is silently ignored under
+  MTP 1.9.1 (the project's runner) — `warning MTP0001` surfaces only
+  for VSTest-specific MSBuild properties, not for the CLI filter
+  argument, so callers used to assume the old syntax worked.
 - `passed` — boolean.
 
 `qa-tester` substitutes these into a fixed template — never builds raw

--- a/.claude/skills/fe-endpoint/SKILL.md
+++ b/.claude/skills/fe-endpoint/SKILL.md
@@ -155,8 +155,10 @@ exact fixture base class name and helpers used.
 2. If you added a new error code, add it to
    `Domain/Constants/ErrorCodes.cs`.
 3. Build: `cd backend && dotnet build`.
-4. Test: `cd backend && dotnet test --filter "FullName~<Action>"` (Docker must
-   be running for Testcontainers).
+4. Test: `cd backend && dotnet test -- --filter-class FitnessPlatform.Tests.Endpoints.<Folder>.<Action>EndpointTests`
+   (Docker must be running for Testcontainers). The leading `--` forwards the
+   option to Microsoft.Testing.Platform; the legacy VSTest
+   `--filter "FullName~..."` syntax is silently ignored under MTP 1.9.x.
 5. If the request/response shape or route changed existing contracts, tell
    the orchestrator to run the `regen-api` skill for `/web` and `/mobile`
    before either client is updated.
@@ -185,10 +187,12 @@ A passing test against a stub doesn't prove anything.
    `ITestUser`/`AuthenticatedHttpClient` helpers. Reference exactly
    ONE existing endpoint test as exemplar (see Read-ONE-exemplar
    in §read-one-exemplar — the patterns are consistent).
-3. **Run the test**: `dotnet test --filter "FullName~<Action>"` — it
-   MUST fail. Confirm the failure mode is what you expect (404 on
-   missing endpoint, not a compilation error). If the test passes
-   against an empty endpoint, the test is wrong — broaden it.
+3. **Run the test**: `dotnet test -- --filter-class FitnessPlatform.Tests.Endpoints.<Folder>.<Action>EndpointTests`
+   — it MUST fail. Confirm the failure mode is what you expect (404
+   on missing endpoint, not a compilation error). If the test passes
+   against an empty endpoint, the test is wrong — broaden it. (The
+   legacy VSTest `--filter "FullName~..."` syntax is silently ignored
+   under MTP 1.9.x — see `rules/verification.md`.)
 4. **Scaffold the Request / Response / Validator / Endpoint** (the
    non-TDD steps above) with **minimal logic** to make the test
    pass. Don't gold-plate. No extra error paths, no extra fields.


### PR DESCRIPTION
## Summary

Documents the canonical `dotnet test -- --filter-class <FullyQualifiedName>` invocation for Microsoft.Testing.Platform 1.9.x + xUnit v3 — the legacy VSTest `--filter "FullyQualifiedName~..."` syntax is silently ignored under MTP, which has been quietly producing full-suite runs whenever a filter was specified.

## What's in this PR

- `bcef059` — `.claude/rules/verification.md`: rewrites the `filter` field doc on the dev-handoff schema. Spells out the FQN requirement (short class names match zero tests silently), the `dotnet test -- --filter-class <FQN>` invocation with the leading `--` separator, and the MTP0001-warning gotcha.
- `83228c2` — `.claude/skills/fe-endpoint/SKILL.md`: updates two stale `dotnet test --filter "FullName~<Action>"` examples (lines 158 + 188) to the canonical MTP form. Every future `fe-endpoint` invocation now picks up the right syntax.

## AC coverage (Fixes #335)

qa-tester empirically verified all three ACs:
- `dotnet test -- --filter-class <FQN>` runs exactly the targeted tests (3/3 for `PhotoDescriptionBackfillServiceTests`, 0 for the short name probe).
- The dev-handoff `filter` field regex still accepts the canonical FQN; no schema change needed.
- `rules/verification.md` + `fe-endpoint/SKILL.md` both now describe the canonical syntax.

## Test plan

- [ ] CI green.
- [ ] Two-pass code review clean.

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
