### PR TITLE
fix: useImagePicker source-selection sheet is a no-op on web (blocks avatar e2e flow)

### DIFF
--- a/mobile/src/hooks/__tests__/useImagePicker.test.ts
+++ b/mobile/src/hooks/__tests__/useImagePicker.test.ts
@@ -100,15 +100,15 @@ describe('getMimeType', () => {
 
 describe('resolveWebSource', () => {
   it("returns 'library' on web (skips the native sheet)", () => {
-    expect(resolveWebSource('web', 'both')).toBe('library');
+    expect(resolveWebSource('web')).toBe('library');
   });
 
   it('returns null on iOS (caller should show native ActionSheetIOS)', () => {
-    expect(resolveWebSource('ios', 'both')).toBeNull();
+    expect(resolveWebSource('ios')).toBeNull();
   });
 
   it('returns null on Android (caller should show Alert.alert sheet)', () => {
-    expect(resolveWebSource('android', 'both')).toBeNull();
+    expect(resolveWebSource('android')).toBeNull();
   });
 });
 

--- a/mobile/src/hooks/__tests__/useImagePicker.test.ts
+++ b/mobile/src/hooks/__tests__/useImagePicker.test.ts
@@ -5,9 +5,10 @@
  * of which require the jest-expo preset that IS wired in this package's
  * package.json ("jest": { "preset": "jest-expo" }).
  *
- * These tests cover the two pure-logic functions extracted from the module:
- *   - getMimeType  (MIME detection from URI extension)
- *   - resolveFileSize fallback path (mocked fetch)
+ * These tests cover the pure-logic functions extracted from the module:
+ *   - getMimeType        (MIME detection from URI extension)
+ *   - resolveWebSource   (web-path source resolution — real exported helper)
+ *   - size guard arithmetic
  *
  * The full hook integration (pick → permission → picker → upload) is verified
  * manually via the Expo simulator; Jest cannot drive native permission dialogs.
@@ -15,6 +16,8 @@
  * To run:
  *   cd mobile && npx jest src/hooks/__tests__/useImagePicker.test.ts
  */
+
+import { resolveWebSource } from '../useImagePicker';
 
 // ---------------------------------------------------------------------------
 // getMimeType — extracted and tested as a pure function
@@ -84,46 +87,28 @@ describe('getMimeType', () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectSource web path — pure-logic simulation
+// resolveWebSource — real exported helper (guards the actual changed line)
 //
-// selectSource is a non-exported closure inside the hook, so we test its
-// branching logic in isolation using the same pattern as getMimeType above:
-// copy the decision logic and assert against it.
+// selectSource() delegates the web-path decision to resolveWebSource(), which
+// is exported so tests can import and assert against the live logic. If the
+// Platform.OS === 'web' branch in useImagePicker.ts is altered, these tests
+// will catch it — unlike the previous local stub which only documented intent.
 //
-// On web (Platform.OS === 'web'), the function resolves 'library' immediately
-// without showing any native sheet. This prevents the Promise from hanging
-// because React-Native-Web does not implement Alert.alert with action buttons.
+// On web:          returns 'library' (resolve immediately; no native sheet).
+// On iOS/Android:  returns null (show the native ActionSheetIOS / Alert sheet).
 // ---------------------------------------------------------------------------
 
-type SourceResolution = 'camera' | 'library' | 'cancel';
-
-/**
- * Distilled source-resolution logic from selectSource().
- * On web: always resolves 'library'.
- * On iOS/Android: would show a native sheet (not exercised here — native
- * dialogs cannot be driven from Jest without a simulator).
- */
-function resolveSourceForPlatform(
-  platform: 'ios' | 'android' | 'web',
-): SourceResolution | 'native-sheet' {
-  if (platform === 'web') {
-    return 'library';
-  }
-  // iOS / Android open a native sheet — not testable without a simulator.
-  return 'native-sheet';
-}
-
-describe('selectSource — web path', () => {
-  it("resolves 'library' on web without showing a native sheet", () => {
-    expect(resolveSourceForPlatform('web')).toBe('library');
+describe('resolveWebSource', () => {
+  it("returns 'library' on web (skips the native sheet)", () => {
+    expect(resolveWebSource('web', 'both')).toBe('library');
   });
 
-  it("does NOT immediately resolve on iOS (uses native ActionSheetIOS)", () => {
-    expect(resolveSourceForPlatform('ios')).toBe('native-sheet');
+  it('returns null on iOS (caller should show native ActionSheetIOS)', () => {
+    expect(resolveWebSource('ios', 'both')).toBeNull();
   });
 
-  it("does NOT immediately resolve on Android (uses Alert.alert)", () => {
-    expect(resolveSourceForPlatform('android')).toBe('native-sheet');
+  it('returns null on Android (caller should show Alert.alert sheet)', () => {
+    expect(resolveWebSource('android', 'both')).toBeNull();
   });
 });
 

--- a/mobile/src/hooks/__tests__/useImagePicker.test.ts
+++ b/mobile/src/hooks/__tests__/useImagePicker.test.ts
@@ -84,6 +84,50 @@ describe('getMimeType', () => {
 });
 
 // ---------------------------------------------------------------------------
+// selectSource web path — pure-logic simulation
+//
+// selectSource is a non-exported closure inside the hook, so we test its
+// branching logic in isolation using the same pattern as getMimeType above:
+// copy the decision logic and assert against it.
+//
+// On web (Platform.OS === 'web'), the function resolves 'library' immediately
+// without showing any native sheet. This prevents the Promise from hanging
+// because React-Native-Web does not implement Alert.alert with action buttons.
+// ---------------------------------------------------------------------------
+
+type SourceResolution = 'camera' | 'library' | 'cancel';
+
+/**
+ * Distilled source-resolution logic from selectSource().
+ * On web: always resolves 'library'.
+ * On iOS/Android: would show a native sheet (not exercised here — native
+ * dialogs cannot be driven from Jest without a simulator).
+ */
+function resolveSourceForPlatform(
+  platform: 'ios' | 'android' | 'web',
+): SourceResolution | 'native-sheet' {
+  if (platform === 'web') {
+    return 'library';
+  }
+  // iOS / Android open a native sheet — not testable without a simulator.
+  return 'native-sheet';
+}
+
+describe('selectSource — web path', () => {
+  it("resolves 'library' on web without showing a native sheet", () => {
+    expect(resolveSourceForPlatform('web')).toBe('library');
+  });
+
+  it("does NOT immediately resolve on iOS (uses native ActionSheetIOS)", () => {
+    expect(resolveSourceForPlatform('ios')).toBe('native-sheet');
+  });
+
+  it("does NOT immediately resolve on Android (uses Alert.alert)", () => {
+    expect(resolveSourceForPlatform('android')).toBe('native-sheet');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Size guard logic — pure arithmetic, no fetch needed
 // ---------------------------------------------------------------------------
 

--- a/mobile/src/hooks/useImagePicker.ts
+++ b/mobile/src/hooks/useImagePicker.ts
@@ -122,7 +122,6 @@ function getFilename(uri: string): string {
  */
 export function resolveWebSource(
   platform: typeof Platform.OS,
-  _source: 'camera' | 'library' | 'both',
 ): 'library' | null {
   if (platform === 'web') return 'library';
   return null;
@@ -198,7 +197,7 @@ export function useImagePicker(
       // buttons — the Promise would never resolve, hanging pick() indefinitely.
       // On web the browser file picker is opened directly via
       // launchImageLibraryAsync, so we resolve 'library' immediately.
-      const webResolution = resolveWebSource(Platform.OS, source);
+      const webResolution = resolveWebSource(Platform.OS);
       if (webResolution !== null) {
         resolve(webResolution);
         return;

--- a/mobile/src/hooks/useImagePicker.ts
+++ b/mobile/src/hooks/useImagePicker.ts
@@ -170,6 +170,18 @@ export function useImagePicker(
 
   function selectSource(): Promise<'camera' | 'library' | 'cancel'> {
     return new Promise((resolve) => {
+      // Web: React-Native-Web does not implement Alert.alert with actionable
+      // buttons — the Promise would never resolve, hanging pick() indefinitely.
+      // On web the browser file picker is opened directly via
+      // launchImageLibraryAsync, so we resolve 'library' immediately.
+      // Note: source:'camera' is not currently used by any caller on web;
+      // launchCameraAsync is not reliably supported in the browser environment.
+      // That gap is documented here rather than handled with dead branching.
+      if (Platform.OS === 'web') {
+        resolve('library');
+        return;
+      }
+
       const cameraLabel = t('imagePicker.sourceCamera');
       const libraryLabel = t('imagePicker.sourceLibrary');
       const cancelLabel = t('common.cancel');

--- a/mobile/src/hooks/useImagePicker.ts
+++ b/mobile/src/hooks/useImagePicker.ts
@@ -105,6 +105,30 @@ function getFilename(uri: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Source-resolution helper (exported for unit-testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a direct source on web (no native sheet exists); null means
+ * "show the native source sheet" (iOS ActionSheetIOS / Android Alert).
+ *
+ * Pure function — no side effects, no React deps. Exported so tests can
+ * import and assert against the real decision logic rather than a stub.
+ *
+ * Note: source:'camera' is not reliably supported in the browser environment
+ * (launchCameraAsync has no universal web implementation). The only current
+ * caller that hits the 'both' path is Avatar, which resolves to 'library' on
+ * web. That gap is documented here rather than handled with dead branching.
+ */
+export function resolveWebSource(
+  platform: typeof Platform.OS,
+  _source: 'camera' | 'library' | 'both',
+): 'library' | null {
+  if (platform === 'web') return 'library';
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -174,11 +198,9 @@ export function useImagePicker(
       // buttons — the Promise would never resolve, hanging pick() indefinitely.
       // On web the browser file picker is opened directly via
       // launchImageLibraryAsync, so we resolve 'library' immediately.
-      // Note: source:'camera' is not currently used by any caller on web;
-      // launchCameraAsync is not reliably supported in the browser environment.
-      // That gap is documented here rather than handled with dead branching.
-      if (Platform.OS === 'web') {
-        resolve('library');
+      const webResolution = resolveWebSource(Platform.OS, source);
+      if (webResolution !== null) {
+        resolve(webResolution);
         return;
       }
 


### PR DESCRIPTION
## Summary
- On the mobile-web bundle, the avatar/image picker's `selectSource()` relied on `Alert.alert` (iOS uses `ActionSheetIOS`, else-branch uses `Alert.alert`), which React-Native-Web does not implement with actionable buttons — the source-selection sheet never rendered and its `onPress` callbacks never fired.
- As a result the `selectSource()` Promise never resolved, so `pick()` hung indefinitely and no file picker opened.
- Fix: add a `Platform.OS === 'web'` branch in `selectSource()` that resolves `'library'` immediately, so the browser file picker opens directly via `launchImageLibraryAsync`, bypassing the no-op native sheet.
- iOS (`ActionSheetIOS`) and Android (`Alert.alert`) source-selection paths are untouched.

## Related issue
Fixes #377

## Unblocks
- #376 — avatar-upload e2e flow (`./scripts/test-env run user-avatar-upload`), which stays soft-gated until this lands.

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — `tsc --noEmit` clean; `useImagePicker` jest 16/16; iOS/Android native branches unchanged. Headline web AC ("picker opens on web, no hung sheet") verified live on the dockerised mobile-web harness (filechooser fires).

## Test plan
- [ ] On the web bundle, tapping the avatar camera badge opens the OS file picker directly (no source-selection sheet, no hung Promise).
- [ ] iOS source selection via `ActionSheetIOS` is unchanged.
- [ ] Android source selection via `Alert.alert` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
