### PR TITLE
feat: training subcard photo-grid button on Today screen

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1135,6 +1135,12 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
     router.push(hrefParams('/(client)/plan-photos', { planId: plan.planId }))
   }, [router, plan?.planId])
 
+  /** Navigate to the training plan-photos gallery screen. */
+  const handleTrainingPhotoGridPress = useCallback(() => {
+    if (!training?.planId) return
+    router.push(hrefParams('/(client)/plan-photos', { planId: training.planId }))
+  }, [router, training?.planId])
+
   /** Navigate to the meal-log-photo modal screen for the tapped meal. */
   const handlePhotoPress = useCallback(
     (mealId: string) => {
@@ -1242,18 +1248,47 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
           <View style={[styles.section, { marginBottom: -8 }]} key="training">
             <SectionHeader
               title={t('today.todaysTraining')}
-              actionLabel={training?.planId ? t('today.sectionActionDetail') : undefined}
-              onActionPress={
-                training?.planId
-                  ? () => {
-                      router.push(
-                        hrefParams('/(client)/(tabs)/plans/[planId]', {
-                          planId: training.planId!,
-                          type: 'training',
-                        }),
-                      )
-                    }
-                  : undefined
+              action={
+                <View style={styles.trainingHeaderActions}>
+                  {training?.planId ? (
+                    <Pressable
+                      onPress={handleTrainingPhotoGridPress}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('training.photoCta')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="camera" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('training.photoCta')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  {training?.planId ? (
+                    <Pressable
+                      onPress={() => {
+                        router.push(
+                          hrefParams('/(client)/(tabs)/plans/[planId]', {
+                            planId: training.planId!,
+                            type: 'training',
+                          }),
+                        )
+                      }}
+                      hitSlop={8}
+                    >
+                      <Text style={[styles.trainingDetailAction, { color: colors.gold }]}>
+                        {t('today.sectionActionDetail')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                </View>
               }
             />
             <TrainingCard
@@ -1372,6 +1407,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
+  },
+  trainingHeaderActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  trainingDetailAction: {
+    ...Type.subheadline,
   },
   mealsProgress: {
     ...Type.footnote,

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -983,6 +983,7 @@
       "resetWorkout": "Resetovat",
       "amrapExerciseDone": "Hotovo {{rounds}}× · {{total}} opak."
     },
+    "photoCta": "Foto",
     "sessions": {
       "reminder": {
         "toggleLabel": "Připomenutí",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -951,6 +951,7 @@
       "resetWorkout": "Zurücksetzen",
       "amrapExerciseDone": "{{rounds}}× erledigt · {{total}} Wdh."
     },
+    "photoCta": "Foto",
     "sessions": {
       "reminder": {
         "toggleLabel": "Erinnerung",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -729,6 +729,7 @@
       "resetWorkout": "Reset",
       "amrapExerciseDone": "Done {{rounds}}× · {{total}} reps"
     },
+    "photoCta": "Photo",
     "sessions": {
       "reminder": {
         "toggleLabel": "Reminder",


### PR DESCRIPTION
## Summary
- Adds the missing photo-grid (camera) button to the Today screen's training subcard `SectionHeader`, mirroring the existing nutrition subcard button in position, styling, tokens, and behaviour.
- Tapping it navigates to `/(client)/plan-photos` with the training plan's `planId`, opening the plan-photos gallery for the training plan (the gallery, upload, backend, and web coach Photos tab have been plan-agnostic since #65).
- The training subcard's call site switches from `SectionHeader`'s `actionLabel`/`onActionPress` props to its existing `action` slot, so the photo button and the existing "Detail" link sit side by side; the Detail link's navigation and gold `Type.subheadline` styling are preserved. (`SectionHeader` itself is unchanged.)
- New `training.photoCta` i18n key added to all three locales (cs/en/de), Czech first; the existing `nutrition.photoCta` key is not reused.

## Related issue
Fixes #361
Part of #328 — this is the single remaining user-facing gap from the Training-plan-photos epic; everything else was already plan-agnostic since #65.

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all 6 ACs met; `tsc --noEmit` clean in worktree; backend training-photo test classes re-run GREEN (FinalizePlanPhoto 10/10, GenerateUploadUrl 8/8, GetTrainerClientPhotos 14/14).

## Test plan
- [ ] Training subcard `SectionHeader` exposes a camera/photo-grid icon button identical in position, styling, and behaviour to the nutrition one (same `photoCtaBtn`/`photoCtaIconChip`/`photoCtaLabel` styles, gold tokens via `useTheme()`, `accessibilityRole="button"`, `hitSlop`).
- [ ] Tapping the button navigates to `/(client)/plan-photos` with the training plan's `planId`.
- [ ] The button renders only when a training plan/day is present (inside the `hasTrainingToday` slot, gated on `training?.planId`).
- [ ] New `training.photoCta` key lands in `mobile/src/i18n/locales/{cs,en,de}.json`, Czech first; `nutrition.photoCta` not reused.
- [ ] All colours, spacing, typography use design tokens (`useTheme()`); no inline hex; no `any`.
- [ ] `npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
