### PR TITLE
fix: skipped sets no longer shown as completed after finishing live session

### DIFF
--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -78,7 +78,7 @@ import { WodTimerHero } from '@/components/training/WodTimerHero'
 import { RestTimerHero } from '@/components/training/RestTimerHero'
 import { PrFlash } from '@/components/training/PrFlash'
 import { LiveFinishedSummary } from '@/components/training/LiveFinishedSummary'
-import type { FinishedWorkoutCardData } from '@/components/training/LiveFinishedSummary'
+import type { FinishedWorkoutCardData, FinishedExerciseSetData } from '@/components/training/LiveFinishedSummary'
 
 import {
   isPR,
@@ -2396,8 +2396,12 @@ export default function WorkoutLogScreen() {
           durationSeconds: isDone ? (override?.durationSeconds ?? null) : undefined,
           // Distance-movement actuals: distanceMeters replaces the weightKg slot.
           distanceMeters: isDone ? (override?.distanceMeters ?? null) : undefined,
-          completedAt:
-            isDone || isSkipped ? new Date().toISOString() : undefined,
+          // Only truly completed sets carry completedAt. Skipped sets must NOT
+          // receive a completedAt timestamp — the backend (GetTodaySession)
+          // uses CompletedAt != null to populate completedSetsBySessionExercise,
+          // so sending completedAt for skipped sets caused them to show as '✓'
+          // on the Today-screen TrainingCard SetGrid (bug #322).
+          completedAt: isDone ? new Date().toISOString() : undefined,
         }
       })
       // Per-exercise WOD result (only present when the exercise has a format override).
@@ -2807,7 +2811,8 @@ export default function WorkoutLogScreen() {
   // ── Derived: per-workout cards for the session-summary screen ──
   // One card per section: WOD sections pull duration + rounds from the
   // stored WodResult; standard sections derive "N/M sérií · X opak." from
-  // completedSets + per-set overrides.
+  // completedSets + per-set overrides and include per-exercise SetGrid data
+  // so skipped sets render as '↷' instead of blending into '✓' (fix #322).
   const finishedWorkoutCards = useMemo<FinishedWorkoutCardData[]>(() => {
     if (phase !== 'finished') return []
     return sections.map((sec) => {
@@ -2823,26 +2828,51 @@ export default function WorkoutLogScreen() {
           fmt === 'AMRAP' && rounds != null
             ? t('training.live.roundsCount', { count: rounds })
             : null
+        // WOD-format workouts don't have per-set grids.
         return {
           name: sec.name ?? '',
           format: fmt,
           durationFormatted: dur,
           metaText: meta,
+          exerciseSets: null,
         }
       }
       // Standard section — count completed vs planned sets across exercises.
       let setsDone = 0
       let setsPlanned = 0
       let totalReps = 0
+      const exerciseSets: FinishedExerciseSetData[] = []
       for (const ex of sec.exercises ?? []) {
         const exId = ex.exerciseExternalId ?? ''
-        const done = completedSets[exId] ?? []
+        const doneIndices = completedSets[exId] ?? []
+        const skippedIndices = skippedExercises.includes(exId)
+          // When the whole exercise was skipped, treat every set as skipped.
+          ? (ex.sets ?? []).map((_, si) => si)
+          : (skippedSets[exId] ?? [])
         setsPlanned += ex.sets?.length ?? 0
-        for (const setIdx of done) {
+        for (const setIdx of doneIndices) {
           setsDone += 1
           const override = formOverrides[exId]?.[setIdx]
           const planned = ex.sets?.[setIdx]
           totalReps += override?.reps ?? planned?.reps ?? 0
+        }
+        // Build 1-based set-number arrays for SetGrid, deriving the set
+        // number from the planned set's own setNumber field (1-based in the
+        // plan) so the grid stays aligned even when setNumber !== si + 1.
+        const plannedSets = ex.sets ?? []
+        const completedSetNums = doneIndices.map(
+          (si) => plannedSets[si]?.setNumber ?? si + 1,
+        )
+        const skippedSetNums = skippedIndices.map(
+          (si) => plannedSets[si]?.setNumber ?? si + 1,
+        )
+        if (plannedSets.length > 0) {
+          exerciseSets.push({
+            exerciseName: ex.exerciseName ?? '',
+            sets: plannedSets,
+            completedSetNumbers: completedSetNums,
+            skippedSetNumbers: skippedSetNums,
+          })
         }
       }
       const meta =
@@ -2854,9 +2884,10 @@ export default function WorkoutLogScreen() {
         format: fmt,
         durationFormatted: null,
         metaText: meta,
+        exerciseSets: exerciseSets.length > 0 ? exerciseSets : null,
       }
     })
-  }, [phase, sections, wodResults, completedSets, formOverrides, t])
+  }, [phase, sections, wodResults, completedSets, skippedSets, skippedExercises, formOverrides, t])
 
   // ── Next preview: usually the next exercise; on the LAST set of the LAST
   //    exercise of the current workout, switch to the next workout (section).

--- a/mobile/src/components/training/LiveFinishedSummary.tsx
+++ b/mobile/src/components/training/LiveFinishedSummary.tsx
@@ -5,12 +5,36 @@ import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { useTranslation } from 'react-i18next'
 import type { WorkoutFormat } from '@/api/wod-types'
+import type { FullPlanSet } from '@/api/training'
+import { SetGrid } from '@/components/training/SetGrid'
+
+/**
+ * Per-exercise set data for the finished-summary view.
+ * Carries the planned sets alongside the 1-based set numbers that were
+ * completed or skipped so SetGrid can render '✓' / '↷' / '—' per cell.
+ */
+export interface FinishedExerciseSetData {
+  exerciseName: string
+  sets: FullPlanSet[]
+  /** 1-based set numbers that the user actually completed. */
+  completedSetNumbers: number[]
+  /** 1-based set numbers that the user skipped (↷). */
+  skippedSetNumbers: number[]
+}
 
 export interface FinishedWorkoutCardData {
   name: string
   format: WorkoutFormat | null
   durationFormatted: string | null
   metaText: string | null
+  /**
+   * Per-exercise set detail for Standard-format workouts.
+   * When present, each exercise's sets are rendered in a SetGrid below the
+   * workout card header so skipped sets show '↷' rather than blending into
+   * the completed '✓' column.
+   * WOD-format workouts leave this null (they don't have per-set grids).
+   */
+  exerciseSets: FinishedExerciseSetData[] | null
 }
 
 interface LiveFinishedSummaryProps {
@@ -132,6 +156,38 @@ export function LiveFinishedSummary({
                 )}
               </View>
             )}
+            {/* Per-exercise set grids — only for Standard-format workouts
+                that carry exerciseSets data. Each exercise gets its own
+                SetGrid so the user can see '✓' / '↷' / '—' per set.
+                The exercise name appears as a small eyebrow above the grid. */}
+            {w.exerciseSets != null && w.exerciseSets.length > 0 && (
+              <View style={[styles.exerciseSetsWrap, { borderTopColor: colors.sep2 }]}>
+                {w.exerciseSets.map((ex, exIdx) => (
+                  <View
+                    key={`${ex.exerciseName}-${exIdx}`}
+                    style={[
+                      styles.exerciseBlock,
+                      exIdx < w.exerciseSets!.length - 1 && {
+                        borderBottomWidth: StyleSheet.hairlineWidth,
+                        borderBottomColor: colors.sep2,
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={[styles.exerciseName, { color: colors.label2 }]}
+                      numberOfLines={1}
+                    >
+                      {ex.exerciseName}
+                    </Text>
+                    <SetGrid
+                      sets={ex.sets}
+                      completedSetNumbers={ex.completedSetNumbers}
+                      skippedSetNumbers={ex.skippedSetNumbers}
+                    />
+                  </View>
+                ))}
+              </View>
+            )}
           </View>
         ))}
       </ScrollView>
@@ -246,6 +302,27 @@ const styles = StyleSheet.create({
   workoutMetaDot: {
     fontSize: 13,
     marginHorizontal: 6,
+  },
+  /** Wrapper for the per-exercise set grids — separated from the card header
+   *  by a hairline divider. Top padding gives breathing room below the meta
+   *  row / chip row. */
+  exerciseSetsWrap: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    marginTop: 8,
+    paddingTop: 4,
+  },
+  exerciseBlock: {
+    paddingVertical: 4,
+  },
+  /** Exercise-name eyebrow above the SetGrid — small, dim, matches the
+   *  section-label style used in the pre-start and plan-detail views. */
+  exerciseName: {
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.08 * 11,
+    paddingHorizontal: 8,
+    paddingBottom: 2,
   },
 })
 

--- a/mobile/src/components/training/SetGrid.tsx
+++ b/mobile/src/components/training/SetGrid.tsx
@@ -9,13 +9,21 @@ interface SetGridProps {
   sets: FullPlanSet[]
   /** 1-based set numbers that have been completed via live-training logging. */
   completedSetNumbers?: number[]
+  /**
+   * 1-based set numbers that were skipped during live-training.
+   * Rendered with the '↷' glyph (matching the in-session SetsList badge)
+   * so skipped sets are visually distinct from both completed ('✓') and
+   * pending ('—') sets. Parallel to completedSetNumbers — a set number
+   * should not appear in both arrays.
+   */
+  skippedSetNumbers?: number[]
 }
 
 /**
  * 5-column grid: Set / Reps / Weight / Rest / Status
  * Matches the tp-ex-set-grid layout in the prototype.
  */
-export function SetGrid({ sets, completedSetNumbers = [] }: SetGridProps) {
+export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = [] }: SetGridProps) {
   const colors = useTheme()
   const { t } = useTranslation()
 
@@ -34,6 +42,9 @@ export function SetGrid({ sets, completedSetNumbers = [] }: SetGridProps) {
       {/* Data rows — every row gets a bottom hairline so the table reads as
           a clean grid (matches prototype .tp-set-cell { border-bottom }). */}
       {sets.map((s) => {
+        const setNum = s.setNumber ?? -1
+        const isCompleted = completedSetNumbers.includes(setNum)
+        const isSkipped = !isCompleted && skippedSetNumbers.includes(setNum)
         const cellBorder = { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }
         return (
           <View key={s.setNumber} style={[styles.grid, cellBorder]}>
@@ -50,12 +61,14 @@ export function SetGrid({ sets, completedSetNumbers = [] }: SetGridProps) {
             <Text
               style={[
                 styles.cellStatus,
-                completedSetNumbers.includes(s.setNumber ?? -1)
+                isCompleted
                   ? { color: colors.green, fontFamily: interFamily('600'), fontWeight: '600' }
-                  : { color: colors.label3 },
+                  : isSkipped
+                    ? { color: colors.label3, fontFamily: interFamily('600'), fontWeight: '600' }
+                    : { color: colors.label3 },
               ]}
             >
-              {completedSetNumbers.includes(s.setNumber ?? -1) ? '✓' : '—'}
+              {isCompleted ? '✓' : isSkipped ? '↷' : '—'}
             </Text>
           </View>
         )


### PR DESCRIPTION
## Summary
- Skipped sets in a live **standard** training session were rendering as completed on the Today screen / training history after the workout was finished. Root cause: `buildRequest()` in `mobile/app/(client)/training-session/[id].tsx` was sending `completedAt: new Date().toISOString()` for skipped sets too. The backend (`GetTodaySession`) uses `CompletedAt != null` to populate `completedSetsBySessionExercise`, so skipped sets were indistinguishable from done ones in the persisted log.
- Skip half of the conditional removed. Done sets still carry `completedAt`; skipped sets now send `undefined`.
- Finished-session summary (`LiveFinishedSummary`) now also renders a per-exercise `SetGrid` for Standard-format workouts, threading `completedSetNumbers` + `skippedSetNumbers` so the user can see `✓` / `↷` / `—` per set inline. `SetGrid` gained an optional `skippedSetNumbers` prop using the `↷` glyph (same convention as the in-session badge at `[id].tsx:394`).

## Related issue
Fixes #322

## Scope
mobile

## QA verdict (from qa-tester)
Static gate ✅ — `tsc --noEmit` clean, no cross-package edits, no hardcoded colors / `any`, i18n parity OK (`training.live.setSkipped` already in cs/en/de). Interactive ACs deferred to user spot-check on iOS Simulator (user explicitly authorized proceeding to review).

## Test plan
- [ ] Start a live **standard** training session.
- [ ] Skip one or more sets, complete the workout.
- [ ] Return to Today / training history — skipped sets must show `↷` (not `✓`).
- [ ] Completed sets still show `✓`; un-attempted sets still show `—`.
- [ ] Finished-session summary renders per-exercise SetGrid for Standard workouts; WOD workouts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)