### PR TITLE
feat: client-side session-lock enforcement (Start→Live CAS, finish release, TTL refresh, lock state in reads)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -16,10 +17,13 @@ namespace FitnessPlatform.Application.Features.ClientTraining.GetFullPlan;
 /// and per-set completion state (derived from <see cref="WorkoutLog"/> documents AND
 /// <see cref="TrainingCompletion"/> documents — the former is populated by the live-workout
 /// assistant, the latter by the lightweight mark-complete toggles on the Today card).
+/// Also enriches each session DTO with its current lock state (Stable/Editing/Live)
+/// and holder (Coach/Client/null) via a single batch <c>GetStateAsync</c> call.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbContext db)
+/// <param name="lockService">Session lock service — used to batch-fetch lock state.</param>
+public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbContext db, ISessionLockService lockService)
     : EndpointWithoutRequest<GetFullTrainingPlanResponse>
 {
     /// <inheritdoc />
@@ -232,6 +236,15 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
             }
         }
 
+        // ── 4c. Batch-fetch lock state for all plan sessions ─────────────────────
+        // Single Mongo round-trip — not one per session.
+        Dictionary<Guid, SessionLock> lockLookup = new();
+        if (planSessionIds.Count > 0)
+        {
+            var lockDocs = await lockService.GetStateAsync(planSessionIds, ct);
+            lockLookup = lockDocs.ToDictionary(l => l.SessionId);
+        }
+
         // ── 5. Resolve current week ───────────────────────────────────────────────
         var publishedWeeks = plan.Weeks
             .Where(w => w.Status == WeekStatus.Published)
@@ -338,6 +351,15 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
 
                 var completedExerciseCount = exerciseDtos.Count(e => e.IsCompleted);
 
+                // Resolve lock state for this session (Stable if no active lock doc).
+                var sessionLockState = "Stable";
+                string? sessionLockHolder = null;
+                if (lockLookup.TryGetValue(session.SessionId, out var sessionLock))
+                {
+                    sessionLockState = sessionLock.Type.ToString();
+                    sessionLockHolder = sessionLock.Holder.ToString();
+                }
+
                 return new SessionDto
                 {
                     SessionId = session.SessionId,
@@ -349,7 +371,9 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                     TotalExerciseCount = exerciseDtos.Count,
                     EstimatedDurationMinutes = null, // deferred — requires product-defined set-duration heuristic
                     Sections = sectionDtos,
-                    Exercises = exerciseDtos
+                    Exercises = exerciseDtos,
+                    LockState = sessionLockState,
+                    LockHolder = sessionLockHolder
                 };
             }).ToList();
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
@@ -117,6 +117,20 @@ public class SessionDto
     /// Kept for backward-compatibility with callers that don't yet read Sections.
     /// </summary>
     public List<ExerciseDto> Exercises { get; set; } = [];
+
+    /// <summary>
+    /// Current lock state of this session.
+    /// Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+    /// "Live" (client has an in-progress workout lock).
+    /// Populated via a batch <c>GetStateAsync</c> call on the session lock service.
+    /// </summary>
+    public string LockState { get; set; } = "Stable";
+
+    /// <summary>
+    /// Who currently holds the lock, if any.
+    /// Possible values: "Coach", "Client", or null when the session is Stable.
+    /// </summary>
+    public string? LockHolder { get; set; }
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
@@ -13,10 +14,13 @@ namespace FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
 
 /// <summary>
 /// Returns today's planned training session based on the client's active training plan.
+/// Enriches each session in the response with its current lock state (Stable/Editing/Live)
+/// and lock holder (Coach/Client/null) via a single batch <c>GetStateAsync</c> call.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
-public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext db) : EndpointWithoutRequest<GetTodaySessionResponse>
+/// <param name="lockService">Session lock service — used to batch-fetch lock state.</param>
+public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext db, ISessionLockService lockService) : EndpointWithoutRequest<GetTodaySessionResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -283,6 +287,21 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
 
             foreach (var (sessionId, set) in completedBySession)
                 response.CompletedExerciseIdsBySession[sessionId] = set.ToList();
+
+            // ── Batch-fetch lock state for today's sessions ───────────────────────
+            // Single Mongo round-trip for all sessions (not one per session).
+            var lockDocs = await lockService.GetStateAsync(todaySessionIds, ct);
+            var lockLookup = lockDocs.ToDictionary(l => l.SessionId);
+
+            foreach (var sessionId in todaySessionIds)
+            {
+                if (lockLookup.TryGetValue(sessionId, out var lockDoc))
+                {
+                    response.LockStateBySession[sessionId] = lockDoc.Type.ToString();
+                    response.LockHolderBySession[sessionId] = lockDoc.Holder.ToString();
+                }
+                // Missing entry = Stable (no active lock). No entry added to the dicts.
+            }
 
             // ── Derive per-set completion from exercise-level completion ──────────
             // When an exercise is marked complete via the Today-card checkbox

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
@@ -106,4 +106,20 @@ public class GetTodaySessionResponse
     /// represents prescription, not actuals.
     /// </summary>
     public Dictionary<Guid, Dictionary<Guid, List<int>>> CompletedSetsBySessionExercise { get; set; } = new();
+
+    /// <summary>
+    /// Per-session lock state, keyed by SessionId.
+    /// Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+    /// "Live" (client has an in-progress workout lock).
+    /// Missing entries are treated as "Stable".
+    /// Populated via a single batch <c>GetStateAsync</c> call on the session lock service.
+    /// </summary>
+    public Dictionary<Guid, string> LockStateBySession { get; set; } = new();
+
+    /// <summary>
+    /// Per-session lock holder, keyed by SessionId.
+    /// Possible values: "Coach" (trainer/nutritionist holds the lock) or "Client".
+    /// Null / missing when the session is in the Stable state.
+    /// </summary>
+    public Dictionary<Guid, string?> LockHolderBySession { get; set; } = new();
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
@@ -7,8 +7,10 @@ using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
@@ -17,17 +19,22 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComple
 /// Marks a single exercise within a session as complete for the client on the specified date.
 /// Idempotent: re-completing an already-complete exercise returns success without side effects.
 /// Uses optimistic concurrency on the <see cref="TrainingCompletion"/> document.
+/// Slides the Live lock TTL forward (keep-alive) when a Live lock exists for this session.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
 /// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
 /// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="lockService">Session lock service — used to refresh the Live TTL on activity.</param>
+/// <param name="lockOptions">Training lock TTL configuration.</param>
 /// <param name="logger">Logger.</param>
 public class MarkExerciseCompleteEndpoint(
     IMongoContext mongo,
     IApplicationDbContext db,
     IRealtimeNotifier notifier,
     IComplianceService compliance,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions,
     ILogger<MarkExerciseCompleteEndpoint> logger)
     : Endpoint<MarkExerciseCompleteRequest, MarkExerciseCompleteResponse>
 {
@@ -46,6 +53,12 @@ public class MarkExerciseCompleteEndpoint(
     /// <inheritdoc />
     public override async Task HandleAsync(MarkExerciseCompleteRequest req, CancellationToken ct)
     {
+        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
+        // Safe no-op when no Live lock exists (returns false).
+        // Fire-and-forget style: lock refresh failure must not block the completion.
+        await lockService.RefreshAsync(req.SessionId, LockType.Live,
+            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
+
         var userId = User.FindFirstValue(AppClaims.UserId);
         if (userId is null)
         {

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkExerciseComplete/MarkExerciseCompleteEndpoint.cs
@@ -53,12 +53,6 @@ public class MarkExerciseCompleteEndpoint(
     /// <inheritdoc />
     public override async Task HandleAsync(MarkExerciseCompleteRequest req, CancellationToken ct)
     {
-        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
-        // Safe no-op when no Live lock exists (returns false).
-        // Fire-and-forget style: lock refresh failure must not block the completion.
-        await lockService.RefreshAsync(req.SessionId, LockType.Live,
-            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
-
         var userId = User.FindFirstValue(AppClaims.UserId);
         if (userId is null)
         {
@@ -101,6 +95,14 @@ public class MarkExerciseCompleteEndpoint(
             await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
             return;
         }
+
+        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
+        // Called after ownership is confirmed so a caller cannot slide a TTL on a session
+        // that does not belong to them.
+        // Safe no-op when no Live lock exists (returns false).
+        // Fire-and-forget style: lock refresh failure must not block the completion.
+        await lockService.RefreshAsync(req.SessionId, LockType.Live,
+            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
 
         session.WithBackfilledSections();
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSectionComplete/MarkSectionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSectionComplete/MarkSectionCompleteEndpoint.cs
@@ -7,8 +7,10 @@ using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkSectionComplete;
@@ -19,17 +21,22 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkSectionComplet
 /// exercise-level tracking is not applicable.
 /// Idempotent: re-completing an already-complete section returns success without side effects.
 /// Uses optimistic concurrency on the <see cref="TrainingCompletion"/> document.
+/// Slides the Live lock TTL forward (keep-alive) when a Live lock exists for this session.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
 /// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
 /// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="lockService">Session lock service — used to refresh the Live TTL on activity.</param>
+/// <param name="lockOptions">Training lock TTL configuration.</param>
 /// <param name="logger">Logger.</param>
 public class MarkSectionCompleteEndpoint(
     IMongoContext mongo,
     IApplicationDbContext db,
     IRealtimeNotifier notifier,
     IComplianceService compliance,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions,
     ILogger<MarkSectionCompleteEndpoint> logger)
     : Endpoint<MarkSectionCompleteRequest, MarkSectionCompleteResponse>
 {
@@ -49,6 +56,11 @@ public class MarkSectionCompleteEndpoint(
     /// <inheritdoc />
     public override async Task HandleAsync(MarkSectionCompleteRequest req, CancellationToken ct)
     {
+        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
+        // Safe no-op when no Live lock exists (returns false).
+        await lockService.RefreshAsync(req.SessionId, LockType.Live,
+            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
+
         var userId = User.FindFirstValue(AppClaims.UserId);
         if (userId is null)
         {

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSectionComplete/MarkSectionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSectionComplete/MarkSectionCompleteEndpoint.cs
@@ -56,11 +56,6 @@ public class MarkSectionCompleteEndpoint(
     /// <inheritdoc />
     public override async Task HandleAsync(MarkSectionCompleteRequest req, CancellationToken ct)
     {
-        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
-        // Safe no-op when no Live lock exists (returns false).
-        await lockService.RefreshAsync(req.SessionId, LockType.Live,
-            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
-
         var userId = User.FindFirstValue(AppClaims.UserId);
         if (userId is null)
         {
@@ -103,6 +98,13 @@ public class MarkSectionCompleteEndpoint(
             await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
             return;
         }
+
+        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
+        // Called after ownership is confirmed so a caller cannot slide a TTL on a session
+        // that does not belong to them.
+        // Safe no-op when no Live lock exists (returns false).
+        await lockService.RefreshAsync(req.SessionId, LockType.Live,
+            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
 
         session.WithBackfilledSections();
         var section = session.Sections.FirstOrDefault(s => s.SectionId == req.SectionId);

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
@@ -7,8 +7,10 @@ using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
@@ -17,17 +19,22 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplet
 /// Marks an entire training session as complete by marking all exercises in the session complete.
 /// Fans out to a single completion document for (clientId, date, sessionId).
 /// Idempotent: re-completing an already-complete session returns success.
+/// Slides the Live lock TTL forward (keep-alive) when a Live lock exists for this session.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
 /// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
 /// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="lockService">Session lock service — used to refresh the Live TTL on activity.</param>
+/// <param name="lockOptions">Training lock TTL configuration.</param>
 /// <param name="logger">Logger.</param>
 public class MarkSessionCompleteEndpoint(
     IMongoContext mongo,
     IApplicationDbContext db,
     IRealtimeNotifier notifier,
     IComplianceService compliance,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions,
     ILogger<MarkSessionCompleteEndpoint> logger)
     : Endpoint<MarkSessionCompleteRequest, MarkSessionCompleteResponse>
 {
@@ -46,6 +53,11 @@ public class MarkSessionCompleteEndpoint(
     /// <inheritdoc />
     public override async Task HandleAsync(MarkSessionCompleteRequest req, CancellationToken ct)
     {
+        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
+        // Safe no-op when no Live lock exists (returns false).
+        await lockService.RefreshAsync(req.SessionId, LockType.Live,
+            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
+
         var userId = User.FindFirstValue(AppClaims.UserId);
         if (userId is null)
         {

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
@@ -53,11 +53,6 @@ public class MarkSessionCompleteEndpoint(
     /// <inheritdoc />
     public override async Task HandleAsync(MarkSessionCompleteRequest req, CancellationToken ct)
     {
-        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
-        // Safe no-op when no Live lock exists (returns false).
-        await lockService.RefreshAsync(req.SessionId, LockType.Live,
-            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
-
         var userId = User.FindFirstValue(AppClaims.UserId);
         if (userId is null)
         {
@@ -100,6 +95,13 @@ public class MarkSessionCompleteEndpoint(
             await this.SendProblemAsync(404, ErrorCodes.TrainingSessionNotFound, "The session was not found in the active training plan.", ct);
             return;
         }
+
+        // Slide the Live lock TTL forward — keep-alive for active workout sessions.
+        // Called after ownership is confirmed so a caller cannot slide a TTL on a session
+        // that does not belong to them.
+        // Safe no-op when no Live lock exists (returns false).
+        await lockService.RefreshAsync(req.SessionId, LockType.Live,
+            TimeSpan.FromHours(lockOptions.Value.LiveTtlHours), ct);
 
         session.WithBackfilledSections();
         var allExerciseIds = session.Exercises.Select(e => e.ExerciseExternalId).ToList();

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkWholeDayComplete/MarkWholeDayCompleteEndpoint.cs
@@ -7,8 +7,10 @@ using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
@@ -18,17 +20,22 @@ namespace FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComple
 /// Resolves which sessions apply to the date by mapping the date to a plan week/day-of-week,
 /// then upserts a <see cref="TrainingCompletion"/> document for each session.
 /// Idempotent: sessions that are already fully complete are skipped.
+/// Slides the Live lock TTL forward for each session resolved for the day (keep-alive).
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context.</param>
 /// <param name="notifier">Realtime notifier for pushing the <c>trainingprogressupdated</c> event.</param>
 /// <param name="compliance">Compliance service for computing today's metrics.</param>
+/// <param name="lockService">Session lock service — used to refresh Live TTLs on activity.</param>
+/// <param name="lockOptions">Training lock TTL configuration.</param>
 /// <param name="logger">Logger.</param>
 public class MarkWholeDayCompleteEndpoint(
     IMongoContext mongo,
     IApplicationDbContext db,
     IRealtimeNotifier notifier,
     IComplianceService compliance,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions,
     ILogger<MarkWholeDayCompleteEndpoint> logger)
     : Endpoint<MarkWholeDayCompleteRequest, MarkWholeDayCompleteResponse>
 {
@@ -83,6 +90,14 @@ public class MarkWholeDayCompleteEndpoint(
 
         // Resolve which sessions are scheduled for the target date
         var sessionsForDay = ResolveSessions(plan, targetDateOnly);
+
+        // Slide Live lock TTLs forward for each resolved session (keep-alive for active workouts).
+        // Safe no-op per session when no Live lock exists. Failures are not surfaced to caller.
+        var liveTtl = TimeSpan.FromHours(lockOptions.Value.LiveTtlHours);
+        foreach (var session in sessionsForDay)
+        {
+            await lockService.RefreshAsync(session.SessionId, LockType.Live, liveTtl, ct);
+        }
 
         var summaries = new List<SessionCompletionSummary>();
 

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
@@ -3,6 +3,7 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Common;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
@@ -15,12 +16,16 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 /// Completes a workout session: runs PR detection, creates notifications, marks as done,
 /// and fans out a <see cref="TrainingCompletion"/> document so that compliance and streak
 /// calculations pick up the live workout alongside plan-driven completions.
+/// Also releases the <c>Live</c> session lock when the log is plan-bound
+/// (i.e. when the log carries a non-null <c>SessionId</c>).
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="completionService">Shared workout completion pipeline (PR detection, fan-out, notification).</param>
+/// <param name="lockService">Session lock service — used to release the Live lock on finish.</param>
 public class CompleteWorkoutEndpoint(
     IMongoContext mongo,
-    IWorkoutCompletionService completionService) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
+    IWorkoutCompletionService completionService,
+    ISessionLockService lockService) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -30,7 +35,8 @@ public class CompleteWorkoutEndpoint(
         Summary(s =>
         {
             s.Summary = "Complete a workout";
-            s.Description = "Marks the workout as completed, runs PR detection, and creates trainer notifications.";
+            s.Description = "Marks the workout as completed, runs PR detection, creates trainer notifications, " +
+                            "and releases the Live session lock (for plan-bound workouts).";
         });
     }
 
@@ -75,6 +81,15 @@ public class CompleteWorkoutEndpoint(
             await this.SendProblemAsync(409, ErrorCodes.SessionAlreadyCompleted,
                 "This session was already completed today by a concurrent request.", ct);
             return;
+        }
+
+        // ── Release the Live lock (plan-bound workouts only) ──────────────────────
+        // Ad-hoc workouts have no session, so no lock was acquired — skip silently.
+        // ReleaseAsync is idempotent: returns false when the lock is already gone
+        // (expired or already released), which is not an error.
+        if (log.SessionId.HasValue)
+        {
+            await lockService.ReleaseAsync(log.SessionId.Value, LockHolder.Client, LockType.Live, ct);
         }
 
         await Send.OkAsync(WorkoutLogDetail.FromDocument(log), ct);

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
@@ -2,15 +2,30 @@ using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 
 /// <summary>
 /// Starts a new workout session for the authenticated client.
+/// When the request references a plan + session (non-ad-hoc workouts),
+/// acquires a <c>Live</c> lock on the session before creating the log.
+/// Returns 409 <c>session_locked</c> when the session is in <c>Editing</c> state.
+/// Ad-hoc workouts (null PlanId or null SessionId) skip the lock entirely.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
-public class StartWorkoutEndpoint(IMongoContext mongo) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
+/// <param name="lockService">Session lock service.</param>
+/// <param name="lockOptions">Training lock TTL configuration.</param>
+public class StartWorkoutEndpoint(
+    IMongoContext mongo,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -20,7 +35,8 @@ public class StartWorkoutEndpoint(IMongoContext mongo) : Endpoint<StartWorkoutRe
         Summary(s =>
         {
             s.Summary = "Start a workout";
-            s.Description = "Creates a new empty workout log and returns its ID for progressive logging.";
+            s.Description = "Creates a new empty workout log and returns its ID for progressive logging. " +
+                            "Acquires a Live lock on the session when PlanId and SessionId are provided.";
         });
     }
 
@@ -35,12 +51,55 @@ public class StartWorkoutEndpoint(IMongoContext mongo) : Endpoint<StartWorkoutRe
             return;
         }
 
+        var clientId = Guid.Parse(userId);
         var now = DateTime.UtcNow;
+
+        // ── Live lock acquisition (plan-bound workouts only) ──────────────────────
+        // Ad-hoc workouts (null PlanId or null SessionId) skip the lock entirely —
+        // there is no session to gate and no trainer who could be editing.
+        if (req.PlanId.HasValue && req.SessionId.HasValue)
+        {
+            // Load the plan to resolve trainerId and validate ownership.
+            var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId.Value);
+            using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+            var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+            if (plan is null)
+            {
+                await Send.NotFoundAsync(ct);
+                return;
+            }
+
+            // Ownership check: the plan must belong to this client.
+            if (plan.ClientId != clientId)
+            {
+                await Send.ForbiddenAsync(ct);
+                return;
+            }
+
+            var liveTtl = TimeSpan.FromHours(lockOptions.Value.LiveTtlHours);
+            var acquireResult = await lockService.AcquireAsync(
+                req.SessionId.Value,
+                req.PlanId.Value,
+                clientId,
+                plan.TrainerId,
+                LockHolder.Client,
+                LockType.Live,
+                liveTtl,
+                ct);
+
+            if (acquireResult is AcquireResult.LockConflict)
+            {
+                await this.SendProblemAsync(409, ErrorCodes.SessionLocked,
+                    "The session is currently being edited by the trainer. Try again later.", ct);
+                return;
+            }
+        }
 
         var log = new WorkoutLog
         {
             ExternalId = Guid.NewGuid(),
-            ClientId = Guid.Parse(userId),
+            ClientId = clientId,
             PlanId = req.PlanId,
             SessionId = req.SessionId,
             StartedAt = now,

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
@@ -91,7 +91,7 @@ public class StartWorkoutEndpoint(
             if (acquireResult is AcquireResult.LockConflict)
             {
                 await this.SendProblemAsync(409, ErrorCodes.SessionLocked,
-                    "The session is currently being edited by the trainer. Try again later.", ct);
+                    "This session is locked and cannot be started right now.", ct);
                 return;
             }
         }

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionEndpointTests.cs
@@ -5,6 +5,7 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
@@ -170,11 +171,19 @@ public class GetTodaySessionEndpointTests
         return mongo;
     }
 
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock>() as IReadOnlyList<SessionLock>);
+        return svc;
+    }
+
     private GetTodaySessionEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
         Factory.Create<GetTodaySessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, CreateStubLockService());
 
     // -------------------------------------------------------------------------
     // Multi-session tests
@@ -510,7 +519,7 @@ public class GetTodaySessionEndpointTests
 
         var ep = Factory.Create<GetTodaySessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db);
+            mongo, db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -527,7 +536,7 @@ public class GetTodaySessionEndpointTests
         var ep = Factory.Create<GetTodaySessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db);
+            mongo, db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -652,7 +661,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, workoutLogs: [log]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -785,7 +794,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, workoutLogs: [partialLog]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -948,7 +957,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, workoutLogs: [completedLog, newerPartialLog]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -1079,7 +1088,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, workoutLogs: [partialLog]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -1246,7 +1255,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, workoutLogs: [completedLog, newerPartialLog]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -1355,7 +1364,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, completions: [completionDoc]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -1499,7 +1508,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, completions: [completionDoc], workoutLogs: [partialLog]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -1667,7 +1676,7 @@ public class GetTodaySessionEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
             CreateMongoWithPlan(plan, workoutLogs: [olderLog, newerLog]),
-            db);
+            db, CreateStubLockService());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteBroadcastTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteBroadcastTests.cs
@@ -4,12 +4,15 @@ using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
@@ -31,8 +34,19 @@ public class MarkExerciseCompleteBroadcastTests
 
     private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
     private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ISessionLockService _lockService = CreateStubLockService();
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
     private readonly ILogger<MarkExerciseCompleteEndpoint> _logger =
         Substitute.For<ILogger<MarkExerciseCompleteEndpoint>>();
+
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.RefreshAsync(Arg.Any<Guid>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+        return svc;
+    }
 
     private IApplicationDbContext CreateMockDb(Guid clientUserId, Guid clientPublicId) =>
         new MockDbBuilder()
@@ -59,7 +73,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -87,7 +101,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -121,7 +135,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -146,7 +160,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -191,7 +205,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // exercise1 is already complete — idempotent no-op
         await ep.HandleAsync(
@@ -226,7 +240,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -269,7 +283,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest
@@ -307,7 +321,7 @@ public class MarkExerciseCompleteBroadcastTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Should NOT throw; the broadcast exception is swallowed
         var act = async () => await ep.HandleAsync(

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSectionCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSectionCompleteEndpointTests.cs
@@ -4,11 +4,14 @@ using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkSectionComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -24,7 +27,18 @@ public class MarkSectionCompleteEndpointTests
     private readonly Guid _sectionId = Guid.NewGuid();
     private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
     private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ISessionLockService _lockService = CreateStubLockService();
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
     private readonly ILogger<MarkSectionCompleteEndpoint> _logger = Substitute.For<ILogger<MarkSectionCompleteEndpoint>>();
+
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.RefreshAsync(Arg.Any<Guid>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+        return svc;
+    }
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -88,7 +102,7 @@ public class MarkSectionCompleteEndpointTests
         var ep = Factory.Create<MarkSectionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSectionCompleteRequest { SessionId = _sessionId, SectionId = _sectionId },
@@ -127,7 +141,7 @@ public class MarkSectionCompleteEndpointTests
         var ep = Factory.Create<MarkSectionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Mark section complete again — idempotent
         await ep.HandleAsync(
@@ -160,7 +174,7 @@ public class MarkSectionCompleteEndpointTests
         var ep = Factory.Create<MarkSectionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(Guid.NewGuid(), AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSectionCompleteRequest { SessionId = _sessionId, SectionId = _sectionId },
@@ -179,7 +193,7 @@ public class MarkSectionCompleteEndpointTests
         var ep = Factory.Create<MarkSectionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSectionCompleteRequest { SessionId = _sessionId, SectionId = Guid.NewGuid() },
@@ -213,7 +227,7 @@ public class MarkSectionCompleteEndpointTests
         var ep = Factory.Create<MarkSectionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSectionCompleteRequest
@@ -235,7 +249,7 @@ public class MarkSectionCompleteEndpointTests
 
         var ep = Factory.Create<MarkSectionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSectionCompleteRequest { SessionId = _sessionId, SectionId = _sectionId },

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkSessionCompleteEndpointTests.cs
@@ -8,8 +8,10 @@ using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkSessionComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -26,7 +28,18 @@ public class MarkSessionCompleteEndpointTests
     private readonly Guid _exercise2 = Guid.NewGuid();
     private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
     private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ISessionLockService _lockService = CreateStubLockService();
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
     private readonly ILogger<MarkSessionCompleteEndpoint> _logger = Substitute.For<ILogger<MarkSessionCompleteEndpoint>>();
+
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.RefreshAsync(Arg.Any<Guid>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+        return svc;
+    }
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -47,7 +60,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -86,7 +99,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -132,7 +145,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -174,7 +187,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },
@@ -204,7 +217,7 @@ public class MarkSessionCompleteEndpointTests
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = Guid.NewGuid() },
@@ -221,7 +234,7 @@ public class MarkSessionCompleteEndpointTests
 
         var ep = Factory.Create<MarkSessionCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkSessionCompleteRequest { SessionId = _sessionId },

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkWholeDayCompleteEndpointTests.cs
@@ -8,8 +8,10 @@ using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkWholeDayComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -28,6 +30,18 @@ public class MarkWholeDayCompleteEndpointTests
     private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
     private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
     private readonly ILogger<MarkWholeDayCompleteEndpoint> _logger = Substitute.For<ILogger<MarkWholeDayCompleteEndpoint>>();
+    private readonly ISessionLockService _lockService = CreateStubLockService();
+    private static readonly IOptions<TrainingLockOptions> LockOptions = Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
+
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock>() as IReadOnlyList<SessionLock>);
+        svc.RefreshAsync(Arg.Any<Guid>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return svc;
+    }
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -130,7 +144,7 @@ public class MarkWholeDayCompleteEndpointTests
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest { Date = DateOnly.FromDateTime(DateTime.UtcNow) },
@@ -174,7 +188,7 @@ public class MarkWholeDayCompleteEndpointTests
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest { Date = DateOnly.FromDateTime(today) },
@@ -198,7 +212,7 @@ public class MarkWholeDayCompleteEndpointTests
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest(),
@@ -215,7 +229,7 @@ public class MarkWholeDayCompleteEndpointTests
 
         var ep = Factory.Create<MarkWholeDayCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkWholeDayCompleteRequest(),

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/SessionLockStateTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/SessionLockStateTests.cs
@@ -1,0 +1,402 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
+using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for session lock state enrichment and TTL refresh behaviour (issue #382).
+/// </summary>
+public class SessionLockStateTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    private static int TodayDow()
+    {
+        var dow = (int)DateTime.UtcNow.DayOfWeek;
+        return dow == 0 ? 7 : dow;
+    }
+
+    private static DateTime StartOfCurrentWeek()
+    {
+        var today = DateTime.UtcNow.Date;
+        return today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
+    }
+
+    private IOptions<TrainingLockOptions> DefaultLockOptions() =>
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6, EditingTtlHours = 2 });
+
+    // ── GetTodaySession lock state enrichment ─────────────────────────────────
+
+    private IMongoContext CreateMongoForTodaySession(
+        TrainingPlan plan,
+        IReadOnlyList<SessionLock>? locks = null)
+    {
+        // Delegate to the existing helper pattern used across GetTodaySession tests
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Training plans
+        var planCollection = Substitute.For<IMongoCollection<TrainingPlan>>();
+        planCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var plans = new List<TrainingPlan> { plan };
+                var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+                var moved = false;
+                cursor.Current.Returns(plans);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                return cursor;
+            });
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Exercises (empty)
+        var exerciseCollection = Substitute.For<IMongoCollection<Exercise>>();
+        exerciseCollection.FindAsync(
+                Arg.Any<FilterDefinition<Exercise>>(),
+                Arg.Any<FindOptions<Exercise, Exercise>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<Exercise>>();
+                cursor.Current.Returns(new List<Exercise>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(false);
+                return cursor;
+            });
+        mongo.Exercises.Returns(exerciseCollection);
+
+        // TrainingCompletions (empty)
+        var completionCollection = Substitute.For<IMongoCollection<TrainingCompletion>>();
+        completionCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<FindOptions<TrainingCompletion, TrainingCompletion>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingCompletion>>();
+                cursor.Current.Returns(new List<TrainingCompletion>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(false);
+                return cursor;
+            });
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        // WorkoutLogs (empty)
+        var logCollection = Substitute.For<IMongoCollection<WorkoutLog>>();
+        logCollection.FindAsync(
+                Arg.Any<FilterDefinition<WorkoutLog>>(),
+                Arg.Any<FindOptions<WorkoutLog, WorkoutLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<WorkoutLog>>();
+                cursor.Current.Returns(new List<WorkoutLog>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(false);
+                return cursor;
+            });
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        return mongo;
+    }
+
+    private ISessionLockService LockServiceWithDocs(IReadOnlyList<SessionLock> docs)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(docs);
+        return svc;
+    }
+
+    [Fact]
+    public async Task GetTodaySession_WithLiveLock_ResponseContainsLockStateAndHolder()
+    {
+        // Arrange — today has one session, that session has a Live lock held by Client
+        var startOfWeek = StartOfCurrentWeek();
+        var todayDow = TodayDow();
+        var planId = Guid.NewGuid();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Live Lock Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = _sessionId,
+                            DayOfWeek = todayDow,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = startOfWeek
+        };
+
+        var liveLock = new SessionLock
+        {
+            SessionId = _sessionId,
+            PlanId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Holder = LockHolder.Client,
+            Type = LockType.Live,
+            AcquiredAt = DateTime.UtcNow.AddMinutes(-10),
+            ExpiresAt = DateTime.UtcNow.AddHours(6)
+        };
+
+        var lockService = LockServiceWithDocs(new List<SessionLock> { liveLock });
+        var mongo = CreateMongoForTodaySession(plan);
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+        var ep = Factory.Create<GetTodaySessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, lockService);
+
+        // Act
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.HasSession.Should().BeTrue();
+
+        ep.Response.LockStateBySession.Should().ContainKey(_sessionId);
+        ep.Response.LockStateBySession[_sessionId].Should().Be("Live");
+        ep.Response.LockHolderBySession.Should().ContainKey(_sessionId);
+        ep.Response.LockHolderBySession[_sessionId].Should().Be("Client");
+    }
+
+    [Fact]
+    public async Task GetTodaySession_NoLock_LockStateFieldsAbsent()
+    {
+        // Arrange — today has one session but no lock document
+        var startOfWeek = StartOfCurrentWeek();
+        var todayDow = TodayDow();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Stable Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = _sessionId,
+                            DayOfWeek = todayDow,
+                            Name = "Pull Day",
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = startOfWeek
+        };
+
+        // No lock documents — session is Stable
+        var lockService = LockServiceWithDocs(new List<SessionLock>());
+        var mongo = CreateMongoForTodaySession(plan);
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+        var ep = Factory.Create<GetTodaySessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, lockService);
+
+        // Act
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.HasSession.Should().BeTrue();
+
+        // Stable sessions have no entry in the dicts (treated as Stable by the client)
+        ep.Response.LockStateBySession.Should().NotContainKey(_sessionId);
+        ep.Response.LockHolderBySession.Should().NotContainKey(_sessionId);
+    }
+
+    // ── MarkExerciseComplete TTL refresh ──────────────────────────────────────
+
+    [Fact]
+    public async Task MarkExerciseComplete_CallsRefreshAsync_BeforeProcessing()
+    {
+        // Arrange — minimal plan/session/exercise setup; only verify RefreshAsync is called
+        var startOfWeek = StartOfCurrentWeek();
+        var todayDow = TodayDow();
+        var sectionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Refresh Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = _sessionId,
+                            DayOfWeek = todayDow,
+                            Name = "Refresh Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            Sets = [new ExerciseSet { SetNumber = 1 }]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = startOfWeek
+        };
+
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Plan cursor
+        var planCollection = Substitute.For<IMongoCollection<TrainingPlan>>();
+        planCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var plans = new List<TrainingPlan> { plan };
+                var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+                var moved = false;
+                cursor.Current.Returns(plans);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                return cursor;
+            });
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Completions cursor (empty — triggers InsertOneAsync)
+        var completionCollection = Substitute.For<IMongoCollection<TrainingCompletion>>();
+        completionCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<FindOptions<TrainingCompletion, TrainingCompletion>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingCompletion>>();
+                cursor.Current.Returns(new List<TrainingCompletion>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(false);
+                return cursor;
+            });
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+        var notifier = Substitute.For<IRealtimeNotifier>();
+        var compliance = Substitute.For<IComplianceService>();
+        var lockService = Substitute.For<ISessionLockService>();
+        lockService.RefreshAsync(Arg.Any<Guid>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>()).Returns(false); // no live lock — safe no-op
+
+        var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, notifier, compliance, lockService, DefaultLockOptions(),
+            NullLogger<MarkExerciseCompleteEndpoint>.Instance);
+
+        var req = new MarkExerciseCompleteRequest
+        {
+            SessionId = _sessionId,
+            SectionId = sectionId,
+            ExerciseExternalId = exerciseId
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // RefreshAsync must have been called with the session's id and Live type
+        await lockService.Received(1).RefreshAsync(
+            _sessionId, LockType.Live,
+            TimeSpan.FromHours(6),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using FitnessPlatform.Application.Domain.Common;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 using NSubstitute;
@@ -30,6 +31,14 @@ public class CompleteWorkoutEndpointTests
         return svc;
     }
 
+    private static ISessionLockService StubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(true);
+        return svc;
+    }
+
     [Fact]
     public async Task HandleAsync_ValidRequest_CompletesWorkout()
     {
@@ -42,7 +51,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService);
+            mongo, completionService, StubLockService());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
@@ -63,7 +72,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService());
+            mongo, StubCompletionService(), StubLockService());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
@@ -74,15 +83,13 @@ public class CompleteWorkoutEndpointTests
     public async Task HandleAsync_OtherClientsLog_Returns404()
     {
         // A log belonging to a different client must not be accessible.
-        // The real MongoDB filter (ClientId == callerClientId) would return empty results.
-        // We model this by returning an empty log collection so the endpoint responds 404.
-        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: []); // no match — filtered by MongoDB
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: []);
 
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService());
+            mongo, StubCompletionService(), StubLockService());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
@@ -92,7 +99,6 @@ public class CompleteWorkoutEndpointTests
     [Fact]
     public async Task HandleAsync_PassesUtcNowAsCompletionInstant()
     {
-        // Verify the endpoint always passes DateTime.UtcNow (not backdated) for live completions.
         var logId = Guid.NewGuid();
         var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
@@ -104,7 +110,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService);
+            mongo, completionService, StubLockService());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
@@ -119,8 +125,6 @@ public class CompleteWorkoutEndpointTests
     [Fact]
     public async Task HandleAsync_WorkoutAlreadyCompleted_Returns409()
     {
-        // When WorkoutCompletionService throws WorkoutAlreadyCompletedException (TOCTOU duplicate-key),
-        // the endpoint must return 409 — not 500.
         var logId = Guid.NewGuid();
         var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
@@ -134,7 +138,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService);
+            mongo, completionService, StubLockService());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
@@ -1,0 +1,270 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
+using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Tests for session-lock enforcement in StartWorkout and CompleteWorkout endpoints (issue #382).
+/// </summary>
+public class SessionLockEnforcementTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    private IOptions<TrainingLockOptions> DefaultLockOptions()
+    {
+        var opts = new TrainingLockOptions { LiveTtlHours = 6, EditingTtlHours = 2 };
+        return Options.Create(opts);
+    }
+
+    private TrainingPlan MakePlan(Guid? clientId = null)
+    {
+        return new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = clientId ?? _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+    }
+
+    private ISessionLockService AcquiredLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(new SessionLock
+            {
+                SessionId = _sessionId,
+                PlanId = _planId,
+                ClientId = _clientId,
+                TrainerId = _trainerId,
+                Holder = LockHolder.Client,
+                Type = LockType.Live,
+                AcquiredAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddHours(6)
+            }));
+        return svc;
+    }
+
+    private ISessionLockService LockedLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.LockConflict());
+        return svc;
+    }
+
+    private StartWorkoutEndpoint CreateStartEndpoint(
+        IMongoContext mongo,
+        ISessionLockService lockService)
+    {
+        return Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, DefaultLockOptions());
+    }
+
+    // ── StartWorkout tests ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StartWorkout_SessionInEditingState_Returns409SessionLocked()
+    {
+        // Arrange — plan exists, lock acquisition fails (session is Editing)
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var lockService = LockedLockService();
+        var ep = CreateStartEndpoint(mongo, lockService);
+
+        var req = new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+        // No WorkoutLog must have been inserted
+        await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
+            Arg.Any<WorkoutLog>(),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartWorkout_StableSession_AcquiresLockAndReturns201()
+    {
+        // Arrange — plan exists, lock acquisition succeeds
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var lockService = AcquiredLockService();
+        var ep = CreateStartEndpoint(mongo, lockService);
+
+        var req = new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // Lock must have been acquired with Client/Live
+        await lockService.Received(1).AcquireAsync(
+            _sessionId, _planId, _clientId, _trainerId,
+            LockHolder.Client, LockType.Live,
+            TimeSpan.FromHours(6),
+            Arg.Any<CancellationToken>());
+
+        // WorkoutLog must have been inserted
+        await mongo.WorkoutLogs.Received(1).InsertOneAsync(
+            Arg.Is<WorkoutLog>(w => w.ClientId == _clientId && w.SessionId == _sessionId),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartWorkout_NullPlanId_SkipsLockAndReturns201()
+    {
+        // Arrange — ad-hoc workout: no PlanId
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+        var lockService = Substitute.For<ISessionLockService>();
+        var ep = CreateStartEndpoint(mongo, lockService);
+
+        // Act
+        await ep.HandleAsync(new StartWorkoutRequest { PlanId = null, SessionId = null },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // Lock must NOT have been acquired
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+
+        await mongo.WorkoutLogs.Received(1).InsertOneAsync(
+            Arg.Is<WorkoutLog>(w => w.ClientId == _clientId && w.PlanId == null && w.SessionId == null),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartWorkout_NullSessionIdOnly_SkipsLockAndReturns201()
+    {
+        // Arrange — PlanId provided but SessionId is null: ad-hoc relative to a plan
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+        var lockService = Substitute.For<ISessionLockService>();
+        var ep = CreateStartEndpoint(mongo, lockService);
+
+        // Act
+        await ep.HandleAsync(new StartWorkoutRequest { PlanId = _planId, SessionId = null },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── CompleteWorkout tests ─────────────────────────────────────────────────
+
+    private IWorkoutCompletionService MockCompletionService()
+    {
+        var svc = Substitute.For<IWorkoutCompletionService>();
+        svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
+        return svc;
+    }
+
+    private CompleteWorkoutEndpoint CreateCompleteEndpoint(
+        IMongoContext mongo,
+        IWorkoutCompletionService completionService,
+        ISessionLockService lockService)
+    {
+        return Factory.Create<CompleteWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, completionService, lockService);
+    }
+
+    [Fact]
+    public async Task CompleteWorkout_PlanBoundLog_ReleasesLiveLock()
+    {
+        // Arrange — plan-bound log (SessionId non-null)
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var completionService = MockCompletionService();
+        var lockService = Substitute.For<ISessionLockService>();
+        lockService.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(true);
+
+        var ep = CreateCompleteEndpoint(mongo, completionService, lockService);
+
+        // Act
+        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // ReleaseAsync must have been called with the session's id and Client/Live
+        await lockService.Received(1).ReleaseAsync(
+            _sessionId, LockHolder.Client, LockType.Live,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CompleteWorkout_AdHocLog_SkipsLockRelease()
+    {
+        // Arrange — ad-hoc log (SessionId is null)
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, sessionId: null);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var completionService = MockCompletionService();
+        var lockService = Substitute.For<ISessionLockService>();
+
+        var ep = CreateCompleteEndpoint(mongo, completionService, lockService);
+
+        // Act
+        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // ReleaseAsync must NOT have been called
+        await lockService.DidNotReceive().ReleaseAsync(
+            Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
@@ -6,6 +6,7 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Endpoints;
 using Microsoft.Extensions.Options;
@@ -40,15 +41,19 @@ public class StartWorkoutEndpointTests
         return svc;
     }
 
+    private StartWorkoutEndpoint CreateEndpointWithUser(IMongoContext mongo, ISessionLockService lockService)
+    {
+        return Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions);
+    }
+
     [Fact]
     public async Task HandleAsync_ValidRequest_CreatesLog()
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
-        var ep = Factory.Create<StartWorkoutEndpoint>(
-            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
-                new ClaimsIdentity(
-                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, CreateNoOpLockService(), LockOptions);
+        var ep = CreateEndpointWithUser(mongo, CreateNoOpLockService());
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
@@ -72,5 +77,71 @@ public class StartWorkoutEndpointTests
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task HandleAsync_PlanNotFound_Returns404()
+    {
+        // Plan-bound request but no matching plan in Mongo → 404, no log created.
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        // Empty plan collection — plan does not exist.
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: []);
+        var lockService = Substitute.For<ISessionLockService>();
+        var ep = CreateEndpointWithUser(mongo, lockService);
+
+        await ep.HandleAsync(new StartWorkoutRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+
+        // Lock must not have been acquired and no log inserted.
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+
+        await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
+            Arg.Any<WorkoutLog>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_PlanBelongsToAnotherClient_Returns403()
+    {
+        // Plan exists but its ClientId does not match the authenticated user → 403, no log created.
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var differentClientId = Guid.NewGuid(); // plan belongs to someone else
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = differentClientId, // NOT _clientId
+            TrainerId = Guid.NewGuid(),
+            Name = "Other Client Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [plan]);
+        var lockService = Substitute.For<ISessionLockService>();
+        var ep = CreateEndpointWithUser(mongo, lockService);
+
+        await ep.HandleAsync(new StartWorkoutRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+
+        // Lock must not have been acquired and no log inserted.
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+
+        await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
+            Arg.Any<WorkoutLog>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
@@ -3,8 +3,12 @@ using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -16,6 +20,25 @@ namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 public class StartWorkoutEndpointTests
 {
     private readonly Guid _clientId = Guid.NewGuid();
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
+
+    private static ISessionLockService CreateNoOpLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(new SessionLock
+            {
+                SessionId = Guid.NewGuid(), PlanId = Guid.NewGuid(),
+                ClientId = Guid.NewGuid(), TrainerId = Guid.NewGuid(),
+                Holder = LockHolder.Client, Type = LockType.Live,
+                AcquiredAt = DateTime.UtcNow, ExpiresAt = DateTime.UtcNow.AddHours(6)
+            }));
+        return svc;
+    }
 
     [Fact]
     public async Task HandleAsync_ValidRequest_CreatesLog()
@@ -25,7 +48,7 @@ public class StartWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo);
+            mongo, CreateNoOpLockService(), LockOptions);
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
@@ -43,7 +66,8 @@ public class StartWorkoutEndpointTests
     public async Task HandleAsync_NoClaims_Returns401()
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
-        var ep = Factory.Create<StartWorkoutEndpoint>(mongo);
+        var ep = Factory.Create<StartWorkoutEndpoint>(
+            mongo, CreateNoOpLockService(), LockOptions);
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
## Summary

Client-side enforcement layer for the training session edit-lock epic. Wires the
session-lock service into the client-facing workout flow:

- **StartWorkout → Live CAS** — plan-bound starts (`PlanId` + `SessionId` present)
  load + ownership-check the plan (404 if missing, 403 if not the caller's), then
  `AcquireAsync` a `Live` lock via a Stable→Live compare-and-set. `LockConflict`
  (session is `Editing`) returns 409 RFC 7807 `session_locked` with holder-agnostic
  copy. Ad-hoc workouts (null PlanId/SessionId) skip the lock entirely.
- **Finish release** — `CompleteWorkout` calls `ReleaseAsync(Live)` for plan-bound
  logs (gated on `SessionId.HasValue`); idempotent no-op when the lock is already gone.
- **TTL refresh (keep-alive)** — `MarkExerciseComplete`, `MarkSectionComplete`,
  `MarkSessionComplete`, and `MarkWholeDayComplete` slide the `Live` TTL forward via
  `RefreshAsync`, placed **after** the ownership gate so a caller cannot refresh a
  TTL on a session they don't own. Safe no-op when no Live lock exists.
- **Additive lock-state in reads** — `GetTodaySession` and `GetFullPlan` enrich each
  session with `state` (`Stable`/`Editing`/`Live`) and `holder` (`Coach`/`Client`/null)
  via a single batch `GetStateAsync` round-trip (no N+1). Missing entries default to
  `Stable`. Response shapes are append-only — backward-compatible with existing callers.
- TTL defaults configurable via `TrainingLock:LiveTtlHours` (6) and
  `TrainingLock:EditingTtlHours` (2); endpoints read `IOptions<TrainingLockOptions>`,
  no hardcoded hour literals.

## Related issue

Fixes #382

## Parent epic

Part of epic #379 (training session edit-lock) — base branch:
`feature/379-training-session-lock`. Full design:
`docs/superpowers/specs/2026-06-01-training-session-lock-design.md` (sections 5, 7, 13).
Phased plan: `PLAN.md` (Phase 3).

## Scope

backend (`Features/WorkoutLogs/**`, `Features/ClientTraining/**` + tests) — backend-only,
no client/generated files touched.

## QA verdict (from qa-tester)

OVERALL ✅ PASS — 68/68 Testcontainers tests, `dotnet build` clean, scope-clean.

## Test plan

- [ ] StartWorkout performs Stable→Live CAS via `AcquireAsync`; 409 `session_locked` when `Editing`; sets `expiresAt = now + LiveTtl`.
- [ ] FinishWorkout / abandon release the Live lock via `ReleaseAsync`.
- [ ] MarkExerciseComplete and set-update endpoints call `RefreshAsync` to slide the Live TTL.
- [ ] GetTodaySession and GetFullPlan responses include per-session lock `state` and `holder`.
- [ ] TTL defaults configurable via `TrainingLock:LiveTtlHours` (6) and `TrainingLock:EditingTtlHours` (2).
- [ ] Integration tests: StartWorkout blocked when Editing; finish releases; set-log refreshes TTL; GetTodaySession carries lock state.
- [ ] `dotnet build` clean and changed-feature `dotnet test` slice passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
