### PR TITLE
feat(#385): client coach-updating banner + start-blocked 409 toast

### DIFF
--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -40,8 +40,10 @@ import { Radius } from '@/constants/radius'
 import { href } from '@/lib/navigation'
 import { useNetworkStatus } from '@/hooks/useNetworkStatus'
 
+import axios from 'axios'
 import { startWorkout, updateWorkout, completeWorkout } from '@/api/workouts'
 import type { UpdateWorkoutRequest } from '@/api/workouts'
+import { Toast } from '@/lib/toast'
 import type {
   SessionExercise,
   ExerciseSet,
@@ -2301,7 +2303,18 @@ export default function WorkoutLogScreen() {
         })
         const newLogId = resp.logId ?? null
         if (newLogId) setLoadedLogId(newLogId)
-      } catch {
+      } catch (err) {
+        // AC (b): 409 with error_code "session_locked" → toast, not generic alert.
+        // The banner (SessionEditingBanner) is a cosmetic warning; the 409 is the
+        // authoritative gate — a trainer finished editing between banner render and tap.
+        if (
+          axios.isAxiosError(err) &&
+          err.response?.status === 409 &&
+          (err.response.data as { error_code?: string } | undefined)?.error_code === 'session_locked'
+        ) {
+          Toast.show(t('training.sessionEditing.startBlockedToast'))
+          return
+        }
         Alert.alert(t('common.error'), t('training.startError'))
       }
     }

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -2304,13 +2304,15 @@ export default function WorkoutLogScreen() {
         const newLogId = resp.logId ?? null
         if (newLogId) setLoadedLogId(newLogId)
       } catch (err) {
-        // AC (b): 409 with error_code "session_locked" → toast, not generic alert.
-        // The banner (SessionEditingBanner) is a cosmetic warning; the 409 is the
-        // authoritative gate — a trainer finished editing between banner render and tap.
+        // AC (b): 409 with Problem Details errorCode "session_locked" → toast, not
+        // generic alert. The backend writes the code into ProblemDetails.Extensions
+        // under the verbatim key "errorCode" (camelCase). The banner is a cosmetic
+        // warning; the 409 is the authoritative gate — a trainer finished editing
+        // between banner render and tap.
         if (
           axios.isAxiosError(err) &&
           err.response?.status === 409 &&
-          (err.response.data as { error_code?: string } | undefined)?.error_code === 'session_locked'
+          (err.response.data as { errorCode?: string } | undefined)?.errorCode === 'session_locked'
         ) {
           Toast.show(t('training.sessionEditing.startBlockedToast'))
           return

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -53,9 +53,19 @@ export type SectionDto = Omit<GeneratedSectionDto, 'exercises'> & {
  * Augmented SessionDto — propagates SectionDto augmentation so
  * `response.weeks[i].sessions[j].sections[k].formatConfig` is typed correctly
  * without per-call casts.
+ * Also adds `lockState` which the backend (#382) now includes in GetFullTrainingPlan
+ * responses. Drop once regen produces this field natively.
  */
 export type SessionDto = Omit<GeneratedSessionDto, 'sections'> & {
   sections?: SectionDto[];
+  /**
+   * Session edit-lock state from the backend.
+   * "Stable"  — no active lock; normal operation.
+   * "Editing" — a trainer currently holds the edit lock; banner should be shown.
+   * "Live"    — the client's own live session is in progress; no banner.
+   * Defaults to "Stable" when the field is absent (pre-#382 response shape).
+   */
+  lockState?: string;
 };
 
 /**
@@ -91,9 +101,15 @@ export type {
 } from './wod-types';
 
 /**
- * @deprecated Use `GetTodaySessionResponse` from generated. Kept as alias for backward compatibility.
+ * Augmented GetTodaySessionResponse — adds `lockStateBySession` which the
+ * backend (#382) now includes. Drop once regen produces this field natively.
+ *
+ * Key: sessionId (string UUID). Value: lock state string ("Stable", "Editing", "Live").
+ * Missing key → treat as "Stable".
  */
-export type TodayTrainingResponse = GetTodaySessionResponse;
+export type TodayTrainingResponse = GetTodaySessionResponse & {
+  lockStateBySession?: Record<string, string>;
+};
 
 /**
  * @deprecated Use `GetFullTrainingPlanResponse` from generated. Kept as alias for backward compatibility.

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -30,6 +30,7 @@ import {
   type FullPlanResponse,
 } from '@/api/nutrition'
 import { getTodaySession, type TodayTrainingResponse, type TrainingSession } from '@/api/training'
+// NOTE: TodayTrainingResponse is augmented in training.ts to include lockStateBySession.
 import {
   markExerciseComplete,
   markExerciseIncomplete,
@@ -1307,6 +1308,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               lockedSessionIds={lockedSessionIds}
               exerciseMuscleGroups={training?.exerciseMuscleGroups ?? {}}
               completedSetsBySessionExercise={trainingQuery.data?.completedSetsBySessionExercise ?? {}}
+              lockStateBySession={trainingQuery.data?.lockStateBySession ?? {}}
               onMarkAllTrainingDone={handleMarkAllTrainingDone}
               isMarkAllTrainingLoading={markAllTrainingDoneMutation.isPending}
             />

--- a/mobile/src/components/today/SessionEditingBanner.tsx
+++ b/mobile/src/components/today/SessionEditingBanner.tsx
@@ -1,0 +1,73 @@
+/**
+ * SessionEditingBanner — gold warning banner shown when a session's LockState
+ * is "Editing" (a trainer currently holds the edit lock).
+ *
+ * AC (a) — spec §9: cosmetic warning banner only.
+ * The Start button STAYS TAPPABLE — this is NOT a hard block.
+ * Banner hidden for "Stable", "Live", or missing lock state (treated as Stable).
+ */
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { goldAlpha } from '@/constants/colors'
+
+interface SessionEditingBannerProps {
+  /** Session edit-lock state from the backend. Banner renders only when "Editing". */
+  lockState?: string | undefined
+}
+
+export function SessionEditingBanner({ lockState }: SessionEditingBannerProps) {
+  const { t } = useTranslation()
+  const colors = useTheme()
+
+  // Banner is only shown while state is explicitly "Editing".
+  // "Stable", "Live", null, undefined → hidden.
+  if (lockState !== 'Editing') return null
+
+  return (
+    <View
+      style={[
+        styles.banner,
+        {
+          backgroundColor: goldAlpha['12'],
+          borderColor: goldAlpha['35'],
+        },
+      ]}
+    >
+      <Ionicons name="warning-outline" size={16} color={colors.gold} style={styles.icon} />
+      <Text style={[styles.text, { color: colors.gold }]}>
+        {t('training.sessionEditing.bannerMessage')}
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: Radius.sm,
+    borderWidth: 1,
+    gap: 8,
+  },
+  icon: {
+    flexShrink: 0,
+  },
+  text: {
+    ...Type.footnote,
+    fontWeight: '600',
+    flex: 1,
+    flexWrap: 'wrap',
+  },
+})
+
+export default SessionEditingBanner

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -20,6 +20,7 @@ import { SetGrid } from '@/components/training/SetGrid'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
 import type { TrainingSession, TrainingSection, MuscleGroup } from '@/api/training'
 import type { SessionCtaState } from './trainingCardHelpers'
+import { SessionEditingBanner } from '@/components/today/SessionEditingBanner'
 
 // ─── Section fallback ──────────────────────────────────────────────────────────
 
@@ -135,6 +136,13 @@ interface TrainingCardProps {
   onMarkAllTrainingDone?: () => void
   /** True while the markWholeDayComplete mutation is in flight. */
   isMarkAllTrainingLoading?: boolean
+  /**
+   * Per-session edit-lock state map, keyed by sessionId.
+   * Value is "Stable" | "Editing" | "Live".
+   * Missing key → treat as "Stable" (no banner).
+   * Sourced from GetTodaySessionResponse.lockStateBySession (#382).
+   */
+  lockStateBySession?: Record<string, string>
 }
 
 // ─── formatSets ───────────────────────────────────────────────────────────────
@@ -256,6 +264,7 @@ export function TrainingCard({
   completedSetsBySessionExercise = {},
   onMarkAllTrainingDone,
   isMarkAllTrainingLoading,
+  lockStateBySession = {},
 }: TrainingCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -445,6 +454,7 @@ export function TrainingCard({
               session={session}
               exerciseMuscleGroups={exerciseMuscleGroups}
               completedSetsBySessionExercise={completedSetsBySessionExercise[sessionId] ?? {}}
+              sessionLockState={lockStateBySession[session.sessionId ?? ''] ?? 'Stable'}
               onToggleExercise={onToggleExercise}
               onToggleExercises={onToggleExercises}
               onToggleSection={onToggleSection}
@@ -513,6 +523,12 @@ interface SessionSectionListProps {
   session: TrainingSession
   exerciseMuscleGroups: Record<string, MuscleGroup[]>
   completedSetsBySessionExercise: Record<string, number[]>
+  /**
+   * Edit-lock state for this specific session.
+   * "Editing" → show the gold warning banner above the CTA.
+   * "Stable" / "Live" / anything else → no banner.
+   */
+  sessionLockState?: string
   onToggleExercise?: (sessionId: string, sectionId: string, exerciseExternalId: string) => void
   /** Batch variant — dispatches N exercise toggles sequentially to avoid version-token races. */
   onToggleExercises?: (sessionId: string, sectionId: string, exerciseIds: string[], complete: boolean) => void
@@ -540,6 +556,7 @@ function SessionSectionList({
   session,
   exerciseMuscleGroups,
   completedSetsBySessionExercise,
+  sessionLockState,
   onToggleExercise,
   onToggleExercises,
   onToggleSection,
@@ -799,6 +816,10 @@ function SessionSectionList({
                   </View>
                 )
               })}
+
+              {/* Session editing banner — shown when a trainer holds the edit lock.
+                  AC (a): cosmetic warning only; Start button remains tappable. */}
+              <SessionEditingBanner lockState={sessionLockState} />
 
               {/* Per-session CTA footer — ctaState and onSessionCta are non-null when showCta is true */}
               {showCta && ctaState != null && onSessionCta != null && (

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -1020,6 +1020,10 @@
       "sectionOf": "Sekce {{current}} ze {{total}}",
       "sectionActionDetail": "Detail",
       "completeA11y": "Označit celou sekci jako hotovou"
+    },
+    "sessionEditing": {
+      "bannerMessage": "Trenér právě upravuje tento trénink — potvrďte, než začnete.",
+      "startBlockedToast": "Trenér ještě nedokončil úpravy. Chvíli počkejte a zkuste to znovu."
     }
   },
   "muscleGroup": {

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -981,6 +981,10 @@
       "sectionOf": "Abschnitt {{current}} von {{total}}",
       "sectionActionDetail": "Detail",
       "completeA11y": "Gesamten Abschnitt als erledigt markieren"
+    },
+    "sessionEditing": {
+      "bannerMessage": "Dein Trainer aktualisiert gerade diese Einheit — bitte bestätige vor dem Start.",
+      "startBlockedToast": "Dein Trainer hat die Bearbeitung noch nicht abgeschlossen. Bitte warte einen Moment und versuche es erneut."
     }
   },
   "muscleGroup": {

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -759,6 +759,10 @@
       "sectionOf": "Section {{current}} of {{total}}",
       "sectionActionDetail": "Detail",
       "completeA11y": "Mark whole section as done"
+    },
+    "sessionEditing": {
+      "bannerMessage": "Your coach is updating this session — confirm before you start.",
+      "startBlockedToast": "Your coach hasn't finished editing yet. Please wait a moment and try again."
     }
   },
   "muscleGroup": {


### PR DESCRIPTION
## Summary

Mobile client UI for the training session edit-lock epic (#379). Surfaces a coach-updating warning banner and handles the Start-blocked 409 as a toast — keeping the server as the authoritative gate.

Part of #379. Builds on #383 (SignalR consumer) and #382 (client read lock state).

## Changes
- **`SessionEditingBanner.tsx`** (new) — gold warning banner "Your coach is updating this session — confirm before you start." Renders **only** when `lockState === 'Editing'` (hidden on Stable/Live/missing).
- **Today screen** — banner mounted on the session-card path (`HasTrainerState` → `TrainingCard`, keyed off `lockStateBySession[sessionId]`).
- **`training-session/[id].tsx`** — Start button stays tappable when Editing; a `StartWorkout` 409 with Problem Details `error_code === 'session_locked'` routes to a **Toast** (non-lock errors fall through to the generic Alert). The prototype's disabled-button hard block was intentionally **not** copied — spec §9 + AC make the server 409 the gate.
- **i18n** — `training.sessionEditing.{bannerMessage,startBlockedToast}` in cs/en/de.
- All colors/spacing via `useTheme()` tokens; no inline hex.

## Prototype-fidelity note
`docs/prototypes/mobile/scenes/session-lock.html` renders Start as disabled with a hard "cannot start" card. Per the design review (spec §9 is authoritative), this was deliberately rejected: Start stays tappable, the banner is cosmetic, and the 409 toast is the feedback path.

## Verification
- `npx tsc --noEmit` ✅ clean.
- `npx expo-doctor` ✅ 19/19.
- QA gate: ✅ PASS (all 5 ACs).

## Known NIT (for reviewer)
`SessionDto.lockState` was mapped in `training.ts` for the full-plan response but is not yet consumed (no banner on the full-plan/detail screens — the AC anchors the banner to the Today session card, which is satisfied). Either wire a banner there in a follow-up or drop the unused mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
