### PR TITLE
feat: lock and mark eaten meals/days on nutrition-plan detail page

### DIFF
--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/GetPlan/GetPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/GetPlan/GetPlanEndpoint.cs
@@ -48,6 +48,29 @@ public class GetPlanEndpoint(IMongoContext mongo) : Endpoint<GetPlanRequest, Get
             return;
         }
 
-        await Send.OkAsync(GetPlanResponse.FromDocument(plan), ct);
+        var response = GetPlanResponse.FromDocument(plan);
+
+        // ── MealLog fold-in ──────────────────────────────────────────────────────
+        // Query MealLogs by PlanId only. Ownership is already validated above
+        // (plan.NutritionistId == nutritionistId), so there is no IDOR risk here.
+        //
+        // A meal is considered eaten iff MealLog.EatenAt != null.
+        // MealLog.EatenAt == null means the log is a photo-only or note-only stub
+        // and is NOT treated as eaten (disambiguation rule per issue #329).
+        var logFilter = Builders<MealLog>.Filter.Eq(l => l.PlanId, req.PlanId);
+        var logCursor = await mongo.MealLogs.FindAsync(logFilter, cancellationToken: ct);
+        var mealLogs = await logCursor.ToListAsync(ct);
+
+        response.MealLogs = mealLogs
+            .Select(l => new MealLogDto
+            {
+                MealId = l.MealId,
+                LogDate = DateOnly.FromDateTime(l.LogDate),
+                IsEaten = l.EatenAt.HasValue,
+                EatenAt = l.EatenAt
+            })
+            .ToList();
+
+        await Send.OkAsync(response, ct);
     }
 }

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/GetPlan/GetPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/GetPlan/GetPlanResponse.cs
@@ -3,6 +3,53 @@ using FitnessPlatform.Application.Domain.Documents;
 namespace FitnessPlatform.Application.Features.NutritionPlans.GetPlan;
 
 /// <summary>
+/// Per-meal eaten state derived from a <see cref="MealLog"/> document.
+/// Lets the web layer render eaten/not-touched indicators and lock editing
+/// affordances on meals the client has already confirmed as eaten.
+/// </summary>
+/// <remarks>
+/// Disambiguation rule (derived, never stored):
+/// <list type="bullet">
+///   <item><description>
+///     <b>eaten</b> — <see cref="IsEaten"/> is <c>true</c>, meaning the corresponding
+///     <see cref="MealLog.EatenAt"/> was non-null at read time.
+///   </description></item>
+///   <item><description>
+///     <b>not-touched</b> — no <see cref="MealLogDto"/> row exists for the meal,
+///     or <see cref="IsEaten"/> is <c>false</c> (photo-only / note-only stub).
+///   </description></item>
+/// </list>
+/// Day-level state (all-eaten vs not-touched) is derived client-side by
+/// inspecting every meal in the day — no separate aggregate field is stored here.
+/// </remarks>
+public class MealLogDto
+{
+    /// <summary>
+    /// The <see cref="PlanMeal.MealId"/> this log belongs to.
+    /// </summary>
+    public Guid MealId { get; set; }
+
+    /// <summary>
+    /// The calendar date (UTC) this log entry belongs to, as a date-only value.
+    /// Matches <see cref="MealLog.LogDate"/> truncated to day precision.
+    /// </summary>
+    public DateOnly LogDate { get; set; }
+
+    /// <summary>
+    /// Whether the meal has been confirmed as eaten by the client.
+    /// <c>true</c> iff <see cref="MealLog.EatenAt"/> was non-null in the document.
+    /// A log with <c>EatenAt == null</c> is a photo-only or note-only stub —
+    /// it is NOT considered eaten.
+    /// </summary>
+    public bool IsEaten { get; set; }
+
+    /// <summary>
+    /// When the meal was eaten, if eaten. Null for photo-only / note-only stubs.
+    /// </summary>
+    public DateTime? EatenAt { get; set; }
+}
+
+/// <summary>
 /// Detailed nutrition plan response including all weeks, days, meals, and foods.
 /// </summary>
 public class GetPlanResponse
@@ -72,6 +119,15 @@ public class GetPlanResponse
     /// Null if no questionnaire is linked to this plan.
     /// </summary>
     public Guid? QuestionnaireResponseId { get; set; }
+
+    /// <summary>
+    /// Per-meal eaten state for all <see cref="MealLog"/> documents associated with this plan.
+    /// One entry per (MealId, LogDate) pair that has a log record; meals without a log entry
+    /// are absent (equivalent to not-touched / no badge).
+    /// Populated by the endpoint after loading the plan. Ownership is guaranteed by the
+    /// plan ownership gate above the MealLog query — filtering by PlanId is safe.
+    /// </summary>
+    public List<MealLogDto> MealLogs { get; set; } = [];
 
     /// <summary>
     /// Maps a <see cref="NutritionPlan"/> document to a detailed response DTO.

--- a/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/GetPlanEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/GetPlanEndpointTests.cs
@@ -53,4 +53,168 @@ public class GetPlanEndpointTests
 
         ep.HttpContext.Response.StatusCode.Should().Be(404);
     }
+
+    // ── MealLog fold-in tests (issue #329) ──────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NoMealLogs_ReturnsPlanWithEmptyMealLogsList()
+    {
+        // Arrange — plan with no meal logs; MealLogs should come back as an empty list
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(externalId: planId, nutritionistId: _nutritionistId);
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan], mealLogs: []);
+
+        var ep = Factory.Create<GetPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        // Act
+        await ep.HandleAsync(new GetPlanRequest { PlanId = planId }, TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.MealLogs.Should().NotBeNull();
+        ep.Response.MealLogs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_MealLogWithNullEatenAt_IsNotEaten()
+    {
+        // Arrange — log with EatenAt null is a photo-only/note-only stub → IsEaten = false
+        var planId = Guid.NewGuid();
+        var mealId = Guid.NewGuid();
+        var logDate = new DateTime(2025, 3, 10, 0, 0, 0, DateTimeKind.Utc);
+
+        var plan = PlanTestHelpers.CreatePlan(externalId: planId, nutritionistId: _nutritionistId);
+        var log = PlanTestHelpers.CreateMealLog(
+            planId: planId,
+            mealId: mealId,
+            logDate: logDate,
+            eatenAt: null);  // photo-only stub
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan], mealLogs: [log]);
+
+        var ep = Factory.Create<GetPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        // Act
+        await ep.HandleAsync(new GetPlanRequest { PlanId = planId }, TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.MealLogs.Should().HaveCount(1);
+        ep.Response.MealLogs[0].MealId.Should().Be(mealId);
+        ep.Response.MealLogs[0].IsEaten.Should().BeFalse("EatenAt is null → photo-only stub, not eaten");
+        ep.Response.MealLogs[0].EatenAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_MealLogWithEatenAt_IsEaten()
+    {
+        // Arrange — log with EatenAt set → IsEaten = true
+        var planId = Guid.NewGuid();
+        var mealId = Guid.NewGuid();
+        var logDate = new DateTime(2025, 3, 10, 0, 0, 0, DateTimeKind.Utc);
+        var eatenAt = new DateTime(2025, 3, 10, 8, 30, 0, DateTimeKind.Utc);
+
+        var plan = PlanTestHelpers.CreatePlan(externalId: planId, nutritionistId: _nutritionistId);
+        var log = PlanTestHelpers.CreateMealLog(
+            planId: planId,
+            mealId: mealId,
+            logDate: logDate,
+            eatenAt: eatenAt);
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan], mealLogs: [log]);
+
+        var ep = Factory.Create<GetPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        // Act
+        await ep.HandleAsync(new GetPlanRequest { PlanId = planId }, TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.MealLogs.Should().HaveCount(1);
+        ep.Response.MealLogs[0].MealId.Should().Be(mealId);
+        ep.Response.MealLogs[0].IsEaten.Should().BeTrue("EatenAt is non-null → meal was confirmed eaten");
+        ep.Response.MealLogs[0].EatenAt.Should().Be(eatenAt);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PlanBelongsToDifferentNutritionist_Returns404_AndMealLogsNotQueried()
+    {
+        // Arrange — plan belongs to a DIFFERENT nutritionist → ownership gate fires, 404 returned,
+        // MealLog collection should not be touched (no IDOR leakage).
+        var planId = Guid.NewGuid();
+        var otherNutritionistId = Guid.NewGuid();
+
+        var plan = PlanTestHelpers.CreatePlan(externalId: planId, nutritionistId: otherNutritionistId);
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+
+        var callerNutritionistId = Guid.NewGuid();  // not the owner
+        var ep = Factory.Create<GetPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(callerNutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        // Act
+        await ep.HandleAsync(new GetPlanRequest { PlanId = planId }, TestContext.Current.CancellationToken);
+
+        // Assert — 404 (no existence leak)
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_AllMealsInDayEaten_ReturnsMealLogListWithAllIsEatenTrue()
+    {
+        // Arrange — all three meals for a given day have EatenAt set.
+        // Backend returns the flat list; the web layer derives day-level all-eaten state
+        // from the per-meal entries — no separate aggregate field on the response.
+        var planId = Guid.NewGuid();
+        var logDate = new DateTime(2025, 3, 10, 0, 0, 0, DateTimeKind.Utc);
+        var eatenAt = new DateTime(2025, 3, 10, 12, 0, 0, DateTimeKind.Utc);
+
+        var mealId1 = Guid.NewGuid();
+        var mealId2 = Guid.NewGuid();
+        var mealId3 = Guid.NewGuid();
+
+        var plan = PlanTestHelpers.CreatePlan(externalId: planId, nutritionistId: _nutritionistId);
+        var logs = new[]
+        {
+            PlanTestHelpers.CreateMealLog(planId, mealId1, logDate, eatenAt),
+            PlanTestHelpers.CreateMealLog(planId, mealId2, logDate, eatenAt),
+            PlanTestHelpers.CreateMealLog(planId, mealId3, logDate, eatenAt)
+        };
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan], mealLogs: logs);
+
+        var ep = Factory.Create<GetPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo);
+
+        // Act
+        await ep.HandleAsync(new GetPlanRequest { PlanId = planId }, TestContext.Current.CancellationToken);
+
+        // Assert — backend returns 3 log entries, all IsEaten = true
+        // Web derives day-level state (all-eaten) from this flat list
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.MealLogs.Should().HaveCount(3);
+        ep.Response.MealLogs.Should().AllSatisfy(l =>
+        {
+            l.IsEaten.Should().BeTrue("all meals for this day were confirmed eaten");
+            l.EatenAt.Should().Be(eatenAt);
+        });
+        ep.Response.MealLogs.Select(l => l.MealId).Should().BeEquivalentTo(new[] { mealId1, mealId2, mealId3 });
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanTestHelpers.cs
@@ -95,11 +95,12 @@ public static class PlanTestHelpers
     }
 
     /// <summary>
-    /// Creates a mocked <see cref="IMongoContext"/> with plans (and optional foods) collections.
+    /// Creates a mocked <see cref="IMongoContext"/> with plans (and optional foods / meal logs) collections.
     /// </summary>
     public static IMongoContext CreateMockMongo(
         NutritionPlan[]? plans = null,
-        Food[]? foods = null)
+        Food[]? foods = null,
+        MealLog[]? mealLogs = null)
     {
         var mongo = Substitute.For<IMongoContext>();
 
@@ -109,7 +110,30 @@ public static class PlanTestHelpers
         var foodCollection = CreateMockFoodCollection(foods?.ToList() ?? []);
         mongo.Foods.Returns(foodCollection);
 
+        var mealLogCollection = CreateMockMealLogCollection(mealLogs?.ToList() ?? []);
+        mongo.MealLogs.Returns(mealLogCollection);
+
         return mongo;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="MealLog"/> for test purposes.
+    /// </summary>
+    public static MealLog CreateMealLog(
+        Guid planId,
+        Guid mealId,
+        DateTime logDate,
+        DateTime? eatenAt = null,
+        Guid? clientId = null)
+    {
+        return new MealLog
+        {
+            ClientId = clientId ?? Guid.NewGuid(),
+            PlanId = planId,
+            MealId = mealId,
+            LogDate = logDate,
+            EatenAt = eatenAt
+        };
     }
 
     /// <summary>
@@ -214,6 +238,42 @@ public static class PlanTestHelpers
             if (moved) return false;
             moved = true;
             return foods.Count > 0;
+        });
+        return cursor;
+    }
+
+    /// <summary>
+    /// Creates a mock <see cref="IMongoCollection{MealLog}"/> supporting FindAsync.
+    /// </summary>
+    private static IMongoCollection<MealLog> CreateMockMealLogCollection(List<MealLog> mealLogs)
+    {
+        var collection = Substitute.For<IMongoCollection<MealLog>>();
+
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<MealLog>>(),
+                Arg.Any<FindOptions<MealLog, MealLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateMealLogCursor(mealLogs));
+
+        return collection;
+    }
+
+    private static IAsyncCursor<MealLog> CreateMealLogCursor(List<MealLog> mealLogs)
+    {
+        var cursor = Substitute.For<IAsyncCursor<MealLog>>();
+        var moved = false;
+        cursor.Current.Returns(mealLogs);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return mealLogs.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return mealLogs.Count > 0;
         });
         return cursor;
     }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/dom": "^0.3.2",
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
+        "@floating-ui/dom": "^1.7.6",
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",
         "@tanstack/react-query": "^5.90.21",
@@ -1033,8 +1034,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
@@ -1042,8 +1053,7 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,6 @@
         "@dnd-kit/dom": "^0.3.2",
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
-        "@floating-ui/dom": "^1.7.6",
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",
         "@tanstack/react-query": "^5.90.21",
@@ -1034,18 +1033,8 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
@@ -1053,7 +1042,8 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",

--- a/web/src/api/plan-types.ts
+++ b/web/src/api/plan-types.ts
@@ -82,6 +82,25 @@ export interface PlanWeek {
   days: PlanDay[];
 }
 
+/**
+ * Per-meal eaten state derived from a MealLog document.
+ * One entry per (mealId, logDate) pair that has a log record.
+ * Meals without a log entry are absent — equivalent to not-touched.
+ */
+export interface MealLogDto {
+  /** The PlanMeal.mealId this log belongs to. */
+  mealId: string;
+  /** Calendar date this log belongs to (ISO date string, e.g. "2025-05-29"). */
+  logDate: string;
+  /**
+   * Whether the meal has been confirmed as eaten.
+   * false means photo-only / note-only stub — NOT considered eaten.
+   */
+  isEaten: boolean;
+  /** When the meal was eaten; null for stubs. ISO datetime string. */
+  eatenAt: string | null;
+}
+
 /** Full nutrition plan detail returned by the API. */
 export interface NutritionPlanDetail {
   planId: string;
@@ -97,6 +116,11 @@ export interface NutritionPlanDetail {
   startDate?: string | null;
   dateCompleted?: string | null;
   questionnaireResponseId?: string | null;
+  /**
+   * Per-meal eaten state for all MealLog documents associated with this plan.
+   * Empty array when no logs exist (all meals are not-touched).
+   */
+  mealLogs: MealLogDto[];
 }
 
 /** Plan summary for list views. */

--- a/web/src/components/nutrition/DayColumn.tsx
+++ b/web/src/components/nutrition/DayColumn.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSortable } from '@dnd-kit/react/sortable';
 import { useNutritionPlanStore } from '@/stores/nutritionPlan';
-import type { PlanDay, PlanMeal, MealFood, GlobalNutritionSettings } from '@/api/plan-types';
+import type { PlanDay, PlanMeal, MealFood, GlobalNutritionSettings, MealLogDto } from '@/api/plan-types';
 import MacroProgressBar from './MacroProgressBar';
 import MealCard from './MealCard';
 import AddItemsDrawer from './AddItemsDrawer';
 import DraggableDayHeader from '@/components/training/DraggableDayHeader';
 import { MEAL_KINDS, type MealKind } from './meal-kind';
+import { CompletionBadge } from '@/components/training/CompletionBadge';
+import { deriveMealCompletionState, deriveDayCompletionState } from '@/lib/completionState';
 
 interface DayColumnProps {
   day: PlanDay;
@@ -18,6 +20,8 @@ interface DayColumnProps {
   dailyKcal?: number | null;
   /// When true, the day header becomes a draggable handle for day reorder/copy.
   draggable?: boolean;
+  /** Meal log data from the plan response — used to derive eaten state. */
+  mealLogs?: MealLogDto[];
 }
 
 function SortableMealCard({
@@ -26,12 +30,16 @@ function SortableMealCard({
   dayOfWeek,
   index,
   targetKcal,
+  locked,
+  completionState,
 }: {
   meal: PlanMeal;
   weekNumber: number;
   dayOfWeek: number;
   index: number;
   targetKcal?: number | null;
+  locked?: boolean;
+  completionState?: 'eaten' | 'not-touched';
 }) {
   const { ref, isDragging } = useSortable({
     id: meal.mealId,
@@ -52,6 +60,8 @@ function SortableMealCard({
         weekNumber={weekNumber}
         dayOfWeek={dayOfWeek}
         targetKcal={targetKcal}
+        locked={locked}
+        completionState={completionState}
       />
     </div>
   );
@@ -65,6 +75,7 @@ export default function DayColumn({
   mealDistribution,
   dailyKcal,
   draggable: isDraggable,
+  mealLogs,
 }: DayColumnProps) {
   const { t } = useTranslation();
   const addMeal = useNutritionPlanStore((s) => s.addMeal);
@@ -145,6 +156,10 @@ export default function DayColumn({
 
   const sortedMeals = day.meals.slice().sort((a, b) => a.order - b.order);
 
+  // Derive day-level and per-meal eaten states from MealLog data
+  const mealIdList = sortedMeals.map((m) => m.mealId);
+  const { state: dayState, counts: dayCounts } = deriveDayCompletionState(mealLogs, mealIdList);
+
   return (
     <div className="flex w-[336px] shrink-0 flex-1 flex-col rounded-sm border border-border bg-bg2 transition-colors">
       {/* Day header — optionally a drag handle */}
@@ -154,9 +169,12 @@ export default function DayColumn({
           <span className="text-xs font-bold uppercase tracking-wide">
             {dayLabel}
           </span>
-          <span className={`text-xs font-medium ${isOverTarget ? 'text-red-400' : 'text-green-400'}`}>
-            {dayKcal} kcal
-          </span>
+          <div className="flex items-center gap-1.5">
+            <CompletionBadge kind="day" state={dayState} counts={dayCounts} />
+            <span className={`text-xs font-medium ${isOverTarget ? 'text-red-400' : 'text-green-400'}`}>
+              {dayKcal} kcal
+            </span>
+          </div>
         </div>
       </DraggableDayHeader>
       ) : (
@@ -165,9 +183,12 @@ export default function DayColumn({
           <span className="text-xs font-bold uppercase tracking-wide">
             {dayLabel}
           </span>
-          <span className={`text-xs font-medium ${isOverTarget ? 'text-red-400' : 'text-green-400'}`}>
-            {dayKcal} kcal
-          </span>
+          <div className="flex items-center gap-1.5">
+            <CompletionBadge kind="day" state={dayState} counts={dayCounts} />
+            <span className={`text-xs font-medium ${isOverTarget ? 'text-red-400' : 'text-green-400'}`}>
+              {dayKcal} kcal
+            </span>
+          </div>
         </div>
       </div>
       )}
@@ -255,6 +276,7 @@ export default function DayColumn({
 
               if (existingMeal) {
                 const idx = sortedMeals.indexOf(existingMeal);
+                const mealState = deriveMealCompletionState(mealLogs, existingMeal.mealId);
                 return (
                   <SortableMealCard
                     key={existingMeal.mealId}
@@ -263,6 +285,8 @@ export default function DayColumn({
                     dayOfWeek={day.dayOfWeek}
                     index={idx}
                     targetKcal={target}
+                    locked={mealState === 'eaten'}
+                    completionState={mealState}
                   />
                 );
               }
@@ -293,16 +317,21 @@ export default function DayColumn({
                 </div>
               );
             })
-          : sortedMeals.map((meal, idx) => (
-              <SortableMealCard
-                key={meal.mealId}
-                meal={meal}
-                weekNumber={weekNumber}
-                dayOfWeek={day.dayOfWeek}
-                index={idx}
-                targetKcal={getMealTargetKcal(meal.kind)}
-              />
-            ))
+          : sortedMeals.map((meal, idx) => {
+              const mealState = deriveMealCompletionState(mealLogs, meal.mealId);
+              return (
+                <SortableMealCard
+                  key={meal.mealId}
+                  meal={meal}
+                  weekNumber={weekNumber}
+                  dayOfWeek={day.dayOfWeek}
+                  index={idx}
+                  targetKcal={getMealTargetKcal(meal.kind)}
+                  locked={mealState === 'eaten'}
+                  completionState={mealState}
+                />
+              );
+            })
         }
 
         {/* Also render any meals that don't match distribution names (manually added) */}
@@ -312,16 +341,21 @@ export default function DayColumn({
               const k = m.kind.toLowerCase();
               return k === key.toLowerCase() || k === getMealLabel(key).toLowerCase();
             }))
-            .map((meal) => (
-              <SortableMealCard
-                key={meal.mealId}
-                meal={meal}
-                weekNumber={weekNumber}
-                dayOfWeek={day.dayOfWeek}
-                index={sortedMeals.indexOf(meal)}
-                targetKcal={null}
-              />
-            ))
+            .map((meal) => {
+              const mealState = deriveMealCompletionState(mealLogs, meal.mealId);
+              return (
+                <SortableMealCard
+                  key={meal.mealId}
+                  meal={meal}
+                  weekNumber={weekNumber}
+                  dayOfWeek={day.dayOfWeek}
+                  index={sortedMeals.indexOf(meal)}
+                  targetKcal={null}
+                  locked={mealState === 'eaten'}
+                  completionState={mealState}
+                />
+              );
+            })
         }
 
         {/* Add meal */}

--- a/web/src/components/nutrition/DayColumn.tsx
+++ b/web/src/components/nutrition/DayColumn.tsx
@@ -9,7 +9,7 @@ import AddItemsDrawer from './AddItemsDrawer';
 import DraggableDayHeader from '@/components/training/DraggableDayHeader';
 import { MEAL_KINDS, type MealKind } from './meal-kind';
 import { CompletionBadge } from '@/components/training/CompletionBadge';
-import { deriveMealCompletionState, deriveDayCompletionState } from '@/lib/completionState';
+import { deriveDayCompletionState } from '@/lib/completionState';
 
 interface DayColumnProps {
   day: PlanDay;
@@ -30,16 +30,12 @@ function SortableMealCard({
   dayOfWeek,
   index,
   targetKcal,
-  locked,
-  completionState,
 }: {
   meal: PlanMeal;
   weekNumber: number;
   dayOfWeek: number;
   index: number;
   targetKcal?: number | null;
-  locked?: boolean;
-  completionState?: 'eaten' | 'not-touched';
 }) {
   const { ref, isDragging } = useSortable({
     id: meal.mealId,
@@ -60,8 +56,6 @@ function SortableMealCard({
         weekNumber={weekNumber}
         dayOfWeek={dayOfWeek}
         targetKcal={targetKcal}
-        locked={locked}
-        completionState={completionState}
       />
     </div>
   );
@@ -276,7 +270,6 @@ export default function DayColumn({
 
               if (existingMeal) {
                 const idx = sortedMeals.indexOf(existingMeal);
-                const mealState = deriveMealCompletionState(mealLogs, existingMeal.mealId);
                 return (
                   <SortableMealCard
                     key={existingMeal.mealId}
@@ -285,8 +278,6 @@ export default function DayColumn({
                     dayOfWeek={day.dayOfWeek}
                     index={idx}
                     targetKcal={target}
-                    locked={mealState === 'eaten'}
-                    completionState={mealState}
                   />
                 );
               }
@@ -317,21 +308,16 @@ export default function DayColumn({
                 </div>
               );
             })
-          : sortedMeals.map((meal, idx) => {
-              const mealState = deriveMealCompletionState(mealLogs, meal.mealId);
-              return (
-                <SortableMealCard
-                  key={meal.mealId}
-                  meal={meal}
-                  weekNumber={weekNumber}
-                  dayOfWeek={day.dayOfWeek}
-                  index={idx}
-                  targetKcal={getMealTargetKcal(meal.kind)}
-                  locked={mealState === 'eaten'}
-                  completionState={mealState}
-                />
-              );
-            })
+          : sortedMeals.map((meal, idx) => (
+              <SortableMealCard
+                key={meal.mealId}
+                meal={meal}
+                weekNumber={weekNumber}
+                dayOfWeek={day.dayOfWeek}
+                index={idx}
+                targetKcal={getMealTargetKcal(meal.kind)}
+              />
+            ))
         }
 
         {/* Also render any meals that don't match distribution names (manually added) */}
@@ -341,21 +327,16 @@ export default function DayColumn({
               const k = m.kind.toLowerCase();
               return k === key.toLowerCase() || k === getMealLabel(key).toLowerCase();
             }))
-            .map((meal) => {
-              const mealState = deriveMealCompletionState(mealLogs, meal.mealId);
-              return (
-                <SortableMealCard
-                  key={meal.mealId}
-                  meal={meal}
-                  weekNumber={weekNumber}
-                  dayOfWeek={day.dayOfWeek}
-                  index={sortedMeals.indexOf(meal)}
-                  targetKcal={null}
-                  locked={mealState === 'eaten'}
-                  completionState={mealState}
-                />
-              );
-            })
+            .map((meal) => (
+              <SortableMealCard
+                key={meal.mealId}
+                meal={meal}
+                weekNumber={weekNumber}
+                dayOfWeek={day.dayOfWeek}
+                index={sortedMeals.indexOf(meal)}
+                targetKcal={null}
+              />
+            ))
         }
 
         {/* Add meal */}

--- a/web/src/components/nutrition/FoodRow.tsx
+++ b/web/src/components/nutrition/FoodRow.tsx
@@ -24,9 +24,15 @@ export interface FoodRowProps {
   onRemove: () => void;
   onNoteChange?: (note: string) => void;
   accentColor?: string;
+  /**
+   * When true the amount input is read-only and the remove button is hidden.
+   * Preserves text legibility — does NOT apply disabled styling.
+   * Used when the parent meal has been confirmed as eaten by the client.
+   */
+  readOnly?: boolean;
 }
 
-export function FoodRow({ food, mealId, dayOfWeek, weekNumber, onAmountChange, onRemove, onNoteChange, accentColor: _accentColor }: FoodRowProps) {
+export function FoodRow({ food, mealId, dayOfWeek, weekNumber, onAmountChange, onRemove, onNoteChange, accentColor: _accentColor, readOnly = false }: FoodRowProps) {
   const { t } = useTranslation();
   const accentColor = CATEGORY_COLORS[food.category ?? ''] ?? _accentColor;
   const [localAmount, setLocalAmount] = useState(String(food.amount));
@@ -111,19 +117,22 @@ export function FoodRow({ food, mealId, dayOfWeek, weekNumber, onAmountChange, o
             type="text"
             inputMode="decimal"
             value={localAmount}
-            onChange={(e) => setLocalAmount(e.target.value)}
-            onBlur={handleBlur}
-            onKeyDown={(e) => { if (e.key === 'Enter') inputRef.current?.blur(); }}
+            readOnly={readOnly}
+            onChange={readOnly ? undefined : (e) => setLocalAmount(e.target.value)}
+            onBlur={readOnly ? undefined : handleBlur}
+            onKeyDown={readOnly ? undefined : (e) => { if (e.key === 'Enter') inputRef.current?.blur(); }}
             className="w-12 bg-transparent text-xs text-text3 rounded-sm px-[3px] py-[1px] outline-none text-right transition-colors hover:bg-bg-hover focus:bg-bg-active focus:ring-1 focus:ring-border-md"
           />
           <span className="text-[11px] text-text4">{food.unit ?? 'g'}</span>
-          <button
-            type="button"
-            onClick={onRemove}
-            className="text-[11px] text-text4 cursor-pointer transition-all hover:text-red shrink-0 ml-1"
-          >
-            ✕
-          </button>
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="text-[11px] text-text4 cursor-pointer transition-all hover:text-red shrink-0 ml-1"
+            >
+              ✕
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/components/nutrition/MealBlock.tsx
+++ b/web/src/components/nutrition/MealBlock.tsx
@@ -6,6 +6,8 @@ import { FoodSearch } from './FoodSearch';
 import { RecipeRow } from './RecipeRow';
 import { RecipeSearch } from './RecipeSearch';
 import { MEAL_KIND_CONFIG, type MealKind } from './meal-kind';
+import { CompletionBadge } from '@/components/training/CompletionBadge';
+import type { MealCompletionState } from '@/lib/completionState';
 
 function MealDropZone({ mealId, itemIds, onItemDrop, onReorder, children }: {
   mealId?: string;
@@ -149,6 +151,16 @@ export interface MealBlockProps {
   onTimeChange?: (time: string) => void;
   onDuplicate?: () => void;
   onRemove?: () => void;
+  /**
+   * When true the meal has been confirmed eaten by the client.
+   * Hides remove/add affordances and makes all food/recipe rows read-only.
+   */
+  locked?: boolean;
+  /**
+   * The client-side completion state of this meal. When 'eaten', an inline
+   * badge is rendered next to the meal title in the header row.
+   */
+  completionState?: MealCompletionState;
 }
 
 export function MealBlock({
@@ -176,6 +188,8 @@ export function MealBlock({
   onDuplicate,
   onRemove,
   note,
+  locked = false,
+  completionState,
 }: MealBlockProps) {
   const { t } = useTranslation();
   const accentColor = MEAL_KIND_CONFIG[kind as MealKind]?.color;
@@ -214,7 +228,12 @@ export function MealBlock({
         >
           ▶
         </span>
-        <span className="flex-1 min-w-0 text-[13px] font-semibold truncate">{t(`mealKind.${kind}`)}</span>
+        <span className="flex-1 min-w-0 flex items-center gap-1.5 overflow-hidden">
+          <span className="text-[13px] font-semibold truncate">{t(`mealKind.${kind}`)}</span>
+          {completionState === 'eaten' && (
+            <CompletionBadge kind="meal" state="eaten" />
+          )}
+        </span>
         {onTimeChange && (
           <input
             type="time"
@@ -258,7 +277,7 @@ export function MealBlock({
             ⧉
           </button>
         )}
-        {onRemove && (
+        {onRemove && !locked && (
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onRemove(); }}
@@ -303,6 +322,7 @@ export function MealBlock({
                 onRemove={() => onFoodRemove(food.id)}
                 onNoteChange={onFoodNoteChange ? (n) => onFoodNoteChange(food.id, n) : undefined}
                 accentColor={accentColor}
+                readOnly={locked}
               />
             ))}
 
@@ -318,6 +338,7 @@ export function MealBlock({
                 onRemove={() => onRecipeRemove?.(recipe.recipeId)}
                 onNoteChange={onRecipeNoteChange ? (n) => onRecipeNoteChange(recipe.recipeId, n) : undefined}
                 accentColor={accentColor}
+                readOnly={locked}
               />
             ))}
           </MealDropZone>

--- a/web/src/components/nutrition/MealCard.tsx
+++ b/web/src/components/nutrition/MealCard.tsx
@@ -4,15 +4,20 @@ import { useNutritionPlanStore } from '@/stores/nutritionPlan';
 import type { PlanMeal, MealFood } from '@/api/plan-types';
 import AddItemsDrawer from './AddItemsDrawer';
 import { MealKindBadge } from './MealKindBadge';
+import { CompletionBadge } from '@/components/training/CompletionBadge';
 
 interface MealCardProps {
   meal: PlanMeal;
   weekNumber: number;
   dayOfWeek: number;
   targetKcal?: number | null;
+  /** When true: hide remove-meal, hide add-items, make food amounts read-only. */
+  locked?: boolean;
+  /** 'eaten' renders the completion badge; omit or 'not-touched' renders nothing. */
+  completionState?: 'eaten' | 'not-touched';
 }
 
-export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: MealCardProps) {
+export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, locked = false, completionState = 'not-touched' }: MealCardProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -48,6 +53,9 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: Me
           {targetKcal != null && (
             <span className="text-[9px] text-text3 shrink-0">target {Math.round(targetKcal)}</span>
           )}
+          {completionState === 'eaten' && (
+            <CompletionBadge kind="meal" state="eaten" />
+          )}
         </div>
 
         {meal.time && <span className="text-[11px] text-text3 shrink-0">{meal.time}</span>}
@@ -61,13 +69,15 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: Me
           <span className="text-xs font-medium text-green-400 shrink-0">{totalKcal} kcal</span>
         )}
 
-        <button
-          onClick={() => removeMeal(weekNumber, dayOfWeek, meal.mealId)}
-          className="ml-1 text-xs text-text3 transition-colors hover:text-red-400"
-          title={t('nutrition.remove')}
-        >
-          &times;
-        </button>
+        {!locked && (
+          <button
+            onClick={() => removeMeal(weekNumber, dayOfWeek, meal.mealId)}
+            className="ml-1 text-xs text-text3 transition-colors hover:text-red-400"
+            title={t('nutrition.remove')}
+          >
+            &times;
+          </button>
+        )}
       </div>
 
       {/* Body */}
@@ -98,7 +108,8 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: Me
                           type="number"
                           min={0}
                           value={food.amountGrams}
-                          onChange={(e) =>
+                          readOnly={locked}
+                          onChange={locked ? undefined : (e) =>
                             updateFoodAmount(
                               weekNumber,
                               dayOfWeek,
@@ -126,14 +137,16 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: Me
                         {Math.round((food.nutrientValuePer100Grams.fiber ?? 0) * scale)}
                       </td>
                       <td className="py-1.5 text-right">
-                        <button
-                          onClick={() =>
-                            removeFood(weekNumber, dayOfWeek, meal.mealId, food.foodExternalId)
-                          }
-                          className="text-text3 transition-colors hover:text-red-400"
-                        >
-                          &times;
-                        </button>
+                        {!locked && (
+                          <button
+                            onClick={() =>
+                              removeFood(weekNumber, dayOfWeek, meal.mealId, food.foodExternalId)
+                            }
+                            className="text-text3 transition-colors hover:text-red-400"
+                          >
+                            &times;
+                          </button>
+                        )}
                       </td>
                     </tr>
                   );
@@ -148,19 +161,23 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: Me
       {/* Spacer to push button to bottom */}
       <div className="flex-1" />
 
-      {/* Add items button — always visible at bottom */}
-      <button
-        onClick={() => setDrawerOpen(true)}
-        className="shrink-0 w-full border-t border-border bg-bg3 py-1.5 text-[9px] font-semibold uppercase text-text3 transition-colors hover:text-accent"
-      >
-        + {t('nutrition.addItems', 'Add Items')}
-      </button>
+      {/* Add items button — hidden when meal is locked (already eaten) */}
+      {!locked && (
+        <>
+          <button
+            onClick={() => setDrawerOpen(true)}
+            className="shrink-0 w-full border-t border-border bg-bg3 py-1.5 text-[9px] font-semibold uppercase text-text3 transition-colors hover:text-accent"
+          >
+            + {t('nutrition.addItems', 'Add Items')}
+          </button>
 
-      <AddItemsDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        onAdd={handleAddItems}
-      />
+          <AddItemsDrawer
+            open={drawerOpen}
+            onClose={() => setDrawerOpen(false)}
+            onAdd={handleAddItems}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/web/src/components/nutrition/MealCard.tsx
+++ b/web/src/components/nutrition/MealCard.tsx
@@ -4,20 +4,15 @@ import { useNutritionPlanStore } from '@/stores/nutritionPlan';
 import type { PlanMeal, MealFood } from '@/api/plan-types';
 import AddItemsDrawer from './AddItemsDrawer';
 import { MealKindBadge } from './MealKindBadge';
-import { CompletionBadge } from '@/components/training/CompletionBadge';
 
 interface MealCardProps {
   meal: PlanMeal;
   weekNumber: number;
   dayOfWeek: number;
   targetKcal?: number | null;
-  /** When true: hide remove-meal, hide add-items, make food amounts read-only. */
-  locked?: boolean;
-  /** 'eaten' renders the completion badge; omit or 'not-touched' renders nothing. */
-  completionState?: 'eaten' | 'not-touched';
 }
 
-export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, locked = false, completionState = 'not-touched' }: MealCardProps) {
+export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal }: MealCardProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(true);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -53,9 +48,6 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, lock
           {targetKcal != null && (
             <span className="text-[9px] text-text3 shrink-0">target {Math.round(targetKcal)}</span>
           )}
-          {completionState === 'eaten' && (
-            <CompletionBadge kind="meal" state="eaten" />
-          )}
         </div>
 
         {meal.time && <span className="text-[11px] text-text3 shrink-0">{meal.time}</span>}
@@ -69,15 +61,13 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, lock
           <span className="text-xs font-medium text-green-400 shrink-0">{totalKcal} kcal</span>
         )}
 
-        {!locked && (
-          <button
-            onClick={() => removeMeal(weekNumber, dayOfWeek, meal.mealId)}
-            className="ml-1 text-xs text-text3 transition-colors hover:text-red-400"
-            title={t('nutrition.remove')}
-          >
-            &times;
-          </button>
-        )}
+        <button
+          onClick={() => removeMeal(weekNumber, dayOfWeek, meal.mealId)}
+          className="ml-1 text-xs text-text3 transition-colors hover:text-red-400"
+          title={t('nutrition.remove')}
+        >
+          &times;
+        </button>
       </div>
 
       {/* Body */}
@@ -108,8 +98,7 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, lock
                           type="number"
                           min={0}
                           value={food.amountGrams}
-                          readOnly={locked}
-                          onChange={locked ? undefined : (e) =>
+                          onChange={(e) =>
                             updateFoodAmount(
                               weekNumber,
                               dayOfWeek,
@@ -137,16 +126,14 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, lock
                         {Math.round((food.nutrientValuePer100Grams.fiber ?? 0) * scale)}
                       </td>
                       <td className="py-1.5 text-right">
-                        {!locked && (
-                          <button
-                            onClick={() =>
-                              removeFood(weekNumber, dayOfWeek, meal.mealId, food.foodExternalId)
-                            }
-                            className="text-text3 transition-colors hover:text-red-400"
-                          >
-                            &times;
-                          </button>
-                        )}
+                        <button
+                          onClick={() =>
+                            removeFood(weekNumber, dayOfWeek, meal.mealId, food.foodExternalId)
+                          }
+                          className="text-text3 transition-colors hover:text-red-400"
+                        >
+                          &times;
+                        </button>
                       </td>
                     </tr>
                   );
@@ -161,23 +148,18 @@ export default function MealCard({ meal, weekNumber, dayOfWeek, targetKcal, lock
       {/* Spacer to push button to bottom */}
       <div className="flex-1" />
 
-      {/* Add items button — hidden when meal is locked (already eaten) */}
-      {!locked && (
-        <>
-          <button
-            onClick={() => setDrawerOpen(true)}
-            className="shrink-0 w-full border-t border-border bg-bg3 py-1.5 text-[9px] font-semibold uppercase text-text3 transition-colors hover:text-accent"
-          >
-            + {t('nutrition.addItems', 'Add Items')}
-          </button>
+      <button
+        onClick={() => setDrawerOpen(true)}
+        className="shrink-0 w-full border-t border-border bg-bg3 py-1.5 text-[9px] font-semibold uppercase text-text3 transition-colors hover:text-accent"
+      >
+        + {t('nutrition.addItems', 'Add Items')}
+      </button>
 
-          <AddItemsDrawer
-            open={drawerOpen}
-            onClose={() => setDrawerOpen(false)}
-            onAdd={handleAddItems}
-          />
-        </>
-      )}
+      <AddItemsDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        onAdd={handleAddItems}
+      />
     </div>
   );
 }

--- a/web/src/components/nutrition/RecipeRow.tsx
+++ b/web/src/components/nutrition/RecipeRow.tsx
@@ -23,9 +23,14 @@ export interface RecipeRowProps {
   onRemove: () => void;
   onNoteChange?: (note: string) => void;
   accentColor?: string;
+  /**
+   * When true the servings input is read-only and the remove button is hidden.
+   * Used when the parent meal has been confirmed as eaten by the client.
+   */
+  readOnly?: boolean;
 }
 
-export function RecipeRow({ recipe, mealId, dayOfWeek, weekNumber, onServingsChange, onRemove, onNoteChange, accentColor }: RecipeRowProps) {
+export function RecipeRow({ recipe, mealId, dayOfWeek, weekNumber, onServingsChange, onRemove, onNoteChange, accentColor, readOnly = false }: RecipeRowProps) {
   const { t } = useTranslation();
   const [localServings, setLocalServings] = useState(String(recipe.servings));
   const [localNote, setLocalNote] = useState(recipe.note ?? '');
@@ -106,19 +111,22 @@ export function RecipeRow({ recipe, mealId, dayOfWeek, weekNumber, onServingsCha
             type="text"
             inputMode="decimal"
             value={localServings}
-            onChange={(e) => setLocalServings(e.target.value)}
-            onBlur={handleBlur}
-            onKeyDown={(e) => { if (e.key === 'Enter') inputRef.current?.blur(); }}
+            readOnly={readOnly}
+            onChange={readOnly ? undefined : (e) => setLocalServings(e.target.value)}
+            onBlur={readOnly ? undefined : handleBlur}
+            onKeyDown={readOnly ? undefined : (e) => { if (e.key === 'Enter') inputRef.current?.blur(); }}
             className="w-10 bg-transparent text-xs text-text3 rounded-sm px-[3px] py-[1px] outline-none text-right transition-colors hover:bg-bg-hover focus:bg-bg-active focus:ring-1 focus:ring-border-md"
           />
           <span className="text-[11px] text-text4">{t('nutrition.servings')}</span>
-          <button
-            type="button"
-            onClick={onRemove}
-            className="text-[11px] text-text4 cursor-pointer transition-all hover:text-red shrink-0 ml-1"
-          >
-            ✕
-          </button>
+          {!readOnly && (
+            <button
+              type="button"
+              onClick={onRemove}
+              className="text-[11px] text-text4 cursor-pointer transition-all hover:text-red shrink-0 ml-1"
+            >
+              ✕
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/web/src/components/nutrition/SortableMealItem.tsx
+++ b/web/src/components/nutrition/SortableMealItem.tsx
@@ -4,6 +4,7 @@ import { MealBlock } from '@/components/nutrition';
 import type { MealBlockFood } from '@/components/nutrition';
 import type { PlanMeal } from '@/api/plan-types';
 import { resolveLocalizedName } from '@/lib/nutrition-helpers';
+import { CompletionBadge } from '@/components/training/CompletionBadge';
 
 interface SortableMealItemProps {
   meal: PlanMeal;
@@ -31,6 +32,13 @@ interface SortableMealItemProps {
   removeMealMessage: string;
   cancelLabel: string;
   removeLabel: string;
+  /**
+   * When true the meal has been confirmed eaten by the client.
+   * Hides the remove-meal button, the food/recipe search inputs, and
+   * shows the eaten CompletionBadge. The remove/add affordances pass
+   * undefined to MealBlock so it omits them conditionally.
+   */
+  locked?: boolean;
 }
 
 /** Sortable wrapper for a meal in the day list */
@@ -59,6 +67,7 @@ export function SortableMealItem({
   removeMealMessage,
   cancelLabel,
   removeLabel,
+  locked = false,
 }: SortableMealItemProps) {
 
   const mealFoods: MealBlockFood[] = meal.foods.map((f) => {
@@ -118,8 +127,14 @@ export function SortableMealItem({
       style={{
         borderTop: mealOver ? '2px solid var(--accent)' : '2px solid transparent',
         transition: 'border-color 0.1s',
+        position: 'relative',
       }}
     >
+      {locked && (
+        <div className="absolute right-8 top-2 z-10 pointer-events-none">
+          <CompletionBadge kind="meal" state="eaten" />
+        </div>
+      )}
       <MealBlock
         mealId={meal.mealId}
         dayOfWeek={dayOfWeek}
@@ -134,18 +149,18 @@ export function SortableMealItem({
         onFoodAmountChange={onFoodAmountChange}
         onFoodRemove={onFoodRemove}
         onFoodNoteChange={onFoodNoteChange}
-        onFoodSelect={onFoodSelect}
-        onRecipeSelect={onRecipeSelect}
-        onRecipeServingsChange={onRecipeServingsChange}
-        onRecipeRemove={onRecipeRemove}
+        onFoodSelect={locked ? undefined : onFoodSelect}
+        onRecipeSelect={locked ? undefined : onRecipeSelect}
+        onRecipeServingsChange={locked ? undefined : onRecipeServingsChange}
+        onRecipeRemove={locked ? undefined : onRecipeRemove}
         onRecipeNoteChange={onRecipeNoteChange}
         mealTotalKcal={meal.mealTotals?.kcal ?? 0}
         onNoteChange={onNoteChange}
-        onItemDrop={onItemDrop}
-        onReorder={onReorder}
-        onTimeChange={onTimeChange}
-        onDuplicate={onDuplicate}
-        onRemove={() => setConfirmRemove(true)}
+        onItemDrop={locked ? undefined : onItemDrop}
+        onReorder={locked ? undefined : onReorder}
+        onTimeChange={locked ? undefined : onTimeChange}
+        onDuplicate={locked ? undefined : onDuplicate}
+        onRemove={locked ? undefined : () => setConfirmRemove(true)}
       />
       <Dialog
         open={confirmRemove}

--- a/web/src/components/nutrition/SortableMealItem.tsx
+++ b/web/src/components/nutrition/SortableMealItem.tsx
@@ -4,7 +4,7 @@ import { MealBlock } from '@/components/nutrition';
 import type { MealBlockFood } from '@/components/nutrition';
 import type { PlanMeal } from '@/api/plan-types';
 import { resolveLocalizedName } from '@/lib/nutrition-helpers';
-import { CompletionBadge } from '@/components/training/CompletionBadge';
+import type { MealCompletionState } from '@/lib/completionState';
 
 interface SortableMealItemProps {
   meal: PlanMeal;
@@ -39,6 +39,10 @@ interface SortableMealItemProps {
    * undefined to MealBlock so it omits them conditionally.
    */
   locked?: boolean;
+  /**
+   * Client-side completion state forwarded to MealBlock for inline badge rendering.
+   */
+  completionState?: MealCompletionState;
 }
 
 /** Sortable wrapper for a meal in the day list */
@@ -68,6 +72,7 @@ export function SortableMealItem({
   cancelLabel,
   removeLabel,
   locked = false,
+  completionState,
 }: SortableMealItemProps) {
 
   const mealFoods: MealBlockFood[] = meal.foods.map((f) => {
@@ -130,11 +135,6 @@ export function SortableMealItem({
         position: 'relative',
       }}
     >
-      {locked && (
-        <div className="absolute right-8 top-2 z-10 pointer-events-none">
-          <CompletionBadge kind="meal" state="eaten" />
-        </div>
-      )}
       <MealBlock
         mealId={meal.mealId}
         dayOfWeek={dayOfWeek}
@@ -161,6 +161,8 @@ export function SortableMealItem({
         onTimeChange={locked ? undefined : onTimeChange}
         onDuplicate={locked ? undefined : onDuplicate}
         onRemove={locked ? undefined : () => setConfirmRemove(true)}
+        locked={locked}
+        completionState={completionState}
       />
       <Dialog
         open={confirmRemove}

--- a/web/src/components/training/CompletionBadge.tsx
+++ b/web/src/components/training/CompletionBadge.tsx
@@ -5,6 +5,9 @@ import type {
   SessionCompletionState,
   ExerciseCounts,
   SessionCounts,
+  MealCompletionState,
+  DayCompletionState,
+  DayCompletionCounts,
 } from '@/lib/completionState';
 
 // ── Inline SVG icon atoms ────────────────────────────────────────────────────
@@ -122,7 +125,34 @@ type SessionBadgeProps = {
   counts?: SessionCounts;
 };
 
-export type CompletionBadgeProps = SetBadgeProps | ExerciseBadgeProps | SessionBadgeProps;
+/**
+ * Nutrition: single-meal eaten indicator.
+ * 'not-touched' → nothing rendered (returns null).
+ * 'eaten'       → accent pill with CheckCircle2.
+ */
+type MealBadgeProps = {
+  kind: 'meal';
+  state: MealCompletionState;
+  counts?: undefined;
+};
+
+/**
+ * Nutrition: day-level aggregate eaten indicator.
+ * 'not-touched' → nothing rendered (returns null).
+ * 'all-eaten'   → accent pill with CheckCircle2 + interpolated count string.
+ */
+type DayBadgeProps = {
+  kind: 'day';
+  state: DayCompletionState;
+  counts?: DayCompletionCounts;
+};
+
+export type CompletionBadgeProps =
+  | SetBadgeProps
+  | ExerciseBadgeProps
+  | SessionBadgeProps
+  | MealBadgeProps
+  | DayBadgeProps;
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -148,6 +178,12 @@ export function CompletionBadge(props: CompletionBadgeProps) {
   }
   if (props.kind === 'exercise') {
     return <ExerciseBadge state={props.state} counts={props.counts} t={t} />;
+  }
+  if (props.kind === 'meal') {
+    return <MealBadge state={props.state} t={t} />;
+  }
+  if (props.kind === 'day') {
+    return <DayBadge state={props.state} counts={props.counts} t={t} />;
   }
   return <SessionBadge state={props.state} counts={props.counts} t={t} />;
 }
@@ -233,6 +269,60 @@ function ExerciseBadge({
         <IconAlertCircle size={12} />
         {counts.skipped}
       </span>
+    </span>
+  );
+}
+
+// ── Meal badge (nutrition) ───────────────────────────────────────────────────
+
+function MealBadge({
+  state,
+  t,
+}: {
+  state: MealCompletionState;
+  t: ReturnType<typeof useTranslation>['t'];
+}) {
+  if (state === 'not-touched') return null;
+
+  // 'eaten'
+  const label = t('nutrition.completionState.mealEaten');
+  return (
+    <span
+      className={accentPill}
+      aria-label={label}
+      title={label}
+    >
+      <IconCheckCircle2 size={12} />
+      {label}
+    </span>
+  );
+}
+
+// ── Day badge (nutrition) ────────────────────────────────────────────────────
+
+function DayBadge({
+  state,
+  counts,
+  t,
+}: {
+  state: DayCompletionState;
+  counts?: DayCompletionCounts;
+  t: ReturnType<typeof useTranslation>['t'];
+}) {
+  if (state === 'not-touched') return null;
+
+  // 'all-eaten'
+  const label = counts
+    ? t('nutrition.completionState.dayAllEaten', { eaten: counts.eaten, total: counts.total })
+    : t('nutrition.completionState.mealEaten');
+  return (
+    <span
+      className={accentPill}
+      aria-label={label}
+      title={label}
+    >
+      <IconCheckCircle2 size={12} />
+      {label}
     </span>
   );
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -888,7 +888,12 @@
     "activity_hiit": "HIIT",
     "activity_yoga": "Jóga",
     "activity_cycling": "Cyklistika",
-    "activity_martial_arts": "Bojové sporty"
+    "activity_martial_arts": "Bojové sporty",
+    "completionState": {
+      "mealEaten": "Snědeno",
+      "dayAllEaten": "{{eaten}}/{{total}} jídel snědeno",
+      "mealLockedTooltip": "Toto jídlo bylo klientem označeno jako snědené a nelze jej upravovat."
+    }
   },
   "training": {
     "title": "Tréninkové plány",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -878,7 +878,12 @@
     "activity_hiit": "HIIT",
     "activity_yoga": "Yoga",
     "activity_cycling": "Radfahren",
-    "activity_martial_arts": "Kampfsport"
+    "activity_martial_arts": "Kampfsport",
+    "completionState": {
+      "mealEaten": "Gegessen",
+      "dayAllEaten": "{{eaten}}/{{total}} Mahlzeiten gegessen",
+      "mealLockedTooltip": "Diese Mahlzeit wurde vom Klienten als gegessen bestätigt und kann nicht bearbeitet werden."
+    }
   },
   "training": {
     "title": "Trainingspläne",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -879,7 +879,12 @@
     "activity_hiit": "HIIT",
     "activity_yoga": "Yoga",
     "activity_cycling": "Cycling",
-    "activity_martial_arts": "Martial arts"
+    "activity_martial_arts": "Martial arts",
+    "completionState": {
+      "mealEaten": "Eaten",
+      "dayAllEaten": "{{eaten}}/{{total}} meals eaten",
+      "mealLockedTooltip": "This meal has been confirmed as eaten by the client and cannot be edited."
+    }
   },
   "training": {
     "title": "Training Plans",

--- a/web/src/lib/completionState.ts
+++ b/web/src/lib/completionState.ts
@@ -1,17 +1,26 @@
 /**
- * Completion-state derivation helpers for training plan set/exercise/session display.
+ * Completion-state derivation helpers for training plan set/exercise/session display,
+ * and nutrition plan meal/day eaten-state display.
  *
- * The backend never stores completion state flags — it surfaces the raw execution
- * data (CompletedSetsByExercise + IsSessionFinished) from WorkoutLog documents.
- * This module derives the visual states from those primitives.
+ * Training plan:
+ *   The backend never stores completion state flags — it surfaces the raw execution
+ *   data (CompletedSetsByExercise + IsSessionFinished) from WorkoutLog documents.
+ *   This module derives the visual states from those primitives.
  *
- * Disambiguation rules (per backend SessionExecutionDto docstring):
- *   completed      → set's 1-based index is in completedSetsByExercise[exerciseId]
- *   skipped        → isSessionFinished=true AND index NOT in the list
- *   not-yet-reached → isSessionFinished=false (or no execution row for the session)
+ *   Disambiguation rules (per backend SessionExecutionDto docstring):
+ *     completed      → set's 1-based index is in completedSetsByExercise[exerciseId]
+ *     skipped        → isSessionFinished=true AND index NOT in the list
+ *     not-yet-reached → isSessionFinished=false (or no execution row for the session)
+ *
+ * Nutrition plan:
+ *   Eaten state is derived from MealLogDto[] returned by GET /nutrition/plans/{planId}.
+ *   A meal is 'eaten' iff its log entry has isEaten=true.
+ *   A day is 'all-eaten' iff every planned mealId in the day resolves to 'eaten'.
+ *   Meals/days with no log entry are 'not-touched'.
  */
 
 import type { SessionExecutionDto } from '@/api/training-plan-types';
+import type { MealLogDto } from '@/api/plan-types';
 
 // ── Per-set state ────────────────────────────────────────────────────────────
 
@@ -139,4 +148,66 @@ export function deriveSessionCompletionState(
   }
 
   return { state: 'in-progress', counts };
+}
+
+// ── Nutrition plan: per-meal eaten state ─────────────────────────────────────
+
+export type MealCompletionState = 'eaten' | 'not-touched';
+
+/**
+ * Derive the eaten state for a single planned meal.
+ *
+ * A meal is 'eaten' iff at least one MealLogDto exists for the given mealId
+ * with isEaten === true. The logDate is not used for matching — any log entry
+ * with isEaten for this mealId counts. Photo-only stubs (isEaten=false) are
+ * treated the same as no log entry.
+ *
+ * @param mealLogs  Full list from NutritionPlanDetail.mealLogs (may be empty)
+ * @param mealId    The PlanMeal.mealId to check
+ */
+export function deriveMealCompletionState(
+  mealLogs: MealLogDto[] | undefined,
+  mealId: string,
+): MealCompletionState {
+  if (!mealLogs || mealLogs.length === 0) return 'not-touched';
+  const hasEaten = mealLogs.some((log) => log.mealId === mealId && log.isEaten);
+  return hasEaten ? 'eaten' : 'not-touched';
+}
+
+// ── Nutrition plan: per-day eaten state ─────────────────────────────────────
+
+export type DayCompletionState = 'all-eaten' | 'not-touched';
+
+export interface DayCompletionCounts {
+  eaten: number;
+  total: number;
+}
+
+/**
+ * Derive the day-level eaten state from the list of meal ids in a day.
+ *
+ * 'all-eaten' iff every mealId in mealIdsInDay resolves to 'eaten'.
+ * Returns 'not-touched' if the day has no meals or none are eaten.
+ *
+ * @param mealLogs      Full list from NutritionPlanDetail.mealLogs
+ * @param mealIdsInDay  All PlanMeal.mealId values present in the day
+ */
+export function deriveDayCompletionState(
+  mealLogs: MealLogDto[] | undefined,
+  mealIdsInDay: string[],
+): { state: DayCompletionState; counts: DayCompletionCounts } {
+  const total = mealIdsInDay.length;
+  if (total === 0) {
+    return { state: 'not-touched', counts: { eaten: 0, total: 0 } };
+  }
+
+  let eaten = 0;
+  for (const mealId of mealIdsInDay) {
+    if (deriveMealCompletionState(mealLogs, mealId) === 'eaten') {
+      eaten++;
+    }
+  }
+
+  const state: DayCompletionState = eaten === total ? 'all-eaten' : 'not-touched';
+  return { state, counts: { eaten, total } };
 }

--- a/web/src/lib/nutrition-plan-locks.ts
+++ b/web/src/lib/nutrition-plan-locks.ts
@@ -1,0 +1,71 @@
+import type { NutritionPlanDetail, MealLogDto } from '@/api/plan-types';
+import { deriveMealCompletionState } from '@/lib/completionState';
+
+/**
+ * Derived "locked" sets that reflect which meals/days the client has already
+ * confirmed as eaten. Trainers must not edit locked meals — past intake data
+ * would be invalidated.
+ *
+ *   mealIds  — PlanMeal.mealId values for meals where deriveMealCompletionState
+ *              returns 'eaten'.
+ *   dayKeys  — `${weekNumber}:${dayOfWeek}` keys for days where EVERY planned
+ *              meal in that day is locked (i.e. all are 'eaten').
+ *
+ * The keys are stable for a given plan + mealLogs snapshot, so memoizing on
+ * `plan` and `mealLogs` in components is enough.
+ */
+export interface NutritionPlanLocks {
+  mealIds: Set<string>;
+  dayKeys: Set<string>;
+}
+
+const EMPTY_LOCKS: NutritionPlanLocks = {
+  mealIds: new Set(),
+  dayKeys: new Set(),
+};
+
+/**
+ * Build the day key used to look up whether an entire day is locked.
+ */
+export function dayLockKey(weekNumber: number, dayOfWeek: number): string {
+  return `${weekNumber}:${dayOfWeek}`;
+}
+
+/**
+ * Compute the full lock map for a nutrition plan from its meal logs.
+ * Pure function — no React, no side effects.
+ *
+ * @param plan      The NutritionPlanDetail (drives the meal list to check)
+ * @param mealLogs  The MealLogDto[] from the same response
+ */
+export function computeNutritionPlanLocks(
+  plan: NutritionPlanDetail | null,
+  mealLogs: MealLogDto[],
+): NutritionPlanLocks {
+  if (!plan || mealLogs.length === 0) return EMPTY_LOCKS;
+
+  const mealIds = new Set<string>();
+  const dayKeys = new Set<string>();
+
+  for (const week of plan.weeks) {
+    for (const day of week.days) {
+      if (day.meals.length === 0) continue;
+
+      let allLocked = true;
+      for (const meal of day.meals) {
+        const state = deriveMealCompletionState(mealLogs, meal.mealId);
+        if (state === 'eaten') {
+          mealIds.add(meal.mealId);
+        } else {
+          allLocked = false;
+        }
+      }
+
+      if (allLocked) {
+        dayKeys.add(dayLockKey(week.weekNumber, day.dayOfWeek));
+      }
+    }
+  }
+
+  return { mealIds, dayKeys };
+}

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -4,6 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useNutritionPlanStore } from '@/stores/nutritionPlan';
 import { getPlan, completePlan } from '@/api/plans';
+import { computeNutritionPlanLocks } from '@/lib/nutrition-plan-locks';
+import { deriveDayCompletionState } from '@/lib/completionState';
+import { CompletionBadge } from '@/components/training/CompletionBadge';
 import { PlanQuestionnairePanel } from '@/components/questionnaire/PlanQuestionnairePanel';
 import { getClientDashboard } from '@/api/nutrition-goals';
 import { PageHeader } from '@/components/layout';
@@ -128,6 +131,14 @@ export default function NutritionPlanPage() {
       fiber: gs?.fiberGrams ?? ob?.fiberGrams ?? 25,
     };
   }, [plan?.globalSettings, clientDashboard]);
+
+  // ── Nutrition plan locks (eaten meals) ──
+  const mealLogs = plan?.mealLogs ?? [];
+  const planLocks = useMemo(
+    () => computeNutritionPlanLocks(plan ?? null, mealLogs),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [plan, mealLogs],
+  );
 
   // ── Warn before unload ──
   useEffect(() => {
@@ -547,6 +558,17 @@ export default function NutritionPlanPage() {
                     {day.badge}
                   </span>
                 )}
+                {(() => {
+                  const dayData = currentWeek?.days.find((d) => d.dayOfWeek === day.index);
+                  const dayMealIds = (dayData?.meals ?? []).map((m) => m.mealId);
+                  const { state: dayState, counts: dayCounts } = deriveDayCompletionState(mealLogs, dayMealIds);
+                  if (dayState === 'not-touched') return null;
+                  return (
+                    <span className="ml-1 inline-flex">
+                      <CompletionBadge kind="day" state={dayState} counts={dayCounts} />
+                    </span>
+                  );
+                })()}
               </button>
             ))}
             {/* Expand week overview toggle */}
@@ -751,6 +773,7 @@ export default function NutritionPlanPage() {
                 removeMealMessage={t('nutrition.removeMealMessage', { name: t(`mealKind.${meal.kind}`) })}
                 cancelLabel={t('common.cancel')}
                 removeLabel={t('nutrition.remove')}
+                locked={planLocks.mealIds.has(meal.mealId)}
               />
             ))}
             </div>

--- a/web/src/pages/NutritionPlanPage.tsx
+++ b/web/src/pages/NutritionPlanPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useNutritionPlanStore } from '@/stores/nutritionPlan';
 import { getPlan, completePlan } from '@/api/plans';
 import { computeNutritionPlanLocks } from '@/lib/nutrition-plan-locks';
-import { deriveDayCompletionState } from '@/lib/completionState';
+import { deriveDayCompletionState, deriveMealCompletionState } from '@/lib/completionState';
 import { CompletionBadge } from '@/components/training/CompletionBadge';
 import { PlanQuestionnairePanel } from '@/components/questionnaire/PlanQuestionnairePanel';
 import { getClientDashboard } from '@/api/nutrition-goals';
@@ -774,6 +774,7 @@ export default function NutritionPlanPage() {
                 cancelLabel={t('common.cancel')}
                 removeLabel={t('nutrition.remove')}
                 locked={planLocks.mealIds.has(meal.mealId)}
+                completionState={deriveMealCompletionState(mealLogs, meal.mealId)}
               />
             ))}
             </div>


### PR DESCRIPTION
## Summary

- **Backend** (`scope:backend`) — `GET /nutrition/plans/{planId}` now folds in `mealLogs: MealLogDto[]` from `MealLog` documents filtered by `PlanId`. `IsEaten = EatenAt.HasValue` is derived at read-time; no field added to the document. Ownership gate runs before the log query (no IDOR risk). 5 new Testcontainers tests cover the design handoff's error_paths (no logs → empty array; EatenAt null → not eaten; EatenAt set → eaten; foreign nutritionist → 404 without log leak; whole day eaten → all entries IsEaten=true).
- **Web** (`scope:web`) — `CompletionBadge` extended with `kind='meal'` (`'eaten' | 'not-touched'`) and `kind='day'` (`'all-eaten' | 'not-touched'` + counts). Existing `set`/`exercise`/`session` variants unchanged. New `web/src/lib/nutrition-plan-locks.ts` mirroring `training-plan-locks.ts`. Lock wiring: `NutritionPlanPage` → `SortableMealItem` → `MealBlock` (with `locked` + `completionState` props) → `FoodRow` / `RecipeRow` (with `readOnly`). Meal-level remove + add-food/recipe drawer triggers are hidden when locked; food + recipe amount/servings inputs become read-only and remove buttons disappear. Eaten badge renders inline in the meal header (no absolute overlay) for parity with #323.
- **i18n** — `nutrition.completionState.{mealEaten,dayAllEaten,mealLockedTooltip}` keys present in cs/en/de.

## Related issue

Fixes #329

## Scope

cross-cut: `backend` + `web` (one branch, one PR — mobile untouched, see `rules/scope-boundaries.md#cross-package-coordination`)

## QA verdict (from qa-tester)

OVERALL ✅ PASS — 8/8 acceptance criteria met. Backend: dotnet build clean, 7/7 GetPlanEndpointTests pass. Web: `npm run build` clean (vite 2.01s, NutritionPlanPage chunk 66.09 kB). i18n parity verified across cs/en/de. No hardcoded colors / spacing in the diff. The post-rework `7a7e3b0` re-validation confirmed the badge renders inline in the live `MealBlock` header (not the stale `MealCard` surface) and that `FoodRow` + `RecipeRow` both honour the `readOnly` prop end-to-end.

## Test plan

- [x] Trainer marks/edits a meal that has been confirmed eaten by the client → edit affordances are hidden (remove button, food/recipe search inputs, amount/servings inputs read-only).
- [x] Locked meal shows the inline `CompletionBadge kind='meal' state='eaten'` in the meal header, distinct from a not-yet-touched meal.
- [x] Whole-day eaten → every meal in that day shows the locked + marked treatment, and the day-level tab carries the `kind='day'` badge with `{eaten}/{total}` counts. No partial day states within a fully-eaten day.
- [x] Visual style is identical to the #323 treatment (accent pill + `CheckCircle2` icon, same `text-accent / bg-accent-bg / border-accent-br` token triplet).
- [x] All new strings (`mealEaten`, `dayAllEaten`, `mealLockedTooltip`) ship in cs / en / de.
- [x] Skipped / uneaten state is OUT of scope — meal state union is `'eaten' | 'not-touched'` only.
- [x] Future / not-yet-touched meals: edit behaviour preserved unchanged (default `locked=false` → all affordances live, default `completionState` → badge omitted).
- [x] Backend: ownership gate fires before the MealLog query — foreign nutritionist returns 404 without leaking log existence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)