### PR TITLE
chore(#357): document MarkReviewed-on-Expired allowance

### DIFF
--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/MarkCheckInReviewed/MarkCheckInReviewedEndpoint.cs
@@ -13,6 +13,32 @@ namespace FitnessPlatform.Application.Features.WeeklyCheckIns.MarkCheckInReviewe
 /// Broadcasts <c>weeklycheckinupdated</c> to both the professional and the client
 /// so the client's read-only view can become locked immediately.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Design decision (#357): this endpoint INTENTIONALLY does NOT guard against
+/// <see cref="WeeklyCheckInStatus.Expired"/> — a trainer can still mark an
+/// expired check-in as Reviewed. This is asymmetric with
+/// <c>RespondToCheckInEndpoint</c> and <c>DismissCheckInEndpoint</c>, which both
+/// return <c>409 CHECK_IN_EXPIRED</c> on terminal rows.
+/// </para>
+/// <para>
+/// Rationale:
+/// <list type="bullet">
+///   <item>Different actor. Respond/Dismiss are client-side actions on a live
+///         check-in; the client engaging with an already-expired prompt is a
+///         workflow error worth rejecting. Review is a coach-side action that
+///         operates on stale data routinely — "clean up the backlog and mark
+///         these as reviewed-for-the-record" is a normal flow.</item>
+///   <item>Audit preservation. The transition sets
+///         <c>Status = Reviewed</c> but does NOT clear <c>ExpiredAt</c>.
+///         The historical timeline ("expired at T1, then reviewed by trainer at T2")
+///         is fully preserved on the row.</item>
+///   <item>Matches #331 AC5 ("Expired records are retained for history and are
+///         never silently deleted") — preserving means the trainer can still
+///         action them, not that the row becomes read-only forever.</item>
+/// </list>
+/// </para>
+/// </remarks>
 public class MarkCheckInReviewedEndpoint(
     IApplicationDbContext db,
     IRealtimeNotifier notifier)

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/MarkCheckInReviewedEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/MarkCheckInReviewedEndpointTests.cs
@@ -166,4 +166,55 @@ public class MarkCheckInReviewedEndpointTests(FitnessApiFactory factory)
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    // ── Design decision (#357): expired rows ARE reviewable ────────────────────
+
+    [Fact]
+    public async Task MarkReviewed_OnExpiredCheckIn_Returns200_PreservesExpiredAt()
+    {
+        // Per #357, trainers can mark Expired check-ins as Reviewed
+        // (audit-friendly cleanup workflow). ExpiredAt MUST survive the
+        // transition so the historical timeline ("expired at T1, then
+        // reviewed by trainer at T2") is preserved on the row.
+
+        var (http, trainerId) = await SetupTrainerAsync();
+        var clientId = await SetupClientUserIdAsync();
+        var checkInId = await InsertCheckInAsync(clientId, trainerId);
+
+        var expiredAtTimestamp = DateTime.UtcNow.AddHours(-3);
+
+        // Manually transition the row to Expired so we can verify MarkReviewed
+        // accepts the input (rather than 409-ing like Respond/Dismiss do).
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var row = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+                .FirstAsync(db.WeeklyCheckIns, c => c.Id == checkInId, TestContext.Current.CancellationToken);
+            row.RespondedAt = null;
+            row.Status = WeeklyCheckInStatus.Expired;
+            row.ExpiredAt = expiredAtTimestamp;
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var response = await http.PostAsJsonAsync(
+            $"/trainer/weekly-check-ins/{checkInId}/mark-reviewed",
+            new { },
+            TestContext.Current.CancellationToken);
+
+        // Allow (NOT 409) — see endpoint <remarks> for design rationale.
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var verifyScope = factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var persisted = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+            .FirstAsync(verifyDb.WeeklyCheckIns, c => c.Id == checkInId, TestContext.Current.CancellationToken);
+
+        // Status flipped to Reviewed, ReviewedByTrainerAt stamped.
+        persisted.Status.Should().Be(WeeklyCheckInStatus.Reviewed);
+        persisted.ReviewedByTrainerAt.Should().NotBeNull();
+
+        // Audit preservation — ExpiredAt MUST survive the transition.
+        persisted.ExpiredAt.Should().NotBeNull();
+        persisted.ExpiredAt.Should().BeCloseTo(expiredAtTimestamp, TimeSpan.FromSeconds(1));
+    }
 }


### PR DESCRIPTION
## Summary

Documents the intentional design decision that `MarkCheckInReviewedEndpoint` ALLOWS marking an Expired check-in as Reviewed (asymmetric with Respond/Dismiss, which both 409 on terminal rows). Surfaced as a NIT during PR #355 (#331) review.

## Design decision

**Allow** — and `ExpiredAt` survives the transition.

**Rationale:**
- **Different actor**: Respond/Dismiss are client-side actions on a live check-in; rejecting on Expired is correct UX (the client engaging with an already-expired prompt is a workflow error). Review is a coach-side workflow action that operates on stale data routinely — "scroll through the backlog and mark these as reviewed-for-the-record" is a normal flow.
- **Audit preservation**: the transition sets `Status = Reviewed` but does NOT clear `ExpiredAt`. The historical timeline ("expired at T1, then reviewed by trainer at T2") is fully preserved on the row.
- **Matches #331 AC5**: "Expired records are retained for history and are never silently deleted" — preserving means the trainer can still action them, not that the row becomes read-only forever.

## Changes

- **`MarkCheckInReviewedEndpoint.cs`**: added `<remarks>` XML doc block on the class explaining the intentional asymmetry + rationale + audit-preservation invariant.
- **`MarkCheckInReviewedEndpointTests.cs`**: new test `MarkReviewed_OnExpiredCheckIn_Returns200_PreservesExpiredAt` that locks in the behavior:
  - Starts a check-in in `Status = Expired` with `ExpiredAt` stamped.
  - Calls `POST /trainer/weekly-check-ins/{id}/mark-reviewed`.
  - Asserts: `200`, `Status = Reviewed`, `ReviewedByTrainerAt` non-null, **`ExpiredAt` preserved** (the audit invariant).

**No behavior change** — documentation + test that locks in the existing behavior. If someone later adds the 409 guard by mistake, this test will fail.

## Test plan

- [x] `dotnet build` clean (only pre-existing warnings + one new resolved cref-warning fix).
- [x] `dotnet test -- --filter-class FitnessPlatform.Tests.Endpoints.WeeklyCheckIns.MarkCheckInReviewedEndpointTests` — 6/6 pass (5 pre-existing + 1 new).

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)