### PR TITLE
feat(#383): realtime SignalR session-lock events (backend emit + web/mobile consume)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Documents/SessionLockChangedPayload.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/SessionLockChangedPayload.cs
@@ -1,0 +1,16 @@
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// Payload for the <c>sessioneditlockchanged</c> SignalR event broadcast whenever
+/// a session lock is acquired (state = Editing/Live) or released (state = Stable).
+/// Emitted to BOTH the client and the trainer user-id groups for the affected plan.
+/// </summary>
+/// <param name="PlanId">The plan the session belongs to.</param>
+/// <param name="SessionId">The locked/unlocked session.</param>
+/// <param name="State">The new state: <c>Editing</c>, <c>Live</c>, or <c>Stable</c>.</param>
+/// <param name="Holder">Who holds (or held) the lock: <c>Coach</c> or <c>Client</c>.</param>
+public record SessionLockChangedPayload(
+    Guid PlanId,
+    Guid SessionId,
+    string State,
+    string Holder);

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/PublishTrainingWeek/PublishTrainingWeekEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/PublishTrainingWeek/PublishTrainingWeekEndpoint.cs
@@ -137,10 +137,24 @@ public class PublishTrainingWeekEndpoint(
         // Defensive cleanup: clear any stale Editing lock docs for the week's sessions.
         // This handles the edge case where a trainer had a session unlocked just before publish.
         // ReleaseAsync is idempotent — safe to call even if no lock exists.
+        // Only emit sessioneditlockchanged when ReleaseAsync returns true — emitting Stable
+        // for a session that had no lock would be spurious fan-out.
         var weekSessionIds = week.Sessions.Select(s => s.SessionId).ToList();
         foreach (var sessionId in weekSessionIds)
         {
-            await lockService.ReleaseAsync(sessionId, LockHolder.Coach, LockType.Editing, ct);
+            var released = await lockService.ReleaseAsync(sessionId, LockHolder.Coach, LockType.Editing, ct);
+
+            if (released)
+            {
+                var lockPayload = new SessionLockChangedPayload(
+                    plan.ExternalId,
+                    sessionId,
+                    "Stable",
+                    "Coach");
+
+                await notifier.NotifyAsync(plan.ClientId, "sessioneditlockchanged", lockPayload, ct);
+                await notifier.NotifyAsync(trainerId, "sessioneditlockchanged", lockPayload, ct);
+            }
         }
 
         // Notify the client about the published week

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/RelockTrainingSession/RelockTrainingSessionEndpoint.cs
@@ -13,10 +13,13 @@ namespace FitnessPlatform.Application.Features.TrainingPlans.RelockTrainingSessi
 /// Releases the Editing lock on a training session, returning it to Stable state.
 /// Idempotent: if the lock is already gone (released, expired) this is a no-op success.
 /// Ownership guard: only the plan's owning trainer may relock.
+/// Emits <c>sessioneditlockchanged</c> (state=Stable) to both client and trainer when a lock is actually released.
+/// Only emits on a real state transition (ReleaseAsync returns true).
 /// </summary>
 public class RelockTrainingSessionEndpoint(
     IMongoContext mongo,
-    ISessionLockService lockService)
+    ISessionLockService lockService,
+    IRealtimeNotifier notifier)
     : Endpoint<RelockTrainingSessionRequest>
 {
     /// <inheritdoc />
@@ -70,11 +73,25 @@ public class RelockTrainingSessionEndpoint(
 
         // Release idempotently: ReleaseAsync returns false when no doc matched
         // (already released/expired), but that is still a success per the spec.
-        await lockService.ReleaseAsync(
+        // Only emit sessioneditlockchanged when ReleaseAsync returns true — emitting Stable
+        // for a session that had no lock would be spurious fan-out.
+        var released = await lockService.ReleaseAsync(
             sessionId: req.SessionId,
             holder: LockHolder.Coach,
             type: LockType.Editing,
             ct: ct);
+
+        if (released)
+        {
+            var payload = new SessionLockChangedPayload(
+                plan.ExternalId,
+                req.SessionId,
+                "Stable",
+                "Coach");
+
+            await notifier.NotifyAsync(plan.ClientId, "sessioneditlockchanged", payload, ct);
+            await notifier.NotifyAsync(trainerId, "sessioneditlockchanged", payload, ct);
+        }
 
         await Send.NoContentAsync(ct);
     }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
@@ -16,11 +16,13 @@ namespace FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSessi
 /// Acquires an Editing lock on a published training session, allowing the trainer to edit it.
 /// Returns 409 if the session is currently in Live state (client is training).
 /// The ownership guard ensures only the plan's owning trainer may unlock.
+/// Emits <c>sessioneditlockchanged</c> (state=Editing) to both client and trainer on successful acquire.
 /// </summary>
 public class UnlockTrainingSessionEndpoint(
     IMongoContext mongo,
     ISessionLockService lockService,
-    IOptions<TrainingLockOptions> lockOptions)
+    IOptions<TrainingLockOptions> lockOptions,
+    IRealtimeNotifier notifier)
     : Endpoint<UnlockTrainingSessionRequest>
 {
     /// <inheritdoc />
@@ -87,10 +89,21 @@ public class UnlockTrainingSessionEndpoint(
         switch (result)
         {
             case AcquireResult.Acquired:
+                // Emit sessioneditlockchanged (state=Editing) to both parties on successful acquire.
+                var payload = new SessionLockChangedPayload(
+                    plan.ExternalId,
+                    req.SessionId,
+                    "Editing",
+                    "Coach");
+
+                await notifier.NotifyAsync(plan.ClientId, "sessioneditlockchanged", payload, ct);
+                await notifier.NotifyAsync(trainerId, "sessioneditlockchanged", payload, ct);
+
                 await Send.NoContentAsync(ct);
                 break;
 
             case AcquireResult.LockConflict:
+                // 409 conflict path — emit nothing; no state transition occurred.
                 // The session is currently locked — either Live (client training) or
                 // already in Editing by someone else. Both cases are 409 session_locked.
                 await this.SendProblemAsync(

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
@@ -16,10 +16,13 @@ namespace FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
 /// Preserves per-week Status and DatePublished. Uses optimistic concurrency.
 /// For published sessions with content changes, an active Editing lock held by this trainer is required.
 /// Draft-week sessions are always editable without a lock.
+/// Emits <c>sessioneditlockchanged</c> (state=Stable) to both client and trainer for each diff-gated
+/// session whose Editing lock is auto-released after a successful save.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="lockService">Session lock service for diff-gate enforcement.</param>
-public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lockService)
+/// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
+public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lockService, IRealtimeNotifier notifier)
     : Endpoint<UpdateTrainingPlanRequest, GetTrainingPlanResponse>
 {
     /// <inheritdoc />
@@ -306,9 +309,24 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService
 
         // Auto-release Editing locks for the changed sessions — ONLY after a successful save
         // (ModifiedCount > 0). A version-conflict loss must NOT release the lock.
+        // Only emit sessioneditlockchanged when ReleaseAsync returns true — emitting Stable
+        // for a session that had no lock would be spurious fan-out (the session may have been
+        // unlocked, saved, and already auto-released by a previous request).
         foreach (var sessionId in changedSessionIds)
         {
-            await lockService.ReleaseAsync(sessionId, LockHolder.Coach, LockType.Editing, ct);
+            var released = await lockService.ReleaseAsync(sessionId, LockHolder.Coach, LockType.Editing, ct);
+
+            if (released)
+            {
+                var payload = new SessionLockChangedPayload(
+                    plan.ExternalId,
+                    sessionId,
+                    "Stable",
+                    "Coach");
+
+                await notifier.NotifyAsync(plan.ClientId, "sessioneditlockchanged", payload, ct);
+                await notifier.NotifyAsync(trainerId, "sessioneditlockchanged", payload, ct);
+            }
         }
 
         await Send.OkAsync(GetTrainingPlanResponse.FromDocument(plan), ct);

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
@@ -18,14 +18,17 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 /// calculations pick up the live workout alongside plan-driven completions.
 /// Also releases the <c>Live</c> session lock when the log is plan-bound
 /// (i.e. when the log carries a non-null <c>SessionId</c>).
+/// Emits <c>sessioneditlockchanged</c> (state=Stable) to both client and trainer when a lock is released.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="completionService">Shared workout completion pipeline (PR detection, fan-out, notification).</param>
 /// <param name="lockService">Session lock service — used to release the Live lock on finish.</param>
+/// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
 public class CompleteWorkoutEndpoint(
     IMongoContext mongo,
     IWorkoutCompletionService completionService,
-    ISessionLockService lockService) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
+    ISessionLockService lockService,
+    IRealtimeNotifier notifier) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -87,9 +90,31 @@ public class CompleteWorkoutEndpoint(
         // Ad-hoc workouts have no session, so no lock was acquired — skip silently.
         // ReleaseAsync is idempotent: returns false when the lock is already gone
         // (expired or already released), which is not an error.
+        // Only emit sessioneditlockchanged when ReleaseAsync returns true — emitting Stable
+        // for a session that had no lock would be spurious fan-out.
         if (log.SessionId.HasValue)
         {
-            await lockService.ReleaseAsync(log.SessionId.Value, LockHolder.Client, LockType.Live, ct);
+            var released = await lockService.ReleaseAsync(log.SessionId.Value, LockHolder.Client, LockType.Live, ct);
+
+            if (released && log.PlanId.HasValue)
+            {
+                // Resolve the trainer to fan out to. Load the plan by ExternalId.
+                var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
+                using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+                var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+                if (plan is not null)
+                {
+                    var payload = new SessionLockChangedPayload(
+                        log.PlanId.Value,
+                        log.SessionId.Value,
+                        "Stable",
+                        "Client");
+
+                    await notifier.NotifyAsync(clientId, "sessioneditlockchanged", payload, ct);
+                    await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
+                }
+            }
         }
 
         await Send.OkAsync(WorkoutLogDetail.FromDocument(log), ct);

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
@@ -18,14 +18,17 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 /// acquires a <c>Live</c> lock on the session before creating the log.
 /// Returns 409 <c>session_locked</c> when the session is in <c>Editing</c> state.
 /// Ad-hoc workouts (null PlanId or null SessionId) skip the lock entirely.
+/// Emits <c>sessioneditlockchanged</c> (state=Live) to both client and trainer on successful acquire.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="lockService">Session lock service.</param>
 /// <param name="lockOptions">Training lock TTL configuration.</param>
+/// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
 public class StartWorkoutEndpoint(
     IMongoContext mongo,
     ISessionLockService lockService,
-    IOptions<TrainingLockOptions> lockOptions) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
+    IOptions<TrainingLockOptions> lockOptions,
+    IRealtimeNotifier notifier) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -90,9 +93,25 @@ public class StartWorkoutEndpoint(
 
             if (acquireResult is AcquireResult.LockConflict)
             {
+                // 409 conflict path — emit nothing; no state transition occurred.
                 await this.SendProblemAsync(409, ErrorCodes.SessionLocked,
                     "This session is locked and cannot be started right now.", ct);
                 return;
+            }
+
+            // Emit sessioneditlockchanged (state=Live) to both parties on successful acquire.
+            // Broadcast after the lock is held but before the log is persisted so clients
+            // see the state update as soon as the lock is confirmed.
+            if (acquireResult is AcquireResult.Acquired)
+            {
+                var payload = new SessionLockChangedPayload(
+                    req.PlanId!.Value,
+                    req.SessionId!.Value,
+                    "Live",
+                    "Client");
+
+                await notifier.NotifyAsync(clientId, "sessioneditlockchanged", payload, ct);
+                await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
             }
         }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/MarkExerciseCompleteEndpointTests.cs
@@ -8,8 +8,10 @@ using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining.MarkExerciseComplete;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -27,7 +29,18 @@ public class MarkExerciseCompleteEndpointTests
     private readonly Guid _exercise2 = Guid.NewGuid();
     private readonly IRealtimeNotifier _notifier = TrainingCompletionTestHelpers.CreateStubNotifier();
     private readonly IComplianceService _compliance = TrainingCompletionTestHelpers.CreateStubComplianceService();
+    private readonly ISessionLockService _lockService = CreateStubLockService();
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
     private readonly ILogger<MarkExerciseCompleteEndpoint> _logger = Substitute.For<ILogger<MarkExerciseCompleteEndpoint>>();
+
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.RefreshAsync(Arg.Any<Guid>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+        return svc;
+    }
 
     private IApplicationDbContext CreateMockDb() =>
         new MockDbBuilder()
@@ -54,7 +67,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -102,7 +115,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Mark exercise1 complete again (already complete — idempotent)
         await ep.HandleAsync(
@@ -140,7 +153,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(wrongClientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -180,7 +193,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Client sends version 2 which matches, but UpdateOneAsync returns ModifiedCount=0 (race)
         await ep.HandleAsync(
@@ -220,7 +233,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Client sends version 1 but server is at version 3
         await ep.HandleAsync(
@@ -251,7 +264,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = Guid.NewGuid(), ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -268,7 +281,7 @@ public class MarkExerciseCompleteEndpointTests
 
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity()),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         await ep.HandleAsync(
             new MarkExerciseCompleteRequest { SessionId = _sessionId, ExerciseExternalId = _exercise1, SectionId = _sectionId },
@@ -292,7 +305,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Use a valid sessionId but an unknown sectionId
         await ep.HandleAsync(
@@ -318,7 +331,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Mark complete in section1 only
         await ep.HandleAsync(
@@ -373,7 +386,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Mark exercise1 complete in sectionId. Since the doc has no section dict, the idempotency
         // check on the section dict won't short-circuit — it will proceed to update and populate the dict.
@@ -431,7 +444,7 @@ public class MarkExerciseCompleteEndpointTests
         var ep = Factory.Create<MarkExerciseCompleteEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, db, _notifier, _compliance, _logger);
+            mongo, db, _notifier, _compliance, _lockService, LockOptions, _logger);
 
         // Act: mark exercise2 complete in the same section — triggers the UpdateOneAsync path.
         await ep.HandleAsync(

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/PublishTrainingWeekEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/PublishTrainingWeekEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.TrainingPlans.PublishTrainingWeek;
 using FitnessPlatform.Tests.Builders;
@@ -16,6 +17,14 @@ namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
 public class PublishTrainingWeekEndpointTests
 {
     private readonly Guid _trainerId = Guid.NewGuid();
+
+    private static ISessionLockService StubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+        return svc;
+    }
 
     [Fact]
     public async Task HandleAsync_ValidPublish_Returns200()
@@ -33,7 +42,8 @@ public class PublishTrainingWeekEndpointTests
             mongo,
             new MockDbBuilder().Build(),
             Substitute.For<INotificationService>(),
-            Substitute.For<IRealtimeNotifier>());
+            Substitute.For<IRealtimeNotifier>(),
+            StubLockService());
 
         await ep.HandleAsync(new PublishTrainingWeekRequest
         {
@@ -60,7 +70,8 @@ public class PublishTrainingWeekEndpointTests
             mongo,
             new MockDbBuilder().Build(),
             Substitute.For<INotificationService>(),
-            Substitute.For<IRealtimeNotifier>());
+            Substitute.For<IRealtimeNotifier>(),
+            StubLockService());
 
         await ep.HandleAsync(new PublishTrainingWeekRequest
         {

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/SessionLockBroadcastTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/SessionLockBroadcastTests.cs
@@ -1,0 +1,492 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.RelockTrainingSession;
+using FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSession;
+using FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests that verify the <c>sessioneditlockchanged</c> SignalR broadcast behaviour
+/// for the trainer-side session-lock endpoints (issue #383).
+/// Covers:
+///   - Unlock (Editing acquire) emits state=Editing to BOTH clientId and trainerId
+///   - Relock (Editing release, ReleaseAsync=true) emits state=Stable to BOTH parties
+///   - Relock idempotent (ReleaseAsync=false) emits NOTHING
+///   - UpdatePlan diff-gated auto-release emits state=Stable to BOTH parties
+///   - UpdatePlan diff-gated auto-release skips emit when ReleaseAsync=false
+///   - Unlock 409 conflict emits NOTHING
+/// </summary>
+public class SessionLockBroadcastTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private IOptions<TrainingLockOptions> DefaultOptions() =>
+        Options.Create(new TrainingLockOptions { EditingTtlHours = 2, LiveTtlHours = 6 });
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a plan with one published week containing a session with <paramref name="sessionId"/>.
+    /// </summary>
+    private TrainingPlan CreatePlanWithPublishedSession(Guid sessionId)
+    {
+        var exerciseId = Guid.NewGuid();
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = DateTime.UtcNow.AddDays(-7),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            MovementType = MovementType.Reps,
+                                            Sets = [new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 100 }]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+    }
+
+    /// <summary>Creates a lock service that returns <see cref="AcquireResult.Acquired"/>.</summary>
+    private ISessionLockService LockServiceAcquired(Guid sessionId, Guid planId)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        var lockDoc = new SessionLock
+        {
+            SessionId = sessionId,
+            PlanId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Holder = LockHolder.Coach,
+            Type = LockType.Editing,
+            AcquiredAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(2)
+        };
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(lockDoc));
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock> { lockDoc });
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        return svc;
+    }
+
+    /// <summary>Creates a lock service that returns <see cref="AcquireResult.LockConflict"/>.</summary>
+    private static ISessionLockService LockServiceConflict()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.LockConflict());
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return svc;
+    }
+
+    /// <summary>
+    /// Creates a lock service where GetStateAsync returns an active lock (so diff-gate allows the save),
+    /// but ReleaseAsync returns false (lock was already gone — idempotent no-op).
+    /// </summary>
+    private ISessionLockService LockServiceNoLock(Guid sessionId, Guid planId)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        var lockDoc = new SessionLock
+        {
+            SessionId = sessionId,
+            PlanId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Holder = LockHolder.Coach,
+            Type = LockType.Editing,
+            AcquiredAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(2)
+        };
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(lockDoc));
+        // GetStateAsync returns a lock so the diff-gate sees an active Editing lock and allows the save
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock> { lockDoc });
+        // ReleaseAsync returns false — lock was already gone (expired between the gate check and release)
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        return svc;
+    }
+
+    private static UpdateSessionRequest ChangedSessionRequest(TrainingSession session, Guid sessionId)
+    {
+        var section = session.Sections[0];
+        var exercise = section.Exercises[0];
+        var set = exercise.Sets[0];
+        return new UpdateSessionRequest
+        {
+            SessionId = sessionId,
+            DayOfWeek = session.DayOfWeek,
+            Name = session.Name,
+            Order = session.Order,
+            Sections =
+            [
+                new UpdateSectionRequest
+                {
+                    SectionId = section.SectionId,
+                    Order = section.Order,
+                    Name = section.Name,
+                    Exercises =
+                    [
+                        new UpdateSessionExerciseRequest
+                        {
+                            ExerciseExternalId = exercise.ExerciseExternalId,
+                            ExerciseName = exercise.ExerciseName,
+                            Order = exercise.Order,
+                            MovementType = exercise.MovementType,
+                            Sets =
+                            [
+                                new UpdateExerciseSetRequest
+                                {
+                                    SetNumber = set.SetNumber,
+                                    Reps = 99, // content change triggers diff gate
+                                    WeightKg = set.WeightKg
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    // ── Unlock: acquire emits state=Editing to BOTH parties ─────────────────────
+
+    [Fact]
+    public async Task Unlock_Acquired_EmitsEditingToBothClientAndTrainer()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = LockServiceAcquired(sessionId, plan.ExternalId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 204 success
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // Must emit to the CLIENT's user id
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == plan.ExternalId &&
+                p.SessionId == sessionId &&
+                p.State == "Editing" &&
+                p.Holder == "Coach"),
+            Arg.Any<CancellationToken>());
+
+        // Must emit to the TRAINER's user id
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == plan.ExternalId &&
+                p.SessionId == sessionId &&
+                p.State == "Editing" &&
+                p.Holder == "Coach"),
+            Arg.Any<CancellationToken>());
+
+        // Exactly 2 total notifications (one per party)
+        await notifier.Received(2).NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Unlock: 409 conflict emits NOTHING ──────────────────────────────────────
+
+    [Fact]
+    public async Task Unlock_LockConflict_EmitsNothing()
+    {
+        // Arrange — session is already Live; acquire returns LockConflict
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = LockServiceConflict();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 409 and zero notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Relock: ReleaseAsync=true emits state=Stable to BOTH parties ─────────────
+
+    [Fact]
+    public async Task Relock_Released_EmitsStableToBothClientAndTrainer()
+    {
+        // Arrange — lock exists and is successfully released
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = LockServiceAcquired(sessionId, plan.ExternalId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<RelockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new RelockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 204 success
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // Must emit to the CLIENT's user id
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == plan.ExternalId &&
+                p.SessionId == sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Coach"),
+            Arg.Any<CancellationToken>());
+
+        // Must emit to the TRAINER's user id
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == plan.ExternalId &&
+                p.SessionId == sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Coach"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Relock: ReleaseAsync=false (already gone) emits NOTHING ─────────────────
+
+    [Fact]
+    public async Task Relock_AlreadyReleased_EmitsNothing()
+    {
+        // Arrange — lock already gone; ReleaseAsync returns false (idempotent no-op)
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = LockServiceNoLock(sessionId, plan.ExternalId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<RelockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new RelockTrainingSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 204 (idempotent success) and NO notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // Only emit on a real state transition (ReleaseAsync returned true)
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── UpdatePlan diff-gate: auto-release emits state=Stable to BOTH parties ───
+
+    [Fact]
+    public async Task UpdatePlan_DiffGateAutoRelease_EmitsStableToBothParties()
+    {
+        // Arrange — published session in Editing by this trainer; content changed → auto-release after save.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = LockServiceAcquired(sessionId, plan.ExternalId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, notifier);
+
+        var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate,
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions = [changedSession]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — save succeeded
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Must emit to the CLIENT's user id
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == plan.ExternalId &&
+                p.SessionId == sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Coach"),
+            Arg.Any<CancellationToken>());
+
+        // Must emit to the TRAINER's user id
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == plan.ExternalId &&
+                p.SessionId == sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Coach"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── UpdatePlan diff-gate: ReleaseAsync=false → no emit ──────────────────────
+
+    [Fact]
+    public async Task UpdatePlan_DiffGateAutoRelease_WhenReleaseReturnsFalse_EmitsNothing()
+    {
+        // Arrange — session in Editing by this trainer; but ReleaseAsync returns false (already expired).
+        // This proves the gate: only emit on a real state transition.
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPublishedSession(sessionId);
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = LockServiceNoLock(sessionId, plan.ExternalId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, notifier);
+
+        var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
+        var req = new UpdateTrainingPlanRequest
+        {
+            PlanId = plan.ExternalId,
+            Name = plan.Name,
+            Version = plan.Version,
+            StartDate = plan.StartDate,
+            Weeks =
+            [
+                new UpdateTrainingWeekRequest
+                {
+                    WeekNumber = 1,
+                    Sessions = [changedSession]
+                }
+            ]
+        };
+
+        // Act
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Assert — save succeeded (200), but NO notifications because ReleaseAsync=false
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Only emit when ReleaseAsync returns true — emitting Stable for a session
+        // that had no lock would be spurious fan-out
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainerSideEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainerSideEnforcementTests.cs
@@ -303,7 +303,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService, DefaultOptions());
+            mongo, lockService, DefaultOptions(), Substitute.For<IRealtimeNotifier>());
 
         // Act
         await ep.HandleAsync(
@@ -329,7 +329,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService, DefaultOptions());
+            mongo, lockService, DefaultOptions(), Substitute.For<IRealtimeNotifier>());
 
         // Act
         await ep.HandleAsync(
@@ -360,7 +360,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
         var req = new UpdateTrainingPlanRequest
@@ -407,7 +407,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
         var req = new UpdateTrainingPlanRequest
@@ -453,7 +453,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         var changedSession = ChangedSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
         var req = new UpdateTrainingPlanRequest
@@ -499,7 +499,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         // Request changes the reps — but this is a draft session, so no gate.
         var req = new UpdateTrainingPlanRequest
@@ -578,7 +578,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<RelockTrainingSessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         // Act
         await ep.HandleAsync(
@@ -603,7 +603,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<RelockTrainingSessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         // Act
         await ep.HandleAsync(
@@ -632,7 +632,7 @@ public class TrainerSideEnforcementTests
         var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, lockService);
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
 
         var identicalSession = IdenticalSessionRequest(plan.Weeks[0].Sessions[0], sessionId);
         var req = new UpdateTrainingPlanRequest

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanEndpointTests.cs
@@ -4,6 +4,8 @@ using FastEndpoints.Testing;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Endpoints;
@@ -37,12 +39,22 @@ public class UpdateTrainingPlanEndpointTests
         return today.AddDays(-daysBack);
     }
 
+    private static ISessionLockService StubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+        return svc;
+    }
+
     private UpdateTrainingPlanEndpoint CreateEndpoint(IMongoContext mongo) =>
         Factory.Create<UpdateTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo, StubLockService(), Substitute.For<IRealtimeNotifier>());
 
     [Fact]
     public async Task HandleAsync_ValidUpdate_Returns200()
@@ -56,7 +68,7 @@ public class UpdateTrainingPlanEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo, StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         var request = new UpdateTrainingPlanRequest
         {
@@ -87,7 +99,7 @@ public class UpdateTrainingPlanEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo, StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         var request = new UpdateTrainingPlanRequest
         {

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanFormatTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UpdateTrainingPlanFormatTests.cs
@@ -39,7 +39,8 @@ public class UpdateTrainingPlanFormatTests
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
             mongo,
-            CreateNoOpLockService());
+            CreateNoOpLockService(),
+            Substitute.For<IRealtimeNotifier>());
 
     /// <summary>Builds a minimal single-section request for a given session.</summary>
     private static UpdateSectionRequest DefaultSection(List<UpdateSessionExerciseRequest>? exercises = null) =>

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
@@ -51,7 +51,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, StubLockService());
+            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
@@ -72,7 +72,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), StubLockService());
+            mongo, StubCompletionService(), StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
@@ -89,7 +89,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), StubLockService());
+            mongo, StubCompletionService(), StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
@@ -110,7 +110,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, StubLockService());
+            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
@@ -138,7 +138,7 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, StubLockService());
+            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
@@ -1,0 +1,337 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
+using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Tests that verify the <c>sessioneditlockchanged</c> SignalR broadcast behaviour
+/// for the workout-log endpoints (issue #383).
+/// Covers:
+///   - StartWorkout: acquire Live lock → emits state=Live to BOTH clientId and trainerId
+///   - StartWorkout: 409 conflict (session in Editing) → emits NOTHING
+///   - StartWorkout: ad-hoc (no SessionId) → emits NOTHING
+///   - CompleteWorkout: plan-bound log, ReleaseAsync=true → emits state=Stable to BOTH parties
+///   - CompleteWorkout: plan-bound log, ReleaseAsync=false (already gone) → emits NOTHING
+///   - CompleteWorkout: ad-hoc log (no SessionId) → emits NOTHING
+/// </summary>
+public class SessionLockBroadcastWorkoutTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private TrainingPlan MakePlan() =>
+        new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+    private ISessionLockService AcquiredLiveService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        var lockDoc = new SessionLock
+        {
+            SessionId = _sessionId,
+            PlanId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Holder = LockHolder.Client,
+            Type = LockType.Live,
+            AcquiredAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(6)
+        };
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(lockDoc));
+        return svc;
+    }
+
+    private static ISessionLockService ConflictLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.LockConflict());
+        return svc;
+    }
+
+    private static IWorkoutCompletionService StubCompletionService()
+    {
+        var svc = Substitute.For<IWorkoutCompletionService>();
+        svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
+        return svc;
+    }
+
+    // ── StartWorkout: Live lock acquired → emits state=Live to BOTH parties ─────
+
+    [Fact]
+    public async Task StartWorkout_LiveLockAcquired_EmitsLiveToBothClientAndTrainer()
+    {
+        // Arrange — plan exists, lock acquisition succeeds (Acquired)
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var lockService = AcquiredLiveService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 201 created
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // Must emit to the CLIENT's user id
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Live" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+
+        // Must emit to the TRAINER's user id
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Live" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+
+        // Exactly 2 notifications (one per party)
+        await notifier.Received(2).NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── StartWorkout: 409 conflict → emits NOTHING ──────────────────────────────
+
+    [Fact]
+    public async Task StartWorkout_LockConflict_Returns409_EmitsNothing()
+    {
+        // Arrange — session is currently in Editing; acquire fails with LockConflict
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var lockService = ConflictLockService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 409 and zero notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── StartWorkout: ad-hoc workout (no SessionId) → emits NOTHING ─────────────
+
+    [Fact]
+    public async Task StartWorkout_AdHoc_NoSessionId_EmitsNothing()
+    {
+        // Arrange — no SessionId in request; lock path is bypassed entirely
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+        var lockService = Substitute.For<ISessionLockService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        // Act — ad-hoc workout (no PlanId, no SessionId)
+        await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
+
+        // Assert — 201 and no lock-change notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── CompleteWorkout: plan-bound, ReleaseAsync=true → emits Stable to BOTH ───
+
+    [Fact]
+    public async Task CompleteWorkout_PlanBound_ReleaseTrue_EmitsStableToBothParties()
+    {
+        // Arrange — plan-bound log (SessionId non-null); lock released → emit Stable
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        // Must include the plan in mongo so the trainer fan-out can resolve TrainerId
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+
+        var lockService = Substitute.For<ISessionLockService>();
+        lockService.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(true);
+
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<CompleteWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, StubCompletionService(), lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new CompleteWorkoutRequest { LogId = logId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 200 and two notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Must emit to the CLIENT's user id
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+
+        // Must emit to the TRAINER's user id
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── CompleteWorkout: ReleaseAsync=false → emits NOTHING ─────────────────────
+
+    [Fact]
+    public async Task CompleteWorkout_PlanBound_ReleaseFalse_EmitsNothing()
+    {
+        // Arrange — plan-bound log but lock was already gone; ReleaseAsync returns false
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+
+        var lockService = Substitute.For<ISessionLockService>();
+        // ReleaseAsync returns false — lock was already expired or released
+        lockService.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(false);
+
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<CompleteWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, StubCompletionService(), lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new CompleteWorkoutRequest { LogId = logId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 200 and NO lock-change notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Only emit on a real state transition (ReleaseAsync=true)
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── CompleteWorkout: ad-hoc (no SessionId) → emits NOTHING ──────────────────
+
+    [Fact]
+    public async Task CompleteWorkout_AdHoc_NoSessionId_EmitsNothing()
+    {
+        // Arrange — ad-hoc log with no SessionId (no lock was acquired)
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId); // no SessionId
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var lockService = Substitute.For<ISessionLockService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<CompleteWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, StubCompletionService(), lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new CompleteWorkoutRequest { LogId = logId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 200 and NO lock-change notifications
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+
+        // Lock release must not have been called on ad-hoc workouts
+        await lockService.DidNotReceive().ReleaseAsync(
+            Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
@@ -86,7 +86,7 @@ public class SessionLockEnforcementTests
         return Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, DefaultLockOptions());
+            mongo, lockService, DefaultLockOptions(), Substitute.For<IRealtimeNotifier>());
     }
 
     // ── StartWorkout tests ────────────────────────────────────────────────────
@@ -209,7 +209,7 @@ public class SessionLockEnforcementTests
         return Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, lockService);
+            mongo, completionService, lockService, Substitute.For<IRealtimeNotifier>());
     }
 
     [Fact]

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
@@ -46,7 +46,7 @@ public class StartWorkoutEndpointTests
         return Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, LockOptions);
+            mongo, lockService, LockOptions, Substitute.For<IRealtimeNotifier>());
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class StartWorkoutEndpointTests
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
         var ep = Factory.Create<StartWorkoutEndpoint>(
-            mongo, CreateNoOpLockService(), LockOptions);
+            mongo, CreateNoOpLockService(), LockOptions, Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 

--- a/mobile/app/(client)/(tabs)/_layout.tsx
+++ b/mobile/app/(client)/(tabs)/_layout.tsx
@@ -250,6 +250,23 @@ export default function ClientTabLayout() {
         queryClient.invalidateQueries({ queryKey: ['personal-records-latest'] });
         queryClient.invalidateQueries({ queryKey: ['personal-records-all'] });
       }),
+      onEvent('sessioneditlockchanged', (raw: unknown) => {
+        const payload = raw as {
+          planId: string;
+          sessionId: string;
+          state: 'Stable' | 'Editing' | 'Live';
+          holder: 'Coach' | 'Client';
+        };
+        // Refresh the today training card so lock-state reads are current.
+        queryClient.invalidateQueries({ queryKey: ['today-training'] });
+        // Refresh the full training plan detail for the specific plan (same
+        // predicate pattern as trainingPlanPublished above).
+        queryClient.invalidateQueries({
+          predicate: (q) =>
+            q.queryKey[0] === 'training-full-plan' &&
+            q.queryKey[1] === payload.planId,
+        });
+      }),
     ];
 
     return () => {

--- a/mobile/src/api/signalr.ts
+++ b/mobile/src/api/signalr.ts
@@ -51,6 +51,10 @@ const KNOWN_EVENTS = [
   'photodiaryaccepted',
   'photodiarydismissed',
   'photodiaryphotouploaded',
+  // Session edit-lock state change: fires when a training session lock is
+  // acquired or released (Stable→Editing→Live and back to Stable).
+  // Payload: { planId: string, sessionId: string, state: 'Stable'|'Editing'|'Live', holder: 'Coach'|'Client' }
+  'sessioneditlockchanged',
 ]
 
 function createConnection(): HubConnection {

--- a/web/src/api/sessionEditLockEvent.ts
+++ b/web/src/api/sessionEditLockEvent.ts
@@ -23,6 +23,9 @@
  */
 export type SessionLockState = 'Stable' | 'Editing' | 'Live';
 
+/** Role of the party holding (or that released) the lock. */
+export type LockHolderRole = 'Coach' | 'Client';
+
 export interface SessionEditLockChangedEvent {
   /** Training plan public identifier (MongoDB planId). */
   planId: string;
@@ -34,10 +37,12 @@ export interface SessionEditLockChangedEvent {
   state: SessionLockState;
 
   /**
-   * Public identifier of the user who holds the lock.
-   * null when state = "Stable" (no holder).
+   * Role of the party that triggered the transition — "Coach" when a trainer
+   * acquired/released the lock, "Client" when a client started/finished a
+   * workout. Always non-null (the backend `string Holder` is never omitted),
+   * including on Stable/release events where it names who released.
    */
-  holder: string | null;
+  holder: LockHolderRole;
 }
 
 /**
@@ -55,6 +60,6 @@ export function isSessionEditLockChangedEvent(
     typeof p.planId === 'string' &&
     typeof p.sessionId === 'string' &&
     (p.state === 'Stable' || p.state === 'Editing' || p.state === 'Live') &&
-    (p.holder === null || typeof p.holder === 'string')
+    (p.holder === 'Coach' || p.holder === 'Client')
   );
 }

--- a/web/src/api/sessionEditLockEvent.ts
+++ b/web/src/api/sessionEditLockEvent.ts
@@ -1,0 +1,60 @@
+/**
+ * Hand-written TypeScript mirror of the C# SessionEditLockChangedEvent DTO.
+ *
+ * This event is broadcast over SignalR only (no REST endpoint), so it will not
+ * appear in generated.ts.  Do NOT move these types into generated.ts — it is
+ * auto-generated and write-locked.
+ *
+ * Source of truth:
+ *   backend/FitnessPlatform.Application/Features/TrainingPlans/ (emitted at
+ *   call sites: StartWorkout, CompleteWorkout, Unlock/Relock, UpdateTrainingPlan,
+ *   PublishTrainingWeek)
+ *
+ * SignalR event name: "sessioneditlockchanged"  (hub convention: lowercase)
+ *
+ * Payload fields are camelCased on the wire (System.Text.Json default).
+ */
+
+/**
+ * Lock state values:
+ *  - "Stable"  — session is unlocked, no active editor
+ *  - "Editing" — trainer has unlocked the session for editing
+ *  - "Live"    — client is in an active workout session
+ */
+export type SessionLockState = 'Stable' | 'Editing' | 'Live';
+
+export interface SessionEditLockChangedEvent {
+  /** Training plan public identifier (MongoDB planId). */
+  planId: string;
+
+  /** Session identifier within the plan. */
+  sessionId: string;
+
+  /** New lock state after the transition. */
+  state: SessionLockState;
+
+  /**
+   * Public identifier of the user who holds the lock.
+   * null when state = "Stable" (no holder).
+   */
+  holder: string | null;
+}
+
+/**
+ * Runtime type guard for `SessionEditLockChangedEvent`.
+ *
+ * Use this whenever consuming the raw SignalR payload to catch backend shape
+ * drift early and avoid silent `undefined` access.
+ */
+export function isSessionEditLockChangedEvent(
+  payload: unknown,
+): payload is SessionEditLockChangedEvent {
+  if (typeof payload !== 'object' || payload === null) return false;
+  const p = payload as Partial<Record<string, unknown>>;
+  return (
+    typeof p.planId === 'string' &&
+    typeof p.sessionId === 'string' &&
+    (p.state === 'Stable' || p.state === 'Editing' || p.state === 'Live') &&
+    (p.holder === null || typeof p.holder === 'string')
+  );
+}

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import { useToastStore } from '@/stores/toast';
 import { useTrainingPlanStore } from '@/stores/trainingPlan';
 import { isTrainingProgressUpdatedEvent } from '@/api/trainingProgressEvent';
 import { isPersonalRecordAchievedEvent } from '@/api/personalRecordEvent';
+import { isSessionEditLockChangedEvent } from '@/api/sessionEditLockEvent';
 import { weeklyCheckInKeys } from '@/hooks/useWeeklyCheckIns';
 
 const DARK_MODE_KEY = 'gf-dark-mode';
@@ -269,6 +270,38 @@ export function AppShell() {
       const data = payload as { id?: string } | undefined;
       void data; // payload available for future fine-grained invalidation
       queryClient.invalidateQueries({ queryKey: weeklyCheckInKeys.all });
+    },
+    sessioneditlockchanged: (payload: unknown) => {
+      if (import.meta.env.DEV) {
+        console.debug('sessioneditlockchanged', payload);
+      }
+      if (!isSessionEditLockChangedEvent(payload)) {
+        if (import.meta.env.DEV) {
+          console.warn('sessioneditlockchanged: invalid payload shape', payload);
+        }
+        return;
+      }
+
+      // The trainer's main dashboard table shows per-client training activity.
+      // A lock change (session started, completed, or trainer unlock/relock) is
+      // a training-state transition that may affect compliance, activity rows,
+      // and session status indicators.
+      // Key shape verified: DashboardPage.tsx line 105 uses ['dashboard-summary'].
+      queryClient.invalidateQueries({ queryKey: ['dashboard-summary'] });
+
+      // If the trainer currently has this plan open in the editor, reload the
+      // plan from the server so lock state will be picked up once #384 adds the
+      // per-session lock fields to the plan response.  The existing
+      // `refreshCompletions()` path re-fetches the whole plan and merges the
+      // fresh data without clobbering unsaved trainer edits.
+      // We also invalidate ['client-dashboard', clientId] here because the plan
+      // is open and we have the clientId in scope.
+      const tp = useTrainingPlanStore.getState();
+      if (tp.plan && tp.plan.planId === payload.planId) {
+        void tp.refreshCompletions();
+        // Key shape verified: ClientDetailPage.tsx line 27 uses ['client-dashboard', id].
+        queryClient.invalidateQueries({ queryKey: ['client-dashboard', tp.plan.clientId] });
+      }
     },
     typing: (payload: unknown) => {
       const data = payload as { conversationId?: string; senderId?: string } | undefined;


### PR DESCRIPTION
## Summary

Realtime SignalR wiring for the training session edit-lock epic (#379). The backend emits `sessioneditlockchanged` on every session-lock acquire/release; web and mobile consume it to keep TanStack Query caches fresh without polling. Infrastructure only — lock-state UI lands in #384 (web) and #385 (mobile).

Part of #379.

## Backend
- New `Domain/Documents/SessionLockChangedPayload.cs` — payload `{ planId, sessionId, state, holder }`. `State`/`Holder` are **strings** (not enums) deliberately, so the SignalR wire shape is stable string values (`"Editing"|"Live"|"Stable"`, `"Coach"|"Client"`) regardless of STJ enum config.
- Emit at the 6 lock acquire/release call sites (not inside the lock service — `ReleaseAsync` returns `bool` and can't read the doc for fan-out; the service seam is Infrastructure and shouldn't carry realtime concerns):
  - **Acquire:** `StartWorkout` (Live), `UnlockTrainingSession` (Editing)
  - **Release:** `CompleteWorkout`, `RelockTrainingSession`, `UpdateTrainingPlan` (diff-gate auto-release loop), `PublishTrainingWeek` (defensive cleanup loop)
- Fan-out to **both** the client and trainer UserId groups. Emit only on an actual transition (acquire success; release gated on `ReleaseAsync == true`) so the publish/diff-gate loops don't emit spurious `Stable` events for never-locked sessions. 409 conflict path emits nothing.
- 2 new broadcast test classes (`SessionLockBroadcastTests`, `SessionLockBroadcastWorkoutTests`) assert both-group fan-out per call site.

### Incidental fix
- `cbc4958` repairs `MarkExerciseCompleteEndpointTests` — a **pre-existing** regression escaped from PR #390 (#382): that PR added `ISessionLockService` + `IOptions<TrainingLockOptions>` to the endpoint's primary constructor for TTL-refresh but didn't update the test's `Factory.Create` args, leaving 11 tests red on the epic branch (`MissingMethodException`). Mirrored the sibling `MarkSectionComplete` test setup; ClientTraining slice now green.

## Web
- Typed runtime guard `web/src/api/sessionEditLockEvent.ts` (no `any`).
- Handler registered in `AppShell.tsx`. No phantom query key — the trainer plan editor loads imperatively into a Zustand store, so the handler invalidates only existing keys.

## Mobile
- Handler in `app/(client)/(tabs)/_layout.tsx` invalidating `['today-training']` + `['training-full-plan', planId]` (predicate).
- `'sessioneditlockchanged'` appended to `KNOWN_EVENTS` in `src/api/signalr.ts`.

## Verification
- Backend: `dotnet build` clean; broadcast tests 12/12; `MarkExerciseCompleteEndpointTests` 11/11.
- Web: `npm run build` ✅ (typecheck included).
- Mobile: `npx tsc --noEmit` ✅. `expo-doctor` 18/19 — the 1 failing check is pre-existing SDK pin drift (22 pkgs); this diff changes no `package.json`/lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
