### PR TITLE
chore: fix ForTime QA seed plan TrainerId to ApplicationUser.Id

### DIFF
--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -406,7 +406,12 @@ public static class QaSeedRunner
         {
             ExternalId      = QaTrainingPlanExternalId,
             ClientId        = clientProfilePublicId,
-            TrainerId       = trainerProfilePublicId,
+            // TrainerId is keyed on ApplicationUser.Id (NOT ProfessionalProfile.PublicId) —
+            // GetTrainingPlansEndpoint and GetTrainingPlanEndpoint scope by
+            // Guid.Parse(User.FindFirstValue(AppClaims.UserId)) which is ApplicationUser.Id.
+            // Using trainerProfilePublicId (bbbb...) makes this plan invisible to
+            // GET /training/plans and GET /training/plans/{planId} for the trainer.
+            TrainerId       = TrainerUserId,
             Name            = "QA Test Plan — ForTime fixture",
             Status          = TrainingPlanStatus.Active,
             DateCreated     = now,

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -454,6 +454,38 @@ public class QaSeedRunnerTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// The ForTime fixture plan (<see cref="QaSeedRunner.QaTrainingPlanExternalId"/>) must have
+    /// TrainerId = TrainerUserId (ApplicationUser.Id = 22222222-...) so that trainer-scoped
+    /// endpoints which filter by Guid.Parse(AppClaims.UserId) can see the plan.
+    /// Using TrainerProfilePublicId (bbbbbbbb-...) makes the plan invisible to
+    /// GET /training/plans and GET /training/plans/{planId}.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_ForTimePlan_TrainerIdIsApplicationUserId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        var plan = await mongo.TrainingPlans
+            .Find(p => p.ExternalId == QaSeedRunner.QaTrainingPlanExternalId)
+            .FirstOrDefaultAsync(ct);
+
+        plan.Should().NotBeNull("the ForTime fixture plan must be seeded");
+        plan!.TrainerId.Should().Be(QaSeedRunner.TrainerUserId,
+            "TrainingPlan.TrainerId must be ApplicationUser.Id (22222222-...) — " +
+            "GetTrainingPlansEndpoint and GetTrainingPlanEndpoint scope by " +
+            "Guid.Parse(AppClaims.UserId) which is ApplicationUser.Id, not ProfessionalProfile.PublicId (bbbbbbbb-...)");
+        plan.ClientId.Should().Be(QaSeedRunner.ClientProfilePublicId,
+            "TrainingPlan.ClientId must remain ClientProfile.PublicId (aaaaaaaa-...) — " +
+            "GetClientPlansEndpoint filters by ClientProfile.PublicId and " +
+            "TrainingCompletion.ClientId is also keyed on ClientProfile.PublicId");
+    }
+
+    /// <summary>
     /// Seeding twice must not create duplicate past-plan or workout-log documents.
     /// </summary>
     [Fact]

--- a/docs/testing/e2e-fixtures.md
+++ b/docs/testing/e2e-fixtures.md
@@ -73,7 +73,7 @@ A deterministic training plan is seeded for the QA client on every `/test/reset`
 | --------------------------------- | -------------------------------------- | -------------------------------------------------- |
 | `QaTrainingPlanExternalId`        | `dddddddd-dddd-dddd-dddd-dddddddddddd` | The plan's `ExternalId` (used in API responses)    |
 | `ClientProfilePublicId`           | `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa` | `TrainingPlan.ClientId` (NOT the user id — see note) |
-| `TrainerProfilePublicId`          | `bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb` | `TrainingPlan.TrainerId`                           |
+| `TrainerUserId`                   | `22222222-2222-2222-2222-222222222222` | `TrainingPlan.TrainerId` (ApplicationUser.Id — see note) |
 | `ForTimeSectionId`                | `eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee` | `TrainingSection.SectionId` for Section 1          |
 | `AmrapSectionId`                  | `ffffffff-ffff-ffff-ffff-ffffffffffff` | `TrainingSection.SectionId` for Section 2          |
 | `StandardSectionId`               | `00000000-0000-0000-aaaa-000000000001` | `TrainingSection.SectionId` for Section 3          |
@@ -83,6 +83,12 @@ A deterministic training plan is seeded for the QA client on every `/test/reset`
 > (the profile's public identifier, `aaaaaaaa-...`), **not** on `ApplicationUser.Id`
 > (`11111111-...`). `GET /client/plans` filters by `ClientProfile.PublicId`. Using the
 > user id directly would make the plan invisible to that endpoint.
+>
+> **Note on TrainerId.** `TrainingPlan.TrainerId` is keyed on `ApplicationUser.Id`
+> (`22222222-...`), **not** on `ProfessionalProfile.PublicId` (`bbbbbbbb-...`).
+> `GET /training/plans` and `GET /training/plans/{planId}` scope by
+> `Guid.Parse(AppClaims.UserId)` which is `ApplicationUser.Id`. Using the profile
+> `PublicId` would make the plan invisible to those trainer endpoints.
 
 ### Seeded plan shape
 


### PR DESCRIPTION
## Summary
- The pre-existing ForTime QA fixture plan (`QaTrainingPlanExternalId` = `dddddddd-…`) had `TrainerId` set to `TrainerProfilePublicId` (`bbbb…`) instead of the trainer's `ApplicationUser.Id` (`TrainerUserId` = `2222…`).
- Trainer-scoped endpoints (`GetTrainingPlansEndpoint`, `GetTrainingPlanEndpoint`) filter by `Guid.Parse(AppClaims.UserId)` = `ApplicationUser.Id`, so the seeded plan was invisible to the QA trainer. Fix sets `TrainerId = TrainerUserId`.
- `ClientId` kept as `ClientProfilePublicId` (`aaaa…`) — confirmed correct per `GetClientPlansEndpoint` / `TrainingCompletion` keying.
- Adds a `QaSeedRunnerTests` guard (`SeedAsync_ForTimePlan_TrainerIdIsApplicationUserId`) and documents the `TrainerId` id-space in `docs/testing/e2e-fixtures.md`.

## Related issue
Fixes #369

## Scope
backend (test fixture only — `QaSeedRunner` + its test + the fixtures doc; no product/endpoint code, no `/web`, no `/mobile`)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — 7 `QaSeedRunnerTests` green; ForTime plan now visible to trainer-scoped endpoints; `ClientId` keying unchanged.

## Test plan
- [ ] The seeded ForTime plan's `TrainerId` equals the trainer's `ApplicationUser.Id` so a logged-in QA trainer can list/open it via `GET /training/plans`.
- [ ] Its `ClientId` remains `ClientProfile.PublicId` (client-detail "Aktivní plány" + `TrainingCompletion` fold-in still resolve).
- [ ] Any ForTime-fixture WorkoutLogs use `ClientId` = `ApplicationUser.Id`, consistent with the live-finish write path.
- [ ] `QaSeedRunnerTests` asserts the ForTime plan's `TrainerId` equals the trainer `ApplicationUser.Id`.
- [ ] `docs/testing/e2e-fixtures.md` updated for the changed id.
- [ ] No product-code or endpoint changes — `QaSeedRunner` (+ tests + fixtures doc) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)