### PR TITLE
feat: allow coach to edit past unfinished items on training-plan detail page

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -232,6 +232,16 @@ public static class ErrorCodes
     /// <summary>Duplicate Order values across sections in the same session.</summary>
     public const string SectionOrderDuplicate = "SECTION_ORDER_DUPLICATE";
 
+    // ── Trainer Finish Session ───────────────────────────────────────
+    /// <summary>The session already has a completed workout log; cannot finish again.</summary>
+    public const string SessionAlreadyCompleted = "SESSION_ALREADY_COMPLETED";
+
+    /// <summary>completedAt is in the future; backdating to the future is not allowed.</summary>
+    public const string CompletedAtInFuture = "COMPLETED_AT_IN_FUTURE";
+
+    /// <summary>completedAt is before the plan's start date; history cannot be written before the plan began.</summary>
+    public const string CompletedAtBeforePlanStart = "COMPLETED_AT_BEFORE_PLAN_START";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IWorkoutCompletionService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IWorkoutCompletionService.cs
@@ -1,0 +1,33 @@
+using FitnessPlatform.Application.Domain.Documents;
+
+namespace FitnessPlatform.Application.Domain.Interfaces;
+
+/// <summary>
+/// Completes a workout log: runs PR detection, marks the log as done, fans out a
+/// <see cref="TrainingCompletion"/> document for compliance/streak, and creates a
+/// trainer notification when personal records are detected.
+///
+/// The <paramref name="completedAtUtc"/> parameter drives BOTH <see cref="WorkoutLog.CompletedAt"/>
+/// AND the <see cref="TrainingCompletion"/> date key, so that backdated finishes are
+/// attributed to the correct calendar day.
+/// </summary>
+public interface IWorkoutCompletionService
+{
+    /// <summary>
+    /// Completes the given workout log at the specified instant.
+    /// </summary>
+    /// <param name="log">
+    ///   The workout log to complete. Must have <see cref="WorkoutLog.IsCompleted"/> == false.
+    ///   The document is mutated in place (CompletedAt, IsCompleted, DateUpdated) and
+    ///   replaced in MongoDB inside this call.
+    /// </param>
+    /// <param name="completedAtUtc">
+    ///   The UTC instant to record as the completion time. Used for both
+    ///   <see cref="WorkoutLog.CompletedAt"/> and the <see cref="TrainingCompletion"/> date key.
+    ///   Pass <see cref="DateTime.UtcNow"/> for live completions; pass a backdated value for
+    ///   trainer-driven historical finishes.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The list of human-readable PR descriptions (may be empty).</returns>
+    Task<List<string>> CompleteAsync(WorkoutLog log, DateTime completedAtUtc, CancellationToken ct);
+}

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IWorkoutCompletionService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IWorkoutCompletionService.cs
@@ -7,7 +7,7 @@ namespace FitnessPlatform.Application.Domain.Interfaces;
 /// <see cref="TrainingCompletion"/> document for compliance/streak, and creates a
 /// trainer notification when personal records are detected.
 ///
-/// The <paramref name="completedAtUtc"/> parameter drives BOTH <see cref="WorkoutLog.CompletedAt"/>
+/// The completion instant drives BOTH <see cref="WorkoutLog.CompletedAt"/>
 /// AND the <see cref="TrainingCompletion"/> date key, so that backdated finishes are
 /// attributed to the correct calendar day.
 /// </summary>

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
@@ -1,0 +1,185 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+
+/// <summary>
+/// Allows a trainer to retroactively finish a skipped or untouched session in their client's
+/// training plan. Produces a completed <see cref="WorkoutLog"/> (materializing from the session
+/// template when no log exists), runs PR detection, and fans out a <see cref="TrainingCompletion"/>
+/// document so that compliance/streak attribution lands on the correct calendar day.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="completionService">Shared workout completion pipeline.</param>
+public class FinishSessionEndpoint(
+    IMongoContext mongo,
+    IWorkoutCompletionService completionService) : Endpoint<FinishSessionRequest, FinishSessionResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/trainer/training/plans/{PlanId}/sessions/{SessionId}/finish");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Finish a session on behalf of a client";
+            s.Description =
+                "Marks a skipped or untouched session as completed. " +
+                "Materializes a WorkoutLog from the session template when none exists. " +
+                "Accepts an optional backdated completedAt; defaults to now.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(FinishSessionRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+
+        // 1. Load the plan and apply the ownership guard.
+        //    Mirror GetTrainingPlanEndpoint: "not mine" is returned as NotFound to prevent existence leak.
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId);
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null || plan.TrainerId != trainerId)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // 2. Locate the session within the plan.
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // 3. Resolve the effective completion instant.
+        var completedAt = req.CompletedAt ?? DateTime.UtcNow;
+
+        // 3a. Guard: completedAt must not be before the plan's start date.
+        if (plan.StartDate.HasValue && completedAt < plan.StartDate.Value)
+        {
+            await this.SendProblemAsync(422, ErrorCodes.CompletedAtBeforePlanStart,
+                "completedAt must not be before the plan's start date.", ct);
+            return;
+        }
+
+        // 4. Look for an existing WorkoutLog for this (PlanId, SessionId).
+        var logFilter = Builders<WorkoutLog>.Filter.Eq(l => l.PlanId, req.PlanId)
+                        & Builders<WorkoutLog>.Filter.Eq(l => l.SessionId, req.SessionId);
+        using var logCursor = await mongo.WorkoutLogs.FindAsync(logFilter, cancellationToken: ct);
+        var existingLogs = await logCursor.ToListAsync(ct);
+
+        // 4a. If there is already a completed log, reject — idempotent-safe message.
+        var completedLog = existingLogs.FirstOrDefault(l => l.IsCompleted);
+        if (completedLog is not null)
+        {
+            await this.SendProblemAsync(409, ErrorCodes.SessionAlreadyCompleted,
+                "This session already has a completed workout log.", ct);
+            return;
+        }
+
+        // 5. Use the most-recently-updated in-progress log if one exists; otherwise materialize
+        //    a new WorkoutLog from the session template.
+        var log = existingLogs
+            .OrderByDescending(l => l.DateUpdated ?? l.DateCreated)
+            .FirstOrDefault();
+
+        if (log is null)
+        {
+            log = MaterializeFromTemplate(plan, session, completedAt, ct);
+            await mongo.WorkoutLogs.InsertOneAsync(log, cancellationToken: ct);
+        }
+
+        // 6. Delegate the full completion pipeline to the shared service.
+        //    The completedAt instant drives BOTH log.CompletedAt and the TrainingCompletion date key,
+        //    so that backdated finishes are attributed to the correct calendar day.
+        await completionService.CompleteAsync(log, completedAt, ct);
+
+        await Send.OkAsync(new FinishSessionResponse
+        {
+            WorkoutLogId = log.ExternalId,
+            PlanId = req.PlanId,
+            SessionId = req.SessionId,
+            CompletedAt = completedAt
+        }, ct);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="WorkoutLog"/> from the session template, with all sets
+    /// initialized from the plan's <see cref="ExerciseSet"/> prescription and
+    /// <see cref="WorkoutSet.CompletedAt"/> stamped with the supplied instant.
+    /// </summary>
+    private static WorkoutLog MaterializeFromTemplate(
+        TrainingPlan plan,
+        TrainingSession session,
+        DateTime completedAt,
+        CancellationToken _)
+    {
+        // Backfill legacy flat-exercise sessions into the section structure first.
+        session.WithBackfilledSections();
+
+        var workoutSections = session.Sections
+            .Select(section => new WorkoutSection
+            {
+                SectionId = section.SectionId,
+                Order = section.Order,
+                Name = section.Name,
+                Format = section.Format,
+                Exercises = section.Exercises
+                    .Select(se => new WorkoutExercise
+                    {
+                        ExerciseExternalId = se.ExerciseExternalId,
+                        ExerciseName = se.ExerciseName,
+                        Sets = se.Sets
+                            .Select(es => new WorkoutSet
+                            {
+                                SetNumber = es.SetNumber,
+                                Reps = es.Reps,
+                                WeightKg = es.WeightKg,
+                                Rpe = es.Rpe,
+                                DurationSeconds = es.DurationSeconds,
+                                DistanceMeters = es.DistanceMeters,
+                                // Stamp all sets as completed at the supplied instant.
+                                // IsPR is left false — the completion service will set it via PR detection.
+                                CompletedAt = completedAt,
+                                IsPR = false
+                            })
+                            .ToList()
+                    })
+                    .ToList()
+            })
+            .ToList();
+
+        return new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = plan.ClientId,
+            PlanId = plan.ExternalId,
+            SessionId = session.SessionId,
+            StartedAt = completedAt,
+            IsCompleted = false, // will be set to true by completionService.CompleteAsync
+            Sections = workoutSections,
+            DateCreated = DateTime.UtcNow
+        };
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
@@ -72,14 +72,24 @@ public class FinishSessionEndpoint(
             return;
         }
 
-        // 3. Resolve the effective completion instant.
-        var completedAt = req.CompletedAt ?? DateTime.UtcNow;
+        // 3. Resolve the effective completion instant, normalizing to UTC so that
+        //    DateOnly.FromDateTime(completedAt) always lands on the correct calendar day
+        //    regardless of the DateTime.Kind the JSON binder assigned to the incoming value.
+        var completedAt = (req.CompletedAt ?? DateTime.UtcNow).ToUniversalTime();
 
         // 3a. Guard: completedAt must not be before the plan's start date.
-        if (plan.StartDate.HasValue && completedAt < plan.StartDate.Value)
+        //    When StartDate is null (plan created but not yet started), fall back to
+        //    plan.DateCreated as the floor — a session cannot have been completed before
+        //    the plan existed, and leaving this unchecked allows arbitrary backdating
+        //    (e.g. year 1900), which fabricates historical compliance records.
+        var completionFloor = plan.StartDate.HasValue
+            ? plan.StartDate.Value
+            : plan.DateCreated;
+
+        if (completedAt < completionFloor)
         {
             await this.SendProblemAsync(422, ErrorCodes.CompletedAtBeforePlanStart,
-                "completedAt must not be before the plan's start date.", ct);
+                "completedAt must not be before the plan's start date (or creation date when no start date is set).", ct);
             return;
         }
 

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionRequest.cs
@@ -1,0 +1,24 @@
+namespace FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+
+/// <summary>
+/// Request for the trainer to retroactively finish a skipped or untouched session.
+/// </summary>
+public class FinishSessionRequest
+{
+    /// <summary>
+    /// The training plan ExternalId (route parameter).
+    /// </summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>
+    /// The session identifier within the plan's weeks (route parameter).
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// Optional backdated completion instant.
+    /// When omitted the server uses <see cref="DateTime.UtcNow"/>.
+    /// Must be in the past (or present) and not before the plan's start date.
+    /// </summary>
+    public DateTime? CompletedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionResponse.cs
@@ -1,0 +1,27 @@
+namespace FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+
+/// <summary>
+/// Response after a trainer successfully finishes a session.
+/// </summary>
+public class FinishSessionResponse
+{
+    /// <summary>
+    /// The workout log ExternalId that was created or completed.
+    /// </summary>
+    public Guid WorkoutLogId { get; set; }
+
+    /// <summary>
+    /// The plan ExternalId.
+    /// </summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>
+    /// The session identifier within the plan.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The instant the session was marked as completed (the effective completedAt value used).
+    /// </summary>
+    public DateTime CompletedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionValidator.cs
@@ -1,4 +1,5 @@
 using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
 using FluentValidation;
 
 namespace FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
@@ -20,7 +21,7 @@ public class FinishSessionValidator : Validator<FinishSessionRequest>
         // The "before plan start" check requires plan data and is done in HandleAsync.
         RuleFor(x => x.CompletedAt)
             .Must(d => d == null || d.Value <= DateTime.UtcNow)
-            .WithErrorCode("COMPLETED_AT_IN_FUTURE")
+            .WithErrorCode(ErrorCodes.CompletedAtInFuture)
             .WithMessage("completedAt must not be in the future")
             .When(x => x.CompletedAt.HasValue);
     }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionValidator.cs
@@ -1,0 +1,27 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+
+/// <summary>
+/// Validator for <see cref="FinishSessionRequest"/>.
+/// </summary>
+public class FinishSessionValidator : Validator<FinishSessionRequest>
+{
+    public FinishSessionValidator()
+    {
+        RuleFor(x => x.PlanId)
+            .NotEmpty();
+
+        RuleFor(x => x.SessionId)
+            .NotEmpty();
+
+        // CompletedAt is optional; when supplied it must not be in the future.
+        // The "before plan start" check requires plan data and is done in HandleAsync.
+        RuleFor(x => x.CompletedAt)
+            .Must(d => d == null || d.Value <= DateTime.UtcNow)
+            .WithErrorCode("COMPLETED_AT_IN_FUTURE")
+            .WithMessage("completedAt must not be in the future")
+            .When(x => x.CompletedAt.HasValue);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
@@ -1,14 +1,10 @@
 using System.Security.Claims;
-using System.Text.Json;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
-using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
-using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
-using Microsoft.EntityFrameworkCore;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
@@ -19,16 +15,10 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 /// calculations pick up the live workout alongside plan-driven completions.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
-/// <param name="db">Relational database context (used to resolve ClientProfile.PublicId).</param>
-/// <param name="prDetection">Personal record detection service.</param>
-/// <param name="notifications">Notification creation service.</param>
-/// <param name="logger">Logger for best-effort fan-out warnings.</param>
+/// <param name="completionService">Shared workout completion pipeline (PR detection, fan-out, notification).</param>
 public class CompleteWorkoutEndpoint(
     IMongoContext mongo,
-    IApplicationDbContext db,
-    IPrDetectionService prDetection,
-    INotificationService notifications,
-    ILogger<CompleteWorkoutEndpoint> logger) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
+    IWorkoutCompletionService completionService) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -68,189 +58,11 @@ public class CompleteWorkoutEndpoint(
             return;
         }
 
-        // Run PR detection
-        var prDescriptions = await prDetection.DetectAndMarkPRsAsync(log, ct);
-
-        // Mark as completed
-        log.CompletedAt = DateTime.UtcNow;
-        log.IsCompleted = true;
-        log.DateUpdated = DateTime.UtcNow;
-
-        await mongo.WorkoutLogs.ReplaceOneAsync(
-            w => w.ExternalId == req.LogId,
-            log,
-            cancellationToken: ct);
-
-        // Fan out a TrainingCompletion doc so compliance/streak picks up this live workout.
-        // Best-effort: a failure here must NOT affect the primary contract (log.IsCompleted=true).
-        try
-        {
-            await UpsertTrainingCompletionAsync(log, ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex,
-                "TrainingCompletion fan-out failed for workout log {LogId}. Workout completion succeeded.",
-                req.LogId);
-        }
-
-        // Create trainer notification if any PRs detected (throttled: max 1 per workout)
-        if (prDescriptions.Count > 0)
-        {
-            // Find the trainer via the training plan
-            if (log.PlanId.HasValue)
-            {
-                var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
-                using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
-                var plan = await planCursor.FirstOrDefaultAsync(ct);
-
-                if (plan is not null)
-                {
-                    var prSummary = string.Join(", ", prDescriptions.Take(3));
-                    var data = JsonSerializer.Serialize(new { workoutLogId = log.ExternalId, clientId });
-
-                    await notifications.CreateAsync(
-                        plan.TrainerId,
-                        NotificationType.PersonalRecord,
-                        "New Personal Record!",
-                        prSummary,
-                        data,
-                        ct);
-                }
-            }
-        }
+        // Delegate the full completion pipeline (PR detection, log update,
+        // TrainingCompletion fan-out, notification) to the shared service.
+        // Live client completions use DateTime.UtcNow as the completion instant.
+        await completionService.CompleteAsync(log, DateTime.UtcNow, ct);
 
         await Send.OkAsync(WorkoutLogDetail.FromDocument(log), ct);
-    }
-
-    // ── Best-effort TrainingCompletion fan-out ────────────────────────────────────
-    // Mirrors the upsert pattern in MarkSessionCompleteEndpoint so that
-    // ComplianceService.IsSessionCompleteForDateAsync sees this live workout.
-
-    private async Task UpsertTrainingCompletionAsync(WorkoutLog log, CancellationToken ct)
-    {
-        // Only planned-session workouts are tracked for compliance.
-        if (!log.SessionId.HasValue || !log.PlanId.HasValue)
-            return;
-
-        var sessionId = log.SessionId.Value;
-
-        // Resolve the plan's session to get all exercise ids.
-        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
-        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
-        var plan = await planCursor.FirstOrDefaultAsync(ct);
-
-        if (plan is null)
-        {
-            logger.LogWarning(
-                "TrainingCompletion fan-out: plan {PlanId} not found for workout log {LogId}.",
-                log.PlanId.Value, log.ExternalId);
-            return;
-        }
-
-        var session = plan.Weeks
-            .SelectMany(w => w.Sessions)
-            .FirstOrDefault(s => s.SessionId == sessionId);
-
-        if (session is null)
-        {
-            logger.LogWarning(
-                "TrainingCompletion fan-out: session {SessionId} not found in plan {PlanId} for workout log {LogId}.",
-                sessionId, log.PlanId.Value, log.ExternalId);
-            return;
-        }
-
-        session.WithBackfilledSections();
-        var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();
-        var allSectionIds = session.Sections.Select(s => s.SectionId).ToList();
-        // Per-section attribution. Required so the Today card flips every
-        // workout (including exercise-free WODs like ForTime "Beh") to
-        // "done" on read. Without this, the read-time backfill in
-        // `TrainingCompletionBackfill` falls back to first-section-wins
-        // attribution from the flat list, which leaves shared-exercise
-        // sections (e.g. AMRAP reusing an earlier section's lift) and
-        // exercise-free sections marked incomplete.
-        var completedBySection = session.Sections.ToDictionary(
-            s => s.SectionId.ToString(),
-            s => s.Exercises.Select(e => e.ExerciseExternalId).ToList());
-
-        // Resolve clientId as PublicId — TrainingCompletion keyed by ClientProfile.PublicId,
-        // not the raw UserId stored on WorkoutLog.ClientId.
-        var clientProfile = await db.ClientProfiles
-            .AsNoTracking()
-            .FirstOrDefaultAsync(cp => cp.UserId == log.ClientId, ct);
-
-        if (clientProfile is null)
-        {
-            logger.LogWarning(
-                "TrainingCompletion fan-out: ClientProfile not found for UserId {UserId}.",
-                log.ClientId);
-            return;
-        }
-
-        var clientId = clientProfile.PublicId;
-
-        // Date key: the calendar day the workout was *finalised* (UTC).
-        // Using completion time (DateTime.UtcNow) aligns with MarkSessionCompleteEndpoint,
-        // MarkSessionIncompleteEndpoint, and MarkExerciseIncompleteEndpoint so that
-        // GetTodaySessionEndpoint — which reads by DateTime.UtcNow.Date — always finds the doc.
-        var date = DateOnly.FromDateTime(DateTime.UtcNow).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
-
-        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
-                               & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, date)
-                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, sessionId);
-
-        using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
-        var existing = await completionCursor.FirstOrDefaultAsync(ct);
-
-        if (existing is not null)
-        {
-            // Idempotency: skip the write only when every per-session field
-            // already matches the full session set. Checking the flat list
-            // alone (the old behaviour) left legacy docs stuck with empty
-            // `CompletedExerciseIdsBySection` / `CompletedSectionIds`,
-            // which kept AMRAP + ForTime workouts marked as un-done on the
-            // Today card even after the live session finalised.
-            var sectionDictAligned =
-                existing.CompletedExerciseIdsBySection is not null
-                && completedBySection.All(kvp =>
-                    existing.CompletedExerciseIdsBySection!.TryGetValue(kvp.Key, out var ids)
-                    && kvp.Value.All(id => ids.Contains(id)));
-            var sectionIdsAligned = allSectionIds.All(id =>
-                (existing.CompletedSectionIds ?? new List<Guid>()).Contains(id));
-            if (allExerciseIds.All(id => existing.CompletedExerciseIds.Contains(id))
-                && sectionDictAligned
-                && sectionIdsAligned)
-                return;
-
-            var versionedFilter = completionFilter
-                                  & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
-
-            var update = Builders<TrainingCompletion>.Update
-                .Set(c => c.CompletedExerciseIds, allExerciseIds)
-                .Set(c => c.CompletedExerciseIdsBySection, completedBySection)
-                .Set(c => c.CompletedSectionIds, allSectionIds)
-                .Set(c => c.DateUpdated, DateTime.UtcNow)
-                .Set(c => c.Version, existing.Version + 1);
-
-            await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
-        }
-        else
-        {
-            var completion = new TrainingCompletion
-            {
-                ExternalId = Guid.NewGuid(),
-                ClientId = clientId,
-                Date = date,
-                SessionId = sessionId,
-                CompletedExerciseIds = allExerciseIds,
-                CompletedExerciseIdsBySection = completedBySection,
-                CompletedSectionIds = allSectionIds,
-                DateCreated = DateTime.UtcNow,
-                Version = 1
-            };
-
-            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
-        }
     }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/WorkoutCompletionService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/WorkoutCompletionService.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IWorkoutCompletionService"/>.
+///
+/// Extracted from <c>CompleteWorkoutEndpoint</c> so that the trainer-driven
+/// <c>FinishSessionEndpoint</c> can reuse the same completion pipeline (PR
+/// detection, TrainingCompletion fan-out, notification) without duplicating
+/// business logic.
+/// </summary>
+public class WorkoutCompletionService(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IPrDetectionService prDetection,
+    INotificationService notifications,
+    ILogger<WorkoutCompletionService> logger) : IWorkoutCompletionService
+{
+    /// <inheritdoc />
+    public async Task<List<string>> CompleteAsync(
+        WorkoutLog log,
+        DateTime completedAtUtc,
+        CancellationToken ct)
+    {
+        // 1. PR detection — mutates log.Exercises[].Sets[].IsPR in place.
+        var prDescriptions = await prDetection.DetectAndMarkPRsAsync(log, ct);
+
+        // 2. Mark the log as completed at the supplied instant.
+        log.CompletedAt = completedAtUtc;
+        log.IsCompleted = true;
+        log.DateUpdated = DateTime.UtcNow;
+
+        await mongo.WorkoutLogs.ReplaceOneAsync(
+            w => w.ExternalId == log.ExternalId,
+            log,
+            cancellationToken: ct);
+
+        // 3. Fan out a TrainingCompletion doc so compliance/streak picks up this workout.
+        // Best-effort: a failure must NOT affect the primary contract (log.IsCompleted=true).
+        try
+        {
+            await UpsertTrainingCompletionAsync(log, completedAtUtc, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "TrainingCompletion fan-out failed for workout log {LogId}. Workout completion succeeded.",
+                log.ExternalId);
+        }
+
+        // 4. Notify trainer when PRs were detected (throttled: max 1 per workout).
+        if (prDescriptions.Count > 0 && log.PlanId.HasValue)
+        {
+            var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
+            using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+            var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+            if (plan is not null)
+            {
+                var prSummary = string.Join(", ", prDescriptions.Take(3));
+                var data = JsonSerializer.Serialize(new { workoutLogId = log.ExternalId, clientId = log.ClientId });
+
+                await notifications.CreateAsync(
+                    plan.TrainerId,
+                    NotificationType.PersonalRecord,
+                    "New Personal Record!",
+                    prSummary,
+                    data,
+                    ct);
+            }
+        }
+
+        return prDescriptions;
+    }
+
+    // ── Best-effort TrainingCompletion fan-out ────────────────────────────────────
+    // Mirrors the upsert pattern in MarkSessionCompleteEndpoint so that
+    // ComplianceService.IsSessionCompleteForDateAsync sees this workout.
+    //
+    // The completedAtUtc parameter drives the date key, ensuring that a backdated
+    // finish is attributed to the correct calendar day — not DateTime.UtcNow.
+    private async Task UpsertTrainingCompletionAsync(
+        WorkoutLog log,
+        DateTime completedAtUtc,
+        CancellationToken ct)
+    {
+        // Only planned-session workouts are tracked for compliance.
+        if (!log.SessionId.HasValue || !log.PlanId.HasValue)
+            return;
+
+        var sessionId = log.SessionId.Value;
+
+        // Resolve the plan's session to get all exercise ids.
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            logger.LogWarning(
+                "TrainingCompletion fan-out: plan {PlanId} not found for workout log {LogId}.",
+                log.PlanId.Value, log.ExternalId);
+            return;
+        }
+
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == sessionId);
+
+        if (session is null)
+        {
+            logger.LogWarning(
+                "TrainingCompletion fan-out: session {SessionId} not found in plan {PlanId} for workout log {LogId}.",
+                sessionId, log.PlanId.Value, log.ExternalId);
+            return;
+        }
+
+        session.WithBackfilledSections();
+        var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();
+        var allSectionIds = session.Sections.Select(s => s.SectionId).ToList();
+        var completedBySection = session.Sections.ToDictionary(
+            s => s.SectionId.ToString(),
+            s => s.Exercises.Select(e => e.ExerciseExternalId).ToList());
+
+        // Resolve clientId as PublicId — TrainingCompletion keyed by ClientProfile.PublicId,
+        // not the raw UserId stored on WorkoutLog.ClientId.
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == log.ClientId, ct);
+
+        if (clientProfile is null)
+        {
+            logger.LogWarning(
+                "TrainingCompletion fan-out: ClientProfile not found for UserId {UserId}.",
+                log.ClientId);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+
+        // Date key: the calendar day of the supplied completion instant (NOT DateTime.UtcNow).
+        // This is the critical fix: for backdated finishes the date key must reflect the
+        // backdated day, not the current clock, so that compliance/streak attribution
+        // lands on the correct calendar day.
+        var date = DateOnly.FromDateTime(completedAtUtc).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, clientId)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.Date, date)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, sessionId);
+
+        using var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+        var existing = await completionCursor.FirstOrDefaultAsync(ct);
+
+        if (existing is not null)
+        {
+            // Idempotency: skip the write only when every per-session field already matches.
+            var sectionDictAligned =
+                existing.CompletedExerciseIdsBySection is not null
+                && completedBySection.All(kvp =>
+                    existing.CompletedExerciseIdsBySection!.TryGetValue(kvp.Key, out var ids)
+                    && kvp.Value.All(id => ids.Contains(id)));
+            var sectionIdsAligned = allSectionIds.All(id =>
+                (existing.CompletedSectionIds ?? new List<Guid>()).Contains(id));
+            if (allExerciseIds.All(id => existing.CompletedExerciseIds.Contains(id))
+                && sectionDictAligned
+                && sectionIdsAligned)
+                return;
+
+            var versionedFilter = completionFilter
+                                  & Builders<TrainingCompletion>.Filter.Eq(c => c.Version, existing.Version);
+
+            var update = Builders<TrainingCompletion>.Update
+                .Set(c => c.CompletedExerciseIds, allExerciseIds)
+                .Set(c => c.CompletedExerciseIdsBySection, completedBySection)
+                .Set(c => c.CompletedSectionIds, allSectionIds)
+                .Set(c => c.DateUpdated, DateTime.UtcNow)
+                .Set(c => c.Version, existing.Version + 1);
+
+            await mongo.TrainingCompletions.UpdateOneAsync(versionedFilter, update, cancellationToken: ct);
+        }
+        else
+        {
+            var completion = new TrainingCompletion
+            {
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientId,
+                Date = date,
+                SessionId = sessionId,
+                CompletedExerciseIds = allExerciseIds,
+                CompletedExerciseIdsBySection = completedBySection,
+                CompletedSectionIds = allSectionIds,
+                DateCreated = DateTime.UtcNow,
+                Version = 1
+            };
+
+            await mongo.TrainingCompletions.InsertOneAsync(completion, cancellationToken: ct);
+        }
+    }
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -163,6 +163,7 @@ builder.Services.AddScoped<NutritionAuthHelper>();
 builder.Services.AddScoped<ProfessionalAuthHelper>();
 builder.Services.AddScoped<IPrDetectionService, PrDetectionService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<IWorkoutCompletionService, WorkoutCompletionService>();
 // Registers IHttpClientFactory — consumed by ExpoPushNotificationService below
 // and by the ResendClient typed client when Email:Provider = Resend.
 builder.Services.AddHttpClient();

--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -48,6 +48,45 @@ public static class QaSeedRunner
     // ClientId on the plan = ClientProfilePublicId (NOT ClientUserId) per GetClientPlansEndpoint filter.
     public static readonly Guid QaTrainingPlanExternalId = new("dddddddd-dddd-dddd-dddd-dddddddddddd");
 
+    // -------------------------------------------------------------------------
+    // #326 past-dated training plan — exercises three past-session states so
+    // Playwright can assert completed/skipped/untouched UI behaviour.
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Past-dated Active training plan owned by qa.trainer for qa.client.
+    /// StartDate is set to ~4 weeks before the seed instant (anchored to the
+    /// preceding Monday) so all sessions in Weeks 1–2 fall in the past.
+    /// </summary>
+    public static readonly Guid QaPastTrainingPlanExternalId = new("11111111-1111-1111-2222-000000000001");
+
+    /// <summary>
+    /// Session in Week 1, DayOfWeek=1 (Monday): a WorkoutLog with IsCompleted=true
+    /// exists → web classifies as COMPLETED (read-only).
+    /// </summary>
+    public static readonly Guid QaPastSessionCompletedId = new("11111111-1111-1111-2222-000000000002");
+
+    /// <summary>
+    /// Session in Week 1, DayOfWeek=3 (Wednesday): a WorkoutLog with IsCompleted=false
+    /// exists → web classifies as SKIPPED (editable + Mark-finished).
+    /// </summary>
+    public static readonly Guid QaPastSessionSkippedId = new("11111111-1111-1111-2222-000000000003");
+
+    /// <summary>
+    /// Session in Week 2, DayOfWeek=1 (Monday): NO WorkoutLog exists
+    /// → web classifies as UNTOUCHED (editable + Mark-finished).
+    /// </summary>
+    public static readonly Guid QaPastSessionUntouchedId = new("11111111-1111-1111-2222-000000000004");
+
+    // Stable WorkoutLog ExternalIds.
+    public static readonly Guid QaPastCompletedWorkoutLogId = new("11111111-1111-1111-2222-000000000005");
+    public static readonly Guid QaPastSkippedWorkoutLogId   = new("11111111-1111-1111-2222-000000000006");
+
+    // Section IDs within the three past sessions.
+    public static readonly Guid PastCompletedSectionId = new("11111111-1111-1111-3333-000000000001");
+    public static readonly Guid PastSkippedSectionId   = new("11111111-1111-1111-3333-000000000002");
+    public static readonly Guid PastUntouchedSectionId = new("11111111-1111-1111-3333-000000000003");
+
     // Stable SectionIds — deterministic for test assertions.
     public static readonly Guid ForTimeSectionId   = new("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
     public static readonly Guid AmrapSectionId     = new("ffffffff-ffff-ffff-ffff-ffffffffffff");
@@ -163,6 +202,9 @@ public static class QaSeedRunner
         {
             // Training plan — ForTime + 0-exercise fixture for #258 non-regression.
             await EnsureTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
+
+            // Past-dated training plan — three sessions in distinct completion states for #326.
+            await EnsurePastTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
 
             // Foods + Recipes + NutritionPlan.
             await EnsureFoodsAsync(mongo, nutriProfile.PublicId, logger);
@@ -461,6 +503,340 @@ public static class QaSeedRunner
         logger.LogInformation(
             "QA TrainingPlan created: externalId={ExternalId} clientId={ClientId}",
             QaTrainingPlanExternalId, clientProfilePublicId);
+    }
+
+    /// <summary>
+    /// Seeds a past-dated training plan for the QA client with three sessions that
+    /// represent the three past-session states the web UI classifies:
+    ///
+    ///   PAST-COMPLETED  (Week 1, Mon) — WorkoutLog exists, IsCompleted=true  → read-only.
+    ///   PAST-SKIPPED    (Week 1, Wed) — WorkoutLog exists, IsCompleted=false → editable.
+    ///   PAST-UNTOUCHED  (Week 2, Mon) — no WorkoutLog at all               → editable.
+    ///
+    /// StartDate is set to 28 days before seed-time anchored to the preceding Monday
+    /// so all Week 1 + Week 2 sessions are firmly in the past regardless of current day.
+    ///
+    /// Each session carries a single Standard section with two exercises so the web
+    /// can render the full section/exercise/set tree.  The WorkoutLog for COMPLETED
+    /// mirrors the section structure with all sets stamped CompletedAt.  The WorkoutLog
+    /// for SKIPPED has one set completed on each exercise, the rest absent (incomplete).
+    /// </summary>
+    private static async Task EnsurePastTrainingPlanAsync(
+        IMongoContext mongo,
+        Guid clientProfilePublicId,
+        Guid trainerProfilePublicId,
+        ILogger logger)
+    {
+        var existingPlan = await mongo.TrainingPlans
+            .Find(p => p.ExternalId == QaPastTrainingPlanExternalId)
+            .FirstOrDefaultAsync();
+
+        // Anchor StartDate to the Monday that is (at least) 28 days in the past.
+        // Using Monday ensures DayOfWeek=1 maps cleanly to that exact Monday.
+        var now = DateTime.UtcNow;
+        var daysUntilLastMonday = ((int)now.DayOfWeek == 0 ? 7 : (int)now.DayOfWeek) - 1;
+        var lastMonday = now.Date.AddDays(-daysUntilLastMonday);
+        // Go back 4 full weeks so Week 1 Mon = lastMonday-28 days.
+        var startDate = lastMonday.AddDays(-28);
+
+        // Stable dates derived deterministically from startDate.
+        var completedSessionDate = startDate;                    // Week 1, Mon (+0d)
+        var skippedSessionDate   = startDate.AddDays(2);        // Week 1, Wed (+2d)
+        var untouchedSessionDate = startDate.AddDays(7);        // Week 2, Mon (+7d)
+
+        if (existingPlan is null)
+        {
+            var plan = new TrainingPlan
+            {
+                ExternalId    = QaPastTrainingPlanExternalId,
+                ClientId      = clientProfilePublicId,
+                TrainerId     = trainerProfilePublicId,
+                Name          = "QA Past Plan — #326 completion states",
+                Status        = TrainingPlanStatus.Active,
+                StartDate     = startDate,
+                DateCreated   = startDate.AddDays(-3),
+                DatePublished = startDate.AddDays(-1),
+                Version       = 1,
+                Weeks =
+                [
+                    new TrainingWeek
+                    {
+                        WeekNumber    = 1,
+                        Status        = WeekStatus.Published,
+                        DatePublished = startDate.AddDays(-1),
+                        Sessions      =
+                        [
+                            // Session 1 — will have a completed WorkoutLog.
+                            new TrainingSession
+                            {
+                                SessionId = QaPastSessionCompletedId,
+                                DayOfWeek = 1, // Monday
+                                Name      = "QA Past Session — Completed",
+                                Order     = 1,
+                                Sections  =
+                                [
+                                    new TrainingSection
+                                    {
+                                        SectionId    = PastCompletedSectionId,
+                                        Order        = 0,
+                                        Name         = "Hlavní",
+                                        Format       = null,
+                                        FormatConfig = null,
+                                        Exercises    =
+                                        [
+                                            new SessionExercise
+                                            {
+                                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000001"),
+                                                ExerciseName       = "QA Bench Press",
+                                                Order              = 1,
+                                                MovementType       = MovementType.Reps,
+                                            },
+                                            new SessionExercise
+                                            {
+                                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000002"),
+                                                ExerciseName       = "QA Overhead Press",
+                                                Order              = 2,
+                                                MovementType       = MovementType.Reps,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            // Session 2 — will have an incomplete (skipped) WorkoutLog.
+                            new TrainingSession
+                            {
+                                SessionId = QaPastSessionSkippedId,
+                                DayOfWeek = 3, // Wednesday
+                                Name      = "QA Past Session — Skipped",
+                                Order     = 2,
+                                Sections  =
+                                [
+                                    new TrainingSection
+                                    {
+                                        SectionId    = PastSkippedSectionId,
+                                        Order        = 0,
+                                        Name         = "Hlavní",
+                                        Format       = null,
+                                        FormatConfig = null,
+                                        Exercises    =
+                                        [
+                                            new SessionExercise
+                                            {
+                                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000003"),
+                                                ExerciseName       = "QA Back Squat",
+                                                Order              = 1,
+                                                MovementType       = MovementType.Reps,
+                                            },
+                                            new SessionExercise
+                                            {
+                                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000004"),
+                                                ExerciseName       = "QA Romanian Deadlift",
+                                                Order              = 2,
+                                                MovementType       = MovementType.Reps,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    new TrainingWeek
+                    {
+                        WeekNumber    = 2,
+                        Status        = WeekStatus.Published,
+                        DatePublished = startDate.AddDays(6),
+                        Sessions      =
+                        [
+                            // Session 3 — NO WorkoutLog (untouched).
+                            new TrainingSession
+                            {
+                                SessionId = QaPastSessionUntouchedId,
+                                DayOfWeek = 1, // Monday
+                                Name      = "QA Past Session — Untouched",
+                                Order     = 1,
+                                Sections  =
+                                [
+                                    new TrainingSection
+                                    {
+                                        SectionId    = PastUntouchedSectionId,
+                                        Order        = 0,
+                                        Name         = "Hlavní",
+                                        Format       = null,
+                                        FormatConfig = null,
+                                        Exercises    =
+                                        [
+                                            new SessionExercise
+                                            {
+                                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000005"),
+                                                ExerciseName       = "QA Pull-down",
+                                                Order              = 1,
+                                                MovementType       = MovementType.Reps,
+                                            },
+                                            new SessionExercise
+                                            {
+                                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000006"),
+                                                ExerciseName       = "QA Seated Row",
+                                                Order              = 2,
+                                                MovementType       = MovementType.Reps,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            await mongo.TrainingPlans.InsertOneAsync(plan);
+            logger.LogInformation(
+                "QA PastTrainingPlan created: externalId={ExternalId} startDate={StartDate}",
+                QaPastTrainingPlanExternalId, startDate);
+        }
+        else
+        {
+            logger.LogInformation(
+                "QA PastTrainingPlan already present: externalId={ExternalId}", QaPastTrainingPlanExternalId);
+        }
+
+        // ---------------------------------------------------------------------------
+        // WorkoutLog: COMPLETED — IsCompleted=true, all sets stamped CompletedAt.
+        // ---------------------------------------------------------------------------
+        var existingCompletedLog = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaPastCompletedWorkoutLogId)
+            .FirstOrDefaultAsync();
+
+        if (existingCompletedLog is null)
+        {
+            var completedAt = completedSessionDate.AddHours(10); // 10:00 UTC on session day.
+            var completedLog = new WorkoutLog
+            {
+                ExternalId  = QaPastCompletedWorkoutLogId,
+                ClientId    = clientProfilePublicId,
+                PlanId      = QaPastTrainingPlanExternalId,
+                SessionId   = QaPastSessionCompletedId,
+                StartedAt   = completedAt.AddMinutes(-45),
+                CompletedAt = completedAt,
+                IsCompleted = true,
+                DateCreated = completedAt.AddMinutes(-45),
+                DateUpdated = completedAt,
+                Sections    =
+                [
+                    new WorkoutSection
+                    {
+                        SectionId = PastCompletedSectionId,
+                        Order     = 0,
+                        Name      = "Hlavní",
+                        Format    = null,
+                        Exercises =
+                        [
+                            new WorkoutExercise
+                            {
+                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000001"),
+                                ExerciseName       = "QA Bench Press",
+                                Sets               =
+                                [
+                                    new WorkoutSet { SetNumber = 1, Reps = 8, WeightKg = 80m, CompletedAt = completedAt.AddMinutes(-30) },
+                                    new WorkoutSet { SetNumber = 2, Reps = 8, WeightKg = 80m, CompletedAt = completedAt.AddMinutes(-25) },
+                                    new WorkoutSet { SetNumber = 3, Reps = 7, WeightKg = 80m, CompletedAt = completedAt.AddMinutes(-20) },
+                                ],
+                            },
+                            new WorkoutExercise
+                            {
+                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000002"),
+                                ExerciseName       = "QA Overhead Press",
+                                Sets               =
+                                [
+                                    new WorkoutSet { SetNumber = 1, Reps = 10, WeightKg = 50m, CompletedAt = completedAt.AddMinutes(-15) },
+                                    new WorkoutSet { SetNumber = 2, Reps = 10, WeightKg = 50m, CompletedAt = completedAt.AddMinutes(-10) },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            await mongo.WorkoutLogs.InsertOneAsync(completedLog);
+            logger.LogInformation(
+                "QA WorkoutLog COMPLETED created: externalId={ExternalId} sessionId={SessionId}",
+                QaPastCompletedWorkoutLogId, QaPastSessionCompletedId);
+        }
+        else
+        {
+            logger.LogInformation(
+                "QA WorkoutLog COMPLETED already present: externalId={ExternalId}", QaPastCompletedWorkoutLogId);
+        }
+
+        // ---------------------------------------------------------------------------
+        // WorkoutLog: SKIPPED — IsCompleted=false, only one set per exercise logged.
+        // The client started but did not finish the session.
+        // ---------------------------------------------------------------------------
+        var existingSkippedLog = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaPastSkippedWorkoutLogId)
+            .FirstOrDefaultAsync();
+
+        if (existingSkippedLog is null)
+        {
+            var skippedStartedAt = skippedSessionDate.AddHours(9); // started at 09:00 UTC.
+            var skippedLog = new WorkoutLog
+            {
+                ExternalId  = QaPastSkippedWorkoutLogId,
+                ClientId    = clientProfilePublicId,
+                PlanId      = QaPastTrainingPlanExternalId,
+                SessionId   = QaPastSessionSkippedId,
+                StartedAt   = skippedStartedAt,
+                CompletedAt = null,
+                IsCompleted = false,
+                DateCreated = skippedStartedAt,
+                DateUpdated = skippedStartedAt.AddMinutes(20),
+                Sections    =
+                [
+                    new WorkoutSection
+                    {
+                        SectionId = PastSkippedSectionId,
+                        Order     = 0,
+                        Name      = "Hlavní",
+                        Format    = null,
+                        Exercises =
+                        [
+                            new WorkoutExercise
+                            {
+                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000003"),
+                                ExerciseName       = "QA Back Squat",
+                                Sets               =
+                                [
+                                    // Only 1 of 3 planned sets was recorded before the client stopped.
+                                    new WorkoutSet { SetNumber = 1, Reps = 5, WeightKg = 100m, CompletedAt = skippedStartedAt.AddMinutes(15) },
+                                ],
+                            },
+                            new WorkoutExercise
+                            {
+                                ExerciseExternalId = new Guid("11111111-1111-1111-4444-000000000004"),
+                                ExerciseName       = "QA Romanian Deadlift",
+                                Sets               = [], // exercise was never started
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            await mongo.WorkoutLogs.InsertOneAsync(skippedLog);
+            logger.LogInformation(
+                "QA WorkoutLog SKIPPED created: externalId={ExternalId} sessionId={SessionId}",
+                QaPastSkippedWorkoutLogId, QaPastSessionSkippedId);
+        }
+        else
+        {
+            logger.LogInformation(
+                "QA WorkoutLog SKIPPED already present: externalId={ExternalId}", QaPastSkippedWorkoutLogId);
+        }
+
+        // PAST-UNTOUCHED: deliberately no WorkoutLog for QaPastSessionUntouchedId.
+        logger.LogInformation(
+            "QA PastTrainingPlan fixture complete: planId={PlanId} startDate={StartDate} " +
+            "completed={CompletedId} skipped={SkippedId} untouched={UntouchedId}",
+            QaPastTrainingPlanExternalId, startDate,
+            QaPastSessionCompletedId, QaPastSessionSkippedId, QaPastSessionUntouchedId);
     }
 
     private static async Task EnsureFoodsAsync(

--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -549,8 +549,18 @@ public static class QaSeedRunner
             var plan = new TrainingPlan
             {
                 ExternalId    = QaPastTrainingPlanExternalId,
+                // ClientId is keyed on ClientProfile.PublicId (NOT ApplicationUser.Id) —
+                // GetTrainingPlansEndpoint filters by ClientId = ClientProfile.PublicId when
+                // the caller passes a clientId query param, and TrainingCompletion.ClientId
+                // (written by WorkoutCompletionService) is also keyed on ClientProfile.PublicId.
+                // plan.ClientId and TrainingCompletion.ClientId must match for the completions
+                // fold-in in GetTrainingPlanEndpoint (line 59 filters by plan.ClientId).
                 ClientId      = clientProfilePublicId,
-                TrainerId     = trainerProfilePublicId,
+                // TrainerId is keyed on ApplicationUser.Id (NOT ProfessionalProfile.PublicId) —
+                // GetTrainingPlansEndpoint and GetTrainingPlanEndpoint scope by
+                // Guid.Parse(User.FindFirstValue(AppClaims.UserId)) which is ApplicationUser.Id.
+                // Using the profile PublicId (bbbb...) makes this plan invisible to GET /training/plans.
+                TrainerId     = TrainerUserId,
                 Name          = "QA Past Plan — #326 completion states",
                 Status        = TrainingPlanStatus.Active,
                 StartDate     = startDate,
@@ -712,7 +722,13 @@ public static class QaSeedRunner
             var completedLog = new WorkoutLog
             {
                 ExternalId  = QaPastCompletedWorkoutLogId,
-                ClientId    = clientProfilePublicId,
+                // ClientId is keyed on ApplicationUser.Id (NOT ClientProfile.PublicId) —
+                // CompleteWorkoutEndpoint (live client finish) filters WorkoutLogs by
+                // ClientId == Guid.Parse(AppClaims.UserId), which is ApplicationUser.Id.
+                // WorkoutCompletionService resolves the ClientProfile by cp.UserId == log.ClientId,
+                // then uses clientProfile.PublicId for the TrainingCompletion — so the fan-out
+                // correctly produces a TrainingCompletion.ClientId = ClientProfile.PublicId.
+                ClientId    = ClientUserId,
                 PlanId      = QaPastTrainingPlanExternalId,
                 SessionId   = QaPastSessionCompletedId,
                 StartedAt   = completedAt.AddMinutes(-45),
@@ -781,7 +797,8 @@ public static class QaSeedRunner
             var skippedLog = new WorkoutLog
             {
                 ExternalId  = QaPastSkippedWorkoutLogId,
-                ClientId    = clientProfilePublicId,
+                // ClientId = ApplicationUser.Id — same reasoning as the completed log above.
+                ClientId    = ClientUserId,
                 PlanId      = QaPastTrainingPlanExternalId,
                 SessionId   = QaPastSessionSkippedId,
                 StartedAt   = skippedStartedAt,

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionEndpointTests.cs
@@ -461,4 +461,112 @@ public class FinishSessionEndpointTests
         // ThrowErrorWithCode maps to 422 Unprocessable Entity in FastEndpoints.
         ep.HttpContext.Response.StatusCode.Should().Be(422);
     }
+
+    // ── MINOR-1: null StartDate floor falls back to DateCreated ──────────────────
+
+    [Fact]
+    public async Task HandleAsync_NullStartDate_CompletedAtBeforeDateCreated_Returns422()
+    {
+        // Arrange: plan has no StartDate (not yet started). completedAt is before DateCreated —
+        // the plan didn't exist yet, so the write would fabricate impossible history.
+        var sessionId = Guid.NewGuid();
+        var dateCreated = DateTime.UtcNow.AddDays(-14);
+
+        // Pass startDate: null explicitly by using the overload that leaves StartDate as its default.
+        var planWithNullStart = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = _trainerId,
+            Name = "Plan Without Start",
+            Status = TrainingPlanStatus.Active,
+            StartDate = null, // explicitly no start date
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = dateCreated
+        };
+
+        var (mongo, _) = CreateMockMongoWithInsert(planWithNullStart, []);
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubCompletionService());
+
+        // completedAt is one day before the plan was created — must be rejected
+        var tooEarly = dateCreated.AddDays(-1);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest
+            {
+                PlanId = planWithNullStart.ExternalId,
+                SessionId = sessionId,
+                CompletedAt = tooEarly
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(422);
+    }
+
+    // ── MINOR-2: non-UTC completedAt is normalized before validation ──────────────
+
+    [Fact]
+    public async Task HandleAsync_UnspecifiedKindCompletedAt_NormalizedToUtc_Returns200()
+    {
+        // Arrange: completedAt arrives with DateTimeKind.Unspecified (as JSON binders produce).
+        // The endpoint must normalize via ToUniversalTime() so the completion lands on the
+        // correct calendar day. This test verifies that a value within a valid range still
+        // succeeds — the normalization must not corrupt the value.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        // Simulate JSON-bound DateTime with Unspecified kind (equivalent to a UTC instant one week ago)
+        var rawFromJson = DateTime.SpecifyKind(DateTime.UtcNow.AddDays(-5), DateTimeKind.Unspecified);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest
+            {
+                PlanId = plan.ExternalId,
+                SessionId = sessionId,
+                CompletedAt = rawFromJson
+            },
+            TestContext.Current.CancellationToken);
+
+        // Should succeed — value is valid once normalized
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The service must receive a UTC-kind DateTime
+        await completionService.Received(1).CompleteAsync(
+            Arg.Any<WorkoutLog>(),
+            Arg.Is<DateTime>(d => d.Kind == DateTimeKind.Utc),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionEndpointTests.cs
@@ -1,0 +1,464 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for <see cref="FinishSessionEndpoint"/>.
+/// </summary>
+public class FinishSessionEndpointTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+
+    private IWorkoutCompletionService StubCompletionService()
+    {
+        var svc = Substitute.For<IWorkoutCompletionService>();
+        svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
+        return svc;
+    }
+
+    private static TrainingPlan CreatePlanWithSession(
+        Guid trainerId,
+        Guid sessionId,
+        Guid? clientId = null,
+        DateTime? startDate = null)
+    {
+        var sectionId = Guid.NewGuid();
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId ?? Guid.NewGuid(),
+            TrainerId = trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startDate ?? DateTime.UtcNow.Date.AddDays(-30),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = Guid.NewGuid(),
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 100 },
+                                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 100 }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+    }
+
+    private static (IMongoContext Mongo, IMongoCollection<WorkoutLog> LogCollection) CreateMockMongoWithInsert(
+        TrainingPlan plan,
+        IReadOnlyList<WorkoutLog> existingLogs)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Plans collection
+        var planCollection = TrainingPlanTestHelpers.CreateMockCollection([plan]);
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // WorkoutLogs collection with FindAsync + InsertOneAsync + ReplaceOneAsync
+        var logCollection = TrainingPlanTestHelpers.CreateMockWorkoutLogCollection(existingLogs.ToList());
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        return (mongo, logCollection);
+    }
+
+    // ── happy path: session has an incomplete log (skipped) ──────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SkippedSession_CompletesExistingLog_Returns200()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+        var incompleteLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = plan.ClientId,
+            PlanId = plan.ExternalId,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow.AddDays(-3),
+            IsCompleted = false,
+            Sections = [],
+            DateCreated = DateTime.UtcNow.AddDays(-3)
+        };
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, [incompleteLog]);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The existing incomplete log must be passed to the service — no InsertOneAsync.
+        await completionService.Received(1).CompleteAsync(
+            Arg.Is<WorkoutLog>(l => l.ExternalId == incompleteLog.ExternalId),
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── happy path: no prior log (untouched) — materializes from template ────────
+
+    [Fact]
+    public async Task HandleAsync_UntouchedSession_MaterializesLogFromTemplate_Returns200()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+
+        var (mongo, logCollection) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // A new log must be inserted.
+        await logCollection.Received(1).InsertOneAsync(
+            Arg.Is<WorkoutLog>(l =>
+                l.PlanId == plan.ExternalId &&
+                l.SessionId == sessionId &&
+                l.ClientId == plan.ClientId &&
+                !l.IsCompleted &&
+                l.Sections.Count > 0),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+
+        // Section structure must be preserved (not flat list).
+        await completionService.Received(1).CompleteAsync(
+            Arg.Is<WorkoutLog>(l =>
+                l.PlanId == plan.ExternalId &&
+                l.SessionId == sessionId &&
+                l.Sections.Count > 0 &&
+                l.Sections[0].Exercises.Count > 0),
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── WorkoutSet planned fields are mapped from ExerciseSet ────────────────────
+
+    [Fact]
+    public async Task HandleAsync_UntouchedSession_MapsPlannedSetsFromTemplate()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        WorkoutLog? capturedLog = null;
+        completionService.CompleteAsync(
+                Arg.Do<WorkoutLog>(l => capturedLog = l),
+                Arg.Any<DateTime>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        capturedLog.Should().NotBeNull();
+        var sets = capturedLog!.Sections[0].Exercises[0].Sets;
+        sets.Should().HaveCount(2);
+        sets[0].SetNumber.Should().Be(1);
+        sets[0].Reps.Should().Be(10);
+        sets[0].WeightKg.Should().Be(100);
+        sets[0].CompletedAt.Should().NotBeNull();
+        sets[0].IsPR.Should().BeFalse(); // PR detection is left to the service
+    }
+
+    // ── backdated finish: TrainingCompletion.Date must use completedAt's day ─────
+
+    [Fact]
+    public async Task HandleAsync_BackdatedFinish_PassesBackdatedInstantToService()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+        var backdated = DateTime.UtcNow.Date.AddDays(-7).AddHours(14); // last week
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest
+            {
+                PlanId = plan.ExternalId,
+                SessionId = sessionId,
+                CompletedAt = backdated
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The service must receive exactly the backdated instant (not UtcNow).
+        await completionService.Received(1).CompleteAsync(
+            Arg.Any<WorkoutLog>(),
+            Arg.Is<DateTime>(d => d == backdated),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── parity with client live-finish: same service, same pipeline ──────────────
+
+    [Fact]
+    public async Task HandleAsync_CallsCompletionServiceWithCorrectLog()
+    {
+        // This test proves the trainer path uses the SAME completion pipeline as the client.
+        // Both endpoints call IWorkoutCompletionService.CompleteAsync; the AC "doc parity"
+        // is structural — the PR detection, TrainingCompletion fan-out, and notification
+        // all happen inside the same service regardless of who triggers the finish.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+        var incompleteLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = plan.ClientId,
+            PlanId = plan.ExternalId,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow.AddDays(-2),
+            IsCompleted = false,
+            Sections = [],
+            DateCreated = DateTime.UtcNow.AddDays(-2)
+        };
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, [incompleteLog]);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // The service is called once — meaning the same pipeline runs.
+        await completionService.Received(1).CompleteAsync(
+            Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── ownership guard: trainer doesn't own the plan ────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_PlanOwnedByOtherTrainer_Returns404()
+    {
+        var sessionId = Guid.NewGuid();
+        var otherTrainerId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(otherTrainerId, sessionId);
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubCompletionService());
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PlanNotFound_Returns404()
+    {
+        var mongo = Substitute.For<IMongoContext>();
+        var emptyPlanCollection = TrainingPlanTestHelpers.CreateMockCollection([]);
+        mongo.TrainingPlans.Returns(emptyPlanCollection);
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubCompletionService());
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = Guid.NewGuid(), SessionId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SessionNotFoundInPlan_Returns404()
+    {
+        var plan = CreatePlanWithSession(_trainerId, Guid.NewGuid());
+        var wrongSessionId = Guid.NewGuid(); // not in the plan
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubCompletionService());
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = wrongSessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── already-completed reject ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_AlreadyCompleted_Returns409()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithSession(_trainerId, sessionId);
+        var completedLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = plan.ClientId,
+            PlanId = plan.ExternalId,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow.AddDays(-1),
+            IsCompleted = true, // already done
+            CompletedAt = DateTime.UtcNow.AddDays(-1).AddHours(1),
+            Sections = [],
+            DateCreated = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, [completedLog]);
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubCompletionService());
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    // ── future-date reject ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_FutureCompletedAt_Returns400()
+    {
+        // The validator rejects future dates; FastEndpoints returns 400 before HandleAsync runs.
+        // This test drives via the validator directly.
+        var futureDate = DateTime.UtcNow.AddHours(1);
+        var validator = new FinishSessionValidator();
+        var req = new FinishSessionRequest
+        {
+            PlanId = Guid.NewGuid(),
+            SessionId = Guid.NewGuid(),
+            CompletedAt = futureDate
+        };
+
+        var result = await validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.ErrorCode == "COMPLETED_AT_IN_FUTURE");
+    }
+
+    // ── completedAt before plan start date ───────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_CompletedAtBeforePlanStart_Returns422()
+    {
+        var sessionId = Guid.NewGuid();
+        var planStart = DateTime.UtcNow.Date.AddDays(-7);
+        var plan = CreatePlanWithSession(_trainerId, sessionId, startDate: planStart);
+
+        var completedAtBeforeStart = planStart.AddDays(-1); // one day before plan started
+
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubCompletionService());
+
+        await ep.HandleAsync(
+            new FinishSessionRequest
+            {
+                PlanId = plan.ExternalId,
+                SessionId = sessionId,
+                CompletedAt = completedAtBeforeStart
+            },
+            TestContext.Current.CancellationToken);
+
+        // ThrowErrorWithCode maps to 422 Unprocessable Entity in FastEndpoints.
+        ep.HttpContext.Response.StatusCode.Should().Be(422);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanTestHelpers.cs
@@ -69,7 +69,8 @@ public static class TrainingPlanTestHelpers
     }
 
     /// <summary>
-    /// Creates a mock <see cref="IMongoCollection{WorkoutLog}"/> that returns the given logs from FindAsync().
+    /// Creates a mock <see cref="IMongoCollection{WorkoutLog}"/> that returns the given logs from FindAsync(),
+    /// and stubs InsertOneAsync and ReplaceOneAsync so they succeed without mutating state.
     /// </summary>
     public static IMongoCollection<WorkoutLog> CreateMockWorkoutLogCollection(List<WorkoutLog> logs)
     {
@@ -84,6 +85,23 @@ public static class TrainingPlanTestHelpers
                 Arg.Any<FindOptions<WorkoutLog, WorkoutLog>>(),
                 Arg.Any<CancellationToken>())
             .Returns(cursorTask);
+
+        // InsertOneAsync — no-op stub so the endpoint can materialize new logs.
+        collection.InsertOneAsync(
+                Arg.Any<WorkoutLog>(),
+                Arg.Any<InsertOneOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        // ReplaceOneAsync stub
+        var replaceResult = Substitute.For<ReplaceOneResult>();
+        replaceResult.ModifiedCount.Returns(1L);
+        collection.ReplaceOneAsync(
+                Arg.Any<FilterDefinition<WorkoutLog>>(),
+                Arg.Any<WorkoutLog>(),
+                Arg.Any<ReplaceOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(replaceResult);
 
         return collection;
     }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
@@ -3,41 +3,30 @@ using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
-using FitnessPlatform.Application.Domain.Entities;
-using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
-using FitnessPlatform.Application.Infrastructure.Data;
-using FitnessPlatform.Tests.Builders;
-using FitnessPlatform.Tests.Endpoints.ClientTraining;
-using Microsoft.Extensions.Logging;
-using MongoDB.Driver;
 using NSubstitute;
 
 namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
 /// <summary>
 /// Tests for <see cref="CompleteWorkoutEndpoint"/>.
+/// The endpoint now delegates the completion pipeline to <see cref="IWorkoutCompletionService"/>;
+/// these tests verify the HTTP contract and ownership check.
+/// Behavioral tests (TrainingCompletion fan-out, PR detection) live in
+/// <see cref="WorkoutCompletionServiceTests"/>.
 /// </summary>
 public class CompleteWorkoutEndpointTests
 {
     private readonly Guid _clientId = Guid.NewGuid();
-    private readonly ILogger<CompleteWorkoutEndpoint> _logger =
-        Substitute.For<ILogger<CompleteWorkoutEndpoint>>();
 
-    // ── helpers ──────────────────────────────────────────────────────────────────
-
-    private IPrDetectionService StubPrDetection()
+    private IWorkoutCompletionService StubCompletionService()
     {
-        var prDetection = Substitute.For<IPrDetectionService>();
-        prDetection.DetectAndMarkPRsAsync(Arg.Any<WorkoutLog>(), Arg.Any<CancellationToken>())
+        var svc = Substitute.For<IWorkoutCompletionService>();
+        svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
             .Returns(new List<string>());
-        return prDetection;
+        return svc;
     }
-
-    private IApplicationDbContext EmptyDb() => new MockDbBuilder().Build();
-
-    // ── existing behaviour ────────────────────────────────────────────────────────
 
     [Fact]
     public async Task HandleAsync_ValidRequest_CompletesWorkout()
@@ -45,22 +34,22 @@ public class CompleteWorkoutEndpointTests
         var logId = Guid.NewGuid();
         var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
-
-        var prDetection = StubPrDetection();
-        var notifications = Substitute.For<INotificationService>();
+        var completionService = StubCompletionService();
 
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, EmptyDb(), prDetection, notifications, _logger);
+            mongo, completionService);
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(200);
 
-        await prDetection.Received(1).DetectAndMarkPRsAsync(
-            Arg.Any<WorkoutLog>(), Arg.Any<CancellationToken>());
+        await completionService.Received(1).CompleteAsync(
+            Arg.Any<WorkoutLog>(),
+            Arg.Is<DateTime>(d => d > DateTime.UtcNow.AddSeconds(-5) && d <= DateTime.UtcNow),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -72,389 +61,56 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, EmptyDb(), StubPrDetection(), Substitute.For<INotificationService>(), _logger);
+            mongo, StubCompletionService());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(404);
     }
 
-    // ── TrainingCompletion fan-out ─────────────────────────────────────────────────
-
     [Fact]
-    public async Task HandleAsync_CompletesWorkout_UpsertsTrainingCompletionWithAllSessionExerciseIds()
+    public async Task HandleAsync_OtherClientsLog_Returns404()
     {
-        // Arrange
-        var publicId = Guid.NewGuid(); // distinct from _clientId (the UserId)
-        var sessionId = Guid.NewGuid();
-        var exerciseA = Guid.NewGuid();
-        var exerciseB = Guid.NewGuid();
-        var startedAt = DateTime.UtcNow;
-
-        // Build the training plan with a session containing exercise A and B.
-        var plan = new TrainingPlan
-        {
-            ExternalId = Guid.NewGuid(),
-            ClientId = publicId,
-            TrainerId = Guid.NewGuid(),
-            Name = "Test Plan",
-            Status = TrainingPlanStatus.Active,
-            Weeks =
-            [
-                new TrainingWeek
-                {
-                    WeekNumber = 1,
-                    Status = WeekStatus.Published,
-                    Sessions =
-                    [
-                        new TrainingSession
-                        {
-                            SessionId = sessionId,
-                            DayOfWeek = 1,
-                            Name = "Test Session",
-                            Order = 1,
-                            Sections =
-                            [
-                                new TrainingSection
-                                {
-                                    SectionId = Guid.NewGuid(),
-                                    Order = 0,
-                                    Name = "Hlavní",
-                                    Exercises =
-                                    [
-                                        new SessionExercise
-                                        {
-                                            ExerciseExternalId = exerciseA,
-                                            ExerciseName = "Exercise A",
-                                            Order = 1
-                                        },
-                                        new SessionExercise
-                                        {
-                                            ExerciseExternalId = exerciseB,
-                                            ExerciseName = "Exercise B",
-                                            Order = 2
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            Version = 1,
-            DateCreated = DateTime.UtcNow
-        };
-
-        var logId = Guid.NewGuid();
-        var log = WorkoutLogTestHelpers.CreateLog(
-            externalId: logId,
-            clientId: _clientId,
-            planId: plan.ExternalId,
-            sessionId: sessionId,
-            startedAt: startedAt);
-
-        // Mongo: workout logs + plan + empty completions (no existing doc).
-        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
-            plan: plan,
-            workoutLogs: [log]);
-
-        // Also wire the WorkoutLogs collection for the initial find + replace.
-        var logCollection = WorkoutLogTestHelpers.CreateMockLogCollection([log]);
-        mongo.WorkoutLogs.Returns(logCollection);
-
-        // DB: ClientProfile with UserId = _clientId and PublicId = publicId.
-        var db = new MockDbBuilder()
-            .With(new ClientProfile { UserId = _clientId, PublicId = publicId })
-            .Build();
+        // A log belonging to a different client must not be accessible.
+        // The real MongoDB filter (ClientId == callerClientId) would return empty results.
+        // We model this by returning an empty log collection so the endpoint responds 404.
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: []); // no match — filtered by MongoDB
 
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, StubPrDetection(), Substitute.For<INotificationService>(), _logger);
+            mongo, StubCompletionService());
 
-        // Act
-        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
-        // Assert: primary contract — WorkoutLog.IsCompleted = true (the ReplaceOneAsync was called)
-        ep.HttpContext.Response.StatusCode.Should().Be(200);
-        await logCollection.Received(1).ReplaceOneAsync(
-            Arg.Any<FilterDefinition<WorkoutLog>>(),
-            Arg.Is<WorkoutLog>(w => w.IsCompleted),
-            Arg.Any<ReplaceOptions>(),
-            Arg.Any<CancellationToken>());
-
-        // Assert: fan-out — TrainingCompletion inserted for (publicId, completion day UTC, sessionId)
-        // Date is keyed by the finalisation day (DateTime.UtcNow.Date), not the log's StartedAt.Date,
-        // so that GetTodaySessionEndpoint — which reads by DateTime.UtcNow.Date — always finds the doc.
-        await completionCollection.Received(1).InsertOneAsync(
-            Arg.Is<TrainingCompletion>(c =>
-                c.ClientId == publicId &&
-                c.SessionId == sessionId &&
-                c.Date == DateTime.UtcNow.Date &&
-                c.CompletedExerciseIds.Count == 2 &&
-                c.CompletedExerciseIds.Contains(exerciseA) &&
-                c.CompletedExerciseIds.Contains(exerciseB) &&
-                c.Version >= 1),
-            Arg.Any<InsertOneOptions>(),
-            Arg.Any<CancellationToken>());
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
     }
 
     [Fact]
-    public async Task HandleAsync_IdempotentCompletion_LeavesExistingTrainingCompletionUnchanged()
+    public async Task HandleAsync_PassesUtcNowAsCompletionInstant()
     {
-        // Arrange
-        var publicId = Guid.NewGuid();
-        var sessionId = Guid.NewGuid();
-        var sectionId = Guid.NewGuid();
-        var exerciseA = Guid.NewGuid();
-        var exerciseB = Guid.NewGuid();
-        var startedAt = DateTime.UtcNow;
-        const int existingVersion = 3;
-
-        var plan = new TrainingPlan
-        {
-            ExternalId = Guid.NewGuid(),
-            ClientId = publicId,
-            TrainerId = Guid.NewGuid(),
-            Name = "Test Plan",
-            Status = TrainingPlanStatus.Active,
-            Weeks =
-            [
-                new TrainingWeek
-                {
-                    WeekNumber = 1,
-                    Status = WeekStatus.Published,
-                    Sessions =
-                    [
-                        new TrainingSession
-                        {
-                            SessionId = sessionId,
-                            DayOfWeek = 1,
-                            Name = "Test Session",
-                            Order = 1,
-                            Sections =
-                            [
-                                new TrainingSection
-                                {
-                                    SectionId = sectionId,
-                                    Order = 0,
-                                    Name = "Hlavní",
-                                    Exercises =
-                                    [
-                                        new SessionExercise
-                                        {
-                                            ExerciseExternalId = exerciseA,
-                                            ExerciseName = "Exercise A",
-                                            Order = 1
-                                        },
-                                        new SessionExercise
-                                        {
-                                            ExerciseExternalId = exerciseB,
-                                            ExerciseName = "Exercise B",
-                                            Order = 2
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            Version = 1,
-            DateCreated = DateTime.UtcNow
-        };
-
+        // Verify the endpoint always passes DateTime.UtcNow (not backdated) for live completions.
         var logId = Guid.NewGuid();
-        var log = WorkoutLogTestHelpers.CreateLog(
-            externalId: logId,
-            clientId: _clientId,
-            planId: plan.ExternalId,
-            sessionId: sessionId,
-            startedAt: startedAt);
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var completionService = StubCompletionService();
 
-        // Pre-existing completion doc with the full section-aware shape
-        // — flat list + per-section dict + section-id list all aligned
-        // with the plan. This is what `CompleteWorkoutEndpoint` writes on
-        // every fan-out now, so a doc in this shape should be a no-op.
-        var existingCompletion = TrainingCompletionTestHelpers.CreateCompletion(
-            clientId: publicId,
-            sessionId: sessionId,
-            date: startedAt.Date,
-            completedExerciseIds: [exerciseA, exerciseB],
-            completedSectionIds: [sectionId],
-            completedExerciseIdsBySection: new Dictionary<string, List<Guid>>
-            {
-                [sectionId.ToString()] = [exerciseA, exerciseB],
-            },
-            version: existingVersion);
-
-        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
-            plan: plan,
-            existingCompletion: existingCompletion,
-            workoutLogs: [log]);
-
-        var logCollection = WorkoutLogTestHelpers.CreateMockLogCollection([log]);
-        mongo.WorkoutLogs.Returns(logCollection);
-
-        var db = new MockDbBuilder()
-            .With(new ClientProfile { UserId = _clientId, PublicId = publicId })
-            .Build();
+        var before = DateTime.UtcNow;
 
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, StubPrDetection(), Substitute.For<INotificationService>(), _logger);
-
-        // Act
-        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
-
-        // Assert: no insert or update on the completions collection (already complete).
-        ep.HttpContext.Response.StatusCode.Should().Be(200);
-        await completionCollection.DidNotReceive().InsertOneAsync(
-            Arg.Any<TrainingCompletion>(),
-            Arg.Any<InsertOneOptions>(),
-            Arg.Any<CancellationToken>());
-        await completionCollection.DidNotReceive().UpdateOneAsync(
-            Arg.Any<FilterDefinition<TrainingCompletion>>(),
-            Arg.Any<UpdateDefinition<TrainingCompletion>>(),
-            Arg.Any<UpdateOptions>(),
-            Arg.Any<CancellationToken>());
-        // Version on the in-memory doc is unchanged.
-        existingCompletion.Version.Should().Be(existingVersion);
-    }
-
-    /// <summary>
-    /// Regression for the midnight-crossing bug: a workout started at 23:50 UTC yesterday
-    /// and completed at 00:10 UTC today must write the TrainingCompletion with today's date,
-    /// not yesterday's, so that GetTodaySessionEndpoint (which reads by DateTime.UtcNow.Date)
-    /// picks up the completion immediately after "done".
-    /// </summary>
-    [Fact]
-    public async Task HandleAsync_StartedLateYesterdayCompletedToday_KeysTrainingCompletionByCompletionDay()
-    {
-        // Arrange — log StartedAt is late yesterday UTC (simulates the midnight-crossing scenario).
-        var publicId = Guid.NewGuid();
-        var sessionId = Guid.NewGuid();
-        var exerciseA = Guid.NewGuid();
-        var startedAt = DateTime.UtcNow.Date.AddDays(-1).AddHours(23).AddMinutes(50); // late yesterday
-
-        var plan = new TrainingPlan
-        {
-            ExternalId = Guid.NewGuid(),
-            ClientId = publicId,
-            TrainerId = Guid.NewGuid(),
-            Name = "Midnight Plan",
-            Status = TrainingPlanStatus.Active,
-            Weeks =
-            [
-                new TrainingWeek
-                {
-                    WeekNumber = 1,
-                    Status = WeekStatus.Published,
-                    Sessions =
-                    [
-                        new TrainingSession
-                        {
-                            SessionId = sessionId,
-                            DayOfWeek = 1,
-                            Name = "Midnight Session",
-                            Order = 1,
-                            Sections =
-                            [
-                                new TrainingSection
-                                {
-                                    SectionId = Guid.NewGuid(),
-                                    Order = 0,
-                                    Name = "Hlavní",
-                                    Exercises =
-                                    [
-                                        new SessionExercise
-                                        {
-                                            ExerciseExternalId = exerciseA,
-                                            ExerciseName = "Exercise A",
-                                            Order = 1
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            Version = 1,
-            DateCreated = DateTime.UtcNow
-        };
-
-        var logId = Guid.NewGuid();
-        var log = WorkoutLogTestHelpers.CreateLog(
-            externalId: logId,
-            clientId: _clientId,
-            planId: plan.ExternalId,
-            sessionId: sessionId,
-            startedAt: startedAt); // started yesterday
-
-        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo(
-            plan: plan,
-            workoutLogs: [log]);
-
-        var logCollection = WorkoutLogTestHelpers.CreateMockLogCollection([log]);
-        mongo.WorkoutLogs.Returns(logCollection);
-
-        var db = new MockDbBuilder()
-            .With(new ClientProfile { UserId = _clientId, PublicId = publicId })
-            .Build();
-
-        var ep = Factory.Create<CompleteWorkoutEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(
-                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, StubPrDetection(), Substitute.For<INotificationService>(), _logger);
-
-        // Act — the endpoint runs now (today UTC), even though StartedAt was yesterday.
-        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
-
-        // Assert: date must equal today, NOT yesterday (startedAt.Date).
-        ep.HttpContext.Response.StatusCode.Should().Be(200);
-        await completionCollection.Received(1).InsertOneAsync(
-            Arg.Is<TrainingCompletion>(c =>
-                c.ClientId == publicId &&
-                c.SessionId == sessionId &&
-                c.Date == DateTime.UtcNow.Date && // completion day, not start day
-                c.Date != startedAt.Date),         // must differ from yesterday
-            Arg.Any<InsertOneOptions>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task HandleAsync_NoSessionId_SkipsFanOut()
-    {
-        // A log without a SessionId (ad-hoc workout) must not attempt completion fan-out.
-        var logId = Guid.NewGuid();
-        var log = WorkoutLogTestHelpers.CreateLog(
-            externalId: logId,
-            clientId: _clientId,
-            sessionId: null);
-
-        var (mongo, completionCollection) = TrainingCompletionTestHelpers.CreateMockMongo();
-        var logCollection = WorkoutLogTestHelpers.CreateMockLogCollection([log]);
-        mongo.WorkoutLogs.Returns(logCollection);
-
-        var db = new MockDbBuilder().Build();
-
-        var ep = Factory.Create<CompleteWorkoutEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(
-                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, StubPrDetection(), Substitute.For<INotificationService>(), _logger);
+            mongo, completionService);
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
-        ep.HttpContext.Response.StatusCode.Should().Be(200);
-        await completionCollection.DidNotReceive().InsertOneAsync(
-            Arg.Any<TrainingCompletion>(),
-            Arg.Any<InsertOneOptions>(),
+        var after = DateTime.UtcNow;
+
+        await completionService.Received(1).CompleteAsync(
+            Arg.Any<WorkoutLog>(),
+            Arg.Is<DateTime>(d => d >= before && d <= after),
             Arg.Any<CancellationToken>());
     }
 }

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -394,6 +394,21 @@ public class QaSeedRunnerTests : IAsyncLifetime
         plan.Weeks.Should().HaveCount(2, "plan has weeks 1 and 2");
         plan.Weeks.Should().AllSatisfy(w =>
             w.Status.Should().Be(FitnessPlatform.Application.Domain.Enums.WeekStatus.Published));
+        // TrainerId must be ApplicationUser.Id (not ProfessionalProfile.PublicId) so that
+        // GetTrainingPlansEndpoint can scope to the trainer:
+        //   filter = filterBuilder.Eq(p => p.TrainerId, Guid.Parse(User.FindFirstValue(AppClaims.UserId)))
+        // UserId from AppClaims.UserId is ApplicationUser.Id = TrainerUserId (22222222-...).
+        // Using TrainerProfilePublicId (bbbb...) would make this plan invisible to GET /training/plans.
+        plan.TrainerId.Should().Be(QaSeedRunner.TrainerUserId,
+            "TrainingPlan.TrainerId must be ApplicationUser.Id — GetTrainingPlansEndpoint scopes by " +
+            "Guid.Parse(AppClaims.UserId) which is ApplicationUser.Id, not ProfessionalProfile.PublicId");
+        // ClientId must stay as ClientProfile.PublicId so that TrainingCompletion.ClientId
+        // (written by WorkoutCompletionService as clientProfile.PublicId) matches
+        // plan.ClientId used in GetTrainingPlanEndpoint's completions fold-in filter.
+        plan.ClientId.Should().Be(QaSeedRunner.ClientProfilePublicId,
+            "TrainingPlan.ClientId must be ClientProfile.PublicId — GetTrainingPlanEndpoint queries " +
+            "TrainingCompletion by plan.ClientId and WorkoutCompletionService writes " +
+            "TrainingCompletion.ClientId = clientProfile.PublicId");
 
         // COMPLETED session — WorkoutLog with IsCompleted=true.
         var completedLog = await mongo.WorkoutLogs
@@ -404,6 +419,13 @@ public class QaSeedRunnerTests : IAsyncLifetime
         completedLog!.IsCompleted.Should().BeTrue("PAST-COMPLETED log must have IsCompleted=true");
         completedLog.SessionId.Should().Be(QaSeedRunner.QaPastSessionCompletedId);
         completedLog.PlanId.Should().Be(QaSeedRunner.QaPastTrainingPlanExternalId);
+        // WorkoutLog.ClientId must be ApplicationUser.Id (not ClientProfile.PublicId) so that
+        // CompleteWorkoutEndpoint can filter by it and WorkoutCompletionService can resolve
+        // the ClientProfile via cp.UserId == log.ClientId for the TrainingCompletion fan-out.
+        completedLog.ClientId.Should().Be(QaSeedRunner.ClientUserId,
+            "WorkoutLog.ClientId must be ApplicationUser.Id — CompleteWorkoutEndpoint filters by " +
+            "Guid.Parse(AppClaims.UserId) which is ApplicationUser.Id, and WorkoutCompletionService " +
+            "resolves the ClientProfile via cp.UserId == log.ClientId");
         completedLog.Sections.Should().HaveCount(1, "log mirrors the single section in the session");
         completedLog.Sections[0].Exercises.Should().HaveCount(2);
         completedLog.Sections[0].Exercises.Should().AllSatisfy(e =>
@@ -418,6 +440,9 @@ public class QaSeedRunnerTests : IAsyncLifetime
         skippedLog!.IsCompleted.Should().BeFalse("PAST-SKIPPED log must have IsCompleted=false");
         skippedLog.SessionId.Should().Be(QaSeedRunner.QaPastSessionSkippedId);
         skippedLog.PlanId.Should().Be(QaSeedRunner.QaPastTrainingPlanExternalId);
+        // Same id-space requirement as the completed log above.
+        skippedLog.ClientId.Should().Be(QaSeedRunner.ClientUserId,
+            "WorkoutLog.ClientId must be ApplicationUser.Id for the same reason as the completed log");
 
         // UNTOUCHED session — must have NO WorkoutLog.
         var untouchedLogCount = await mongo.WorkoutLogs.CountDocumentsAsync(

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -304,6 +304,14 @@ public class QaSeedRunnerTests : IAsyncLifetime
             Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaTrainingPlanExternalId),
             cancellationToken: ct))
             .Should().Be(0, "minimal seed skips the training plan");
+        (await mongo.TrainingPlans.CountDocumentsAsync(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaPastTrainingPlanExternalId),
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips the past training plan (#326)");
+        (await mongo.WorkoutLogs.CountDocumentsAsync(
+            Builders<WorkoutLog>.Filter.Empty,
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips all workout logs");
         (await mongo.Foods.CountDocumentsAsync(
             Builders<Food>.Filter.Empty,
             cancellationToken: ct))
@@ -354,6 +362,100 @@ public class QaSeedRunnerTests : IAsyncLifetime
                  || u.Email == QaSeedRunner.NutriEmail,
             ct);
         userCount.Should().Be(0, "ResolveKind must run before any database write");
+    }
+
+    /// <summary>
+    /// The past training plan (#326 fixture) must have:
+    ///  - A WorkoutLog for the COMPLETED session with IsCompleted=true.
+    ///  - A WorkoutLog for the SKIPPED session with IsCompleted=false.
+    ///  - No WorkoutLog for the UNTOUCHED session.
+    /// This is the minimal assertion the Playwright spec depends on to distinguish
+    /// the three past-session states.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_PastTrainingPlan_HasThreeDistinctSessionStates()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        // Plan must exist with StartDate in the past.
+        var plan = await mongo.TrainingPlans
+            .Find(p => p.ExternalId == QaSeedRunner.QaPastTrainingPlanExternalId)
+            .FirstOrDefaultAsync(ct);
+
+        plan.Should().NotBeNull("the past training plan must be seeded");
+        plan!.StartDate.Should().NotBeNull("past plan must have a StartDate");
+        plan.StartDate!.Value.Should().BeBefore(DateTime.UtcNow.AddDays(-7),
+            "StartDate must be at least one week in the past");
+        plan.Weeks.Should().HaveCount(2, "plan has weeks 1 and 2");
+        plan.Weeks.Should().AllSatisfy(w =>
+            w.Status.Should().Be(FitnessPlatform.Application.Domain.Enums.WeekStatus.Published));
+
+        // COMPLETED session — WorkoutLog with IsCompleted=true.
+        var completedLog = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaSeedRunner.QaPastCompletedWorkoutLogId)
+            .FirstOrDefaultAsync(ct);
+
+        completedLog.Should().NotBeNull("completed WorkoutLog must be seeded");
+        completedLog!.IsCompleted.Should().BeTrue("PAST-COMPLETED log must have IsCompleted=true");
+        completedLog.SessionId.Should().Be(QaSeedRunner.QaPastSessionCompletedId);
+        completedLog.PlanId.Should().Be(QaSeedRunner.QaPastTrainingPlanExternalId);
+        completedLog.Sections.Should().HaveCount(1, "log mirrors the single section in the session");
+        completedLog.Sections[0].Exercises.Should().HaveCount(2);
+        completedLog.Sections[0].Exercises.Should().AllSatisfy(e =>
+            e.Sets.Should().NotBeEmpty("completed log has sets on every exercise"));
+
+        // SKIPPED session — WorkoutLog with IsCompleted=false.
+        var skippedLog = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaSeedRunner.QaPastSkippedWorkoutLogId)
+            .FirstOrDefaultAsync(ct);
+
+        skippedLog.Should().NotBeNull("skipped WorkoutLog must be seeded");
+        skippedLog!.IsCompleted.Should().BeFalse("PAST-SKIPPED log must have IsCompleted=false");
+        skippedLog.SessionId.Should().Be(QaSeedRunner.QaPastSessionSkippedId);
+        skippedLog.PlanId.Should().Be(QaSeedRunner.QaPastTrainingPlanExternalId);
+
+        // UNTOUCHED session — must have NO WorkoutLog.
+        var untouchedLogCount = await mongo.WorkoutLogs.CountDocumentsAsync(
+            Builders<WorkoutLog>.Filter.Eq(l => l.SessionId, QaSeedRunner.QaPastSessionUntouchedId),
+            cancellationToken: ct);
+
+        untouchedLogCount.Should().Be(0,
+            "PAST-UNTOUCHED session must have no WorkoutLog so the web classifies it as untouched");
+    }
+
+    /// <summary>
+    /// Seeding twice must not create duplicate past-plan or workout-log documents.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_PastTrainingPlan_IsIdempotent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        var planCount = await mongo.TrainingPlans.CountDocumentsAsync(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaPastTrainingPlanExternalId),
+            cancellationToken: ct);
+        planCount.Should().Be(1, "past training plan must not be duplicated on re-seed");
+
+        var completedLogCount = await mongo.WorkoutLogs.CountDocumentsAsync(
+            Builders<WorkoutLog>.Filter.Eq(l => l.ExternalId, QaSeedRunner.QaPastCompletedWorkoutLogId),
+            cancellationToken: ct);
+        completedLogCount.Should().Be(1, "completed WorkoutLog must not be duplicated on re-seed");
+
+        var skippedLogCount = await mongo.WorkoutLogs.CountDocumentsAsync(
+            Builders<WorkoutLog>.Filter.Eq(l => l.ExternalId, QaSeedRunner.QaPastSkippedWorkoutLogId),
+            cancellationToken: ct);
+        skippedLogCount.Should().Be(1, "skipped WorkoutLog must not be duplicated on re-seed");
     }
 
     /// <summary>

--- a/docs/testing/e2e-fixtures.md
+++ b/docs/testing/e2e-fixtures.md
@@ -126,6 +126,69 @@ Replace `<QA_SEED_PASSWORD>` with the value from your `.env.test` file. The plan
 appears in the response because the week `Status = Published` — a Draft week would
 be silently excluded by the `ElemMatch` filter in `GetClientPlansEndpoint`.
 
+## Seeded past-dated training plan (#326)
+
+A second training plan is seeded for the QA client alongside the ForTime fixture. Its `StartDate` is anchored to the Monday that is exactly 28 days before the seed instant, ensuring all Week 1 + Week 2 sessions resolve to past calendar dates regardless of when the harness boots.
+
+### Purpose
+
+The plan exercises the three past-session states the web portal classifies in `completionState.ts`:
+
+| State | Definition | Fixture session |
+|-------|------------|-----------------|
+| **completed** (read-only) | `WorkoutLog` exists with `IsCompleted = true` | `QaPastSessionCompletedId` (Week 1, Mon) |
+| **skipped** (editable + Mark-finished) | `WorkoutLog` exists with `IsCompleted = false` | `QaPastSessionSkippedId` (Week 1, Wed) |
+| **untouched** (editable + Mark-finished) | No `WorkoutLog` at all | `QaPastSessionUntouchedId` (Week 2, Mon) |
+
+### Stable GUIDs
+
+| Constant | Value | What it maps to |
+|---|---|---|
+| `QaPastTrainingPlanExternalId` | `11111111-1111-1111-2222-000000000001` | Plan `ExternalId` |
+| `QaPastSessionCompletedId` | `11111111-1111-1111-2222-000000000002` | Session in Week 1, DayOfWeek=1 (Monday) |
+| `QaPastSessionSkippedId` | `11111111-1111-1111-2222-000000000003` | Session in Week 1, DayOfWeek=3 (Wednesday) |
+| `QaPastSessionUntouchedId` | `11111111-1111-1111-2222-000000000004` | Session in Week 2, DayOfWeek=1 (Monday) |
+| `QaPastCompletedWorkoutLogId` | `11111111-1111-1111-2222-000000000005` | WorkoutLog for the completed session |
+| `QaPastSkippedWorkoutLogId` | `11111111-1111-1111-2222-000000000006` | WorkoutLog for the skipped session |
+
+### Plan ownership
+
+- `TrainingPlan.ClientId` = `ClientProfilePublicId` (`aaaaaaaa-...`) — same client as the ForTime plan.
+- `TrainingPlan.TrainerId` = `TrainerProfilePublicId` (`bbbbbbbb-...`) — same trainer as the ForTime plan.
+- Login as `qa.trainer@fitnessplatform.test` to access via `GET /training/plans/{planId}`.
+
+### Plan shape
+
+```
+TrainingPlan (ExternalId = 11111111-1111-1111-2222-000000000001)
+  Status: Active
+  StartDate: <Monday ~28 days before seed time>
+  Weeks:
+    Week 1 (Status = Published)
+      Session "QA Past Session — Completed" (DayOfWeek = 1 = Monday)
+        Section "Hlavní" (Standard, PastCompletedSectionId = 11111111-1111-1111-3333-000000000001)
+          [QA Bench Press, QA Overhead Press]
+        → WorkoutLog (ExternalId = 11111111-1111-1111-2222-000000000005, IsCompleted=true)
+      Session "QA Past Session — Skipped" (DayOfWeek = 3 = Wednesday)
+        Section "Hlavní" (Standard, PastSkippedSectionId = 11111111-1111-1111-3333-000000000002)
+          [QA Back Squat, QA Romanian Deadlift]
+        → WorkoutLog (ExternalId = 11111111-1111-1111-2222-000000000006, IsCompleted=false, 1 partial set)
+    Week 2 (Status = Published)
+      Session "QA Past Session — Untouched" (DayOfWeek = 1 = Monday)
+        Section "Hlavní" (Standard, PastUntouchedSectionId = 11111111-1111-1111-3333-000000000003)
+          [QA Pull-down, QA Seated Row]
+        → NO WorkoutLog
+```
+
+### Playwright targeting
+
+When driving the trainer portal to the plan detail page, navigate to
+`/training/plans/11111111-1111-1111-2222-000000000001` (use the plan `ExternalId` from the API response, or derive it via `GET /training/plans?clientId=<ClientProfilePublicId>`).
+
+Use the session IDs above as stable selectors in spec assertions (`data-session-id` attributes or API probe keys).
+
+---
+
 ## Seeded foods, recipes, nutrition plan, blobs
 
 Five foods, three recipes, and one nutrition plan are seeded by `QaSeedRunner` alongside the training plan. All constants are in `QaSeedRunner.cs`.

--- a/docs/testing/e2e-fixtures.md
+++ b/docs/testing/e2e-fixtures.md
@@ -153,8 +153,9 @@ The plan exercises the three past-session states the web portal classifies in `c
 
 ### Plan ownership
 
-- `TrainingPlan.ClientId` = `ClientProfilePublicId` (`aaaaaaaa-...`) — same client as the ForTime plan.
-- `TrainingPlan.TrainerId` = `TrainerProfilePublicId` (`bbbbbbbb-...`) — same trainer as the ForTime plan.
+- `TrainingPlan.ClientId` = `ClientProfilePublicId` (`aaaaaaaa-...`) — keyed on `ClientProfile.PublicId`, same as all other training plans. `GetTrainingPlanEndpoint` queries `TrainingCompletion` by `plan.ClientId` and `WorkoutCompletionService` writes `TrainingCompletion.ClientId = clientProfile.PublicId`, so these must match.
+- `TrainingPlan.TrainerId` = `TrainerUserId` (`22222222-...`) — keyed on **`ApplicationUser.Id`**, NOT `ProfessionalProfile.PublicId`. `GetTrainingPlansEndpoint` and `GetTrainingPlanEndpoint` scope by `Guid.Parse(AppClaims.UserId)` which is `ApplicationUser.Id`. Using the profile `PublicId` (`bbbbbbbb-...`) would make the plan invisible to `GET /training/plans`.
+- `WorkoutLog.ClientId` = `ClientUserId` (`11111111-...`) — keyed on **`ApplicationUser.Id`**, NOT `ClientProfile.PublicId`. `CompleteWorkoutEndpoint` filters WorkoutLogs by `ClientId == Guid.Parse(AppClaims.UserId)` = `ApplicationUser.Id`. `WorkoutCompletionService` then resolves the ClientProfile via `cp.UserId == log.ClientId` and writes `TrainingCompletion.ClientId = clientProfile.PublicId`.
 - Login as `qa.trainer@fitnessplatform.test` to access via `GET /training/plans/{planId}`.
 
 ### Plan shape

--- a/web/src/api/training-plans.ts
+++ b/web/src/api/training-plans.ts
@@ -82,6 +82,38 @@ export async function publishTrainingWeek(
   return data;
 }
 
+/** Response from the retroactive session-finish endpoint. */
+export interface FinishSessionResponse {
+  workoutLogId: string;
+  planId: string;
+  sessionId: string;
+  completedAt: string;
+}
+
+/**
+ * Retroactively mark a past unfinished session as completed on behalf of the
+ * client. Only applicable to sessions the client skipped or never started.
+ * The caller must supply `completedAt` as the session's scheduled calendar
+ * date in UTC ISO-8601 so history attributes to the correct historical day.
+ *
+ * Errors:
+ *   404 — plan not found / not owned, or session not in plan
+ *   409 — SESSION_ALREADY_COMPLETED
+ *   400 — COMPLETED_AT_IN_FUTURE
+ *   422 — COMPLETED_AT_BEFORE_PLAN_START
+ */
+export async function finishSession(
+  planId: string,
+  sessionId: string,
+  completedAt: string,
+): Promise<FinishSessionResponse> {
+  const { data } = await api.post<FinishSessionResponse>(
+    `/trainer/training/plans/${planId}/sessions/${sessionId}/finish`,
+    { completedAt },
+  );
+  return data;
+}
+
 /** Get exercise progress for a client. */
 export async function getExerciseProgress(
   clientId: string,

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -801,7 +801,10 @@
     "CLIENT_REQUEST_NOT_FOUND": "Žádost klienta nebyla nalezena.",
     "REQUIRED": "Toto pole je povinné.",
     "OUT_OF_RANGE": "Hodnota je mimo povolený rozsah.",
-    "INVALID_DEADLINE_OFFSET_HOURS": "Neplatná lhůta. Povolené hodnoty: 24, 48, 72, 120 nebo 168 hodin."
+    "INVALID_DEADLINE_OFFSET_HOURS": "Neplatná lhůta. Povolené hodnoty: 24, 48, 72, 120 nebo 168 hodin.",
+    "SESSION_ALREADY_COMPLETED": "Tento trénink byl již dokončen.",
+    "COMPLETED_AT_IN_FUTURE": "Datum dokončení nesmí být v budoucnosti.",
+    "COMPLETED_AT_BEFORE_PLAN_START": "Datum dokončení nesmí být před začátkem plánu."
   },
   "nutritionGoals": {
     "title": "Cíle & makra",
@@ -1198,6 +1201,15 @@
       "exerciseSkippedSuffix": "{{count}} vynecháno",
       "sessionAllComplete": "Vše dokončeno",
       "sessionMixed": "{{completed}} dokončeno · {{skipped}} vynecháno"
+    },
+    "retroactiveFinish": {
+      "buttonLabel": "Označit jako dokončeno",
+      "buttonTooltip": "Zpětně označit tento trénink jako dokončený za klienta",
+      "dialogTitle": "Označit trénink jako dokončený",
+      "dialogBody": "Označit «{{name}}» jako dokončený? Trénink bude zaznamenán jako splněný k naplánovanému datu. Tuto akci nelze vrátit.",
+      "dialogConfirm": "Označit jako dokončeno",
+      "success": "Trénink označen jako dokončený.",
+      "noStartDate": "Trénink nelze označit: plán nemá nastavené datum začátku."
     }
   },
   "exercises": {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -791,7 +791,10 @@
     "CLIENT_REQUEST_NOT_FOUND": "Klientenanfrage nicht gefunden.",
     "REQUIRED": "Dieses Feld ist erforderlich.",
     "OUT_OF_RANGE": "Der Wert liegt außerhalb des zulässigen Bereichs.",
-    "INVALID_DEADLINE_OFFSET_HOURS": "Ungültige Frist. Erlaubte Werte: 24, 48, 72, 120 oder 168 Stunden."
+    "INVALID_DEADLINE_OFFSET_HOURS": "Ungültige Frist. Erlaubte Werte: 24, 48, 72, 120 oder 168 Stunden.",
+    "SESSION_ALREADY_COMPLETED": "Diese Einheit wurde bereits abgeschlossen.",
+    "COMPLETED_AT_IN_FUTURE": "Das Abschlussdatum darf nicht in der Zukunft liegen.",
+    "COMPLETED_AT_BEFORE_PLAN_START": "Das Abschlussdatum darf nicht vor dem Startdatum des Plans liegen."
   },
   "nutritionGoals": {
     "title": "Ziele & Makros",
@@ -1182,6 +1185,15 @@
       "exerciseSkippedSuffix": "{{count}} übersprungen",
       "sessionAllComplete": "Alles erledigt",
       "sessionMixed": "{{completed}} abgeschlossen · {{skipped}} übersprungen"
+    },
+    "retroactiveFinish": {
+      "buttonLabel": "Als abgeschlossen markieren",
+      "buttonTooltip": "Diese vergangene Einheit nachträglich als abgeschlossen markieren",
+      "dialogTitle": "Einheit als abgeschlossen markieren",
+      "dialogBody": "«{{name}}» als abgeschlossen markieren? Die Einheit wird als erledigt am geplanten Datum gespeichert. Diese Aktion kann nicht rückgängig gemacht werden.",
+      "dialogConfirm": "Als abgeschlossen markieren",
+      "success": "Einheit als abgeschlossen markiert.",
+      "noStartDate": "Einheit kann nicht markiert werden: Dieser Plan hat kein Startdatum."
     }
   },
   "exercises": {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -792,7 +792,10 @@
     "CLIENT_REQUEST_NOT_FOUND": "Client request not found.",
     "REQUIRED": "This field is required.",
     "OUT_OF_RANGE": "Value is out of the allowed range.",
-    "INVALID_DEADLINE_OFFSET_HOURS": "Invalid deadline. Allowed values: 24, 48, 72, 120 or 168 hours."
+    "INVALID_DEADLINE_OFFSET_HOURS": "Invalid deadline. Allowed values: 24, 48, 72, 120 or 168 hours.",
+    "SESSION_ALREADY_COMPLETED": "This session has already been completed.",
+    "COMPLETED_AT_IN_FUTURE": "Completion date cannot be in the future.",
+    "COMPLETED_AT_BEFORE_PLAN_START": "Completion date cannot be before the plan's start date."
   },
   "nutritionGoals": {
     "title": "Goals & Macros",
@@ -1183,6 +1186,15 @@
       "exerciseSkippedSuffix": "{{count}} skipped",
       "sessionAllComplete": "All complete",
       "sessionMixed": "{{completed}} completed · {{skipped}} skipped"
+    },
+    "retroactiveFinish": {
+      "buttonLabel": "Mark finished",
+      "buttonTooltip": "Mark this past session as finished on behalf of the client",
+      "dialogTitle": "Mark session as finished",
+      "dialogBody": "Mark \"{{name}}\" as finished? This will record the session as completed on the scheduled date. This action cannot be undone.",
+      "dialogConfirm": "Mark as finished",
+      "success": "Session marked as finished.",
+      "noStartDate": "Cannot mark as finished: this plan has no start date set."
     }
   },
   "exercises": {

--- a/web/src/lib/training-plan-dates.ts
+++ b/web/src/lib/training-plan-dates.ts
@@ -112,6 +112,12 @@ export function sessionScheduledDateUtc(
   if (Number.isNaN(start.getTime())) return null;
   // Advance to the Monday of the target week (week 1 = startDate itself).
   const dayOffset = (weekNumber - 1) * 7 + (dayOfWeek - 1);
+  // UTC anchoring is intentional here: `completedAt` must represent the
+  // session's scheduled calendar day in UTC so the backend's date key resolves
+  // to the correct historical day regardless of the trainer's local timezone.
+  // `weekStartDate` uses local-time anchoring (for display/comparison against
+  // the trainer's clock), but `completedAt` is an instant sent to the server —
+  // it must be timezone-stable, hence UTC throughout.
   const utc = Date.UTC(
     start.getUTCFullYear(),
     start.getUTCMonth(),

--- a/web/src/lib/training-plan-dates.ts
+++ b/web/src/lib/training-plan-dates.ts
@@ -90,6 +90,38 @@ export function todayWeekdayInPlan(
 }
 
 /**
+ * Returns the UTC ISO-8601 string for the scheduled calendar date of a
+ * specific session within a plan — i.e. the Monday of the given week offset by
+ * `(dayOfWeek - 1)` days, at 00:00:00 UTC.
+ *
+ * This is the value to send as `completedAt` when a trainer retroactively
+ * finishes a past session on behalf of the client. Attributing to 00:00 UTC on
+ * the session's scheduled day ensures the backend's TrainingCompletion date key
+ * resolves to that calendar day regardless of the server's local timezone.
+ *
+ * Returns `null` when the plan has no `startDate` — the caller should NOT send
+ * the request in that case (completedAt would be unresolvable).
+ */
+export function sessionScheduledDateUtc(
+  plan: { startDate?: string | null },
+  weekNumber: number,
+  dayOfWeek: number,
+): string | null {
+  if (!plan.startDate) return null;
+  const start = new Date(plan.startDate);
+  if (Number.isNaN(start.getTime())) return null;
+  // Advance to the Monday of the target week (week 1 = startDate itself).
+  const dayOffset = (weekNumber - 1) * 7 + (dayOfWeek - 1);
+  const utc = Date.UTC(
+    start.getUTCFullYear(),
+    start.getUTCMonth(),
+    start.getUTCDate() + dayOffset,
+    0, 0, 0, 0,
+  );
+  return new Date(utc).toISOString();
+}
+
+/**
  * Returns the `weekNumber` of the week that contains `now` based on the plan's
  * `startDate`. Falls back to the first week's number when:
  *   - the plan has no `startDate` (no date math possible),

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -876,7 +876,6 @@ export default function TrainingPlanPage() {
               className={cn(
                 isCurrentWeekFinished && 'opacity-70 select-none',
               )}
-              aria-disabled={isCurrentWeekFinished || undefined}
             >
             {/* Day note — read-only when the selected day has already
                 passed (existing text stays visible, "Add note" affordance

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { getTrainingPlan, completeTrainingPlan, finishSession } from '@/api/training-plans';
 import { listSectionTemplates, createSectionTemplate } from '@/api/sectionTemplates';
@@ -100,7 +100,6 @@ export default function TrainingPlanPage() {
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [completeDialogOpen, setCompleteDialogOpen] = useState(false);
   const [isCompleting, setIsCompleting] = useState(false);
-  const queryClient = useQueryClient();
   const [pendingNav, setPendingNav] = useState<string | null>(null);
   // State for the retroactive "mark session finished" confirmation dialog.
   const [markFinishedTarget, setMarkFinishedTarget] = useState<{
@@ -312,6 +311,9 @@ export default function TrainingPlanPage() {
       setMarkFinishedTarget(null);
       showSuccess('training.retroactiveFinish.success');
       // Reload plan so sessionExecutions update (lock state + completion badges recompute).
+      // This page holds plan state locally via the Zustand store (setPlan), so the
+      // imperative refetch + setPlan is the canonical refresh mechanism — consistent
+      // with handleReset and other mutation handlers on this page.
       if (planId) {
         try {
           const data = await getTrainingPlan(planId);
@@ -320,7 +322,6 @@ export default function TrainingPlanPage() {
           // Non-fatal — reload on next navigation
         }
       }
-      queryClient.invalidateQueries({ queryKey: ['training-plan', planId] });
     },
     onError: (err: unknown) => {
       showApiError(err, 'common.error');

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useCallback, useState, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getTrainingPlan, completeTrainingPlan } from '@/api/training-plans';
+import { getTrainingPlan, completeTrainingPlan, finishSession } from '@/api/training-plans';
 import { listSectionTemplates, createSectionTemplate } from '@/api/sectionTemplates';
 import type { SectionTemplateResponse } from '@/api/sectionTemplates';
 import type { WorkoutFormat, MovementType, SetType } from '@/api/training-plan-types';
@@ -13,7 +13,7 @@ import type { MuscleGroup } from '@/api/exercise-types';
 import { apiClient } from '@/api/client';
 import { useTrainingPlanStore } from '@/stores/trainingPlan';
 import { PageHeader } from '@/components/layout';
-import { showApiError, showSuccess } from '@/lib/api-errors';
+import { showApiError, showSuccess, showError } from '@/lib/api-errors';
 import { Button, Dialog } from '@/components/ui';
 import { MondayDatePicker } from '@/components/ui/MondayDatePicker';
 import { WeekDayTabs } from '@/components/nutrition';
@@ -21,7 +21,7 @@ import type { WeekTabData } from '@/components/nutrition/WeekDayTabs';
 import { TrainingSidebar } from '@/components/training/TrainingSidebar';
 import { SectionTemplateSearch } from '@/components/training/SectionTemplateSearch';
 import { cn } from '@/lib/cn';
-import { isDayInPast, isWeekFinished, todayWeekdayInPlan, weekStartDate } from '@/lib/training-plan-dates';
+import { isDayInPast, isWeekFinished, todayWeekdayInPlan, weekStartDate, sessionScheduledDateUtc } from '@/lib/training-plan-dates';
 import { estimatedSectionDurationSeconds, formatDurationCompact } from '@/lib/training-plan-format';
 import { computePlanLocks, exerciseLockKey } from '@/lib/training-plan-locks';
 import { deriveSessionCompletionState } from '@/lib/completionState';
@@ -100,7 +100,14 @@ export default function TrainingPlanPage() {
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [completeDialogOpen, setCompleteDialogOpen] = useState(false);
   const [isCompleting, setIsCompleting] = useState(false);
+  const queryClient = useQueryClient();
   const [pendingNav, setPendingNav] = useState<string | null>(null);
+  // State for the retroactive "mark session finished" confirmation dialog.
+  const [markFinishedTarget, setMarkFinishedTarget] = useState<{
+    sessionId: string;
+    sessionName: string;
+    completedAt: string;
+  } | null>(null);
   const [dragOverDay, setDragOverDay] = useState<number | null>(null);
   const dayHoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Set during `confirmLeave` so the popstate trap and pushState interceptor
@@ -293,6 +300,39 @@ export default function TrainingPlanPage() {
     } finally {
       setIsCompleting(false);
     }
+  };
+
+  // ── Retroactive finish mutation ──
+  const finishSessionMutation = useMutation({
+    mutationFn: ({ sessionId, completedAt }: { sessionId: string; completedAt: string }) => {
+      if (!planId) return Promise.reject(new Error('planId missing'));
+      return finishSession(planId, sessionId, completedAt);
+    },
+    onSuccess: async () => {
+      setMarkFinishedTarget(null);
+      showSuccess('training.retroactiveFinish.success');
+      // Reload plan so sessionExecutions update (lock state + completion badges recompute).
+      if (planId) {
+        try {
+          const data = await getTrainingPlan(planId);
+          setPlan(data);
+        } catch {
+          // Non-fatal — reload on next navigation
+        }
+      }
+      queryClient.invalidateQueries({ queryKey: ['training-plan', planId] });
+    },
+    onError: (err: unknown) => {
+      showApiError(err, 'common.error');
+    },
+  });
+
+  const handleConfirmMarkFinished = () => {
+    if (!markFinishedTarget) return;
+    finishSessionMutation.mutate({
+      sessionId: markFinishedTarget.sessionId,
+      completedAt: markFinishedTarget.completedAt,
+    });
   };
 
   // Apply-template client-side splice: replaces exercises + format of the target session.
@@ -857,12 +897,27 @@ export default function TrainingPlanPage() {
 
             {daySessions.map((session) => {
               const isSessionOpen = !collapsedSessions.has(session.sessionId);
-              const isSessionLocked = planLocks.sessionIds.has(session.sessionId);
-              // Combined read-only flag for the session-header action buttons
-              // and the session-notes input — locked sessions (every section
-              // finished by the client) AND any session on a day that has
-              // already passed should reject edits + show the disabled cue.
-              const isSessionReadOnly = isSessionLocked || isSelectedDayInPast;
+              // A session is "client-locked" when the client has completed every
+              // section in it (planLocks.sessionIds, derived from completions).
+              const isClientLockedSession = planLocks.sessionIds.has(session.sessionId);
+              // Execution record for this session — present when the client has
+              // interacted with it (at least one set logged or session finished).
+              const sessionExec = plan?.sessionExecutions?.find(
+                (e) => e.sessionId === session.sessionId,
+              );
+              // A past session is "completed" (read-only) when the client
+              // formally finished the workout log (isSessionFinished=true).
+              // Skipped or untouched past sessions remain editable per AC.
+              const isPastCompletedSession =
+                isSelectedDayInPast && (sessionExec?.isSessionFinished ?? false);
+              // Read-only when client-locked OR the client actually finished
+              // this specific session. Sessions the client never touched or
+              // skipped stay editable even when in the past.
+              const isSessionReadOnly = isClientLockedSession || isPastCompletedSession;
+              // True when the session is in the past AND not completed — these
+              // sessions show the "Mark finished" retroactive affordance.
+              const isPastUnfinishedSession =
+                isSelectedDayInPast && !isPastCompletedSession && !isClientLockedSession;
 
               return (
                 <SessionDragWrapper
@@ -942,10 +997,8 @@ export default function TrainingPlanPage() {
                       })()}
                       {(() => {
                         // Session-level completion badge — derive from execution data.
+                        // sessionExec is already resolved above in the outer scope.
                         const allExercises = session.sections.flatMap((sec) => sec.exercises);
-                        const sessionExec = plan?.sessionExecutions?.find(
-                          (e) => e.sessionId === session.sessionId,
-                        );
                         const { state, counts } = deriveSessionCompletionState(
                           sessionExec ? [sessionExec] : undefined,
                           session.sessionId,
@@ -961,6 +1014,40 @@ export default function TrainingPlanPage() {
                         );
                       })()}
                     </span>
+                    {/* "Mark finished" retroactive affordance — only shown on
+                        past sessions the client did not complete. The button is
+                        visually distinct (tinted outline style) to separate it
+                        clearly from the client's live-finish flow. */}
+                    {isPastUnfinishedSession && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          const completedAt = sessionScheduledDateUtc(plan, selectedWeek, selectedDay);
+                          if (!completedAt) {
+                            showError('training.retroactiveFinish.noStartDate');
+                            return;
+                          }
+                          setMarkFinishedTarget({
+                            sessionId: session.sessionId,
+                            sessionName: session.name || t('training.untitledSession'),
+                            completedAt,
+                          });
+                        }}
+                        disabled={finishSessionMutation.isPending}
+                        className={cn(
+                          'shrink-0 rounded-sm border px-2 py-[2px] text-[10px] font-medium transition-colors',
+                          'border-amber-500/50 text-amber-600 bg-amber-50/80',
+                          'hover:bg-amber-100 hover:border-amber-500',
+                          'disabled:opacity-40 disabled:cursor-not-allowed',
+                          'dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-500/40',
+                        )}
+                        title={t('training.retroactiveFinish.buttonTooltip')}
+                        aria-label={t('training.retroactiveFinish.buttonLabel')}
+                      >
+                        {t('training.retroactiveFinish.buttonLabel')}
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={(e) => {
@@ -1114,13 +1201,15 @@ export default function TrainingPlanPage() {
                             isSectionLocked={
                               // A section's inputs are read-only when any of:
                               //   - the section itself is finished by the client
-                              //   - the whole session is finished (every section
-                              //     locked) — adding/editing on a wrapped-up
-                              //     session has no clinical value
-                              //   - the selected day has already passed
+                              //   - the whole session is client-locked (every
+                              //     section finished by the client)
+                              //   - the session is a past completed session
+                              //     (client formally finished the workout log)
+                              // NOTE: isSelectedDayInPast alone no longer locks —
+                              // past skipped / untouched sessions are editable.
                               planLocks.sectionIds.has(section.sectionId) ||
-                              planLocks.sessionIds.has(session.sessionId) ||
-                              isSelectedDayInPast
+                              isClientLockedSession ||
+                              isPastCompletedSession
                             }
                             lockedExerciseIds={new Set(
                               section.exercises
@@ -1137,11 +1226,7 @@ export default function TrainingPlanPage() {
                             )}
                             exerciseDetailsMap={exerciseDetailsMap}
                             exerciseFullMap={exerciseFullMap}
-                            sessionExecution={
-                              plan?.sessionExecutions?.find(
-                                (e) => e.sessionId === session.sessionId,
-                              )
-                            }
+                            sessionExecution={sessionExec}
                             onUpdate={(patch) =>
                               updateSection(selectedWeek, session.sessionId, section.sectionId, patch)
                             }
@@ -1367,6 +1452,36 @@ export default function TrainingPlanPage() {
         <p style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.6 }}>
           {t('training.template.applyConfirmMessage', {
             name: templateConfirmTarget?.template.name ?? '',
+          })}
+        </p>
+      </Dialog>
+
+      {/* ── Mark Session Finished (Retroactive) Dialog ── */}
+      <Dialog
+        open={!!markFinishedTarget}
+        onClose={() => setMarkFinishedTarget(null)}
+        title={t('training.retroactiveFinish.dialogTitle')}
+        maxWidth={420}
+        footer={
+          <>
+            <Button onClick={() => setMarkFinishedTarget(null)} disabled={finishSessionMutation.isPending}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              variant="brand"
+              onClick={handleConfirmMarkFinished}
+              disabled={finishSessionMutation.isPending}
+            >
+              {finishSessionMutation.isPending
+                ? t('common.saving')
+                : t('training.retroactiveFinish.dialogConfirm')}
+            </Button>
+          </>
+        }
+      >
+        <p style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.6 }}>
+          {t('training.retroactiveFinish.dialogBody', {
+            name: markFinishedTarget?.sessionName ?? '',
           })}
         </p>
       </Dialog>


### PR DESCRIPTION
## Summary
- **Backend:** extract `IWorkoutCompletionService` from `CompleteWorkoutEndpoint` (shared by client live-finish + new trainer endpoint); add `POST /trainer/training/plans/{planId}/sessions/{sessionId}/finish` — `Roles(Trainer)`, ownership-guarded (not-mine → 404), materializes a `WorkoutLog` from the session template for untouched sessions, optional backdated `completedAt` (validated not-future / not-before-plan-start), completion instant drives both `log.CompletedAt` and the `TrainingCompletion` date key.
- **Web:** relax the past-lock on `TrainingPlanPage` so past *completed* sessions stay read-only but past *skipped/untouched* sessions are editable (keys on #323 `SessionExecutionDto.isSessionFinished`); add an amber "Mark finished" affordance + confirmation dialog wired to the new endpoint; query invalidation; drop a wrapper-level `aria-disabled` that had silenced the affordance to assistive tech.
- **i18n:** `training.retroactiveFinish.*` + three `apiErrors.*` keys in cs/en/de.
- **Fixtures/docs:** insert-only `QaSeedRunner` past-dated training plan (3 completion states) + owner id-space correction; `docs/testing/e2e-fixtures.md` notes.

## Related issue
Fixes #326

## Scope
cross-cut (backend + web) — one issue, one branch

## QA verdict (from qa-tester)
OVERALL ✅ PASS — static surface green, all 5 interactive ACs verified via Playwright drive, i18n cs/en/de complete, mobile untouched. (Defect + fixture findings from the interactive drive were fixed on-branch: web `aria-disabled` removed + re-verified; seed owner id-space corrected.)

## Notes
- Defense-in-depth TOCTOU concurrency gap (duplicate completed `WorkoutLog`, shared with the pre-existing client path) deferred to follow-up **#367** with rationale.
- A focused security review already ran clean on the backend write path (IDOR / role-subject / input-validation / idempotent fan-out / no swallowed exceptions).

## Test plan
- [ ] Past **completed** items remain locked (read-only) — behaviour unchanged.
- [ ] Past **skipped** items are editable: change reps/weights, swap exercise, modify set/exercise structure.
- [ ] Past **untouched** items behave identically to past skipped — fully editable.
- [ ] Coach can mark a past unfinished item finished retroactively; persisted record matches the client's live-finish flow (totals, history, lock state).
- [ ] Retroactive-finish affordance is visually distinct from the live-finish flow — not silent or ambiguous.
- [ ] All new copy ships in cs, en, de.
- [ ] No hardcoded colors or spacing — design tokens only.
- [ ] Mobile live-training UX unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)