### PR TITLE
fix: signalr.ts resolves API base URL from EXPO_PUBLIC_API_BASE_URL

### DIFF
--- a/mobile/src/api/signalr.ts
+++ b/mobile/src/api/signalr.ts
@@ -1,9 +1,15 @@
 import { HubConnectionBuilder, HubConnection, LogLevel, HubConnectionState } from '@microsoft/signalr';
 import { useAuthStore } from '../stores/auth';
 
-const API_BASE_URL = __DEV__
-  ? 'https://localhost:5001'
-  : 'https://api.gfplatform.com';
+// `EXPO_PUBLIC_API_BASE_URL` lets QA dev builds point at the compose-exposed
+// API without rebuilding — same precedence as client.ts.
+// iOS NSURLSession strips the Authorization header on HTTP→HTTPS redirects, so
+// dev MUST hit the HTTPS port directly.
+const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ??
+  (__DEV__
+    ? 'https://localhost:5001'
+    : 'https://api.gfplatform.com');
 
 let connection: HubConnection | null = null;
 


### PR DESCRIPTION
## Summary
- `mobile/src/api/signalr.ts` now resolves `API_BASE_URL` from `process.env.EXPO_PUBLIC_API_BASE_URL ?? (__DEV__ ? 'https://localhost:5001' : 'https://api.gfplatform.com')` — byte-identical precedence to `mobile/src/api/client.ts`.
- Previously the hub URL hardcoded the `__DEV__` ternary and ignored the env override, flooding the dev client with SignalR negotiation failures when pointed at a non-5001 harness (surfaced during #327).
- Env-unset fallback behavior is unchanged: dev → `https://localhost:5001`, release → `https://api.gfplatform.com`.
- Minimal fix only — no shared base-URL helper extracted (the issue's AC explicitly allows this).

## Related issue
Fixes #373

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — static-verified config change; deterministic, no interactive run needed (runtime empirically confirmed in #327).

## Test plan
- [ ] `signalr.ts` derives `API_BASE_URL` from `process.env.EXPO_PUBLIC_API_BASE_URL` first, falling back to `__DEV__ ? 'https://localhost:5001' : 'https://api.gfplatform.com'` — matching `client.ts` exactly.
- [ ] With `EXPO_PUBLIC_API_BASE_URL` unset, dev still targets `https://localhost:5001` and release still targets `https://api.gfplatform.com` (no regression).
- [ ] No hardcoded URL literals beyond the existing fallback constants; no new `any`; `npx tsc --noEmit` clean.
- [ ] Scope is `mobile/src/api/signalr.ts` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)