### PR TITLE
feat: drinking regime — daily target, drink reminders, intake logging (#334)

### DIFF
--- a/mobile/app/(client)/(tabs)/_layout.tsx
+++ b/mobile/app/(client)/(tabs)/_layout.tsx
@@ -294,7 +294,8 @@ export default function ClientTabLayout() {
     pathname.match(/\/plans\/[^/]+$/) && !pathname.endsWith('/plans') ||
     pathname.endsWith('/pending-questionnaires') ||
     pathname.includes('/nutrition/') && !pathname.endsWith('/nutrition/index') ||
-    pathname.includes('/training/')
+    pathname.includes('/training/') ||
+    pathname.includes('/hydration/')
 
   return (
     <Tabs
@@ -348,6 +349,7 @@ export default function ClientTabLayout() {
       <Tabs.Screen name="training" options={{ href: null }} />
       <Tabs.Screen name="nutrition" options={{ href: null }} />
       <Tabs.Screen name="measurements" options={{ href: null }} />
+      <Tabs.Screen name="hydration" options={{ href: null }} />
       <Tabs.Screen name="pending-questionnaires" options={{ href: null }} />
     </Tabs>
   );

--- a/mobile/app/(client)/(tabs)/hydration/_layout.tsx
+++ b/mobile/app/(client)/(tabs)/hydration/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from 'expo-router'
+
+export default function HydrationLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  )
+}

--- a/mobile/app/(client)/(tabs)/hydration/index.tsx
+++ b/mobile/app/(client)/(tabs)/hydration/index.tsx
@@ -1,0 +1,352 @@
+/**
+ * HydrationScreen — daily water-intake tracking screen (#334).
+ *
+ * Sections:
+ *  1. Header bar with screen title.
+ *  2. Progress bar (today total / target).
+ *  3. Quick-log chips (preset amounts + custom sheet).
+ *  4. Today's drink log (sortable list with delete).
+ *  5. 7-day history strip.
+ *  6. Settings: daily target input + reminder slots list + "Add slot" button.
+ *
+ * Orphan-reminder cleanup: on mount, any reminder key whose slot index is ≥
+ * the current slot count is cancelled.
+ */
+
+import React, { useState, useCallback, useEffect, useRef } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import {
+  useHydrationStore,
+  selectTodayDrinks,
+  selectTodayTotalMl,
+} from '@/stores/hydrationStore'
+import { listReminderKeys, cancelReminder } from '@/lib/reminderScheduler'
+import { HydrationProgressBar } from '@/components/hydration/HydrationProgressBar'
+import { QuickLogChips } from '@/components/hydration/QuickLogChips'
+import { CustomAmountSheet } from '@/components/hydration/CustomAmountSheet'
+import { HydrationLogList } from '@/components/hydration/HydrationLogList'
+import { HydrationHistoryStrip } from '@/components/hydration/HydrationHistoryStrip'
+import { WaterReminderRow } from '@/components/hydration/WaterReminderRow'
+import { SectionHeader } from '@/components/ui/SectionHeader'
+
+const MAX_SLOTS = 8
+
+export default function HydrationScreen() {
+  const { t } = useTranslation()
+  const colors = useTheme()
+
+  // ── Store ──────────────────────────────────────────────────────────────────
+  const log = useHydrationStore((s) => s.log)
+  const targetMl = useHydrationStore((s) => s.targetMl)
+  const slots = useHydrationStore((s) => s.slots)
+  const addDrink = useHydrationStore((s) => s.addDrink)
+  const removeDrink = useHydrationStore((s) => s.removeDrink)
+  const setTarget = useHydrationStore((s) => s.setTarget)
+  const addSlot = useHydrationStore((s) => s.addSlot)
+  const removeSlot = useHydrationStore((s) => s.removeSlot)
+
+  // ── Derived ─────────────────────────────────────────────────────────────
+  const todayDrinks = selectTodayDrinks(log)
+  const todayTotal = selectTodayTotalMl(log)
+
+  // ── Custom-amount sheet state ──────────────────────────────────────────
+  const [customSheetVisible, setCustomSheetVisible] = useState(false)
+
+  // ── Target input (local editing state) ────────────────────────────────
+  const [targetInput, setTargetInput] = useState(String(targetMl))
+  // Sync local input if the store target changes externally (e.g. MMKV restore).
+  const prevTargetRef = useRef(targetMl)
+  useEffect(() => {
+    if (prevTargetRef.current !== targetMl) {
+      setTargetInput(String(targetMl))
+      prevTargetRef.current = targetMl
+    }
+  }, [targetMl])
+
+  const handleTargetBlur = useCallback(() => {
+    const parsed = parseInt(targetInput, 10)
+    if (!isNaN(parsed) && parsed > 0 && parsed <= 10_000) {
+      setTarget(parsed)
+      prevTargetRef.current = parsed
+    } else {
+      // Revert to the current store value if the entry is invalid.
+      setTargetInput(String(targetMl))
+    }
+  }, [targetInput, setTarget, targetMl])
+
+  // ── Quick-log handlers ────────────────────────────────────────────────
+  const handleLog = useCallback(
+    (amountMl: number) => {
+      addDrink(amountMl)
+    },
+    [addDrink],
+  )
+
+  const handleCustomConfirm = useCallback(
+    (amountMl: number) => {
+      addDrink(amountMl)
+      setCustomSheetVisible(false)
+    },
+    [addDrink],
+  )
+
+  // ── Orphan-reminder cleanup ───────────────────────────────────────────
+  // Cancel any reminder whose slot index is ≥ the current slot count.
+  // This handles cases where slots were removed while the app was backgrounded
+  // and the previous session's reminders were not cleaned up.
+  useEffect(() => {
+    const keys = listReminderKeys('water-slot-')
+    const slotCount = slots.length
+    for (const key of keys) {
+      // Key format: water-slot-<N>
+      const parts = key.split('-')
+      const idx = parseInt(parts[parts.length - 1], 10)
+      if (!isNaN(idx) && idx >= slotCount) {
+        cancelReminder(key).catch(() => {
+          // Best-effort; ignore failures.
+        })
+      }
+    }
+    // Run only when slot count changes (not on every render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slots.length])
+
+  const styles = makeStyles(colors)
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Screen title */}
+        <View style={styles.headerRow}>
+          <Text style={[styles.screenTitle, { color: colors.label }]}>
+            {t('hydration.screen.title')}
+          </Text>
+        </View>
+
+        {/* Progress */}
+        <View style={[styles.progressCard, { backgroundColor: colors.bg2 }]}>
+          <View style={styles.progressHeader}>
+            <Text style={[styles.progressLabel, { color: colors.label }]}>
+              {t('hydration.card.todayProgress', {
+                current: todayTotal,
+                target: targetMl,
+              })}
+            </Text>
+          </View>
+          <HydrationProgressBar
+            currentMl={todayTotal}
+            targetMl={targetMl}
+            barHeight={8}
+          />
+        </View>
+
+        {/* Quick-log chips */}
+        <View style={styles.chipsSection}>
+          <QuickLogChips
+            onLog={handleLog}
+            onCustomPress={() => setCustomSheetVisible(true)}
+          />
+        </View>
+
+        {/* Today's log */}
+        <View style={[styles.card, { backgroundColor: colors.bg2 }]}>
+          <HydrationLogList drinks={todayDrinks} onRemove={removeDrink} />
+        </View>
+
+        {/* 7-day history strip */}
+        <View style={[styles.card, { backgroundColor: colors.bg2 }]}>
+          <HydrationHistoryStrip log={log} targetMl={targetMl} />
+        </View>
+
+        {/* Settings section */}
+        <View style={styles.settingsSection}>
+          <SectionHeader title={t('hydration.settings.targetLabel')} />
+
+          {/* Target input */}
+          <View style={[styles.card, { backgroundColor: colors.bg2 }]}>
+            <View style={styles.targetRow}>
+              <Text style={[styles.targetLabel, { color: colors.label }]}>
+                {t('hydration.settings.targetLabel')}
+              </Text>
+              <View style={styles.targetInputWrap}>
+                <TextInput
+                  style={[
+                    styles.targetInput,
+                    {
+                      color: colors.label,
+                      backgroundColor: colors.fill,
+                      borderColor: colors.sep,
+                    },
+                  ]}
+                  keyboardType="number-pad"
+                  value={targetInput}
+                  onChangeText={setTargetInput}
+                  onBlur={handleTargetBlur}
+                  maxLength={5}
+                  returnKeyType="done"
+                  onSubmitEditing={handleTargetBlur}
+                  accessibilityLabel={t('hydration.settings.targetLabel')}
+                />
+                <Text style={[styles.targetSuffix, { color: colors.label2 }]}>
+                  {t('hydration.settings.targetSuffix')}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {/* Reminder slots */}
+          <SectionHeader title={t('hydration.settings.remindersLabel')} />
+
+          <View style={[styles.card, { backgroundColor: colors.bg2 }]}>
+            {slots.map((_, idx) => (
+              <WaterReminderRow key={idx} index={idx} onRemove={removeSlot} />
+            ))}
+
+            {/* Add slot button — disabled when cap reached */}
+            {slots.length < MAX_SLOTS && (
+              <Pressable
+                onPress={addSlot}
+                style={({ pressed }) => [
+                  styles.addSlotBtn,
+                  { borderTopColor: colors.sep, opacity: pressed ? 0.7 : 1 },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={t('hydration.settings.addSlot')}
+              >
+                <Text style={[styles.addSlotLabel, { color: colors.gold }]}>
+                  {t('hydration.settings.addSlot')}
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+
+        {/* Bottom padding */}
+        <View style={styles.bottomPad} />
+      </ScrollView>
+
+      {/* Custom amount sheet */}
+      <CustomAmountSheet
+        visible={customSheetVisible}
+        onConfirm={handleCustomConfirm}
+        onDismiss={() => setCustomSheetVisible(false)}
+      />
+    </KeyboardAvoidingView>
+  )
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    flex: {
+      flex: 1,
+      backgroundColor: colors.bg,
+    },
+    scroll: {
+      flex: 1,
+    },
+    content: {
+      paddingTop: 8,
+      gap: 12,
+    },
+    headerRow: {
+      paddingHorizontal: 20,
+      paddingVertical: 6,
+    },
+    screenTitle: {
+      ...Type.largeTitle,
+      fontWeight: '700',
+    },
+    progressCard: {
+      marginHorizontal: 16,
+      borderRadius: Radius.lg,
+      paddingHorizontal: 16,
+      paddingVertical: 14,
+      gap: 10,
+    },
+    progressHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    progressLabel: {
+      ...Type.headline,
+      fontWeight: '600',
+    },
+    chipsSection: {
+      marginHorizontal: 0,
+    },
+    card: {
+      marginHorizontal: 16,
+      borderRadius: Radius.lg,
+      overflow: 'hidden',
+    },
+    settingsSection: {
+      gap: 12,
+    },
+    targetRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+    },
+    targetLabel: {
+      ...Type.body,
+    },
+    targetInputWrap: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    targetInput: {
+      width: 80,
+      height: 36,
+      borderRadius: Radius.md,
+      borderWidth: 1,
+      paddingHorizontal: 10,
+      textAlign: 'center',
+      ...Type.body,
+    },
+    targetSuffix: {
+      ...Type.body,
+      fontWeight: '600',
+    },
+    addSlotBtn: {
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      alignItems: 'center',
+    },
+    addSlotLabel: {
+      ...Type.subheadline,
+      fontWeight: '600',
+    },
+    bottomPad: {
+      height: 32,
+    },
+  })
+}

--- a/mobile/app/(client)/(tabs)/hydration/index.tsx
+++ b/mobile/app/(client)/(tabs)/hydration/index.tsx
@@ -9,8 +9,15 @@
  *  5. 7-day history strip.
  *  6. Settings: daily target input + reminder slots list + "Add slot" button.
  *
- * Orphan-reminder cleanup: on mount, any reminder key whose slot index is ≥
- * the current slot count is cancelled.
+ * Orphan-reminder cleanup: on mount, any `water-slot-*` MMKV reminder key
+ * whose suffix is not in the current slots.map(s => s.id) set is cancelled.
+ * This covers both middle-slot removals (old index-based orphans from before
+ * the UUID migration) and the v1→v2 migration path.
+ *
+ * Migration: if pendingMigrationV1Count > 0 the store was just migrated from
+ * the old index-based shape.  Cancel the old `water-slot-0…N` keys, then
+ * re-schedule any newly-migrated slots that are marked enabled, and finally
+ * call clearMigrationFlag() so the effect doesn't re-run.
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react'
@@ -33,7 +40,7 @@ import {
   selectTodayDrinks,
   selectTodayTotalMl,
 } from '@/stores/hydrationStore'
-import { listReminderKeys, cancelReminder } from '@/lib/reminderScheduler'
+import { listReminderKeys, cancelReminder, scheduleDailyReminder } from '@/lib/reminderScheduler'
 import { HydrationProgressBar } from '@/components/hydration/HydrationProgressBar'
 import { QuickLogChips } from '@/components/hydration/QuickLogChips'
 import { CustomAmountSheet } from '@/components/hydration/CustomAmountSheet'
@@ -52,11 +59,13 @@ export default function HydrationScreen() {
   const log = useHydrationStore((s) => s.log)
   const targetMl = useHydrationStore((s) => s.targetMl)
   const slots = useHydrationStore((s) => s.slots)
+  const pendingMigrationV1Count = useHydrationStore((s) => s.pendingMigrationV1Count)
   const addDrink = useHydrationStore((s) => s.addDrink)
   const removeDrink = useHydrationStore((s) => s.removeDrink)
   const setTarget = useHydrationStore((s) => s.setTarget)
   const addSlot = useHydrationStore((s) => s.addSlot)
   const removeSlot = useHydrationStore((s) => s.removeSlot)
+  const clearMigrationFlag = useHydrationStore((s) => s.clearMigrationFlag)
 
   // ── Derived ─────────────────────────────────────────────────────────────
   const todayDrinks = selectTodayDrinks(log)
@@ -103,26 +112,54 @@ export default function HydrationScreen() {
     [addDrink],
   )
 
-  // ── Orphan-reminder cleanup ───────────────────────────────────────────
-  // Cancel any reminder whose slot index is ≥ the current slot count.
-  // This handles cases where slots were removed while the app was backgrounded
-  // and the previous session's reminders were not cleaned up.
+  // ── v1→v2 migration: cancel old index-keyed reminders, re-schedule enabled slots ──
   useEffect(() => {
+    if (pendingMigrationV1Count === 0) return
+    // Cancel old `water-slot-0` … `water-slot-(N-1)` reminder keys.
+    const runMigration = async () => {
+      for (let i = 0; i < pendingMigrationV1Count; i++) {
+        await cancelReminder(`water-slot-${i}`).catch(() => {
+          // Best-effort.
+        })
+      }
+      // Re-schedule any newly migrated slots that are enabled.
+      for (const s of slots) {
+        if (s.enabled) {
+          await scheduleDailyReminder({
+            key: `water-slot-${s.id}`,
+            time: { hour: s.hour, minute: s.minute },
+            title: t('hydration.reminders.notificationTitle'),
+            body: t('hydration.reminders.notificationBody'),
+            data: { slotId: s.id },
+          }).catch(() => {
+            // Best-effort.
+          })
+        }
+      }
+      clearMigrationFlag()
+    }
+    runMigration()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingMigrationV1Count])
+
+  // ── Orphan-reminder cleanup (UUID-based) ─────────────────────────────────
+  // Cancel any `water-slot-*` reminder key whose suffix is not in the current
+  // slot UUID set.  This covers middle-slot removals and any leftover index-
+  // based keys that survived the migration (e.g. app killed mid-migration).
+  useEffect(() => {
+    const knownIds = new Set(slots.map((s) => s.id))
     const keys = listReminderKeys('water-slot-')
-    const slotCount = slots.length
     for (const key of keys) {
-      // Key format: water-slot-<N>
-      const parts = key.split('-')
-      const idx = parseInt(parts[parts.length - 1], 10)
-      if (!isNaN(idx) && idx >= slotCount) {
+      // key format: water-slot-<id>  (UUID or legacy index N)
+      const suffix = key.slice('water-slot-'.length)
+      if (!knownIds.has(suffix)) {
         cancelReminder(key).catch(() => {
           // Best-effort; ignore failures.
         })
       }
     }
-    // Run only when slot count changes (not on every render).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slots.length])
+  }, [slots])
 
   const styles = makeStyles(colors)
 
@@ -218,8 +255,13 @@ export default function HydrationScreen() {
           <SectionHeader title={t('hydration.settings.remindersLabel')} />
 
           <View style={[styles.card, { backgroundColor: colors.bg2 }]}>
-            {slots.map((_, idx) => (
-              <WaterReminderRow key={idx} index={idx} onRemove={removeSlot} />
+            {slots.map((slot, idx) => (
+              <WaterReminderRow
+                key={slot.id}
+                slot={slot}
+                displayIndex={idx + 1}
+                onRemove={removeSlot}
+              />
             ))}
 
             {/* Add slot button — disabled when cap reached */}

--- a/mobile/src/components/hydration/CustomAmountSheet.tsx
+++ b/mobile/src/components/hydration/CustomAmountSheet.tsx
@@ -1,0 +1,196 @@
+/**
+ * CustomAmountSheet — bottom-sheet with a numeric input for a custom water
+ * intake amount (1–5000 ml).
+ *
+ * Validation: rejects zero, negative, NaN, and values > 5000 ml.
+ * No MMKV write occurs for invalid entries.
+ */
+
+import React, { useState, useCallback } from 'react'
+import { View, Text, TextInput, StyleSheet, Pressable } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { BottomSheet } from '@/components/ui/BottomSheet'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+
+const MAX_AMOUNT_ML = 5000
+
+interface CustomAmountSheetProps {
+  visible: boolean
+  onConfirm: (amountMl: number) => void
+  onDismiss: () => void
+}
+
+export function CustomAmountSheet({
+  visible,
+  onConfirm,
+  onDismiss,
+}: CustomAmountSheetProps): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+  const [inputValue, setInputValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleInputChange = useCallback((text: string) => {
+    setInputValue(text)
+    setError(null)
+  }, [])
+
+  const handleConfirm = useCallback(() => {
+    const parsed = parseInt(inputValue, 10)
+    if (isNaN(parsed) || parsed <= 0) {
+      setError(t('hydration.quickLog.errorInvalid'))
+      return
+    }
+    if (parsed > MAX_AMOUNT_ML) {
+      setError(t('hydration.quickLog.errorTooLarge', { max: MAX_AMOUNT_ML }))
+      return
+    }
+    setInputValue('')
+    setError(null)
+    onConfirm(parsed)
+  }, [inputValue, onConfirm, t])
+
+  const handleDismiss = useCallback(() => {
+    setInputValue('')
+    setError(null)
+    onDismiss()
+  }, [onDismiss])
+
+  const styles = makeStyles(colors)
+
+  return (
+    <BottomSheet
+      visible={visible}
+      onClose={handleDismiss}
+      title={t('hydration.quickLog.customSheetTitle')}
+      fitContent
+    >
+      <View style={styles.content}>
+        {/* Input row */}
+        <View style={styles.inputRow}>
+          <TextInput
+            style={[
+              styles.input,
+              {
+                color: colors.label,
+                backgroundColor: colors.fill,
+                borderColor: error ? colors.red : colors.sep,
+              },
+            ]}
+            keyboardType="number-pad"
+            placeholder={t('hydration.quickLog.customPlaceholder')}
+            placeholderTextColor={colors.label3}
+            value={inputValue}
+            onChangeText={handleInputChange}
+            maxLength={5}
+            autoFocus
+            returnKeyType="done"
+            onSubmitEditing={handleConfirm}
+            accessibilityLabel={t('hydration.quickLog.customPlaceholder')}
+          />
+          <Text style={[styles.unit, { color: colors.label2 }]}>
+            {t('hydration.settings.targetSuffix')}
+          </Text>
+        </View>
+
+        {/* Validation error */}
+        {error !== null && (
+          <Text style={[styles.errorText, { color: colors.red }]}>{error}</Text>
+        )}
+
+        {/* Action buttons */}
+        <View style={styles.actions}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.cancelBtn,
+              { borderColor: colors.sep, opacity: pressed ? 0.7 : 1 },
+            ]}
+            onPress={handleDismiss}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.cancelLabel, { color: colors.label2 }]}>
+              {t('hydration.quickLog.cancel')}
+            </Text>
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [
+              styles.confirmBtn,
+              { backgroundColor: colors.gold, opacity: pressed ? 0.8 : 1 },
+            ]}
+            onPress={handleConfirm}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.confirmLabel, { color: colors.onAccent }]}>
+              {t('hydration.quickLog.confirm')}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </BottomSheet>
+  )
+}
+
+export default CustomAmountSheet
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    content: {
+      paddingHorizontal: 16,
+      paddingTop: 8,
+      gap: 12,
+    },
+    inputRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+    },
+    input: {
+      flex: 1,
+      height: 48,
+      borderRadius: Radius.md,
+      borderWidth: 1,
+      paddingHorizontal: 14,
+      ...Type.body,
+    },
+    unit: {
+      ...Type.body,
+      fontWeight: '600',
+      minWidth: 24,
+    },
+    errorText: {
+      ...Type.footnote,
+    },
+    actions: {
+      flexDirection: 'row',
+      gap: 10,
+      marginTop: 4,
+    },
+    cancelBtn: {
+      flex: 1,
+      height: 46,
+      borderRadius: Radius.md,
+      borderWidth: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cancelLabel: {
+      ...Type.subheadline,
+      fontWeight: '600',
+    },
+    confirmBtn: {
+      flex: 2,
+      height: 46,
+      borderRadius: Radius.md,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    confirmLabel: {
+      ...Type.subheadline,
+      fontWeight: '600',
+    },
+  })
+}

--- a/mobile/src/components/hydration/HydrationCard.tsx
+++ b/mobile/src/components/hydration/HydrationCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * HydrationCard — Today-screen card for the drinking regime feature (#334).
+ *
+ * Shows current intake / target, a compact progress bar, and a primary
+ * "+250 ml" button. Tapping the card body navigates to /hydration.
+ */
+
+import React, { useCallback } from 'react'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Radius } from '@/constants/radius'
+import { Type } from '@/constants/typography'
+import { HydrationProgressBar } from './HydrationProgressBar'
+import { useHydrationStore, selectTodayTotalMl } from '@/stores/hydrationStore'
+
+export function HydrationCard(): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+  const router = useRouter()
+
+  const log = useHydrationStore((s) => s.log)
+  const targetMl = useHydrationStore((s) => s.targetMl)
+  const addDrink = useHydrationStore((s) => s.addDrink)
+
+  const todayTotal = selectTodayTotalMl(log)
+
+  const handleCardPress = useCallback(() => {
+    router.push('/(client)/(tabs)/hydration' as never)
+  }, [router])
+
+  const handleQuickAdd = useCallback(() => {
+    addDrink(250)
+  }, [addDrink])
+
+  const styles = makeStyles(colors)
+
+  return (
+    <Pressable
+      onPress={handleCardPress}
+      style={({ pressed }) => [
+        styles.card,
+        { backgroundColor: colors.bg2, opacity: pressed ? 0.92 : 1 },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={t('hydration.card.title')}
+    >
+      {/* Header row */}
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: colors.label }]}>
+          {t('hydration.card.title')}
+        </Text>
+        <Text style={[styles.progress, { color: colors.label2 }]}>
+          {t('hydration.card.todayProgress', { current: todayTotal, target: targetMl })}
+        </Text>
+      </View>
+
+      {/* Progress bar */}
+      <View style={styles.barWrap}>
+        <HydrationProgressBar currentMl={todayTotal} targetMl={targetMl} />
+      </View>
+
+      {/* Quick-add button */}
+      <Pressable
+        onPress={handleQuickAdd}
+        style={({ pressed }) => [
+          styles.quickAddBtn,
+          { backgroundColor: colors.gold, opacity: pressed ? 0.8 : 1 },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={t('hydration.card.quickAdd')}
+        // Stop propagation so tapping the button doesn't also trigger the card press.
+        onStartShouldSetResponder={() => true}
+      >
+        <Text style={[styles.quickAddLabel, { color: colors.onAccent }]}>
+          {t('hydration.card.quickAdd')}
+        </Text>
+      </Pressable>
+    </Pressable>
+  )
+}
+
+export default HydrationCard
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    card: {
+      marginHorizontal: 16,
+      borderRadius: Radius.lg,
+      paddingHorizontal: 16,
+      paddingTop: 14,
+      paddingBottom: 14,
+      gap: 10,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    title: {
+      ...Type.headline,
+    },
+    progress: {
+      ...Type.footnote,
+    },
+    barWrap: {
+      marginVertical: 2,
+    },
+    quickAddBtn: {
+      borderRadius: Radius.md,
+      paddingVertical: 9,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    quickAddLabel: {
+      ...Type.subheadline,
+      fontWeight: '600',
+    },
+  })
+}

--- a/mobile/src/components/hydration/HydrationCard.tsx
+++ b/mobile/src/components/hydration/HydrationCard.tsx
@@ -27,7 +27,7 @@ export function HydrationCard(): React.ReactElement {
   const todayTotal = selectTodayTotalMl(log)
 
   const handleCardPress = useCallback(() => {
-    router.push('/(client)/(tabs)/hydration' as never)
+    router.push('/(client)/(tabs)/hydration')
   }, [router])
 
   const handleQuickAdd = useCallback(() => {

--- a/mobile/src/components/hydration/HydrationHistoryStrip.tsx
+++ b/mobile/src/components/hydration/HydrationHistoryStrip.tsx
@@ -1,0 +1,136 @@
+/**
+ * HydrationHistoryStrip — 7-day daily totals bar strip (oldest → newest,
+ * left to right). Each column shows a proportional bar and abbreviated day
+ * label. Today's column is highlighted in gold.
+ */
+
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { selectLast7DaysTotals } from '@/stores/hydrationStore'
+import type { DrinkLog } from '@/stores/hydrationStore'
+import { goldAlpha } from '@/constants/colors'
+
+interface HydrationHistoryStripProps {
+  log: DrinkLog[]
+  targetMl: number
+}
+
+/** Abbreviated day labels matching the locale in i18n (2-char). */
+function dayAbbrev(dateStr: string, t: ReturnType<typeof useTranslation>['t']): string {
+  const d = new Date(dateStr)
+  const dayIndex = d.getDay() // 0=Sun
+  return t(`hydration.history.dayLabels.${dayIndex}`)
+}
+
+export function HydrationHistoryStrip({ log, targetMl }: HydrationHistoryStripProps): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+  const styles = makeStyles(colors)
+
+  // selectLast7DaysTotals returns newest-first; reverse to render oldest→newest left→right
+  const days = selectLast7DaysTotals(log).reverse()
+  const maxMl = Math.max(...days.map((d) => d.totalMl), targetMl, 1)
+
+  const todayStr = days[days.length - 1]?.date ?? ''
+
+  return (
+    <View style={styles.container}>
+      {days.map((day) => {
+        const ratio = maxMl > 0 ? Math.min(day.totalMl / maxMl, 1) : 0
+        const isToday = day.date === todayStr
+        const reachedTarget = day.totalMl >= targetMl
+        const barColor = reachedTarget ? colors.green : colors.gold
+
+        return (
+          <View key={day.date} style={styles.column}>
+            {/* Bar track + fill */}
+            <View style={[styles.barTrack, { backgroundColor: colors.fill }]}>
+              <View
+                style={[
+                  styles.barFill,
+                  {
+                    height: `${ratio * 100}%`,
+                    backgroundColor: isToday ? barColor : colors.label3,
+                  },
+                ]}
+              />
+              {/* Target line */}
+              {targetMl > 0 && maxMl > 0 && (
+                <View
+                  style={[
+                    styles.targetLine,
+                    {
+                      bottom: `${(targetMl / maxMl) * 100}%`,
+                      backgroundColor: isToday ? goldAlpha['35'] : colors.sep,
+                    },
+                  ]}
+                />
+              )}
+            </View>
+
+            {/* Day label */}
+            <Text
+              style={[
+                styles.dayLabel,
+                { color: isToday ? colors.gold : colors.label3 },
+                isToday && styles.dayLabelToday,
+              ]}
+            >
+              {dayAbbrev(day.date, t)}
+            </Text>
+          </View>
+        )
+      })}
+    </View>
+  )
+}
+
+export default HydrationHistoryStrip
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'flex-end',
+      gap: 6,
+      paddingHorizontal: 16,
+      height: 80,
+    },
+    column: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      gap: 4,
+    },
+    barTrack: {
+      width: '100%',
+      flex: 1,
+      borderRadius: Radius.sm,
+      overflow: 'hidden',
+      justifyContent: 'flex-end',
+      position: 'relative',
+    },
+    barFill: {
+      width: '100%',
+      borderRadius: Radius.sm,
+    },
+    targetLine: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      height: 1,
+    },
+    dayLabel: {
+      ...Type.caption2,
+    },
+    dayLabelToday: {
+      fontWeight: '700',
+    },
+  })
+}

--- a/mobile/src/components/hydration/HydrationLogList.tsx
+++ b/mobile/src/components/hydration/HydrationLogList.tsx
@@ -1,0 +1,135 @@
+/**
+ * HydrationLogList — today's drink entries, newest first.
+ *
+ * Each row shows the time and amount. A delete button removes the entry.
+ * Displays an empty-state message when there are no entries for today.
+ */
+
+import React, { useCallback } from 'react'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import type { DrinkLog } from '@/stores/hydrationStore'
+
+interface HydrationLogListProps {
+  drinks: DrinkLog[]
+  onRemove: (id: string) => void
+}
+
+function formatTime(isoTimestamp: string): string {
+  const d = new Date(isoTimestamp)
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+export function HydrationLogList({ drinks, onRemove }: HydrationLogListProps): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+  const styles = makeStyles(colors)
+
+  if (drinks.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={[styles.emptyText, { color: colors.label3 }]}>
+          {t('hydration.log.empty')}
+        </Text>
+      </View>
+    )
+  }
+
+  // Newest first
+  const sorted = [...drinks].sort(
+    (a, b) => new Date(b.timestampISO).getTime() - new Date(a.timestampISO).getTime(),
+  )
+
+  return (
+    <View style={styles.container}>
+      {sorted.map((drink) => (
+        <DrinkRow key={drink.id} drink={drink} onRemove={onRemove} />
+      ))}
+    </View>
+  )
+}
+
+// ─── DrinkRow ─────────────────────────────────────────────────────────────────
+
+interface DrinkRowProps {
+  drink: DrinkLog
+  onRemove: (id: string) => void
+}
+
+function DrinkRow({ drink, onRemove }: DrinkRowProps): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+  const styles = makeRowStyles(colors)
+
+  const handleRemove = useCallback(() => {
+    onRemove(drink.id)
+  }, [onRemove, drink.id])
+
+  return (
+    <View style={[styles.row, { borderBottomColor: colors.sep }]}>
+      <Text style={[styles.time, { color: colors.label3 }]}>{formatTime(drink.timestampISO)}</Text>
+      <Text style={[styles.amount, { color: colors.label }]}>
+        {t('hydration.log.amountMl', { amount: drink.amountMl })}
+      </Text>
+      <Pressable
+        onPress={handleRemove}
+        hitSlop={8}
+        style={({ pressed }) => [{ opacity: pressed ? 0.6 : 1 }]}
+        accessibilityRole="button"
+        accessibilityLabel={t('hydration.log.removeDrink')}
+      >
+        <Text style={[styles.removeBtn, { color: colors.red }]}>✕</Text>
+      </Pressable>
+    </View>
+  )
+}
+
+export default HydrationLogList
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    container: {
+      paddingHorizontal: 16,
+    },
+    empty: {
+      paddingHorizontal: 16,
+      paddingVertical: 20,
+      alignItems: 'center',
+    },
+    emptyText: {
+      ...Type.footnote,
+      textAlign: 'center',
+    },
+  })
+}
+
+function makeRowStyles(colors: Colors) {
+  return StyleSheet.create({
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 10,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      gap: 10,
+    },
+    time: {
+      ...Type.footnote,
+      minWidth: 42,
+    },
+    amount: {
+      flex: 1,
+      ...Type.subheadline,
+      fontWeight: '600',
+    },
+    removeBtn: {
+      ...Type.footnote,
+      fontWeight: '600',
+    },
+  })
+}

--- a/mobile/src/components/hydration/HydrationProgressBar.tsx
+++ b/mobile/src/components/hydration/HydrationProgressBar.tsx
@@ -1,0 +1,58 @@
+/**
+ * HydrationProgressBar — compact horizontal progress bar for the Today-screen
+ * HydrationCard. Shows current ml vs. target with a gold fill.
+ *
+ * Uses `useTheme()` tokens exclusively — no hardcoded colors.
+ */
+
+import React from 'react'
+import { View, StyleSheet } from 'react-native'
+import { useTheme } from '@/hooks/useTheme'
+
+interface HydrationProgressBarProps {
+  currentMl: number
+  targetMl: number
+  /** Bar height in points. Default 6. */
+  barHeight?: number
+}
+
+export function HydrationProgressBar({
+  currentMl,
+  targetMl,
+  barHeight = 6,
+}: HydrationProgressBarProps): React.ReactElement {
+  const colors = useTheme()
+  const ratio = targetMl > 0 ? Math.min(currentMl / targetMl, 1) : 0
+
+  return (
+    <View
+      style={[
+        styles.track,
+        { height: barHeight, backgroundColor: colors.fill, borderRadius: barHeight / 2 },
+      ]}
+    >
+      <View
+        style={[
+          styles.fill,
+          {
+            width: `${ratio * 100}%`,
+            backgroundColor: colors.gold,
+            borderRadius: barHeight / 2,
+          },
+        ]}
+      />
+    </View>
+  )
+}
+
+export default HydrationProgressBar
+
+const styles = StyleSheet.create({
+  track: {
+    width: '100%',
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+  },
+})

--- a/mobile/src/components/hydration/QuickLogChips.tsx
+++ b/mobile/src/components/hydration/QuickLogChips.tsx
@@ -1,0 +1,111 @@
+/**
+ * QuickLogChips — horizontal scroll row of preset ml chips + a "Custom" chip.
+ *
+ * Preset amounts: 200, 250, 330, 500, 750 ml.
+ * The "Custom" chip calls onCustomPress to open the CustomAmountSheet.
+ */
+
+import React, { useCallback } from 'react'
+import { ScrollView, Text, Pressable, StyleSheet, View } from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { goldAlpha } from '@/constants/colors'
+
+export const PRESET_AMOUNTS = [200, 250, 330, 500, 750] as const
+
+interface QuickLogChipsProps {
+  onLog: (amountMl: number) => void
+  onCustomPress: () => void
+}
+
+export function QuickLogChips({ onLog, onCustomPress }: QuickLogChipsProps): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+
+  const styles = makeStyles(colors)
+
+  const handlePress = useCallback(
+    (amount: number) => {
+      onLog(amount)
+    },
+    [onLog],
+  )
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.row}
+      style={styles.scroll}
+    >
+      {PRESET_AMOUNTS.map((amount) => (
+        <Pressable
+          key={amount}
+          onPress={() => handlePress(amount)}
+          style={({ pressed }) => [
+            styles.chip,
+            { opacity: pressed ? 0.7 : 1, backgroundColor: goldAlpha['10'], borderColor: goldAlpha['35'] },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={t('hydration.quickLog.presetLabel', { amount })}
+        >
+          <Text style={[styles.chipText, { color: colors.gold }]}>
+            {t('hydration.quickLog.presetLabel', { amount })}
+          </Text>
+        </Pressable>
+      ))}
+
+      {/* Custom chip */}
+      <Pressable
+        onPress={onCustomPress}
+        style={({ pressed }) => [
+          styles.chip,
+          { opacity: pressed ? 0.7 : 1, backgroundColor: colors.fill, borderColor: colors.sep },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={t('hydration.quickLog.customLabel')}
+      >
+        <View style={styles.chipInner}>
+          <Text style={[styles.chipText, { color: colors.label2 }]}>
+            {t('hydration.quickLog.customLabel')}
+          </Text>
+        </View>
+      </Pressable>
+    </ScrollView>
+  )
+}
+
+export default QuickLogChips
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    scroll: {
+      flexShrink: 0,
+    },
+    row: {
+      flexDirection: 'row',
+      gap: 8,
+      paddingHorizontal: 16,
+      paddingVertical: 4,
+    },
+    chip: {
+      borderRadius: Radius.full,
+      borderWidth: 1,
+      paddingHorizontal: 14,
+      paddingVertical: 7,
+    },
+    chipInner: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+    chipText: {
+      ...Type.footnote,
+      fontWeight: '600',
+    },
+  })
+}

--- a/mobile/src/components/hydration/WaterReminderRow.tsx
+++ b/mobile/src/components/hydration/WaterReminderRow.tsx
@@ -1,0 +1,248 @@
+/**
+ * WaterReminderRow — single reminder slot row for the hydration settings.
+ *
+ * Mirrors MealReminderRow's structure exactly:
+ *  - Toggle gated on scheduleDailyReminder({ ... }).scheduled === true.
+ *  - Permission-denied: toast + leave toggle off.
+ *  - Web-unsupported: disables toggle + shows "Reminders are mobile-only" note.
+ *
+ * Key format:  water-slot-<index>
+ */
+
+import React, { useState, useCallback, useEffect } from 'react'
+import {
+  View,
+  Text,
+  Switch,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native'
+import { useTranslation } from 'react-i18next'
+import { Platform } from 'react-native'
+import { useTheme } from '@/hooks/useTheme'
+import {
+  scheduleDailyReminder,
+  cancelReminder,
+  getReminder,
+} from '@/lib/reminderScheduler'
+import type { ReminderTime } from '@/lib/reminderScheduler'
+import { ReminderTimePicker } from '@/components/nutrition/ReminderTimePicker'
+import { useHydrationStore } from '@/stores/hydrationStore'
+import { Toast } from '@/lib/toast'
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export interface WaterReminderRowProps {
+  /** Slot index within the hydration settings (0-based). */
+  index: number
+  onRemove: (index: number) => void
+}
+
+/**
+ * Manages one water reminder slot. On toggle ON, calls scheduleDailyReminder
+ * with key `water-slot-<index>` and only sets enabled=true if result.scheduled.
+ * On toggle OFF, cancels the reminder and marks the slot disabled in the store.
+ */
+export function WaterReminderRow({ index, onRemove }: WaterReminderRowProps): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+
+  const slot = useHydrationStore((s) => s.slots[index])
+  const slotEnabled = useHydrationStore((s) => s.slotsEnabled[index])
+  const setSlotTime = useHydrationStore((s) => s.setSlotTime)
+  const setSlotEnabled = useHydrationStore((s) => s.setSlotEnabled)
+
+  const reminderKey = `water-slot-${index}`
+
+  // Local state initialised from MMKV via reminderScheduler.
+  const [localEnabled, setLocalEnabled] = useState<boolean>(() => {
+    const stored = getReminder(reminderKey)
+    return stored?.enabled ?? slotEnabled ?? false
+  })
+
+  const [localTime, setLocalTime] = useState<ReminderTime>(() => {
+    const stored = getReminder(reminderKey)
+    return stored?.time ?? slot ?? { hour: 8, minute: 0 }
+  })
+
+  const [pickerVisible, setPickerVisible] = useState(false)
+
+  // Keep in sync if index changes (list rebuild).
+  useEffect(() => {
+    const stored = getReminder(reminderKey)
+    setLocalEnabled(stored?.enabled ?? slotEnabled ?? false)
+    setLocalTime(stored?.time ?? slot ?? { hour: 8, minute: 0 })
+  }, [reminderKey, slot, slotEnabled])
+
+  const isWebPlatform = Platform.OS === 'web'
+
+  const handleToggle = useCallback(
+    async (value: boolean) => {
+      if (value) {
+        const result = await scheduleDailyReminder({
+          key: reminderKey,
+          time: localTime,
+          title: t('hydration.reminders.notificationTitle'),
+          body: t('hydration.reminders.notificationBody'),
+          data: { slotIndex: index },
+        })
+        if (!result.scheduled) {
+          // Permission denied — leave toggle off, show non-blocking toast.
+          setLocalEnabled(false)
+          setSlotEnabled(index, false)
+          if (result.reason === 'permission-denied') {
+            Toast.show(t('hydration.reminders.permissionDeniedToast'))
+          }
+          return
+        }
+        setLocalEnabled(true)
+        setSlotEnabled(index, true)
+      } else {
+        await cancelReminder(reminderKey)
+        setLocalEnabled(false)
+        setSlotEnabled(index, false)
+      }
+    },
+    [reminderKey, localTime, index, setSlotEnabled, t],
+  )
+
+  const handleTimeConfirm = useCallback(
+    async (time: ReminderTime) => {
+      setPickerVisible(false)
+      setLocalTime(time)
+      setSlotTime(index, time)
+      if (localEnabled) {
+        // Reschedule with the new time.
+        await scheduleDailyReminder({
+          key: reminderKey,
+          time,
+          title: t('hydration.reminders.notificationTitle'),
+          body: t('hydration.reminders.notificationBody'),
+          data: { slotIndex: index },
+        })
+      }
+    },
+    [localEnabled, reminderKey, index, setSlotTime, t],
+  )
+
+  const handleRemove = useCallback(() => {
+    onRemove(index)
+  }, [onRemove, index])
+
+  const styles = makeStyles(colors)
+
+  const pad2 = (n: number): string => n.toString().padStart(2, '0')
+  const timeLabel = `${pad2(localTime.hour)}:${pad2(localTime.minute)}`
+
+  return (
+    <View style={[styles.container, { borderTopColor: colors.sep }]}>
+      {/* Toggle row */}
+      <View style={styles.topRow}>
+        <Text style={[styles.label, { color: colors.label2 }]}>
+          {t('hydration.settings.reminderSlot', { n: index + 1 })}
+        </Text>
+        <View style={styles.rightSide}>
+          {isWebPlatform ? (
+            <Text style={[styles.webNote, { color: colors.label3 }]}>
+              {t('hydration.reminders.webUnsupported')}
+            </Text>
+          ) : (
+            <Switch
+              value={localEnabled}
+              onValueChange={handleToggle}
+              trackColor={{ false: colors.sep, true: colors.gold }}
+              thumbColor={colors.bg}
+              accessibilityLabel={t('hydration.settings.reminderSlot', { n: index + 1 })}
+              accessibilityRole="switch"
+            />
+          )}
+          <TouchableOpacity
+            onPress={handleRemove}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('hydration.settings.removeSlot')}
+          >
+            <Text style={[styles.removeBtn, { color: colors.red }]}>
+              {t('hydration.settings.removeSlot')}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Time picker row — only visible when toggle is on and not web */}
+      {localEnabled && !isWebPlatform && (
+        <TouchableOpacity
+          style={styles.timeRow}
+          onPress={() => setPickerVisible(true)}
+          accessibilityRole="button"
+          accessibilityLabel={t('hydration.settings.reminderTimeLabel')}
+        >
+          <Text style={[styles.timeLabel, { color: colors.label2 }]}>
+            {t('hydration.settings.reminderTimeLabel')}
+          </Text>
+          <Text style={[styles.timeValue, { color: colors.gold }]}>
+            {timeLabel}
+          </Text>
+        </TouchableOpacity>
+      )}
+
+      {/* Time picker modal */}
+      <ReminderTimePicker
+        visible={pickerVisible}
+        initialTime={localTime}
+        onConfirm={handleTimeConfirm}
+        onDismiss={() => setPickerVisible(false)}
+      />
+    </View>
+  )
+}
+
+export default WaterReminderRow
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    container: {
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderTopWidth: StyleSheet.hairlineWidth,
+    },
+    topRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    label: {
+      fontSize: 13,
+    },
+    rightSide: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+    },
+    webNote: {
+      fontSize: 12,
+      fontStyle: 'italic',
+    },
+    removeBtn: {
+      fontSize: 12,
+      fontWeight: '600',
+    },
+    timeRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginTop: 8,
+    },
+    timeLabel: {
+      fontSize: 13,
+    },
+    timeValue: {
+      fontSize: 14,
+      fontWeight: '600',
+    },
+  })
+}

--- a/mobile/src/components/hydration/WaterReminderRow.tsx
+++ b/mobile/src/components/hydration/WaterReminderRow.tsx
@@ -6,7 +6,7 @@
  *  - Permission-denied: toast + leave toggle off.
  *  - Web-unsupported: disables toggle + shows "Reminders are mobile-only" note.
  *
- * Key format:  water-slot-<index>
+ * Key format:  water-slot-<slot.id>  (UUID-stable, never shifts on remove)
  */
 
 import React, { useState, useCallback, useEffect } from 'react'
@@ -28,51 +28,53 @@ import {
 import type { ReminderTime } from '@/lib/reminderScheduler'
 import { ReminderTimePicker } from '@/components/nutrition/ReminderTimePicker'
 import { useHydrationStore } from '@/stores/hydrationStore'
+import type { ReminderSlot } from '@/stores/hydrationStore'
 import { Toast } from '@/lib/toast'
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export interface WaterReminderRowProps {
-  /** Slot index within the hydration settings (0-based). */
-  index: number
-  onRemove: (index: number) => void
+  /** The full slot record — identity is the stable UUID slot.id. */
+  slot: ReminderSlot
+  /** Display number shown to the user (1-based position in the list). */
+  displayIndex: number
+  onRemove: (slotId: string) => void
 }
 
 /**
  * Manages one water reminder slot. On toggle ON, calls scheduleDailyReminder
- * with key `water-slot-<index>` and only sets enabled=true if result.scheduled.
+ * with key `water-slot-<slot.id>` and only sets enabled=true if result.scheduled.
  * On toggle OFF, cancels the reminder and marks the slot disabled in the store.
  */
-export function WaterReminderRow({ index, onRemove }: WaterReminderRowProps): React.ReactElement {
+export function WaterReminderRow({ slot, displayIndex, onRemove }: WaterReminderRowProps): React.ReactElement {
   const { t } = useTranslation()
   const colors = useTheme()
 
-  const slot = useHydrationStore((s) => s.slots[index])
-  const slotEnabled = useHydrationStore((s) => s.slotsEnabled[index])
   const setSlotTime = useHydrationStore((s) => s.setSlotTime)
   const setSlotEnabled = useHydrationStore((s) => s.setSlotEnabled)
 
-  const reminderKey = `water-slot-${index}`
+  // Reminder key is UUID-stable — never shifts when slots above are removed.
+  const reminderKey = `water-slot-${slot.id}`
 
   // Local state initialised from MMKV via reminderScheduler.
   const [localEnabled, setLocalEnabled] = useState<boolean>(() => {
     const stored = getReminder(reminderKey)
-    return stored?.enabled ?? slotEnabled ?? false
+    return stored?.enabled ?? slot.enabled ?? false
   })
 
   const [localTime, setLocalTime] = useState<ReminderTime>(() => {
     const stored = getReminder(reminderKey)
-    return stored?.time ?? slot ?? { hour: 8, minute: 0 }
+    return stored?.time ?? { hour: slot.hour, minute: slot.minute }
   })
 
   const [pickerVisible, setPickerVisible] = useState(false)
 
-  // Keep in sync if index changes (list rebuild).
+  // Re-sync local state if the slot record reference changes (e.g. store reload).
   useEffect(() => {
     const stored = getReminder(reminderKey)
-    setLocalEnabled(stored?.enabled ?? slotEnabled ?? false)
-    setLocalTime(stored?.time ?? slot ?? { hour: 8, minute: 0 })
-  }, [reminderKey, slot, slotEnabled])
+    setLocalEnabled(stored?.enabled ?? slot.enabled ?? false)
+    setLocalTime(stored?.time ?? { hour: slot.hour, minute: slot.minute })
+  }, [reminderKey, slot.id, slot.hour, slot.minute, slot.enabled])
 
   const isWebPlatform = Platform.OS === 'web'
 
@@ -84,33 +86,33 @@ export function WaterReminderRow({ index, onRemove }: WaterReminderRowProps): Re
           time: localTime,
           title: t('hydration.reminders.notificationTitle'),
           body: t('hydration.reminders.notificationBody'),
-          data: { slotIndex: index },
+          data: { slotId: slot.id },
         })
         if (!result.scheduled) {
           // Permission denied — leave toggle off, show non-blocking toast.
           setLocalEnabled(false)
-          setSlotEnabled(index, false)
+          setSlotEnabled(slot.id, false)
           if (result.reason === 'permission-denied') {
             Toast.show(t('hydration.reminders.permissionDeniedToast'))
           }
           return
         }
         setLocalEnabled(true)
-        setSlotEnabled(index, true)
+        setSlotEnabled(slot.id, true)
       } else {
         await cancelReminder(reminderKey)
         setLocalEnabled(false)
-        setSlotEnabled(index, false)
+        setSlotEnabled(slot.id, false)
       }
     },
-    [reminderKey, localTime, index, setSlotEnabled, t],
+    [reminderKey, localTime, slot.id, setSlotEnabled, t],
   )
 
   const handleTimeConfirm = useCallback(
     async (time: ReminderTime) => {
       setPickerVisible(false)
       setLocalTime(time)
-      setSlotTime(index, time)
+      setSlotTime(slot.id, time)
       if (localEnabled) {
         // Reschedule with the new time.
         await scheduleDailyReminder({
@@ -118,16 +120,16 @@ export function WaterReminderRow({ index, onRemove }: WaterReminderRowProps): Re
           time,
           title: t('hydration.reminders.notificationTitle'),
           body: t('hydration.reminders.notificationBody'),
-          data: { slotIndex: index },
+          data: { slotId: slot.id },
         })
       }
     },
-    [localEnabled, reminderKey, index, setSlotTime, t],
+    [localEnabled, reminderKey, slot.id, setSlotTime, t],
   )
 
   const handleRemove = useCallback(() => {
-    onRemove(index)
-  }, [onRemove, index])
+    onRemove(slot.id)
+  }, [onRemove, slot.id])
 
   const styles = makeStyles(colors)
 
@@ -139,7 +141,7 @@ export function WaterReminderRow({ index, onRemove }: WaterReminderRowProps): Re
       {/* Toggle row */}
       <View style={styles.topRow}>
         <Text style={[styles.label, { color: colors.label2 }]}>
-          {t('hydration.settings.reminderSlot', { n: index + 1 })}
+          {t('hydration.settings.reminderSlot', { n: displayIndex })}
         </Text>
         <View style={styles.rightSide}>
           {isWebPlatform ? (
@@ -152,7 +154,7 @@ export function WaterReminderRow({ index, onRemove }: WaterReminderRowProps): Re
               onValueChange={handleToggle}
               trackColor={{ false: colors.sep, true: colors.gold }}
               thumbColor={colors.bg}
-              accessibilityLabel={t('hydration.settings.reminderSlot', { n: index + 1 })}
+              accessibilityLabel={t('hydration.settings.reminderSlot', { n: displayIndex })}
               accessibilityRole="switch"
             />
           )}

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -17,6 +17,7 @@ import { SectionHeader } from '@/components/ui/SectionHeader'
 import { TrainingCard } from '@/components/training/TrainingCard'
 import { NutritionCard } from '@/components/nutrition/NutritionCard'
 import { WaitingForPlanCard } from '@/components/today/WaitingForPlanCard'
+import { HydrationCard } from '@/components/hydration/HydrationCard'
 import { ShoppingPrepBanner } from '@/components/today/ShoppingPrepBanner'
 import {
   getTodayPlan,
@@ -1345,6 +1346,11 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
           />
         </View>
       )}
+
+      {/* Hydration card — always visible, MMKV-local, no trainer dependency */}
+      <View style={styles.section}>
+        <HydrationCard />
+      </View>
 
     </>
   )

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -1241,5 +1241,59 @@
       "headline": "Pokračuj v nahrávání",
       "subtitle": "Dokončete nahrávání fotek a odešlete je svému kouči."
     }
+  },
+  "hydration": {
+    "card": {
+      "title": "Pitný režim",
+      "todayProgress": "{{current}} z {{target}} ml",
+      "quickAdd": "+250 ml"
+    },
+    "screen": {
+      "title": "Pitný režim"
+    },
+    "settings": {
+      "targetLabel": "Denní cíl",
+      "targetSuffix": "ml",
+      "remindersLabel": "Připomínky",
+      "addSlot": "Přidat čas",
+      "removeSlot": "Odebrat",
+      "reminderSlot": "Připomenutí {{n}}",
+      "reminderTimeLabel": "Čas"
+    },
+    "quickLog": {
+      "customLabel": "Vlastní množství",
+      "customPlaceholder": "Zadejte ml",
+      "confirm": "Zaznamenat",
+      "cancel": "Zrušit",
+      "customSheetTitle": "Vlastní množství",
+      "presetLabel": "+{{amount}} ml",
+      "errorInvalid": "Zadejte platné množství (1–5000 ml)",
+      "errorTooLarge": "Maximální množství je {{max}} ml"
+    },
+    "log": {
+      "empty": "Dnes jste si zatím nic nezaznamenali",
+      "removeDrink": "Odebrat tento záznam",
+      "amountMl": "{{amount}} ml"
+    },
+    "history": {
+      "daily": "{{ml}} ml / {{target}} ml",
+      "dayLabels": {
+        "0": "Ne",
+        "1": "Po",
+        "2": "Út",
+        "3": "St",
+        "4": "Čt",
+        "5": "Pá",
+        "6": "So"
+      }
+    },
+    "reminders": {
+      "toggleLabel": "Připomenutí",
+      "timeLabel": "Čas",
+      "notificationTitle": "Pitný režim",
+      "notificationBody": "Čas se napít vody!",
+      "permissionDeniedToast": "Povolte notifikace v Nastavení, abyste dostávali připomínky",
+      "webUnsupported": "Připomínky jsou k dispozici pouze v mobilní aplikaci"
+    }
   }
 }

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -1212,5 +1212,59 @@
       "headline": "Upload fortsetzen",
       "subtitle": "Lade die Fotos zu Ende hoch und sende sie an deinen Coach."
     }
+  },
+  "hydration": {
+    "card": {
+      "title": "Trinkmodus",
+      "todayProgress": "{{current}} von {{target}} ml",
+      "quickAdd": "+250 ml"
+    },
+    "screen": {
+      "title": "Trinkmodus"
+    },
+    "settings": {
+      "targetLabel": "Tagesziel",
+      "targetSuffix": "ml",
+      "remindersLabel": "Erinnerungen",
+      "addSlot": "Zeit hinzufügen",
+      "removeSlot": "Entfernen",
+      "reminderSlot": "Erinnerung {{n}}",
+      "reminderTimeLabel": "Zeit"
+    },
+    "quickLog": {
+      "customLabel": "Benutzerdefinierte Menge",
+      "customPlaceholder": "ml eingeben",
+      "confirm": "Erfassen",
+      "cancel": "Abbrechen",
+      "customSheetTitle": "Benutzerdefinierte Menge",
+      "presetLabel": "+{{amount}} ml",
+      "errorInvalid": "Gültige Menge eingeben (1–5000 ml)",
+      "errorTooLarge": "Maximale Menge ist {{max}} ml"
+    },
+    "log": {
+      "empty": "Heute noch nichts erfasst",
+      "removeDrink": "Diesen Eintrag entfernen",
+      "amountMl": "{{amount}} ml"
+    },
+    "history": {
+      "daily": "{{ml}} ml / {{target}} ml",
+      "dayLabels": {
+        "0": "So",
+        "1": "Mo",
+        "2": "Di",
+        "3": "Mi",
+        "4": "Do",
+        "5": "Fr",
+        "6": "Sa"
+      }
+    },
+    "reminders": {
+      "toggleLabel": "Erinnerung",
+      "timeLabel": "Zeit",
+      "notificationTitle": "Trinkmodus",
+      "notificationBody": "Zeit, Wasser zu trinken!",
+      "permissionDeniedToast": "Aktiviere Benachrichtigungen in den Einstellungen, um Erinnerungen zu erhalten",
+      "webUnsupported": "Erinnerungen sind nur in der mobilen App verfügbar"
+    }
   }
 }

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -1213,5 +1213,59 @@
       "headline": "Resume your upload",
       "subtitle": "Finish uploading photos and submit them to your coach."
     }
+  },
+  "hydration": {
+    "card": {
+      "title": "Hydration",
+      "todayProgress": "{{current}} of {{target}} ml",
+      "quickAdd": "+250 ml"
+    },
+    "screen": {
+      "title": "Hydration"
+    },
+    "settings": {
+      "targetLabel": "Daily goal",
+      "targetSuffix": "ml",
+      "remindersLabel": "Reminders",
+      "addSlot": "Add time",
+      "removeSlot": "Remove",
+      "reminderSlot": "Reminder {{n}}",
+      "reminderTimeLabel": "Time"
+    },
+    "quickLog": {
+      "customLabel": "Custom amount",
+      "customPlaceholder": "Enter ml",
+      "confirm": "Log",
+      "cancel": "Cancel",
+      "customSheetTitle": "Custom amount",
+      "presetLabel": "+{{amount}} ml",
+      "errorInvalid": "Enter a valid amount (1–5000 ml)",
+      "errorTooLarge": "Maximum amount is {{max}} ml"
+    },
+    "log": {
+      "empty": "Nothing logged today yet",
+      "removeDrink": "Remove this entry",
+      "amountMl": "{{amount}} ml"
+    },
+    "history": {
+      "daily": "{{ml}} ml / {{target}} ml",
+      "dayLabels": {
+        "0": "Sun",
+        "1": "Mon",
+        "2": "Tue",
+        "3": "Wed",
+        "4": "Thu",
+        "5": "Fri",
+        "6": "Sat"
+      }
+    },
+    "reminders": {
+      "toggleLabel": "Reminder",
+      "timeLabel": "Time",
+      "notificationTitle": "Hydration reminder",
+      "notificationBody": "Time to drink some water!",
+      "permissionDeniedToast": "Enable notifications in Settings to receive reminders",
+      "webUnsupported": "Reminders are available in the mobile app only"
+    }
   }
 }

--- a/mobile/src/stores/hydrationStore.ts
+++ b/mobile/src/stores/hydrationStore.ts
@@ -3,10 +3,21 @@
  *
  * Storage keys (all MMKV, instance 'mmkv.hydration'):
  *   hydration:v1:log       — DrinkLog[] (per-drink rows, rolling 7 days)
- *   hydration:v1:settings  — HydrationSettings (target + slots)
+ *                            NOTE: v1 log key is reused — only the settings
+ *                            key is versioned (v1 → v2) because the log shape
+ *                            has not changed.
+ *   hydration:v2:settings  — HydrationSettingsV2 (target + UUID-keyed slots)
+ *
+ * Migration (v1 → v2 settings):
+ *   On first load, if only the v1 settings key is present, the store reads the
+ *   old shape (slots: ReminderTime[], slotsEnabled: boolean[]), assigns a UUID
+ *   to each slot folding enabled into the record, writes the v2 key, and deletes
+ *   the v1 key.  Old reminder MMKV keys (water-slot-0 … water-slot-N) are
+ *   cancelled by the consumer after migration so they are re-scheduled under the
+ *   new UUID-keyed names.
  *
  * Reminder MMKV keys are stored by reminderScheduler under 'mmkv.reminders'
- * using the scheme  reminders:v1:water-slot-<index>.
+ * using the scheme  reminders:v1:water-slot-<slotId>.
  *
  * Daily totals are computed lazily by selector. No scheduled reset timer is
  * needed — the selectors filter by today's local date key.
@@ -29,20 +40,25 @@ const mmkv = createStore()
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const LOG_KEY = 'hydration:v1:log'
-const SETTINGS_KEY = 'hydration:v1:settings'
+const SETTINGS_KEY_V1 = 'hydration:v1:settings'
+const SETTINGS_KEY_V2 = 'hydration:v2:settings'
 const MAX_SLOTS = 8
 const DAYS_RETENTION = 7
 const DEFAULT_TARGET_ML = 2500
 
-const DEFAULT_SLOTS: ReminderTime[] = [
-  { hour: 8, minute: 0 },
-  { hour: 11, minute: 0 },
-  { hour: 14, minute: 0 },
-  { hour: 17, minute: 0 },
-  { hour: 20, minute: 0 },
-]
-
 // ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * A single reminder slot with a stable UUID identity.
+ * Replaces the old (ReminderTime + parallel slotsEnabled[]) pattern.
+ */
+export interface ReminderSlot {
+  /** Stable UUID — used as the MMKV reminder key suffix. */
+  id: string
+  hour: number
+  minute: number
+  enabled: boolean
+}
 
 export interface DrinkLog {
   /** UUID string, unique per drink entry. */
@@ -52,13 +68,32 @@ export interface DrinkLog {
   amountMl: number
 }
 
-export interface HydrationSettings {
+/** Shape stored under hydration:v2:settings. */
+export interface HydrationSettingsV2 {
+  targetMl: number
+  slots: ReminderSlot[]
+}
+
+/**
+ * Legacy shape (hydration:v1:settings).
+ * Kept for migration read only — never written.
+ */
+interface HydrationSettingsV1 {
   targetMl: number
   slots: ReminderTime[]
   slotsEnabled: boolean[]
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Simple UUID v4 generator (no external dependency). */
+function uuid(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
 
 /** Returns YYYY-MM-DD in local time for a given ISO timestamp string. */
 function dayKey(isoTimestamp: string): string {
@@ -82,15 +117,6 @@ function daysAgoISO(days: number): string {
   return d.toISOString()
 }
 
-/** Simple UUID v4 generator (no external dependency). */
-function uuid(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0
-    const v = c === 'x' ? r : (r & 0x3) | 0x8
-    return v.toString(16)
-  })
-}
-
 // ─── MMKV read helpers ────────────────────────────────────────────────────────
 
 function readLog(): DrinkLog[] {
@@ -112,25 +138,110 @@ function writeLog(log: DrinkLog[]): void {
   mmkv.set(LOG_KEY, JSON.stringify(log))
 }
 
-function readSettings(): HydrationSettings {
-  if (!mmkv) return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
-  try {
-    const raw = mmkv.getString(SETTINGS_KEY)
-    if (!raw) return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
-    const parsed = JSON.parse(raw) as unknown
-    if (typeof parsed !== 'object' || parsed === null) {
-      return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
-    }
-    return parsed as HydrationSettings
-  } catch {
-    // Malformed JSON — fall back to defaults.
-    return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
-  }
+/**
+ * Detect whether a parsed settings object is the old v1 shape.
+ * V1: has a `slotsEnabled` array (v2 folds enabled into each slot).
+ */
+function isV1Shape(parsed: object): parsed is HydrationSettingsV1 {
+  return 'slotsEnabled' in parsed && Array.isArray((parsed as HydrationSettingsV1).slotsEnabled)
 }
 
-function writeSettings(settings: HydrationSettings): void {
+/**
+ * Detect whether a parsed settings object already has UUID-keyed slots (v2).
+ * V2: slots[0] has an `id` string field.
+ */
+function isV2Shape(parsed: object): parsed is HydrationSettingsV2 {
+  const s = parsed as HydrationSettingsV2
+  return (
+    Array.isArray(s.slots) &&
+    (s.slots.length === 0 || typeof (s.slots[0] as ReminderSlot).id === 'string')
+  )
+}
+
+const DEFAULT_SLOTS: ReminderSlot[] = [
+  { id: uuid(), hour: 8, minute: 0, enabled: false },
+  { id: uuid(), hour: 11, minute: 0, enabled: false },
+  { id: uuid(), hour: 14, minute: 0, enabled: false },
+  { id: uuid(), hour: 17, minute: 0, enabled: false },
+  { id: uuid(), hour: 20, minute: 0, enabled: false },
+]
+
+/**
+ * Read + migrate settings to v2 format.
+ *
+ * Returns:
+ *   { settings, migratedFromV1: boolean, oldV1IndexCount: number }
+ *
+ * When migratedFromV1 is true the caller must:
+ *   1. Cancel old reminders keyed water-slot-0 .. water-slot-(oldV1IndexCount-1).
+ *   2. Re-schedule any enabled slots under their new UUID keys.
+ *   3. The v1 MMKV key has already been deleted inside this function.
+ */
+function readSettings(): {
+  settings: HydrationSettingsV2
+  migratedFromV1: boolean
+  oldV1IndexCount: number
+} {
+  const fallback: HydrationSettingsV2 = {
+    targetMl: DEFAULT_TARGET_ML,
+    slots: DEFAULT_SLOTS,
+  }
+
+  if (!mmkv) {
+    return { settings: fallback, migratedFromV1: false, oldV1IndexCount: 0 }
+  }
+
+  // ── Try v2 key first ──────────────────────────────────────────────────────
+  try {
+    const rawV2 = mmkv.getString(SETTINGS_KEY_V2)
+    if (rawV2) {
+      const parsed = JSON.parse(rawV2) as unknown
+      if (typeof parsed === 'object' && parsed !== null && isV2Shape(parsed)) {
+        return { settings: parsed, migratedFromV1: false, oldV1IndexCount: 0 }
+      }
+    }
+  } catch {
+    // Malformed v2 — fall through to try v1, then default.
+  }
+
+  // ── Try v1 key (migration path) ───────────────────────────────────────────
+  try {
+    const rawV1 = mmkv.getString(SETTINGS_KEY_V1)
+    if (rawV1) {
+      const parsed = JSON.parse(rawV1) as unknown
+      if (typeof parsed === 'object' && parsed !== null && isV1Shape(parsed)) {
+        const v1 = parsed as HydrationSettingsV1
+        const oldCount = v1.slots.length
+        const migratedSlots: ReminderSlot[] = v1.slots.map((s, i) => ({
+          id: uuid(),
+          hour: s.hour,
+          minute: s.minute,
+          enabled: v1.slotsEnabled[i] ?? false,
+        }))
+        const v2: HydrationSettingsV2 = {
+          targetMl: v1.targetMl ?? DEFAULT_TARGET_ML,
+          slots: migratedSlots,
+        }
+        // Write v2 and delete v1 atomically (best-effort — MMKV is not
+        // transactional but the worst case is re-migrating on the next boot,
+        // which is idempotent since we write v2 first).
+        mmkv.set(SETTINGS_KEY_V2, JSON.stringify(v2))
+        mmkv.remove(SETTINGS_KEY_V1)
+        return { settings: v2, migratedFromV1: true, oldV1IndexCount: oldCount }
+      }
+    }
+  } catch {
+    // Malformed v1 — fall through to defaults.
+  }
+
+  // ── No usable state — write fresh defaults ────────────────────────────────
+  mmkv.set(SETTINGS_KEY_V2, JSON.stringify(fallback))
+  return { settings: fallback, migratedFromV1: false, oldV1IndexCount: 0 }
+}
+
+function writeSettings(settings: HydrationSettingsV2): void {
   if (!mmkv) return
-  mmkv.set(SETTINGS_KEY, JSON.stringify(settings))
+  mmkv.set(SETTINGS_KEY_V2, JSON.stringify(settings))
 }
 
 // ─── Selectors (pure functions over store state) ──────────────────────────────
@@ -163,26 +274,37 @@ export function selectLast7DaysTotals(log: DrinkLog[]): { date: string; totalMl:
 
 interface HydrationState {
   targetMl: number
-  slots: ReminderTime[]
-  slotsEnabled: boolean[]
+  slots: ReminderSlot[]
   log: DrinkLog[]
+  /**
+   * Populated only on the very first store creation if the MMKV data was
+   * migrated from v1 (index-based) to v2 (UUID-based).  The caller
+   * (HydrationScreen) reads this once and cancels the old index-keyed
+   * reminders, then resets it to 0.
+   *
+   * Stored as the count of old v1 slots so the screen can iterate
+   * 0..<count to cancel each old key.
+   */
+  pendingMigrationV1Count: number
 }
 
 interface HydrationActions {
   setTarget: (ml: number) => void
-  setSlotTime: (index: number, time: ReminderTime) => void
-  setSlotEnabled: (index: number, on: boolean) => void
+  setSlotTime: (id: string, time: Pick<ReminderSlot, 'hour' | 'minute'>) => void
+  setSlotEnabled: (id: string, on: boolean) => void
   addSlot: () => void
-  removeSlot: (index: number) => void
+  removeSlot: (id: string) => void
   addDrink: (amountMl: number, timestampISO?: string) => void
   removeDrink: (id: string) => void
   /** Remove entries older than beforeIso. Called on store hydration. */
   pruneOldDrinks: (beforeIso: string) => void
+  /** Called by the screen after it has cancelled the v1 reminders. */
+  clearMigrationFlag: () => void
 }
 
 type HydrationStore = HydrationState & HydrationActions
 
-const initialSettings = readSettings()
+const { settings: initialSettings, migratedFromV1, oldV1IndexCount } = readSettings()
 const initialLog = readLog()
 
 export const useHydrationStore = create<HydrationStore>((set, get) => {
@@ -197,55 +319,55 @@ export const useHydrationStore = create<HydrationStore>((set, get) => {
     // ── State ──────────────────────────────────────────────────────────
     targetMl: initialSettings.targetMl,
     slots: initialSettings.slots,
-    slotsEnabled: initialSettings.slotsEnabled,
     log: prunedLog,
+    pendingMigrationV1Count: migratedFromV1 ? oldV1IndexCount : 0,
 
     // ── Actions ────────────────────────────────────────────────────────
 
     setTarget: (ml) => {
       set((s) => {
-        const next: HydrationSettings = { targetMl: ml, slots: s.slots, slotsEnabled: s.slotsEnabled }
+        const next: HydrationSettingsV2 = { targetMl: ml, slots: s.slots }
         writeSettings(next)
         return { targetMl: ml }
       })
     },
 
-    setSlotTime: (index, time) => {
+    setSlotTime: (id, time) => {
       set((s) => {
-        const slots = s.slots.map((slot, i) => (i === index ? time : slot))
-        const next: HydrationSettings = { targetMl: s.targetMl, slots, slotsEnabled: s.slotsEnabled }
+        const slots = s.slots.map((slot) =>
+          slot.id === id ? { ...slot, hour: time.hour, minute: time.minute } : slot,
+        )
+        const next: HydrationSettingsV2 = { targetMl: s.targetMl, slots }
         writeSettings(next)
         return { slots }
       })
     },
 
-    setSlotEnabled: (index, on) => {
+    setSlotEnabled: (id, on) => {
       set((s) => {
-        const slotsEnabled = s.slotsEnabled.map((v, i) => (i === index ? on : v))
-        const next: HydrationSettings = { targetMl: s.targetMl, slots: s.slots, slotsEnabled }
+        const slots = s.slots.map((slot) => (slot.id === id ? { ...slot, enabled: on } : slot))
+        const next: HydrationSettingsV2 = { targetMl: s.targetMl, slots }
         writeSettings(next)
-        return { slotsEnabled }
+        return { slots }
       })
     },
 
     addSlot: () => {
       set((s) => {
         if (s.slots.length >= MAX_SLOTS) return {}
-        const slots = [...s.slots, { hour: 8, minute: 0 }]
-        const slotsEnabled = [...s.slotsEnabled, false]
-        const next: HydrationSettings = { targetMl: s.targetMl, slots, slotsEnabled }
+        const slots: ReminderSlot[] = [...s.slots, { id: uuid(), hour: 8, minute: 0, enabled: false }]
+        const next: HydrationSettingsV2 = { targetMl: s.targetMl, slots }
         writeSettings(next)
-        return { slots, slotsEnabled }
+        return { slots }
       })
     },
 
-    removeSlot: (index) => {
+    removeSlot: (id) => {
       set((s) => {
-        const slots = s.slots.filter((_, i) => i !== index)
-        const slotsEnabled = s.slotsEnabled.filter((_, i) => i !== index)
-        const next: HydrationSettings = { targetMl: s.targetMl, slots, slotsEnabled }
+        const slots = s.slots.filter((slot) => slot.id !== id)
+        const next: HydrationSettingsV2 = { targetMl: s.targetMl, slots }
         writeSettings(next)
-        return { slots, slotsEnabled }
+        return { slots }
       })
     },
 
@@ -277,6 +399,10 @@ export const useHydrationStore = create<HydrationStore>((set, get) => {
         writeLog(pruned)
         set({ log: pruned })
       }
+    },
+
+    clearMigrationFlag: () => {
+      set({ pendingMigrationV1Count: 0 })
     },
   }
 })

--- a/mobile/src/stores/hydrationStore.ts
+++ b/mobile/src/stores/hydrationStore.ts
@@ -1,0 +1,282 @@
+/**
+ * hydrationStore — daily water-intake tracking + reminder settings.
+ *
+ * Storage keys (all MMKV, instance 'mmkv.hydration'):
+ *   hydration:v1:log       — DrinkLog[] (per-drink rows, rolling 7 days)
+ *   hydration:v1:settings  — HydrationSettings (target + slots)
+ *
+ * Reminder MMKV keys are stored by reminderScheduler under 'mmkv.reminders'
+ * using the scheme  reminders:v1:water-slot-<index>.
+ *
+ * Daily totals are computed lazily by selector. No scheduled reset timer is
+ * needed — the selectors filter by today's local date key.
+ */
+
+import { create } from 'zustand'
+import { createMMKV } from 'react-native-mmkv'
+import type { ReminderTime } from '@/lib/reminderScheduler'
+
+// ─── MMKV instance ────────────────────────────────────────────────────────────
+
+// Guard: MMKV throws on Node SSR (expo-web pre-render pass).
+function createStore() {
+  if (typeof window === 'undefined') return null
+  return createMMKV({ id: 'mmkv.hydration' })
+}
+
+const mmkv = createStore()
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const LOG_KEY = 'hydration:v1:log'
+const SETTINGS_KEY = 'hydration:v1:settings'
+const MAX_SLOTS = 8
+const DAYS_RETENTION = 7
+const DEFAULT_TARGET_ML = 2500
+
+const DEFAULT_SLOTS: ReminderTime[] = [
+  { hour: 8, minute: 0 },
+  { hour: 11, minute: 0 },
+  { hour: 14, minute: 0 },
+  { hour: 17, minute: 0 },
+  { hour: 20, minute: 0 },
+]
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DrinkLog {
+  /** UUID string, unique per drink entry. */
+  id: string
+  /** ISO 8601 timestamp. */
+  timestampISO: string
+  amountMl: number
+}
+
+export interface HydrationSettings {
+  targetMl: number
+  slots: ReminderTime[]
+  slotsEnabled: boolean[]
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Returns YYYY-MM-DD in local time for a given ISO timestamp string. */
+function dayKey(isoTimestamp: string): string {
+  const d = new Date(isoTimestamp)
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+/** Returns today's YYYY-MM-DD string in local time. */
+function todayKey(): string {
+  return dayKey(new Date().toISOString())
+}
+
+/** Returns ISO date string for N days ago at 00:00:00 local time. */
+function daysAgoISO(days: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() - days)
+  return d.toISOString()
+}
+
+/** Simple UUID v4 generator (no external dependency). */
+function uuid(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+// ─── MMKV read helpers ────────────────────────────────────────────────────────
+
+function readLog(): DrinkLog[] {
+  if (!mmkv) return []
+  try {
+    const raw = mmkv.getString(LOG_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed as DrinkLog[]
+  } catch {
+    // Malformed JSON — fall back to defaults; the next write will overwrite.
+    return []
+  }
+}
+
+function writeLog(log: DrinkLog[]): void {
+  if (!mmkv) return
+  mmkv.set(LOG_KEY, JSON.stringify(log))
+}
+
+function readSettings(): HydrationSettings {
+  if (!mmkv) return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
+  try {
+    const raw = mmkv.getString(SETTINGS_KEY)
+    if (!raw) return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
+    }
+    return parsed as HydrationSettings
+  } catch {
+    // Malformed JSON — fall back to defaults.
+    return { targetMl: DEFAULT_TARGET_ML, slots: DEFAULT_SLOTS, slotsEnabled: DEFAULT_SLOTS.map(() => true) }
+  }
+}
+
+function writeSettings(settings: HydrationSettings): void {
+  if (!mmkv) return
+  mmkv.set(SETTINGS_KEY, JSON.stringify(settings))
+}
+
+// ─── Selectors (pure functions over store state) ──────────────────────────────
+
+export function selectTodayDrinks(log: DrinkLog[]): DrinkLog[] {
+  const today = todayKey()
+  return log.filter((d) => dayKey(d.timestampISO) === today)
+}
+
+export function selectTodayTotalMl(log: DrinkLog[]): number {
+  return selectTodayDrinks(log).reduce((sum, d) => sum + d.amountMl, 0)
+}
+
+/** Returns last 7 days including today, newest first. */
+export function selectLast7DaysTotals(log: DrinkLog[]): { date: string; totalMl: number }[] {
+  const result: { date: string; totalMl: number }[] = []
+  for (let i = 0; i < DAYS_RETENTION; i++) {
+    const d = new Date()
+    d.setDate(d.getDate() - i)
+    const key = dayKey(d.toISOString())
+    const totalMl = log
+      .filter((entry) => dayKey(entry.timestampISO) === key)
+      .reduce((sum, entry) => sum + entry.amountMl, 0)
+    result.push({ date: key, totalMl })
+  }
+  return result
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+interface HydrationState {
+  targetMl: number
+  slots: ReminderTime[]
+  slotsEnabled: boolean[]
+  log: DrinkLog[]
+}
+
+interface HydrationActions {
+  setTarget: (ml: number) => void
+  setSlotTime: (index: number, time: ReminderTime) => void
+  setSlotEnabled: (index: number, on: boolean) => void
+  addSlot: () => void
+  removeSlot: (index: number) => void
+  addDrink: (amountMl: number, timestampISO?: string) => void
+  removeDrink: (id: string) => void
+  /** Remove entries older than beforeIso. Called on store hydration. */
+  pruneOldDrinks: (beforeIso: string) => void
+}
+
+type HydrationStore = HydrationState & HydrationActions
+
+const initialSettings = readSettings()
+const initialLog = readLog()
+
+export const useHydrationStore = create<HydrationStore>((set, get) => {
+  // Prune on initialisation (lazy 7-day rolling retention).
+  const cutoff = daysAgoISO(DAYS_RETENTION)
+  const prunedLog = initialLog.filter((d) => d.timestampISO >= cutoff)
+  if (prunedLog.length !== initialLog.length) {
+    writeLog(prunedLog)
+  }
+
+  return {
+    // ── State ──────────────────────────────────────────────────────────
+    targetMl: initialSettings.targetMl,
+    slots: initialSettings.slots,
+    slotsEnabled: initialSettings.slotsEnabled,
+    log: prunedLog,
+
+    // ── Actions ────────────────────────────────────────────────────────
+
+    setTarget: (ml) => {
+      set((s) => {
+        const next: HydrationSettings = { targetMl: ml, slots: s.slots, slotsEnabled: s.slotsEnabled }
+        writeSettings(next)
+        return { targetMl: ml }
+      })
+    },
+
+    setSlotTime: (index, time) => {
+      set((s) => {
+        const slots = s.slots.map((slot, i) => (i === index ? time : slot))
+        const next: HydrationSettings = { targetMl: s.targetMl, slots, slotsEnabled: s.slotsEnabled }
+        writeSettings(next)
+        return { slots }
+      })
+    },
+
+    setSlotEnabled: (index, on) => {
+      set((s) => {
+        const slotsEnabled = s.slotsEnabled.map((v, i) => (i === index ? on : v))
+        const next: HydrationSettings = { targetMl: s.targetMl, slots: s.slots, slotsEnabled }
+        writeSettings(next)
+        return { slotsEnabled }
+      })
+    },
+
+    addSlot: () => {
+      set((s) => {
+        if (s.slots.length >= MAX_SLOTS) return {}
+        const slots = [...s.slots, { hour: 8, minute: 0 }]
+        const slotsEnabled = [...s.slotsEnabled, false]
+        const next: HydrationSettings = { targetMl: s.targetMl, slots, slotsEnabled }
+        writeSettings(next)
+        return { slots, slotsEnabled }
+      })
+    },
+
+    removeSlot: (index) => {
+      set((s) => {
+        const slots = s.slots.filter((_, i) => i !== index)
+        const slotsEnabled = s.slotsEnabled.filter((_, i) => i !== index)
+        const next: HydrationSettings = { targetMl: s.targetMl, slots, slotsEnabled }
+        writeSettings(next)
+        return { slots, slotsEnabled }
+      })
+    },
+
+    addDrink: (amountMl, timestampISO) => {
+      const drink: DrinkLog = {
+        id: uuid(),
+        timestampISO: timestampISO ?? new Date().toISOString(),
+        amountMl,
+      }
+      set((s) => {
+        const log = [...s.log, drink]
+        writeLog(log)
+        return { log }
+      })
+    },
+
+    removeDrink: (id) => {
+      set((s) => {
+        const log = s.log.filter((d) => d.id !== id)
+        writeLog(log)
+        return { log }
+      })
+    },
+
+    pruneOldDrinks: (beforeIso) => {
+      const current = get().log
+      const pruned = current.filter((d) => d.timestampISO >= beforeIso)
+      if (pruned.length !== current.length) {
+        writeLog(pruned)
+        set({ log: pruned })
+      }
+    },
+  }
+})


### PR DESCRIPTION
## Summary

Drinking regime feature on mobile. The client gets a daily hydration target, a Today-screen `HydrationCard` (current intake / target + `+250 ml` quick-add), and a dedicated `/hydration` screen with quick-log chips, custom-amount sheet, today's drink log, a 7-day history strip, and a settings section (editable target + up to 8 reminder slots).

- New MMKV-backed `hydrationStore` under `mmkv.hydration` with rolling 7-day retention; daily totals are computed lazily by selector so no midnight-reset timer is needed.
- Reminder scheduling reuses `lib/reminderScheduler.ts` and `components/nutrition/ReminderTimePicker.tsx` from #332/#333 **unchanged** — no duplicate notification code.
- `WaterReminderRow` mirrors the established meal/supplement pattern: the ON state is gated on `scheduleDailyReminder(...).scheduled === true`, permission-denied surfaces a toast and leaves the toggle off, and web platform shows "reminders are mobile-only".
- New `hydration.*` i18n namespace in cs/en/de — 22 leaf keys per locale, parity verified.
- All colors / radii / typography come from design tokens (`useTheme()`, `Radius`, `Type`, `goldAlpha`). No hardcoded hex, no `any`, no `@ts-ignore`.

## Related issue

Fixes #334

## Scope

mobile

## QA verdict (from qa-tester)

OVERALL ✅ PASS — static gate clean (`npx tsc --noEmit` passes). Interactive AC drive deferred per established pattern; rerun in the orchestrator's interactive playbook if a regression is suspected.

## Test plan

- [ ] AC1 — Daily hydration target editable, persisted across restarts, displayed in ml (locale-aware unit handling deferred — ml everywhere).
- [ ] AC2 — Drink reminders configurable as discrete times (up to 8 slots), each toggleable and editable independently.
- [ ] AC3 — Reminders fire as push notifications using `reminderScheduler`'s `scheduleDailyReminder` helper; body localised in cs/en/de.
- [ ] AC4 — Quick-log surface: `+250 ml` on the Today card, preset chips {200, 250, 330, 500, 750} ml on the hydration screen, plus a custom-amount sheet (1–5000 ml validated).
- [ ] AC5 — Today screen `HydrationCard` shows current intake vs target as a progress bar; full-screen `/hydration` shows a larger progress + the 7-day history strip.
- [ ] AC6 — Midnight reset via selector-based filtering (today's drinks = `selectTodayDrinks(log)`); previous days retained for the 7-day strip; entries older than 7 days pruned on store init.
- [ ] AC7 — Target, slots, slot-enabled flags, and the drink log all persist via MMKV (`mmkv.hydration` instance).
- [ ] AC8 — Notification permission is requested via the shared `reminderScheduler` path; no re-prompt if previously granted.
- [ ] AC9 — Zero duplicate scheduling code; `reminderScheduler.ts` and `ReminderTimePicker.tsx` are reused unchanged.
- [ ] AC10 — All new copy lands in cs/en/de under the `hydration.*` namespace.
- [ ] AC11 — No hardcoded colors / spacing; all styling via `useTheme()` and constants.
- [ ] AC12 — N/A (mobile-only, MMKV-local; no backend entity added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)