### PR TITLE
feat: trainer-side enforcement — unlock/relock + diff-gated plan edit

### DIFF
--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/PublishTrainingWeek/PublishTrainingWeekEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/PublishTrainingWeek/PublishTrainingWeekEndpoint.cs
@@ -15,12 +15,14 @@ namespace FitnessPlatform.Application.Features.TrainingPlans.PublishTrainingWeek
 /// <summary>
 /// Publishes a single week of a training plan, making it visible to the client.
 /// Archives other active training plans for the same client when the first week is published.
+/// Defensively clears any stale Editing lock docs for the week's sessions on publish.
 /// </summary>
 public class PublishTrainingWeekEndpoint(
     IMongoContext mongo,
     IApplicationDbContext db,
     INotificationService notificationService,
-    IRealtimeNotifier notifier) : Endpoint<PublishTrainingWeekRequest, GetTrainingPlanResponse>
+    IRealtimeNotifier notifier,
+    ISessionLockService lockService) : Endpoint<PublishTrainingWeekRequest, GetTrainingPlanResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -30,7 +32,8 @@ public class PublishTrainingWeekEndpoint(
         Summary(s =>
         {
             s.Summary = "Publish a week of a training plan";
-            s.Description = "Sets the week's status to Published. Archives other active training plans for the same client.";
+            s.Description = "Sets the week's status to Published. Archives other active training plans for the same client. " +
+                            "Clears any stale Editing lock docs for the week's sessions.";
         });
     }
 
@@ -129,6 +132,15 @@ public class PublishTrainingWeekEndpoint(
             await HttpContext.Response.SendAsync(
                 new { Error = "Version conflict." }, 409, cancellation: ct);
             return;
+        }
+
+        // Defensive cleanup: clear any stale Editing lock docs for the week's sessions.
+        // This handles the edge case where a trainer had a session unlocked just before publish.
+        // ReleaseAsync is idempotent — safe to call even if no lock exists.
+        var weekSessionIds = week.Sessions.Select(s => s.SessionId).ToList();
+        foreach (var sessionId in weekSessionIds)
+        {
+            await lockService.ReleaseAsync(sessionId, LockHolder.Coach, LockType.Editing, ct);
         }
 
         // Notify the client about the published week

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionEndpoint.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.TrainingPlans.RelockTrainingSession;
+
+/// <summary>
+/// Releases the Editing lock on a training session, returning it to Stable state.
+/// Idempotent: if the lock is already gone (released, expired) this is a no-op success.
+/// Ownership guard: only the plan's owning trainer may relock.
+/// </summary>
+public class RelockTrainingSessionEndpoint(
+    IMongoContext mongo,
+    ISessionLockService lockService)
+    : Endpoint<RelockTrainingSessionRequest>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/training/plans/{PlanId}/sessions/{SessionId}/relock");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Relock a training session (release the Editing lock)";
+            s.Description = "Releases the Editing lock, returning the session to Stable state. " +
+                            "Idempotent: if the lock is already released or expired this is a no-op success.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(RelockTrainingSessionRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Ownership guard first: plan must exist AND belong to the calling trainer.
+        var filter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId)
+                     & Builders<TrainingPlan>.Filter.Eq(p => p.TrainerId, trainerId);
+
+        var cursor = await mongo.TrainingPlans.FindAsync(filter, cancellationToken: ct);
+        var plan = await cursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify the session exists in the plan (any week).
+        var sessionExists = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .Any(s => s.SessionId == req.SessionId);
+
+        if (!sessionExists)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Release idempotently: ReleaseAsync returns false when no doc matched
+        // (already released/expired), but that is still a success per the spec.
+        await lockService.ReleaseAsync(
+            sessionId: req.SessionId,
+            holder: LockHolder.Coach,
+            type: LockType.Editing,
+            ct: ct);
+
+        await Send.NoContentAsync(ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.TrainingPlans.RelockTrainingSession;
+
+/// <summary>
+/// Request to release the Editing lock on a training session (relock it to Stable).
+/// </summary>
+public class RelockTrainingSessionRequest
+{
+    /// <summary>Training plan identifier.</summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>Session identifier to relock.</summary>
+    public Guid SessionId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionValidator.cs
@@ -1,0 +1,17 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.TrainingPlans.RelockTrainingSession;
+
+/// <summary>
+/// Validator for <see cref="RelockTrainingSessionRequest"/>.
+/// </summary>
+public class RelockTrainingSessionValidator : Validator<RelockTrainingSessionRequest>
+{
+    /// <inheritdoc />
+    public RelockTrainingSessionValidator()
+    {
+        RuleFor(x => x.PlanId).NotEmpty();
+        RuleFor(x => x.SessionId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
@@ -1,0 +1,104 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSession;
+
+/// <summary>
+/// Acquires an Editing lock on a published training session, allowing the trainer to edit it.
+/// Returns 409 if the session is currently in Live state (client is training).
+/// The ownership guard ensures only the plan's owning trainer may unlock.
+/// </summary>
+public class UnlockTrainingSessionEndpoint(
+    IMongoContext mongo,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions)
+    : Endpoint<UnlockTrainingSessionRequest>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/training/plans/{PlanId}/sessions/{SessionId}/unlock");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Unlock a training session for editing";
+            s.Description = "Acquires an Editing lock on the session. " +
+                            "Returns 409 if the session is currently Live (client is training).";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(UnlockTrainingSessionRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Ownership guard first: plan must exist AND belong to the calling trainer.
+        var filter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId)
+                     & Builders<TrainingPlan>.Filter.Eq(p => p.TrainerId, trainerId);
+
+        var cursor = await mongo.TrainingPlans.FindAsync(filter, cancellationToken: ct);
+        var plan = await cursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify the session exists in the plan (any week).
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var ttl = TimeSpan.FromHours(lockOptions.Value.EditingTtlHours);
+
+        var result = await lockService.AcquireAsync(
+            sessionId: req.SessionId,
+            planId: plan.ExternalId,
+            clientId: plan.ClientId,
+            trainerId: trainerId,
+            holder: LockHolder.Coach,
+            type: LockType.Editing,
+            ttl: ttl,
+            ct: ct);
+
+        switch (result)
+        {
+            case AcquireResult.Acquired:
+                await Send.NoContentAsync(ct);
+                break;
+
+            case AcquireResult.LockConflict:
+                // The session is currently locked — either Live (client training) or
+                // already in Editing by someone else. Both cases are 409 session_locked.
+                await this.SendProblemAsync(
+                    409,
+                    ErrorCodes.SessionLocked,
+                    $"Session {req.SessionId} is currently locked and cannot be unlocked for editing.",
+                    ct);
+                break;
+        }
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSession;
+
+/// <summary>
+/// Request to acquire an Editing lock on a published training session.
+/// </summary>
+public class UnlockTrainingSessionRequest
+{
+    /// <summary>Training plan identifier.</summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>Session identifier to unlock for editing.</summary>
+    public Guid SessionId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionValidator.cs
@@ -1,0 +1,17 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSession;
+
+/// <summary>
+/// Validator for <see cref="UnlockTrainingSessionRequest"/>.
+/// </summary>
+public class UnlockTrainingSessionValidator : Validator<UnlockTrainingSessionRequest>
+{
+    /// <inheritdoc />
+    public UnlockTrainingSessionValidator()
+    {
+        RuleFor(x => x.PlanId).NotEmpty();
+        RuleFor(x => x.SessionId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
@@ -3,6 +3,8 @@ using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using MongoDB.Driver;
@@ -12,9 +14,12 @@ namespace FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
 /// <summary>
 /// Full-state update of a training plan: replaces name, description, and all weeks/sessions/exercises/sets.
 /// Preserves per-week Status and DatePublished. Uses optimistic concurrency.
+/// For published sessions with content changes, an active Editing lock held by this trainer is required.
+/// Draft-week sessions are always editable without a lock.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
-public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
+/// <param name="lockService">Session lock service for diff-gate enforcement.</param>
+public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lockService)
     : Endpoint<UpdateTrainingPlanRequest, GetTrainingPlanResponse>
 {
     /// <inheritdoc />
@@ -26,7 +31,8 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
         {
             s.Summary = "Full-state update of a training plan";
             s.Description = "Replaces the plan's name, description, and all weeks/sessions/exercises/sets. " +
-                            "Per-week publish status is preserved. Uses optimistic concurrency via version field.";
+                            "Per-week publish status is preserved. Uses optimistic concurrency via version field. " +
+                            "Published sessions with content changes require an active Editing lock.";
         });
     }
 
@@ -42,7 +48,7 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
 
         var trainerId = Guid.Parse(userId);
 
-        // Fetch current plan
+        // Fetch current plan (ownership guard: TrainerId == trainerId).
         var filter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId)
                      & Builders<TrainingPlan>.Filter.Eq(p => p.TrainerId, trainerId);
 
@@ -55,7 +61,7 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
             return;
         }
 
-        // Optimistic concurrency check
+        // Optimistic concurrency check — must precede diff-gate.
         if (plan.Version != req.Version)
         {
             await HttpContext.Response.SendAsync(
@@ -118,6 +124,74 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
                 return;
             }
         }
+
+        // ── Diff-gate: check published sessions for content changes ──────────
+        //
+        // Ordering per spec §6 and design-review directives:
+        //   1. After the Version check (above).
+        //   2. Before ReplaceOneAsync (below).
+        //   3. Auto-release Editing locks only after ModifiedCount > 0.
+        //
+        // Run the projection on the backfilled section view for BOTH stored and
+        // incoming sessions so legacy flat-exercise docs don't false-positive.
+        // Key change-detection on stable SessionId; do NOT diff on freshly-assigned
+        // SectionId Guids (they are minted at map time and are not stable).
+        //
+        // Draft weeks are never gated.
+
+        // Build a map of stored published sessions keyed by SessionId.
+        var storedPublishedSessions = plan.Weeks
+            .Where(w => w.Status == WeekStatus.Published)
+            .SelectMany(w => w.Sessions)
+            .Select(s => s.WithBackfilledSections())
+            .ToDictionary(s => s.SessionId);
+
+        // Build a map of incoming sessions for published weeks keyed by SessionId.
+        var incomingPublishedSessions = req.Weeks
+            .Where(rw => existingWeeks.TryGetValue(rw.WeekNumber, out var ew) && ew.Status == WeekStatus.Published)
+            .SelectMany(rw => rw.Sessions)
+            .Where(rs => rs.SessionId.HasValue)
+            .ToDictionary(rs => rs.SessionId!.Value);
+
+        // Identify which stored published sessions have content changes.
+        var changedSessionIds = new List<Guid>();
+        foreach (var (sessionId, storedSession) in storedPublishedSessions)
+        {
+            if (!incomingPublishedSessions.TryGetValue(sessionId, out var incomingSession))
+                continue; // session removed — handled elsewhere or not a content change
+
+            if (HasContentChanged(storedSession, incomingSession))
+                changedSessionIds.Add(sessionId);
+        }
+
+        if (changedSessionIds.Count > 0)
+        {
+            // Load active Editing locks for the changed sessions.
+            var activeLocks = await lockService.GetStateAsync(changedSessionIds, ct);
+            var editingLocksBySession = activeLocks
+                .Where(l => l.Type == LockType.Editing
+                         && l.Holder == LockHolder.Coach
+                         && l.TrainerId == trainerId)
+                .Select(l => l.SessionId)
+                .ToHashSet();
+
+            // Any changed published session not currently in Editing by THIS trainer → 409.
+            var ungatedSessions = changedSessionIds
+                .Where(sid => !editingLocksBySession.Contains(sid))
+                .ToList();
+
+            if (ungatedSessions.Count > 0)
+            {
+                await this.SendProblemAsync(
+                    409,
+                    ErrorCodes.SessionLocked,
+                    $"Published sessions must be unlocked for editing before saving changes. " +
+                    $"Offending session IDs: {string.Join(", ", ungatedSessions)}",
+                    ct);
+                return;
+            }
+        }
+        // ── End diff-gate ─────────────────────────────────────────────────────
 
         // Map request to domain
         plan.Name = req.Name;
@@ -200,6 +274,108 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo)
             return;
         }
 
+        // Auto-release Editing locks for the changed sessions — ONLY after a successful save
+        // (ModifiedCount > 0). A version-conflict loss must NOT release the lock.
+        foreach (var sessionId in changedSessionIds)
+        {
+            await lockService.ReleaseAsync(sessionId, LockHolder.Coach, LockType.Editing, ct);
+        }
+
         await Send.OkAsync(GetTrainingPlanResponse.FromDocument(plan), ct);
+    }
+
+    /// <summary>
+    /// Computes a normalized content projection for a stored session and an incoming request
+    /// session (both already backfilled to section view) and returns true if the content differs.
+    /// Keys on section order/name/format/notes and exercise content; does NOT key on SectionId Guids
+    /// (they are freshly-assigned at map time and are not stable identifiers).
+    /// </summary>
+    private static bool HasContentChanged(TrainingSession stored, UpdateSessionRequest incoming)
+    {
+        // Compare session-level content fields.
+        if (stored.DayOfWeek != incoming.DayOfWeek) return true;
+        if (stored.Name != incoming.Name) return true;
+        if (stored.Order != incoming.Order) return true;
+        if (stored.Notes?.Trim() != incoming.Notes?.Trim()) return true;
+        if (stored.Format != incoming.Format) return true;
+        if (!FormatConfigEqual(stored.FormatConfig, incoming.FormatConfig)) return true;
+
+        // Compare sections by structural content (order, name, format, notes, exercises).
+        // Do NOT compare SectionId — incoming sections may have newly-assigned Guids.
+        var storedSections = stored.Sections.OrderBy(s => s.Order).ToList();
+        var incomingSections = incoming.Sections.OrderBy(s => s.Order).ToList();
+
+        if (storedSections.Count != incomingSections.Count) return true;
+
+        for (var i = 0; i < storedSections.Count; i++)
+        {
+            var ss = storedSections[i];
+            var rs = incomingSections[i];
+
+            if (ss.Order != rs.Order) return true;
+            if (ss.Name != rs.Name) return true;
+            if (ss.Format != rs.Format) return true;
+            if (ss.Notes?.Trim() != rs.Notes?.Trim()) return true;
+            if (!FormatConfigEqual(ss.FormatConfig, rs.FormatConfig)) return true;
+
+            // Compare exercises within this section.
+            var storedExercises = ss.Exercises.OrderBy(e => e.Order).ToList();
+            var incomingExercises = rs.Exercises.OrderBy(e => e.Order).ToList();
+
+            if (storedExercises.Count != incomingExercises.Count) return true;
+
+            for (var j = 0; j < storedExercises.Count; j++)
+            {
+                var se = storedExercises[j];
+                var re = incomingExercises[j];
+
+                if (se.ExerciseExternalId != re.ExerciseExternalId) return true;
+                if (se.ExerciseName != re.ExerciseName) return true;
+                if (se.Order != re.Order) return true;
+                if (se.Notes?.Trim() != re.Notes?.Trim()) return true;
+                if (se.RestSeconds != re.RestSeconds) return true;
+                if (se.MovementType != re.MovementType) return true;
+                if (se.Format != re.Format) return true;
+                if (!FormatConfigEqual(se.FormatConfig, re.FormatConfig)) return true;
+
+                // Compare sets.
+                var storedSets = se.Sets.OrderBy(s => s.SetNumber).ToList();
+                var incomingSets = re.Sets.OrderBy(s => s.SetNumber).ToList();
+
+                if (storedSets.Count != incomingSets.Count) return true;
+
+                for (var k = 0; k < storedSets.Count; k++)
+                {
+                    var storedSet = storedSets[k];
+                    var incomingSet = incomingSets[k];
+
+                    if (storedSet.SetNumber != incomingSet.SetNumber) return true;
+                    if (storedSet.Type != incomingSet.Type) return true;
+                    if (storedSet.Reps != incomingSet.Reps) return true;
+                    if (storedSet.WeightKg != incomingSet.WeightKg) return true;
+                    if (storedSet.DurationSeconds != incomingSet.DurationSeconds) return true;
+                    if (storedSet.Rpe != incomingSet.Rpe) return true;
+                    if (storedSet.DistanceMeters != incomingSet.DistanceMeters) return true;
+                    if (storedSet.RestSeconds != incomingSet.RestSeconds) return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Equality check for <see cref="WodConfig"/> nullable pairs.
+    /// </summary>
+    private static bool FormatConfigEqual(WodConfig? a, WodConfig? b)
+    {
+        if (a is null && b is null) return true;
+        if (a is null || b is null) return false;
+
+        return a.IntervalSeconds == b.IntervalSeconds
+            && a.TimeCapSeconds == b.TimeCapSeconds
+            && a.TotalRounds == b.TotalRounds
+            && a.WorkSeconds == b.WorkSeconds
+            && a.RestSeconds == b.RestSeconds;
     }
 }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
@@ -146,19 +146,49 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService
             .Select(s => s.WithBackfilledSections())
             .ToDictionary(s => s.SessionId);
 
+        // Pre-flight: every session in a published week must carry a non-null SessionId.
+        // A null SessionId in a published week would create a new session while silently
+        // dropping the stored published session — bypassing the diff-gate entirely (M1).
+        var publishedWeekNumbersSet = existingWeeks
+            .Where(kv => kv.Value.Status == WeekStatus.Published)
+            .Select(kv => kv.Key)
+            .ToHashSet();
+
+        var publishedWeekSessionsMissingId = req.Weeks
+            .Where(rw => publishedWeekNumbersSet.Contains(rw.WeekNumber))
+            .SelectMany(rw => rw.Sessions)
+            .Any(rs => !rs.SessionId.HasValue);
+
+        if (publishedWeekSessionsMissingId)
+        {
+            ThrowError(
+                "Every session in a published week must include a SessionId. " +
+                "Omitting or nulling a SessionId in a published week is not allowed.");
+            return;
+        }
+
         // Build a map of incoming sessions for published weeks keyed by SessionId.
+        // The pre-flight above guarantees all sessions in published weeks have a non-null
+        // SessionId, so the .Where(HasValue) filter here is now a defensive no-op.
         var incomingPublishedSessions = req.Weeks
-            .Where(rw => existingWeeks.TryGetValue(rw.WeekNumber, out var ew) && ew.Status == WeekStatus.Published)
+            .Where(rw => publishedWeekNumbersSet.Contains(rw.WeekNumber))
             .SelectMany(rw => rw.Sessions)
             .Where(rs => rs.SessionId.HasValue)
             .ToDictionary(rs => rs.SessionId!.Value);
 
-        // Identify which stored published sessions have content changes.
+        // Identify which stored published sessions have content changes OR have been removed/replaced.
+        // A stored published session that is absent from the incoming map is treated the same as a
+        // changed session — removing or replacing a published session requires an Editing lock (M1).
         var changedSessionIds = new List<Guid>();
         foreach (var (sessionId, storedSession) in storedPublishedSessions)
         {
             if (!incomingPublishedSessions.TryGetValue(sessionId, out var incomingSession))
-                continue; // session removed — handled elsewhere or not a content change
+            {
+                // Session removed or replaced — gate it; removing a published session is a
+                // structural change that requires an Editing lock.
+                changedSessionIds.Add(sessionId);
+                continue;
+            }
 
             if (HasContentChanged(storedSession, incomingSession))
                 changedSessionIds.Add(sessionId);

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
@@ -30,7 +30,21 @@ public class UpdateTrainingPlanValidator : Validator<UpdateTrainingPlanRequest>
             .NotEmpty().WithMessage("At least one week is required.")
             .Must(weeks => weeks.Count <= 52).WithMessage("A plan may not exceed 52 weeks.")
             .Must(weeks => weeks.Select(w => w.WeekNumber).Distinct().Count() == weeks.Count)
-                .WithMessage("Duplicate WeekNumber values are not allowed.");
+                .WithMessage("Duplicate WeekNumber values are not allowed.")
+            .Must(weeks =>
+            {
+                // Duplicate SessionId values across ALL sessions in ALL weeks are forbidden.
+                // A duplicate SessionId on published-week sessions causes an unhandled
+                // ToDictionary crash (M2 fix). We validate globally (not just per-week) to
+                // catch cross-week duplicates too.
+                var allSessionIds = weeks
+                    .SelectMany(w => w.Sessions)
+                    .Where(s => s.SessionId.HasValue)
+                    .Select(s => s.SessionId!.Value)
+                    .ToList();
+                return allSessionIds.Distinct().Count() == allSessionIds.Count;
+            })
+                .WithMessage("Duplicate SessionId values are not allowed across sessions.");
 
         RuleForEach(x => x.Weeks).ChildRules(week =>
         {

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainerSideEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainerSideEnforcementTests.cs
@@ -1,0 +1,664 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.RelockTrainingSession;
+using FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSession;
+using FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the trainer-side enforcement: unlock/relock endpoints and diff-gated plan edit.
+/// Issue #381 — covers:
+///   - Unlock 409 when session is Live
+///   - Unlock 404 when plan not owned by caller
+///   - Diff-gate rejects edit to a Stable/Live published session (no Editing lock)
+///   - Diff-gate allows edit to a published session that is in Editing by this trainer
+///   - Auto-release of Editing locks after a successful save
+///   - Draft-week edit is never gated (no lock required)
+///   - Relock is idempotent (succeeds even when lock already gone)
+/// </summary>
+public class TrainerSideEnforcementTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _otherTrainerId = Guid.NewGuid();
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private IOptions<TrainingLockOptions> DefaultOptions() =>
+        Options.Create(new TrainingLockOptions { EditingTtlHours = 2, LiveTtlHours = 6 });
+
+    /// <summary>
+    /// Creates a plan with one published week containing a session with <paramref name="sessionId"/>.
+    /// The session has a single section with one exercise and one set.
+    /// </summary>
+    private TrainingPlan CreatePlanWithPublishedSession(
+        Guid sessionId,
+        Guid? trainerId = null,
+        Guid? exerciseId = null)
+    {
+        var tid = trainerId ?? _trainerId;
+        var exId = exerciseId ?? Guid.NewGuid();
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = tid,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = DateTime.UtcNow.AddDays(-7),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            MovementType = MovementType.Reps,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 100 }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+    }
+
+    /// <summary>
+    /// Creates a plan with one DRAFT week containing a session with <paramref name="sessionId"/>.
+    /// </summary>
+    private TrainingPlan CreatePlanWithDraftSession(Guid sessionId, Guid? exerciseId = null)
+    {
+        var exId = exerciseId ?? Guid.NewGuid();
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = _trainerId,
+            Name = "Draft Plan",
+            Status = TrainingPlanStatus.Draft,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Draft,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Draft Session",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            MovementType = MovementType.Reps,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 5, WeightKg = 80 }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+    }
+
+    /// <summary>
+    /// Builds the incoming session request with identical content to a published session
+    /// (no content changes → diff should detect no diff).
+    /// </summary>
+    private static UpdateSessionRequest IdenticalSessionRequest(TrainingSession session, Guid sessionId)
+    {
+        var section = session.Sections[0];
+        var exercise = section.Exercises[0];
+        var set = exercise.Sets[0];
+        return new UpdateSessionRequest
+        {
+            SessionId = sessionId,
+            DayOfWeek = session.DayOfWeek,
+            Name = session.Name,
+            Order = session.Order,
+            Notes = session.Notes,
+            Format = session.Format,
+            FormatConfig = session.FormatConfig,
+            Sections =
+            [
+                new UpdateSectionRequest
+                {
+                    SectionId = section.SectionId,
+                    Order = section.Order,
+                    Name = section.Name,
+                    Format = section.Format,
+                    FormatConfig = section.FormatConfig,
+                    Notes = section.Notes,
+                    Exercises =
+                    [
+                        new UpdateSessionExerciseRequest
+                        {
+                            ExerciseExternalId = exercise.ExerciseExternalId,
+                            ExerciseName = exercise.ExerciseName,
+                            Order = exercise.Order,
+                            Notes = exercise.Notes,
+                            RestSeconds = exercise.RestSeconds,
+                            MovementType = exercise.MovementType,
+                            Format = exercise.Format,
+                            FormatConfig = exercise.FormatConfig,
+                            Sets =
+                            [
+                                new UpdateExerciseSetRequest
+                                {
+                                    SetNumber = set.SetNumber,
+                                    Type = set.Type,
+                                    Reps = set.Reps,
+                                    WeightKg = set.WeightKg,
+                                    DurationSeconds = set.DurationSeconds,
+                                    Rpe = set.Rpe,
+                                    DistanceMeters = set.DistanceMeters,
+                                    RestSeconds = set.RestSeconds
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    /// <summary>
+    /// Builds the incoming session request with a content change (different reps).
+    /// </summary>
+    private static UpdateSessionRequest ChangedSessionRequest(TrainingSession session, Guid sessionId)
+    {
+        var req = IdenticalSessionRequest(session, sessionId);
+        // Mutate reps to trigger the diff gate.
+        req.Sections[0].Exercises[0].Sets[0].Reps = 99;
+        return req;
+    }
+
+    private ISessionLockService CreateLockServiceReturningConflict()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.LockConflict());
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return svc;
+    }
+
+    private ISessionLockService CreateLockServiceReturningAcquired(Guid sessionId, Guid planId, Guid clientId, Guid trainerId)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        var lockDoc = new SessionLock
+        {
+            SessionId = sessionId,
+            PlanId = planId,
+            ClientId = clientId,
+            TrainerId = trainerId,
+            Holder = LockHolder.Coach,
+            Type = LockType.Editing,
+            AcquiredAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(2)
+        };
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(lockDoc));
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock> { lockDoc });
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        return svc;
+    }
+
+    private ISessionLockService CreateLockServiceWithNoLocks()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(new SessionLock()));
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return svc;
+    }
+
+    // ── Unlock: 409 when session is Live ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Unlock_Returns409_WhenSessionIsLive()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = CreateLockServiceReturningConflict();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions());
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — AcquireAsync returned LockConflict → 409
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    // ── Unlock: 404 when plan not owned by caller ─────────────────────────────────
+
+    [Fact]
+    public async Task Unlock_Returns404_WhenPlanNotOwnedByCaller()
+    {
+        // Arrange — plan owned by _otherTrainerId, caller is _trainerId
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId, trainerId: _otherTrainerId);
+        // Return empty so the ownership filter finds nothing
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo();
+        var lockService = CreateLockServiceWithNoLocks();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions());
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+
+        // Lock service must not have been called
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Diff-gate: rejects edit to a Stable published session ─────────────────────
+
+    [Fact]
+    public async Task UpdatePlan_DiffGate_Returns409_WhenPublishedSessionChangedWithoutEditingLock()
+    {
+        // Arrange — session is Stable (no lock held), but request contains a content change.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = CreateLockServiceWithNoLocks(); // GetStateAsync returns empty = no lock
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate, // preserve so start-date lock check passes
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions = [changedSession]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — diff detected a change and no Editing lock → 409
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+
+        // Plan must NOT have been saved
+        await mongo.TrainingPlans.DidNotReceive().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<TrainingPlan>>(),
+            Arg.Any<TrainingPlan>(),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Diff-gate: allows edit to a published session that is in Editing by this trainer ──
+
+    [Fact]
+    public async Task UpdatePlan_DiffGate_Allows_WhenPublishedSessionInEditingByThisTrainer()
+    {
+        // Arrange — session is Editing by this trainer.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = CreateLockServiceReturningAcquired(sessionId, plan.ExternalId, plan.ClientId, _trainerId);
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate, // preserve so start-date lock check passes
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions = [changedSession]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — lock held by this trainer → save proceeds → 200
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.TrainingPlans.Received(1).ReplaceOneAsync(
+            Arg.Any<FilterDefinition<TrainingPlan>>(),
+            Arg.Any<TrainingPlan>(),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Auto-release: Editing locks released after successful save ────────────────
+
+    [Fact]
+    public async Task UpdatePlan_AutoReleasesEditingLock_AfterSuccessfulSave()
+    {
+        // Arrange — session in Editing by this trainer; save succeeds; lock must be released.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = CreateLockServiceReturningAcquired(sessionId, plan.ExternalId, plan.ClientId, _trainerId);
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate, // preserve so start-date lock check passes
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions = [changedSession]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — save succeeded (200) and lock was released.
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        await lockService.Received(1).ReleaseAsync(
+            sessionId, LockHolder.Coach, LockType.Editing, Arg.Any<CancellationToken>());
+    }
+
+    // ── Draft-week edit is never gated ───────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdatePlan_DraftWeekEdit_IsNotGated_Returns200()
+    {
+        // Arrange — plan has only a draft week; no lock needed even for content changes.
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var plan = CreatePlanWithDraftSession(sessionId, exerciseId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        // Lock service should NOT be queried for draft-week sessions.
+        var lockService = Substitute.For<ISessionLockService>();
+        lockService.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        // Request changes the reps — but this is a draft session, so no gate.
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions =
+                    [
+                        new UpdateSessionRequest
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Draft Session",
+                            Order = 1,
+                            Sections =
+                            [
+                                new UpdateSectionRequest
+                                {
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new UpdateSessionExerciseRequest
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            MovementType = MovementType.Reps,
+                                            Sets =
+                                            [
+                                                new UpdateExerciseSetRequest
+                                                {
+                                                    SetNumber = 1,
+                                                    Reps = 99, // changed — but draft week, so no gate
+                                                    WeightKg = 80
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — no gate for draft weeks → 200
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // GetStateAsync must NOT be called since no published sessions were changed.
+        await lockService.DidNotReceive().GetStateAsync(
+            Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Relock: idempotent success even when lock already gone ───────────────────
+
+    [Fact]
+    public async Task Relock_Returns204_WhenLockAlreadyReleased()
+    {
+        // Arrange — lock already expired/released; ReleaseAsync returns false (idempotent).
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = CreateLockServiceWithNoLocks(); // ReleaseAsync returns false
+
+        var ep = Factory.Create<RelockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        // Act
+        await ep.HandleAsync(
+            new RelockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 204 regardless of whether a lock existed
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+    }
+
+    // ── Relock: 404 when plan not owned by caller ─────────────────────────────────
+
+    [Fact]
+    public async Task Relock_Returns404_WhenPlanNotOwnedByCaller()
+    {
+        // Arrange — plan exists but belongs to _otherTrainerId; caller is _trainerId.
+        var sessionId = Guid.NewGuid();
+        // Return empty plans to simulate ownership filter finding nothing.
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo();
+        var lockService = CreateLockServiceWithNoLocks();
+
+        var ep = Factory.Create<RelockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        // Act
+        await ep.HandleAsync(
+            new RelockTrainingSessionRequest { PlanId = Guid.NewGuid(), SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+
+        // ReleaseAsync must not have been called
+        await lockService.DidNotReceive().ReleaseAsync(
+            Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Diff-gate: no content change → no lock required ─────────────────────────
+
+    [Fact]
+    public async Task UpdatePlan_NoContentChange_Returns200_WithoutRequiringLock()
+    {
+        // Arrange — published session with identical content (no diff detected).
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = CreateLockServiceWithNoLocks(); // no locks held
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService);
+
+        var identicalSession = IdenticalSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate, // preserve so start-date lock check passes
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions = [identicalSession]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — no diff detected → no lock needed → 200
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // GetStateAsync must NOT be called since there are no changed sessions.
+        await lockService.DidNotReceive().GetStateAsync(
+            Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanDiffGateIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanDiffGateIntegrationTests.cs
@@ -1,0 +1,352 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Testcontainers integration tests (real MongoDB) for the diff-gate in
+/// <c>PUT /training/plans/{planId}</c>. Covers two gaps found in the fresh-eyes
+/// review of issue #381:
+/// <list type="bullet">
+///   <item>
+///     <term>Legacy-doc no false-positive (gap #5a)</term>
+///     <description>
+///       A plan stored with legacy flat-exercise layout (no Sections, non-empty
+///       LegacyExercises) paired with a section-shaped incoming request that
+///       represents the SAME content after backfill must NOT produce a 409 —
+///       the backfill no-diff path must be clean.
+///     </description>
+///   </item>
+///   <item>
+///     <term>Removed/replaced published session without lock → 409 (gap #5b)</term>
+///     <description>
+///       Dropping a published session from the request (i.e. the stored published
+///       SessionId does not appear in the incoming map) must be rejected with 409
+///       <c>session_locked</c> unless the trainer holds an Editing lock for that
+///       session.
+///     </description>
+///   </item>
+/// </list>
+/// </summary>
+[Collection(TestCollection.Name)]
+public class UpdateTrainingPlanDiffGateIntegrationTests(FitnessApiFactory factory)
+{
+    private static string UniqueEmail() => $"{Guid.NewGuid():N}@diff-gate-test.com";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    // ── shared plan-building helpers ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a published plan in Mongo whose single session uses the LEGACY flat-exercise
+    /// layout (empty Sections list, LegacyExercises populated). Returns the plan + the
+    /// legacy exercise IDs so the caller can build a matching section-shaped request.
+    /// </summary>
+    private async Task<(TrainingPlan Plan, Guid SessionId, Guid ExerciseId)>
+        SeedLegacyPublishedPlanAsync(Guid trainerUserId)
+    {
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var exId = Guid.NewGuid();
+
+        var session = new TrainingSession
+        {
+            SessionId = sessionId,
+            DayOfWeek = 1,
+            Name = "Legacy Day",
+            Order = 1,
+            Sections = [],          // legacy — no sections
+            LegacyExercises =
+            [
+                new SessionExercise
+                {
+                    ExerciseExternalId = exId,
+                    ExerciseName = "Squat",
+                    Order = 1,
+                    MovementType = MovementType.Reps,
+                    Sets =
+                    [
+                        new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 5, WeightKg = 100 }
+                    ]
+                }
+            ]
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = Guid.NewGuid(),
+            TrainerId = trainerUserId,
+            Name = "Legacy Diff-Gate Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = DateTime.UtcNow.AddDays(-7),
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-14),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-7),
+                    Sessions = [session]
+                }
+            ]
+        };
+
+        using var scope = factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+        await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+
+        return (plan, sessionId, exId);
+    }
+
+    /// <summary>
+    /// Seeds a published plan in Mongo whose single session uses the CURRENT
+    /// sections-based layout (Sections populated, LegacyExercises empty).
+    /// </summary>
+    private async Task<(TrainingPlan Plan, Guid SessionId, Guid SectionId, Guid ExerciseId)>
+        SeedSectionPublishedPlanAsync(Guid trainerUserId)
+    {
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
+        var exId = Guid.NewGuid();
+
+        var session = new TrainingSession
+        {
+            SessionId = sessionId,
+            DayOfWeek = 1,
+            Name = "Modern Day",
+            Order = 1,
+            Sections =
+            [
+                new TrainingSection
+                {
+                    SectionId = sectionId,
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new SessionExercise
+                        {
+                            ExerciseExternalId = exId,
+                            ExerciseName = "Bench Press",
+                            Order = 1,
+                            MovementType = MovementType.Reps,
+                            Sets =
+                            [
+                                new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 10, WeightKg = 80 }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = Guid.NewGuid(),
+            TrainerId = trainerUserId,
+            Name = "Section Diff-Gate Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = DateTime.UtcNow.AddDays(-7),
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-14),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = DateTime.UtcNow.AddDays(-7),
+                    Sessions = [session]
+                }
+            ]
+        };
+
+        using var scope = factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+        await mongo.TrainingPlans.InsertOneAsync(plan, cancellationToken: TestContext.Current.CancellationToken);
+
+        return (plan, sessionId, sectionId, exId);
+    }
+
+    // ── gap #5a: legacy-doc backfill no false-positive ───────────────────────────
+
+    /// <summary>
+    /// A plan whose session is stored in legacy flat-exercise format (Sections=[],
+    /// LegacyExercises=[…]) must NOT produce a 409 when the incoming request for
+    /// the same session is shaped as a single "Hlavní" section with exactly the same
+    /// exercise content — the <see cref="TrainingSession.WithBackfilledSections"/>
+    /// backfill equalises the views and HasContentChanged must return false.
+    /// </summary>
+    [Fact]
+    public async Task UpdatePlan_LegacyFlatDoc_SameContentAsSectionRequest_Returns200_NoFalsePositive()
+    {
+        // ── 1. Register + login trainer ───────────────────────────────────────────
+        var httpClient = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, email, "TestPass1!", "Legacy", "DiffGate", "Trainer");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, email, "TestPass1!");
+
+        Guid trainerUserId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == email,
+                TestContext.Current.CancellationToken);
+            trainerUserId = user.Id;
+        }
+
+        // ── 2. Seed a legacy-format published plan ────────────────────────────────
+        var (plan, sessionId, exerciseId) = await SeedLegacyPublishedPlanAsync(trainerUserId);
+
+        // ── 3. Build an UPDATE request with section-shaped content ─────────────────
+        // The content is identical to the legacy doc after backfill: one "Hlavní"
+        // section with one exercise (same ExerciseExternalId / ExerciseName / Order /
+        // MovementType / Sets). HasContentChanged must NOT flag this as changed.
+        var body = new
+        {
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate,
+            Weeks = new[]
+            {
+                new
+                {
+                    WeekNumber = 1,
+                    Sessions = new[]
+                    {
+                        new
+                        {
+                            SessionId = sessionId.ToString(),
+                            DayOfWeek = 1,
+                            Name = "Legacy Day",
+                            Order = 1,
+                            Sections = new[]
+                            {
+                                new
+                                {
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises = new[]
+                                    {
+                                        new
+                                        {
+                                            ExerciseExternalId = exerciseId.ToString(),
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            MovementType = "Reps",
+                                            Sets = new[]
+                                            {
+                                                new { SetNumber = 1, Type = "Normal", Reps = 5, WeightKg = 100.0 }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        // ── 4. PUT /training/plans/{planId} ───────────────────────────────────────
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.PutAsJsonAsync(
+            $"/training/plans/{plan.ExternalId}",
+            body,
+            TestContext.Current.CancellationToken);
+
+        // ── 5. Assert no false-positive 409 ───────────────────────────────────────
+        // The diff-gate must NOT fire — the incoming content is identical to the
+        // stored legacy doc after backfill. No Editing lock is held, so a 409 would
+        // be wrong. Expect 200.
+        var body200 = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        response.StatusCode.Should().Be(
+            HttpStatusCode.OK,
+            $"legacy flat-exercise doc with unchanged section-shaped request must not trigger the diff-gate. Body: {body200}");
+    }
+
+    // ── gap #5b: removed/replaced published session without lock → 409 ───────────
+
+    /// <summary>
+    /// Dropping a stored published session from the incoming request (its SessionId
+    /// is absent from the request) must be rejected with HTTP 409. The plan is stored
+    /// with sections-layout; no Editing lock is held by the trainer for that session.
+    /// </summary>
+    [Fact]
+    public async Task UpdatePlan_RemovedPublishedSession_WithoutEditingLock_Returns409()
+    {
+        // ── 1. Register + login trainer ───────────────────────────────────────────
+        var httpClient = factory.CreateClient();
+        var email = UniqueEmail();
+        await TestHelpers.RegisterAsync(httpClient, email, "TestPass1!", "Remove", "DiffGate", "Trainer");
+        var (accessToken, _) = await TestHelpers.LoginAsync(httpClient, email, "TestPass1!");
+
+        Guid trainerUserId;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = await db.Users.FirstAsync(
+                u => u.Email == email,
+                TestContext.Current.CancellationToken);
+            trainerUserId = user.Id;
+        }
+
+        // ── 2. Seed a published plan with a session ───────────────────────────────
+        var (plan, sessionId, _, exerciseId) = await SeedSectionPublishedPlanAsync(trainerUserId);
+
+        // ── 3. Build an UPDATE request that OMITS the published session ────────────
+        // Sending week 1 with an EMPTY sessions list effectively removes the published
+        // session. No SessionId mismatch is needed — pure absence is enough. No lock.
+        var body = new
+        {
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate,
+            Weeks = new[]
+            {
+                new
+                {
+                    WeekNumber = 1,
+                    Sessions = Array.Empty<object>() // session removed
+                }
+            }
+        };
+
+        // ── 4. PUT /training/plans/{planId} ───────────────────────────────────────
+        TestHelpers.SetBearerToken(httpClient, accessToken);
+        var response = await httpClient.PutAsJsonAsync(
+            $"/training/plans/{plan.ExternalId}",
+            body,
+            TestContext.Current.CancellationToken);
+
+        // ── 5. Assert 409 with session_locked error code ───────────────────────────
+        var responseBody = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(
+            HttpStatusCode.Conflict,
+            $"removing a published session without an Editing lock must be rejected 409. Body: {responseBody}");
+        responseBody.Should().Contain(
+            "session_locked",
+            "the RFC 7807 error_code must be 'session_locked'");
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanFormatTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanFormatTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Endpoints;
@@ -22,12 +23,23 @@ public class UpdateTrainingPlanFormatTests
 {
     private readonly Guid _trainerId = Guid.NewGuid();
 
+    private static ISessionLockService CreateNoOpLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return svc;
+    }
+
     private UpdateTrainingPlanEndpoint CreateEndpoint(IMongoContext mongo) =>
         Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo,
+            CreateNoOpLockService());
 
     /// <summary>Builds a minimal single-section request for a given session.</summary>
     private static UpdateSectionRequest DefaultSection(List<UpdateSessionExerciseRequest>? exercises = null) =>


### PR DESCRIPTION
## Summary
- Adds `POST /training/plans/{planId}/sessions/{sessionId}/unlock` — acquires an `Editing` lock (`ISessionLockService.AcquireAsync`); returns 409 RFC 7807 `session_locked` when the session is `Live` or otherwise conflict-locked.
- Adds `POST /training/plans/{planId}/sessions/{sessionId}/relock` — releases the `Editing` lock idempotently (`ReleaseAsync`), returning the session to Stable; no-op success when already released/expired.
- Adds the **diff+gate** to `UpdateTrainingPlan` (PUT): computes a normalized content projection (sections → exercises → sets) per published session keyed on stable `SessionId`; any changed *or removed/replaced* published session requires an `Editing` lock held by the calling trainer, else 409 `session_locked` listing the offending session IDs. Draft weeks stay freely editable. Locks auto-release only after a successful save (`ModifiedCount > 0`).
- `PublishTrainingWeek` defensively clears any stale `Editing` lock docs for the week's sessions before transitioning to `Stable`.

## Related issue
Part of #379 — base branch: `feature/379-training-session-lock` (epic branch).
Fixes #381

## Spec
Design: `docs/superpowers/specs/2026-06-01-training-session-lock-design.md` (§§5-6, 13). Phased plan: `PLAN.md` (Phase 2).

## Scope
backend — `Features/TrainingPlans/**` + Testcontainers integration/format tests. No edits to the shared `ISessionLockService` / `ErrorCodes` / `TrainingLockOptions`.

## Review-rework notes
Two prior MAJOR findings closed: validator now requires a non-null `SessionId` on every published-week session and rejects duplicate `SessionId`s globally → 400; removed/replaced published sessions are gated → 409 `session_locked`. Added 2 Testcontainers diff-gate integration tests.

## QA verdict (from qa-tester)
OVERALL ✅ PASS — 25/25 affected tests green, no regression.

## Test plan
- [ ] `unlock` returns 409 `session_locked` when the session is `Live`.
- [ ] `unlock` acquires an `Editing` lock on a published (Stable) session.
- [ ] `relock` releases the `Editing` lock idempotently (no-op success when already gone).
- [ ] Diff-gate rejects an edit to a `Stable` or `Live` published session without an `Editing` lock → 409 listing offending IDs.
- [ ] Diff-gate allows an edit to a published session the trainer holds in `Editing`.
- [ ] Removing/replacing a published session without a lock → 409.
- [ ] Auto-release fires on a successful save (`ModifiedCount > 0`); a version-conflict loss does NOT release.
- [ ] `PublishTrainingWeek` clears stale `Editing` lock docs before transitioning to `Stable`.
- [ ] Draft-week sessions remain freely editable without a lock.
- [ ] `dotnet build` clean; changed-feature `dotnet test` slice passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)