### PR TITLE
feat: color WOD live Tabata timer card background by work/rest phase

### DIFF
--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -104,7 +104,7 @@ public static class QaSeedRunner
 
     // Stable SectionId + exercise for the Tabata section (Order=3, #327 iOS QA fixture).
     public static readonly Guid TabataSectionId    = new("00000000-0000-0000-aaaa-000000000002");
-    public static readonly Guid TabataExercise1Id  = new("00000000-0000-0000-eeee-100000000001");
+    public static readonly Guid TabataExercise1Id  = new("00000000-0000-0000-eeee-000000000006");
 
     // Foods — owned by Nutri (NutritionistId = NutriProfilePublicId).
     public static readonly Guid QaFood1ExternalId = new("00000000-0000-0000-eeee-000000000001"); // Chicken Breast 100g

--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -24,10 +24,11 @@ namespace FitnessPlatform.Application.Seed;
 ///   dashboard shows "QA Client" without any further setup.
 /// - QA Nutri (33333333-...) has a ProfessionalProfile (no client link seeded).
 /// - A TrainingPlan (dddddddd-...) is seeded for the QA client with a Published week
-///   containing one session with three sections:
+///   containing one session with four sections:
 ///   Section 1 — ForTime + 0 exercises (the #258 bug shape).
 ///   Section 2 — AMRAP + 2 synthetic exercises (non-regression).
 ///   Section 3 — Standard (null format) + 2 synthetic exercises (non-regression).
+///   Section 4 — Tabata (20s/10s × 8) + 1 synthetic exercise (#327 iOS QA fixture).
 /// </summary>
 public static class QaSeedRunner
 {
@@ -95,11 +96,15 @@ public static class QaSeedRunner
     // Stable SessionId.
     public static readonly Guid QaSessionId = new("00000000-0000-0000-bbbb-000000000001");
 
-    // Stable ExternalIds for the synthetic exercises in AMRAP + Standard sections.
+    // Stable ExternalIds for the synthetic exercises in AMRAP + Standard + Tabata sections.
     public static readonly Guid AmrapExercise1Id   = new("00000000-0000-0000-cccc-000000000001");
     public static readonly Guid AmrapExercise2Id   = new("00000000-0000-0000-cccc-000000000002");
     public static readonly Guid StandardExercise1Id = new("00000000-0000-0000-dddd-000000000001");
     public static readonly Guid StandardExercise2Id = new("00000000-0000-0000-dddd-000000000002");
+
+    // Stable SectionId + exercise for the Tabata section (Order=3, #327 iOS QA fixture).
+    public static readonly Guid TabataSectionId    = new("00000000-0000-0000-aaaa-000000000002");
+    public static readonly Guid TabataExercise1Id  = new("00000000-0000-0000-eeee-100000000001");
 
     // Foods — owned by Nutri (NutritionistId = NutriProfilePublicId).
     public static readonly Guid QaFood1ExternalId = new("00000000-0000-0000-eeee-000000000001"); // Chicken Breast 100g
@@ -370,10 +375,11 @@ public static class QaSeedRunner
     /// <summary>
     /// Seeds a deterministic training plan for the QA client.
     ///
-    /// The plan contains one Published week with one session with three sections:
+    /// The plan contains one Published week with one session with four sections:
     ///   1. ForTime, TimeCapSeconds=1800, Exercises=[] — the #258 bug shape.
     ///   2. AMRAP, TimeCapSeconds=600, two synthetic exercises — non-regression.
     ///   3. Standard (null format), two synthetic exercises — non-regression.
+    ///   4. Tabata, WorkSeconds=20, RestSeconds=10, TotalRounds=8, one exercise — #327 iOS QA fixture.
     ///
     /// ClientId = clientProfilePublicId (NOT ClientUserId) — GetClientPlansEndpoint
     /// filters by ClientProfile.PublicId. Using the user id would make the plan
@@ -492,6 +498,30 @@ public static class QaSeedRunner
                                             ExerciseExternalId = StandardExercise2Id,
                                             ExerciseName       = "QA Deadlift",
                                             Order              = 2,
+                                            MovementType       = MovementType.Reps,
+                                        },
+                                    ],
+                                },
+                                // Section 4 — Tabata 20s/10s × 8 + 1 exercise (#327 iOS QA fixture)
+                                new TrainingSection
+                                {
+                                    SectionId    = TabataSectionId,
+                                    Order        = 3,
+                                    Name         = "Tabata test",
+                                    Format       = WorkoutFormat.Tabata,
+                                    FormatConfig = new WodConfig
+                                    {
+                                        WorkSeconds  = 20,
+                                        RestSeconds  = 10,
+                                        TotalRounds  = 8,
+                                    },
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = TabataExercise1Id,
+                                            ExerciseName       = "QA Burpee",
+                                            Order              = 1,
                                             MovementType       = MovementType.Reps,
                                         },
                                     ],

--- a/backend/FitnessPlatform.Tests/Endpoints/Testing/ResetTestStateEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Testing/ResetTestStateEndpointTests.cs
@@ -334,7 +334,7 @@ public class ResetTestStateEndpointTests : IAsyncLifetime
         week.Sessions.Should().HaveCount(1);
         var session = week.Sessions[0];
 
-        session.Sections.Should().HaveCount(3, because: "one ForTime section + one AMRAP section + one Standard section");
+        session.Sections.Should().HaveCount(4, because: "one ForTime section + one AMRAP section + one Standard section + one Tabata section");
 
         // Section 1 — ForTime + 0 exercises (the #258 bug shape).
         var section1 = session.Sections[0];
@@ -359,6 +359,24 @@ public class ResetTestStateEndpointTests : IAsyncLifetime
             because: "Section 3 must be Standard (null format)");
         section3.Exercises.Should().HaveCountGreaterThanOrEqualTo(1,
             because: "Standard section must have at least one exercise for non-regression");
+
+        // Section 4 — Tabata 20s/10s × 8 + 1 exercise (#327 iOS QA fixture).
+        var section4 = session.Sections[3];
+        section4.Format.Should().Be(WorkoutFormat.Tabata,
+            because: "Section 4 must be Tabata format");
+        section4.Order.Should().Be(3,
+            because: "Tabata section must be Order=3");
+        section4.Name.Should().Be("Tabata test",
+            because: "Tabata section must have the seeded name");
+        section4.FormatConfig.Should().NotBeNull();
+        section4.FormatConfig!.WorkSeconds.Should().Be(20,
+            because: "Tabata FormatConfig must have WorkSeconds=20");
+        section4.FormatConfig.RestSeconds.Should().Be(10,
+            because: "Tabata FormatConfig must have RestSeconds=10");
+        section4.FormatConfig.TotalRounds.Should().Be(8,
+            because: "Tabata FormatConfig must have TotalRounds=8");
+        section4.Exercises.Should().HaveCount(1,
+            because: "Tabata section must have exactly one seeded exercise");
     }
 
     /// <summary>

--- a/mobile/src/components/training/WodTimerHero.tsx
+++ b/mobile/src/components/training/WodTimerHero.tsx
@@ -988,8 +988,21 @@ function TabataTimer({ label, workSeconds, restSeconds, totalRounds, onFinish, o
   // EmomTimer's `showPrepUI` for the same rationale.
   const showPrepUI = preparing && running
 
+  // Phase-tinted background for the Tabata hero region — green on work,
+  // red on rest, neutral (no tint) during the pre-roll countdown. Uses the
+  // same hex-alpha suffix pattern as phaseChip (`colors.gold + '22'`), so
+  // the tint reads clearly without overpowering card text. Both `isWork`
+  // and `showPrepUI` derive from the same `phase` / `preparing` state, so
+  // the background flips in the same React render as the phase chip label
+  // with zero stale-color flash at the work ↔ rest boundary.
+  const phaseBg = showPrepUI
+    ? undefined
+    : isWork
+      ? colors.green + '20'
+      : colors.red + '20'
+
   return (
-    <View style={styles.heroWrap}>
+    <View style={[styles.heroWrap, { backgroundColor: phaseBg }]}>
       <Text style={[styles.formatLabel, { color: colors.label3 }]}>
         {label}
       </Text>

--- a/mobile/src/components/training/WodTimerHero.tsx
+++ b/mobile/src/components/training/WodTimerHero.tsx
@@ -995,6 +995,10 @@ function TabataTimer({ label, workSeconds, restSeconds, totalRounds, onFinish, o
   // and `showPrepUI` derive from the same `phase` / `preparing` state, so
   // the background flips in the same React render as the phase chip label
   // with zero stale-color flash at the work ↔ rest boundary.
+  // During pre-roll `phaseBg` is `undefined`; RN treats `undefined` as a
+  // no-op for `backgroundColor`, so the style falls through to
+  // `styles.heroWrap`'s default surface — the neutral pre-roll look is
+  // intentional and requires no explicit color value.
   const phaseBg = showPrepUI
     ? undefined
     : isWork


### PR DESCRIPTION
## Summary
- Tabata WOD live timer (`WodTimerHero` → `TabataTimer`) now tints the hero card background by phase: green on work, red on rest, neutral during the pre-roll countdown.
- Tint is derived from the existing `phase`/`preparing` state in the same React render as the phase-chip label, so it flips synchronously with zero stale-color flash at the work↔rest boundary.
- Colors come exclusively from `useTheme()` tokens (`colors.green` / `colors.red`) with the established `+ '20'` hex-alpha suffix pattern (mirrors `colors.gold + '22'` on the existing phaseChip). Zero hardcoded hex.
- Scope is Tabata-only per the issue triage comment; EMOM / AMRAP / ForTime / Standard are untouched.
- Adds a Tabata section (20s/10s × 8) to `QaSeedRunner` so a live `TabataTimer` is reachable on the iOS sim for QA (the seed previously had no Tabata-format session). Test-only fixture: additive, no migration, no product endpoint.

## Related issue
Fixes #327

## Scope
mobile (+ backend QA seed fixture)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all 7 ACs met. The 4 visual ACs (work→green, rest→red, synchronous no-flash, a11y label-not-color-alone) verified via orchestrator iOS-sim drive; evidence in `.qa-artifacts/327/orchestrator-tabata-*.jpg`.

## Test plan
- [ ] Work phase → timer card background uses green design token via `useTheme()` (no hardcoded hex)
- [ ] Rest phase → timer card background uses red design token via `useTheme()` (no hardcoded hex)
- [ ] Background updates synchronously with timer-state change — no flash of stale color at phase boundary
- [ ] Color values come exclusively from `mobile/src/constants/` via `useTheme()` — zero hardcoded hex
- [ ] Tabata covered (primary case); EMOM/AMRAP/ForTime/Standard out of scope per triage
- [ ] Standard (non-WOD) live training session unchanged
- [ ] Accessibility: work/pause not conveyed by color alone — phase label/text retained, nothing removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)