### PR TITLE
feat: training-plan detail screen photo entry point (plan-level)

### DIFF
--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -1160,6 +1160,17 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
             <Ionicons name="clipboard-outline" size={20} color={colors.label} />
           </Pressable>
         )}
+
+        {planId ? (
+          <Pressable
+            onPress={() => router.push(hrefParams('/(client)/plan-photos', { planId }))}
+            hitSlop={12}
+            style={[styles.nutritionMenuBtn, { backgroundColor: colors.fill }]}
+            accessibilityLabel={t('planPhotos.openA11y')}
+          >
+            <Ionicons name="images-outline" size={20} color={colors.label} />
+          </Pressable>
+        ) : null}
       </View>
 
       {/* ── Week grid overlay ── */}

--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -1166,6 +1166,7 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
             onPress={() => router.push(hrefParams('/(client)/plan-photos', { planId }))}
             hitSlop={12}
             style={[styles.nutritionMenuBtn, { backgroundColor: colors.fill }]}
+            accessibilityRole="button"
             accessibilityLabel={t('planPhotos.openA11y')}
           >
             <Ionicons name="images-outline" size={20} color={colors.label} />


### PR DESCRIPTION
## Summary
- Adds a single `images-outline` icon button to the `TrainingPlanDetail` header (after the questionnaire chip) that navigates to `/(client)/plan-photos` with the training plan's `planId`.
- Mirrors the existing nutrition plan-photos entry point; reuses `styles.nutritionMenuBtn` + `colors.fill`/`colors.label` tokens and the existing `planPhotos.openA11y` i18n key.
- Guarded on `planId` — the affordance renders only when the plan id is present. No backend change, no new route, no new locale keys.

## Related issue
Fixes #364
Part of #328.

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — 5/5 acceptance criteria met; `npx tsc --noEmit` clean; i18n key present in cs/en/de.

## Test plan
- [ ] TrainingPlanDetail exposes a photo entry point in its header that navigates to `/(client)/plan-photos` with the training plan `planId`, mirroring the nutrition detail screen pattern.
- [ ] The entry point renders only when the training plan id is present; guarded against undefined `planId`.
- [ ] No backend change introduced; the existing `/(client)/plan-photos` route is reused as-is; photo association stays plan-level only.
- [ ] Any new user-facing string lands in all three locale files; an existing key may be reused if it fits (reuses `planPhotos.openA11y`).
- [ ] Implementation uses design tokens exclusively via `useTheme()`; no inline hex; no `any`; `npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)