### PR TITLE
feat(#384): trainer portal lock UI + read-model prereq + StartWorkout #394 fix

### DIFF
--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using MongoDB.Driver;
@@ -12,9 +13,14 @@ namespace FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
 /// Retrieves a single training plan with full detail (weeks, sessions, exercises, sets).
 /// Also returns per-session WorkoutLog execution data so the web layer can render
 /// completed / skipped / not-yet-reached indicators on each set.
+/// Also enriches each session with its current edit-lock state (Stable/Editing/Live) and
+/// holder (Coach/Client/null) via a single batch <c>GetStateAsync</c> call on the lock service.
+/// This gives the trainer plan editor the initial lock state on page load, so the Live
+/// in-progress badge and unlock affordance are correct before any SignalR events arrive.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
-public class GetTrainingPlanEndpoint(IMongoContext mongo) : Endpoint<GetTrainingPlanRequest, GetTrainingPlanResponse>
+/// <param name="lockService">Session lock service — used to batch-fetch lock state.</param>
+public class GetTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lockService) : Endpoint<GetTrainingPlanRequest, GetTrainingPlanResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -162,6 +168,28 @@ public class GetTrainingPlanEndpoint(IMongoContext mongo) : Endpoint<GetTraining
                         IsSessionFinished = log.IsCompleted,
                         CompletedSetsByExercise = completedSetsByExercise
                     };
+                })
+                .ToList();
+        }
+
+        // ── 3. Batch-fetch session lock state ────────────────────────────────────
+        // Single Mongo round-trip — not one per session. Mirrors the pattern used
+        // in GetFullTrainingPlanEndpoint (client read) so the shape is consistent.
+        var allSessionIds = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .Select(s => s.SessionId)
+            .ToList();
+
+        if (allSessionIds.Count > 0)
+        {
+            var lockDocs = await lockService.GetStateAsync(allSessionIds, ct);
+
+            response.SessionLockStates = lockDocs
+                .Select(l => new SessionLockStateDto
+                {
+                    SessionId = l.SessionId,
+                    LockState = l.Type.ToString(),
+                    LockHolder = l.Holder.ToString()
                 })
                 .ToList();
         }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
@@ -3,6 +3,32 @@ using FitnessPlatform.Application.Domain.Documents;
 namespace FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
 
 /// <summary>
+/// Per-session edit-lock state projected into the trainer read model.
+/// A session with no active lock document reports <c>Stable</c> with a null holder.
+/// </summary>
+public class SessionLockStateDto
+{
+    /// <summary>
+    /// The <see cref="TrainingSession.SessionId"/> this lock state belongs to.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// Current lock state of this session.
+    /// Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+    /// "Live" (client has an in-progress workout lock).
+    /// Populated via a batch <c>GetStateAsync</c> call on the session lock service.
+    /// </summary>
+    public string LockState { get; set; } = "Stable";
+
+    /// <summary>
+    /// Who currently holds the lock, if any.
+    /// Possible values: "Coach", "Client", or null when the session is Stable.
+    /// </summary>
+    public string? LockHolder { get; set; }
+}
+
+/// <summary>
 /// Per-set execution data returned by the trainer endpoint.
 /// Lets the web layer derive completed / skipped / not-yet-reached states
 /// without storing those as flags on the document.
@@ -162,6 +188,15 @@ public class GetTrainingPlanResponse
     /// per-exercise, and per-session completed/skipped/unreached state indicators.
     /// </summary>
     public List<SessionExecutionDto> SessionExecutions { get; set; } = [];
+
+    /// <summary>
+    /// Per-session edit-lock state for all sessions in the plan.
+    /// Only sessions with an active (non-expired) lock appear here; a session absent from
+    /// this list is implicitly <c>Stable</c>.
+    /// The web editor uses this on initial load to show the Live in-progress badge and gate
+    /// the unlock affordance — SignalR events update this state while the page is open.
+    /// </summary>
+    public List<SessionLockStateDto> SessionLockStates { get; set; } = [];
 
     /// <summary>
     /// Maps a <see cref="TrainingPlan"/> document to a detailed response DTO.

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
@@ -5,8 +5,10 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
@@ -21,11 +23,13 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 /// Emits <c>sessioneditlockchanged</c> (state=Live) to both client and trainer on successful acquire.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context — used to resolve the caller's ClientProfile.PublicId.</param>
 /// <param name="lockService">Session lock service.</param>
 /// <param name="lockOptions">Training lock TTL configuration.</param>
 /// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
 public class StartWorkoutEndpoint(
     IMongoContext mongo,
+    IApplicationDbContext db,
     ISessionLockService lockService,
     IOptions<TrainingLockOptions> lockOptions,
     IRealtimeNotifier notifier) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
@@ -54,7 +58,12 @@ public class StartWorkoutEndpoint(
             return;
         }
 
-        var clientId = Guid.Parse(userId);
+        // clientUserIdGuid is the ApplicationUser.Id (what JWT AppClaims.UserId stores).
+        // It is used for:
+        //   1. WorkoutLog.ClientId — the log is owned by the user id.
+        //   2. AcquireAsync clientId arg — SignalR groups connections by ApplicationUser.Id,
+        //      so realtime events (sessioneditlockchanged) must target the user id, not the profile id.
+        var clientUserIdGuid = Guid.Parse(userId);
         var now = DateTime.UtcNow;
 
         // ── Live lock acquisition (plan-bound workouts only) ──────────────────────
@@ -62,6 +71,20 @@ public class StartWorkoutEndpoint(
         // there is no session to gate and no trainer who could be editing.
         if (req.PlanId.HasValue && req.SessionId.HasValue)
         {
+            // Resolve the caller's ClientProfile.PublicId — this is what TrainingPlan.ClientId stores.
+            // (TrainingPlan.ClientId = ClientProfile.PublicId, NOT ApplicationUser.Id.)
+            var clientProfile = await db.ClientProfiles
+                .AsNoTracking()
+                .FirstOrDefaultAsync(cp => cp.UserId == clientUserIdGuid, ct);
+
+            if (clientProfile is null)
+            {
+                await Send.NotFoundAsync(ct);
+                return;
+            }
+
+            var profilePublicId = clientProfile.PublicId;
+
             // Load the plan to resolve trainerId and validate ownership.
             var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId.Value);
             using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
@@ -73,18 +96,22 @@ public class StartWorkoutEndpoint(
                 return;
             }
 
-            // Ownership check: the plan must belong to this client.
-            if (plan.ClientId != clientId)
+            // Ownership check: TrainingPlan.ClientId holds the ClientProfile.PublicId.
+            // Compare against the resolved publicId, NOT the ApplicationUser.Id.
+            if (plan.ClientId != profilePublicId)
             {
                 await Send.ForbiddenAsync(ct);
                 return;
             }
 
             var liveTtl = TimeSpan.FromHours(lockOptions.Value.LiveTtlHours);
+            // AcquireAsync clientId must be the ApplicationUser.Id (clientUserIdGuid), not the
+            // profile PublicId — SessionLock.ClientId feeds SignalR fan-out via IRealtimeNotifier
+            // which routes by ApplicationUser.Id (NotificationHub groups connections by user id).
             var acquireResult = await lockService.AcquireAsync(
                 req.SessionId.Value,
                 req.PlanId.Value,
-                clientId,
+                clientUserIdGuid,
                 plan.TrainerId,
                 LockHolder.Client,
                 LockType.Live,
@@ -110,7 +137,7 @@ public class StartWorkoutEndpoint(
                     "Live",
                     "Client");
 
-                await notifier.NotifyAsync(clientId, "sessioneditlockchanged", payload, ct);
+                await notifier.NotifyAsync(clientUserIdGuid, "sessioneditlockchanged", payload, ct);
                 await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
             }
         }
@@ -118,7 +145,7 @@ public class StartWorkoutEndpoint(
         var log = new WorkoutLog
         {
             ExternalId = Guid.NewGuid(),
-            ClientId = clientId,
+            ClientId = clientUserIdGuid,
             PlanId = req.PlanId,
             SessionId = req.SessionId,
             StartedAt = now,

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanEndpointTests.cs
@@ -25,7 +25,8 @@ public class GetTrainingPlanEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
 
         await ep.HandleAsync(new GetTrainingPlanRequest { PlanId = planId }, TestContext.Current.CancellationToken);
 
@@ -42,7 +43,8 @@ public class GetTrainingPlanEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
 
         await ep.HandleAsync(new GetTrainingPlanRequest { PlanId = plan.ExternalId }, TestContext.Current.CancellationToken);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLockStateTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLockStateTests.cs
@@ -1,0 +1,148 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
+using FitnessPlatform.Tests.Endpoints;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the per-session edit-lock state projection added to
+/// <see cref="GetTrainingPlanEndpoint"/> as the backend prerequisite for #384.
+/// Verifies the three lock state scenarios:
+/// <list type="bullet">
+///   <item><description>(a) No active lock → SessionLockStates is empty (Stable implied).</description></item>
+///   <item><description>(b) Session has an active Editing lock held by Coach → appears in SessionLockStates.</description></item>
+///   <item><description>(c) Session has an active Live lock held by Client → appears in SessionLockStates.</description></item>
+/// </list>
+/// </summary>
+public class GetTrainingPlanLockStateTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    // ── Helper builders ───────────────────────────────────────────────────────
+
+    private TrainingPlan BuildPlanWithSession()
+    {
+        return new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Lock State Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = _sessionId,
+                            Name = "Push Day",
+                            DayOfWeek = 1,
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+    }
+
+    private SessionLock BuildLock(LockType type, LockHolder holder)
+    {
+        return new SessionLock
+        {
+            SessionId = _sessionId,
+            PlanId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Type = type,
+            Holder = holder,
+            AcquiredAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddHours(2)
+        };
+    }
+
+    private async Task<GetTrainingPlanResponse?> ExecuteAsync(params SessionLock[] locks)
+    {
+        var plan = BuildPlanWithSession();
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+        var lockService = TrainingPlanTestHelpers.CreateLockServiceWith(locks);
+
+        var ep = Factory.Create<GetTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo,
+            lockService);
+
+        await ep.HandleAsync(
+            new GetTrainingPlanRequest { PlanId = _planId },
+            TestContext.Current.CancellationToken);
+
+        return ep.HttpContext.Response.StatusCode == 200 ? ep.Response : null;
+    }
+
+    // ── Test cases ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// (a) No active lock → <c>SessionLockStates</c> is empty.
+    /// A session absent from the list is implicitly Stable.
+    /// </summary>
+    [Fact]
+    public async Task GetPlan_NoActiveLock_SessionLockStatesIsEmpty()
+    {
+        var response = await ExecuteAsync(); // no locks
+
+        response.Should().NotBeNull();
+        response!.SessionLockStates.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// (b) Session has an active Editing lock held by Coach →
+    /// <c>SessionLockStates</c> contains one entry with LockState="Editing" and LockHolder="Coach".
+    /// </summary>
+    [Fact]
+    public async Task GetPlan_SessionWithEditingLock_ReturnsEditingCoach()
+    {
+        var editingLock = BuildLock(LockType.Editing, LockHolder.Coach);
+
+        var response = await ExecuteAsync(editingLock);
+
+        response.Should().NotBeNull();
+        response!.SessionLockStates.Should().ContainSingle(ls =>
+            ls.SessionId == _sessionId &&
+            ls.LockState == "Editing" &&
+            ls.LockHolder == "Coach");
+    }
+
+    /// <summary>
+    /// (c) Session has an active Live lock held by Client →
+    /// <c>SessionLockStates</c> contains one entry with LockState="Live" and LockHolder="Client".
+    /// </summary>
+    [Fact]
+    public async Task GetPlan_SessionWithLiveLock_ReturnsLiveClient()
+    {
+        var liveLock = BuildLock(LockType.Live, LockHolder.Client);
+
+        var response = await ExecuteAsync(liveLock);
+
+        response.Should().NotBeNull();
+        response!.SessionLockStates.Should().ContainSingle(ls =>
+            ls.SessionId == _sessionId &&
+            ls.LockState == "Live" &&
+            ls.LockHolder == "Client");
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanSessionExecutionTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanSessionExecutionTests.cs
@@ -141,7 +141,8 @@ public class GetTrainingPlanSessionExecutionTests
         var ep = Factory.Create<GetTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo);
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
 
         await ep.HandleAsync(
             new GetTrainingPlanRequest { PlanId = _planId },
@@ -320,7 +321,8 @@ public class GetTrainingPlanSessionExecutionTests
         var ep = Factory.Create<GetTrainingPlanEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(otherTrainerId, AppRoles.Trainer))),
-            mongo);
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
 
         await ep.HandleAsync(
             new GetTrainingPlanRequest { PlanId = _planId },

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanTestHelpers.cs
@@ -1,5 +1,6 @@
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
@@ -171,6 +172,29 @@ public static class TrainingPlanTestHelpers
             .Returns(updateResult);
 
         return collection;
+    }
+
+    /// <summary>
+    /// Creates a no-op <see cref="ISessionLockService"/> that always returns an empty lock list.
+    /// Use in tests that don't care about lock state.
+    /// </summary>
+    public static ISessionLockService CreateNoOpLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+        return svc;
+    }
+
+    /// <summary>
+    /// Creates a mocked <see cref="ISessionLockService"/> that returns the given lock documents.
+    /// </summary>
+    public static ISessionLockService CreateLockServiceWith(params SessionLock[] locks)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(locks.ToList());
+        return svc;
     }
 
     /// <summary>

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
@@ -3,11 +3,14 @@ using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -49,6 +52,15 @@ public class SessionLockBroadcastWorkoutTests
             Version = 1,
             DateCreated = DateTime.UtcNow
         };
+
+    /// <summary>
+    /// Builds a mock IApplicationDbContext with a ClientProfile for _clientId.
+    /// PublicId = _clientId (test shortcut — plan.ClientId uses _clientId so it still matches).
+    /// </summary>
+    private IApplicationDbContext CreateDbWithProfile() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { Id = 1, UserId = _clientId, PublicId = _clientId })
+            .Build();
 
     private ISessionLockService AcquiredLiveService()
     {
@@ -104,7 +116,7 @@ public class SessionLockBroadcastWorkoutTests
         var ep = Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, LockOptions, notifier);
+            mongo, CreateDbWithProfile(), lockService, LockOptions, notifier);
 
         // Act
         await ep.HandleAsync(
@@ -157,7 +169,7 @@ public class SessionLockBroadcastWorkoutTests
         var ep = Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, LockOptions, notifier);
+            mongo, CreateDbWithProfile(), lockService, LockOptions, notifier);
 
         // Act
         await ep.HandleAsync(
@@ -187,9 +199,9 @@ public class SessionLockBroadcastWorkoutTests
         var ep = Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, LockOptions, notifier);
+            mongo, Substitute.For<IApplicationDbContext>(), lockService, LockOptions, notifier);
 
-        // Act — ad-hoc workout (no PlanId, no SessionId)
+        // Act — ad-hoc workout (no PlanId, no SessionId) — db is never queried on ad-hoc path
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
         // Assert — 201 and no lock-change notifications

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
@@ -3,12 +3,15 @@ using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
@@ -79,6 +82,15 @@ public class SessionLockEnforcementTests
         return svc;
     }
 
+    /// <summary>
+    /// Builds a mock IApplicationDbContext with a ClientProfile for _clientId.
+    /// PublicId = _clientId (test shortcut — plan.ClientId uses _clientId so it still matches).
+    /// </summary>
+    private IApplicationDbContext CreateDbWithProfile() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { Id = 1, UserId = _clientId, PublicId = _clientId })
+            .Build();
+
     private StartWorkoutEndpoint CreateStartEndpoint(
         IMongoContext mongo,
         ISessionLockService lockService)
@@ -86,7 +98,7 @@ public class SessionLockEnforcementTests
         return Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, DefaultLockOptions(), Substitute.For<IRealtimeNotifier>());
+            mongo, CreateDbWithProfile(), lockService, DefaultLockOptions(), Substitute.For<IRealtimeNotifier>());
     }
 
     // ── StartWorkout tests ────────────────────────────────────────────────────

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
@@ -3,11 +3,14 @@ using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
@@ -41,12 +44,25 @@ public class StartWorkoutEndpointTests
         return svc;
     }
 
-    private StartWorkoutEndpoint CreateEndpointWithUser(IMongoContext mongo, ISessionLockService lockService)
+    /// <summary>
+    /// Builds a mock IApplicationDbContext containing a ClientProfile for _clientId
+    /// with PublicId = _clientId (test shortcut — makes plan.ClientId = _clientId still match).
+    /// </summary>
+    private IApplicationDbContext CreateDbWithProfile() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { Id = 1, UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    private StartWorkoutEndpoint CreateEndpointWithUser(
+        IMongoContext mongo,
+        ISessionLockService lockService,
+        IApplicationDbContext? db = null)
     {
+        var dbContext = db ?? CreateDbWithProfile();
         return Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, lockService, LockOptions, Substitute.For<IRealtimeNotifier>());
+            mongo, dbContext, lockService, LockOptions, Substitute.For<IRealtimeNotifier>());
     }
 
     [Fact]
@@ -71,8 +87,10 @@ public class StartWorkoutEndpointTests
     public async Task HandleAsync_NoClaims_Returns401()
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+        // No user claims — endpoint returns 401 before any db/lock lookup.
         var ep = Factory.Create<StartWorkoutEndpoint>(
-            mongo, CreateNoOpLockService(), LockOptions, Substitute.For<IRealtimeNotifier>());
+            mongo, Substitute.For<IApplicationDbContext>(), CreateNoOpLockService(),
+            LockOptions, Substitute.For<IRealtimeNotifier>());
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
@@ -109,15 +127,15 @@ public class StartWorkoutEndpointTests
     [Fact]
     public async Task HandleAsync_PlanBelongsToAnotherClient_Returns403()
     {
-        // Plan exists but its ClientId does not match the authenticated user → 403, no log created.
+        // Plan exists but its ClientId does not match the authenticated client's ProfilePublicId → 403.
         var planId = Guid.NewGuid();
         var sessionId = Guid.NewGuid();
-        var differentClientId = Guid.NewGuid(); // plan belongs to someone else
+        var differentProfileId = Guid.NewGuid(); // plan belongs to someone else's profile
 
         var plan = new TrainingPlan
         {
             ExternalId = planId,
-            ClientId = differentClientId, // NOT _clientId
+            ClientId = differentProfileId, // NOT the caller's ProfilePublicId (_clientId)
             TrainerId = Guid.NewGuid(),
             Name = "Other Client Plan",
             Status = TrainingPlanStatus.Active,

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutOwnershipTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutOwnershipTests.cs
@@ -1,0 +1,213 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Regression tests for the StartWorkout ownership identity bug (issue #382/PR-#390 regression).
+///
+/// Root cause: the endpoint previously compared <c>plan.ClientId != Guid.Parse(userId)</c>
+/// where <c>userId</c> is the <c>ApplicationUser.Id</c>. But <c>TrainingPlan.ClientId</c> stores
+/// the <c>ClientProfile.PublicId</c>, which is a different GUID. The comparison never matched,
+/// so every plan-bound StartWorkout returned 403 and the Live lock was never acquired.
+///
+/// The fix resolves <c>ClientProfile.PublicId</c> via EF for the ownership comparison while
+/// keeping <c>ApplicationUser.Id</c> (the JWT user id) as the lock's <c>clientId</c> — because
+/// <c>NotificationHub</c> groups SignalR connections by <c>ApplicationUser.Id</c>, so realtime
+/// events must target the user id.
+/// </summary>
+public class StartWorkoutOwnershipTests
+{
+    // Two distinct GUIDs to prove neither side of the identity split is collapsed.
+    private readonly Guid _clientUserId = Guid.NewGuid();   // ApplicationUser.Id (from JWT)
+    private readonly Guid _clientProfilePublicId = Guid.NewGuid(); // ClientProfile.PublicId
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A training plan whose ClientId = _clientProfilePublicId (the real store value).
+    /// This is what the trainer creates on behalf of the client.
+    /// </summary>
+    private TrainingPlan MakePlan() =>
+        new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientProfilePublicId, // stores the PROFILE public id, not the user id
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+    /// <summary>
+    /// A ClientProfile linking the user (_clientUserId) to their profile public id.
+    /// </summary>
+    private IApplicationDbContext MakeDbWithOwnerProfile() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { Id = 1, UserId = _clientUserId, PublicId = _clientProfilePublicId })
+            .Build();
+
+    private static ISessionLockService AcquiredLockService(
+        Guid expectedClientId,
+        Guid expectedTrainerId,
+        Guid expectedSessionId,
+        Guid expectedPlanId)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(new SessionLock
+            {
+                SessionId = expectedSessionId,
+                PlanId = expectedPlanId,
+                ClientId = expectedClientId,
+                TrainerId = expectedTrainerId,
+                Holder = LockHolder.Client,
+                Type = LockType.Live,
+                AcquiredAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddHours(6)
+            }));
+        return svc;
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The owning client (JWT user id → ClientProfile.PublicId == plan.ClientId) starts a
+    /// plan-bound workout.
+    /// Expected: 201, Live lock acquired with clientId = ApplicationUser.Id (not the profile id),
+    /// WorkoutLog.ClientId = ApplicationUser.Id.
+    /// </summary>
+    [Fact]
+    public async Task StartWorkout_OwningClient_Returns201_LockClientIdIsUserId()
+    {
+        // Arrange
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var lockService = AcquiredLockService(_clientUserId, _trainerId, _sessionId, _planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientUserId, AppRoles.Client))),
+            mongo, MakeDbWithOwnerProfile(), lockService, LockOptions, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 201 created
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        // Lock must be acquired with the LOCK clientId = ApplicationUser.Id (not profile id).
+        // This is critical — NotificationHub routes events by ApplicationUser.Id.
+        await lockService.Received(1).AcquireAsync(
+            _sessionId,
+            _planId,
+            _clientUserId,    // must be user id — NOT _clientProfilePublicId
+            _trainerId,
+            LockHolder.Client,
+            LockType.Live,
+            TimeSpan.FromHours(6),
+            Arg.Any<CancellationToken>());
+
+        // WorkoutLog.ClientId must also be the ApplicationUser.Id
+        await mongo.WorkoutLogs.Received(1).InsertOneAsync(
+            Arg.Is<WorkoutLog>(w =>
+                w.ClientId == _clientUserId &&   // user id, not profile id
+                w.PlanId == _planId &&
+                w.SessionId == _sessionId),
+            Arg.Any<MongoDB.Driver.InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+
+        // SignalR events must be sent to the user id (not profile id)
+        await notifier.Received(1).NotifyAsync(
+            _clientUserId,   // ApplicationUser.Id — what NotificationHub groups on
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Live" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A different client (JWT user id → a profile whose PublicId != plan.ClientId) tries to start
+    /// a plan that belongs to another client.
+    /// Expected: 403, no lock acquired, no log created.
+    /// </summary>
+    [Fact]
+    public async Task StartWorkout_NonOwningClient_Returns403()
+    {
+        // Arrange — attacker has a valid profile but it's for a DIFFERENT plan
+        var attackerUserId = Guid.NewGuid();
+        var attackerProfilePublicId = Guid.NewGuid(); // attacker's public id != plan.ClientId
+
+        var attackerDb = new MockDbBuilder()
+            .With(new ClientProfile { Id = 2, UserId = attackerUserId, PublicId = attackerProfilePublicId })
+            .Build();
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var lockService = Substitute.For<ISessionLockService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<StartWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(attackerUserId, AppRoles.Client))),
+            mongo, attackerDb, lockService, LockOptions, notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert — 403, nothing acquired, nothing created
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+
+        await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
+            Arg.Any<WorkoutLog>(),
+            Arg.Any<MongoDB.Driver.InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/web/src/api/training-plan-types.ts
+++ b/web/src/api/training-plan-types.ts
@@ -171,6 +171,34 @@ export interface SessionExecutionDto {
   completedSetsByExercise: Record<string, number[]>;
 }
 
+/**
+ * Edit-lock state of a single training session as reported by the backend.
+ *
+ * Mirrors the C# SessionLockStateDto in GetTrainingPlanResponse.
+ * Only sessions with an active (non-expired) lock appear in
+ * `TrainingPlanDetail.sessionLockStates`; absent sessions are implicitly "Stable".
+ *
+ * Hand-written (not from generated.ts) — the plan response is consumed via the
+ * hand-written `TrainingPlanDetail` type, not the NSwag-generated client.
+ */
+export interface SessionLockStateDto {
+  /** The session this lock state belongs to. Matches TrainingSession.sessionId. */
+  sessionId: string;
+  /**
+   * Current edit-lock state.
+   *   "Stable"  — no active lock; fully editable.
+   *   "Editing" — trainer holds an Editing lock (after calling Unlock).
+   *   "Live"    — client has an active workout; editing is blocked.
+   */
+  lockState: 'Stable' | 'Editing' | 'Live';
+  /**
+   * Who currently holds the lock. Null when lockState is "Stable".
+   *   "Coach" — trainer holds the Editing lock.
+   *   "Client" — client holds the Live lock.
+   */
+  lockHolder: 'Coach' | 'Client' | null;
+}
+
 /** Full training plan detail. */
 export interface TrainingPlanDetail {
   planId: string;
@@ -188,6 +216,13 @@ export interface TrainingPlanDetail {
    * Sessions with no entry are treated as fully not-yet-reached.
    */
   sessionExecutions?: SessionExecutionDto[];
+  /**
+   * Per-session edit-lock state at load time. Only sessions with an active
+   * (non-expired) lock appear here; absent sessions are implicitly "Stable".
+   * The store mirrors this into a Map keyed by sessionId for O(1) lookup.
+   * SignalR `sessioneditlockchanged` events patch the map while the page is open.
+   */
+  sessionLockStates?: SessionLockStateDto[];
   version: number;
   dateCreated: string;
   dateUpdated?: string | null;

--- a/web/src/api/training-plans.ts
+++ b/web/src/api/training-plans.ts
@@ -124,3 +124,29 @@ export async function getExerciseProgress(
   );
   return data;
 }
+
+/**
+ * Acquires an Editing lock on a published training session, allowing the trainer to edit it.
+ *
+ * Returns 204 on success.
+ * Returns 409 (errorCode: "session_locked") when the session is Live (client is
+ * training) or already locked by another party.
+ */
+export async function unlockTrainingSession(
+  planId: string,
+  sessionId: string,
+): Promise<void> {
+  await api.post(`/training/plans/${planId}/sessions/${sessionId}/unlock`);
+}
+
+/**
+ * Releases the Editing lock on a training session, returning it to Stable state.
+ *
+ * Idempotent: succeeds (204) even when the lock was already released or expired.
+ */
+export async function relockTrainingSession(
+  planId: string,
+  sessionId: string,
+): Promise<void> {
+  await api.post(`/training/plans/${planId}/sessions/${sessionId}/relock`);
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -804,7 +804,8 @@
     "INVALID_DEADLINE_OFFSET_HOURS": "Neplatná lhůta. Povolené hodnoty: 24, 48, 72, 120 nebo 168 hodin.",
     "SESSION_ALREADY_COMPLETED": "Tento trénink byl již dokončen.",
     "COMPLETED_AT_IN_FUTURE": "Datum dokončení nesmí být v budoucnosti.",
-    "COMPLETED_AT_BEFORE_PLAN_START": "Datum dokončení nesmí být před začátkem plánu."
+    "COMPLETED_AT_BEFORE_PLAN_START": "Datum dokončení nesmí být před začátkem plánu.",
+    "session_locked": "Trénink je aktuálně uzamčen — uložení selhalo."
   },
   "nutritionGoals": {
     "title": "Cíle & makra",
@@ -1055,6 +1056,18 @@
     "cancelButton": "Zrušit",
     "weekFinishedTooltip": "Týden byl ukončen",
     "weekPublishedTooltip": "Týden je publikován a stále upravitelný",
+    "lock": {
+      "unlockLabel": "Odemknout pro úpravy",
+      "relockLabel": "Zamknout a uložit",
+      "liveLabel": "Probíhá trénink",
+      "liveTooltip": "Klient právě trénuje — úpravy jsou zablokované.",
+      "unlocking": "Odemykám...",
+      "relocking": "Zamykám...",
+      "unlockError": "Nepodařilo se odemknout trénink.",
+      "relockError": "Nepodařilo se zamknout trénink.",
+      "sessionLockedError": "Uložení selhalo — tyto tréninky jsou aktuálně uzamčeny klientem:",
+      "unlockToSave": "Odemkněte nebo počkejte na dokončení tréninku"
+    },
     "sidebarVolume": "Objem tréninku",
     "sidebarTotalSets": "sérií celkem",
     "sidebarDayOverview": "Přehled dne",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -794,7 +794,8 @@
     "INVALID_DEADLINE_OFFSET_HOURS": "Ungültige Frist. Erlaubte Werte: 24, 48, 72, 120 oder 168 Stunden.",
     "SESSION_ALREADY_COMPLETED": "Diese Einheit wurde bereits abgeschlossen.",
     "COMPLETED_AT_IN_FUTURE": "Das Abschlussdatum darf nicht in der Zukunft liegen.",
-    "COMPLETED_AT_BEFORE_PLAN_START": "Das Abschlussdatum darf nicht vor dem Startdatum des Plans liegen."
+    "COMPLETED_AT_BEFORE_PLAN_START": "Das Abschlussdatum darf nicht vor dem Startdatum des Plans liegen.",
+    "session_locked": "Einheit ist derzeit gesperrt — Speichern fehlgeschlagen."
   },
   "nutritionGoals": {
     "title": "Ziele & Makros",
@@ -1041,6 +1042,18 @@
     "cancelButton": "Abbrechen",
     "weekFinishedTooltip": "Woche ist abgeschlossen",
     "weekPublishedTooltip": "Woche ist veröffentlicht und noch bearbeitbar",
+    "lock": {
+      "unlockLabel": "Zur Bearbeitung entsperren",
+      "relockLabel": "Sperren & speichern",
+      "liveLabel": "Training läuft",
+      "liveTooltip": "Klient trainiert gerade — Bearbeitung ist gesperrt.",
+      "unlocking": "Entsperre...",
+      "relocking": "Sperre...",
+      "unlockError": "Einheit konnte nicht entsperrt werden.",
+      "relockError": "Einheit konnte nicht gesperrt werden.",
+      "sessionLockedError": "Speichern fehlgeschlagen — diese Einheiten sind durch den Klienten gesperrt:",
+      "unlockToSave": "Entsperren oder warten, bis das Training abgeschlossen ist"
+    },
     "sidebarVolume": "Trainingsvolumen",
     "sidebarTotalSets": "Sätze gesamt",
     "sidebarDayOverview": "Tagesübersicht",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -795,7 +795,8 @@
     "INVALID_DEADLINE_OFFSET_HOURS": "Invalid deadline. Allowed values: 24, 48, 72, 120 or 168 hours.",
     "SESSION_ALREADY_COMPLETED": "This session has already been completed.",
     "COMPLETED_AT_IN_FUTURE": "Completion date cannot be in the future.",
-    "COMPLETED_AT_BEFORE_PLAN_START": "Completion date cannot be before the plan's start date."
+    "COMPLETED_AT_BEFORE_PLAN_START": "Completion date cannot be before the plan's start date.",
+    "session_locked": "Session is currently locked — save failed."
   },
   "nutritionGoals": {
     "title": "Goals & Macros",
@@ -1042,6 +1043,18 @@
     "cancelButton": "Cancel",
     "weekFinishedTooltip": "Week is finished",
     "weekPublishedTooltip": "Week is published and still editable",
+    "lock": {
+      "unlockLabel": "Unlock to edit",
+      "relockLabel": "Relock & save",
+      "liveLabel": "In progress",
+      "liveTooltip": "Client is training — locked for edits.",
+      "unlocking": "Unlocking...",
+      "relocking": "Relocking...",
+      "unlockError": "Failed to unlock session.",
+      "relockError": "Failed to relock session.",
+      "sessionLockedError": "Save failed — these sessions are locked by the client:",
+      "unlockToSave": "Unlock or wait for the workout to finish"
+    },
     "sidebarVolume": "Training volume",
     "sidebarTotalSets": "total sets",
     "sidebarDayOverview": "Day overview",

--- a/web/src/lib/api-errors.ts
+++ b/web/src/lib/api-errors.ts
@@ -10,6 +10,8 @@ interface ProblemDetailsError {
 
 interface ProblemDetails {
   errors?: ProblemDetailsError[];
+  /** RFC 7807 Extensions field used by non-FastEndpoints error paths. */
+  errorCode?: string;
 }
 
 /**
@@ -18,6 +20,10 @@ interface ProblemDetails {
  * FastEndpoints returns errors as { name, reason, code } where:
  *   - `reason` contains the error code string (e.g. "START_DATE_REQUIRED")
  *   - `code`   contains the human-readable message
+ *
+ * NOTE: Non-FastEndpoints RFC 7807 errors (e.g. 409 session_locked) put the
+ * code in `response.data.errorCode` (camelCase), not in `errors[0].reason`.
+ * Use `getRfc7807ErrorCode()` to read those.
  */
 export function getErrorCode(error: unknown): string | null {
   const axiosError = error as AxiosError<ProblemDetails>;
@@ -26,6 +32,19 @@ export function getErrorCode(error: unknown): string | null {
     return errors[0].reason ?? null;
   }
   return null;
+}
+
+/**
+ * Extracts the `errorCode` from an RFC 7807 ProblemDetails Extensions field.
+ *
+ * Used for endpoints that set `errorCode` at the top level of the problem JSON
+ * (e.g. 409 session_locked from UpdateTrainingPlan, UnlockTrainingSession).
+ * FastEndpoints validation errors use `errors[0].reason` instead — use
+ * `getErrorCode()` for those.
+ */
+export function getRfc7807ErrorCode(error: unknown): string | null {
+  const axiosError = error instanceof AxiosError ? error : null;
+  return (axiosError?.response?.data as ProblemDetails | undefined)?.errorCode ?? null;
 }
 
 /**

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useState, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getTrainingPlan, completeTrainingPlan, finishSession } from '@/api/training-plans';
+import { getTrainingPlan, completeTrainingPlan, finishSession, unlockTrainingSession, relockTrainingSession } from '@/api/training-plans';
 import { listSectionTemplates, createSectionTemplate } from '@/api/sectionTemplates';
 import type { SectionTemplateResponse } from '@/api/sectionTemplates';
 import type { WorkoutFormat, MovementType, SetType } from '@/api/training-plan-types';
@@ -78,11 +78,17 @@ export default function TrainingPlanPage() {
   const setStartDate = useTrainingPlanStore((s) => s.setStartDate);
   const moveSessionToDay = useTrainingPlanStore((s) => s.moveSessionToDay);
   const moveSessionToWeek = useTrainingPlanStore((s) => s.moveSessionToWeek);
+  const sessionLockMap = useTrainingPlanStore((s) => s.sessionLockMap);
+  const patchSessionLockState = useTrainingPlanStore((s) => s.patchSessionLockState);
+  const sessionLockedError = useTrainingPlanStore((s) => s.sessionLockedError);
+  const clearSessionLockedError = useTrainingPlanStore((s) => s.clearSessionLockedError);
 
   // ── Local UI state ──
   const [pageTab, setPageTab] = useState<'sessions' | 'photos'>('sessions');
   const [selectedDay, setSelectedDay] = useState(1);
   const [collapsedSessions, setCollapsedSessions] = useState<Set<string>>(new Set());
+  /** Sessions currently undergoing an unlock/relock request (prevents double-click). */
+  const [lockPendingIds, setLockPendingIds] = useState<Set<string>>(new Set());
   // Section collapse state lives at the page level so it survives moving a
   // section between sessions (a SectionCard instance otherwise unmounts and
   // its local state resets when the parent session changes).
@@ -268,7 +274,51 @@ export default function TrainingPlanPage() {
 
   // ── Handlers ──
   const handleSave = async () => {
+    clearSessionLockedError();
     await save();
+  };
+
+  /**
+   * Acquires an Editing lock on a published session so the trainer can edit it.
+   * On success, patches the lock state in the store immediately (optimistic) and
+   * the SignalR event will confirm it asynchronously.
+   */
+  const handleUnlock = async (sessionId: string) => {
+    if (!plan?.planId) return;
+    setLockPendingIds((prev) => new Set([...prev, sessionId]));
+    try {
+      await unlockTrainingSession(plan.planId, sessionId);
+      patchSessionLockState(sessionId, 'Editing', 'Coach');
+    } catch (err) {
+      showApiError(err, 'training.lock.unlockError');
+    } finally {
+      setLockPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
+  };
+
+  /**
+   * Releases the Editing lock on a session (returns it to Stable).
+   * Optimistically patches the store then triggers a save.
+   */
+  const handleRelock = async (sessionId: string) => {
+    if (!plan?.planId) return;
+    setLockPendingIds((prev) => new Set([...prev, sessionId]));
+    try {
+      await relockTrainingSession(plan.planId, sessionId);
+      patchSessionLockState(sessionId, 'Stable', null);
+    } catch (err) {
+      showApiError(err, 'training.lock.relockError');
+    } finally {
+      setLockPendingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
   };
 
   const handleReset = async () => {
@@ -889,6 +939,55 @@ export default function TrainingPlanPage() {
               disabled={isSelectedDayInPast}
             />
 
+            {/* Gated-save inline error — shown when a save attempt returned 409
+                session_locked. Names the blocked session(s) and offers an
+                unlock CTA. Cleared on next successful save. */}
+            {sessionLockedError && sessionLockedError.length > 0 && (
+              <div
+                className={cn(
+                  'mb-3 rounded-md border px-3 py-2',
+                  'border-red/40 bg-red/5 text-text',
+                )}
+                role="alert"
+              >
+                <p className="text-[12px] font-medium text-red mb-1">
+                  {t('training.lock.sessionLockedError')}
+                </p>
+                <ul className="mb-2 list-inside list-disc">
+                  {sessionLockedError
+                    .filter((sid) => sid !== 'unknown')
+                    .map((sid) => {
+                      const sessionName =
+                        plan?.weeks
+                          .flatMap((w) => w.sessions)
+                          .find((s) => s.sessionId === sid)?.name ||
+                        t('training.untitledSession');
+                      return (
+                        <li key={sid} className="text-[11px] text-text2">
+                          {sessionName}
+                        </li>
+                      );
+                    })}
+                  {sessionLockedError.includes('unknown') &&
+                    sessionLockedError.length === 1 && (
+                      <li className="text-[11px] text-text2">
+                        {t('training.lock.unlockToSave')}
+                      </li>
+                    )}
+                </ul>
+                <p className="text-[11px] text-text3">
+                  {t('training.lock.unlockToSave')}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => clearSessionLockedError()}
+                  className="mt-1 text-[11px] text-text4 underline hover:text-text2 transition-colors"
+                >
+                  {t('common.close')}
+                </button>
+              </div>
+            )}
+
             {daySessions.length === 0 && (
               <div className="py-12 text-center text-[13px] text-text3">
                 {t('training.restDay')}
@@ -919,6 +1018,25 @@ export default function TrainingPlanPage() {
               const isPastUnfinishedSession =
                 isSelectedDayInPast && !isPastCompletedSession && !isClientLockedSession;
 
+              // ── Edit-lock state (distinct from completion-based planLocks) ──
+              // Session edit-lock is only relevant for published sessions. For
+              // draft sessions there is no lock gate — they are always editable.
+              const isPublishedSession = currentWeek?.status === 'Published';
+              const sessionLockEntry = isPublishedSession
+                ? sessionLockMap.get(session.sessionId)
+                : undefined;
+              // Absent from map = Stable (no active lock).
+              const sessionEditLockState = sessionLockEntry?.lockState ?? 'Stable';
+              const isLive = sessionEditLockState === 'Live';
+              const isEditing = sessionEditLockState === 'Editing';
+              const isLockPending = lockPendingIds.has(session.sessionId);
+              // For published sessions, only allow content editing when in Editing state.
+              // Stable = locked (must unlock first); Live = locked by client workout.
+              const isEditLocked =
+                isPublishedSession && (isLive || sessionEditLockState === 'Stable');
+              // Combined read-only guard (completion-based OR edit-locked).
+              const isSessionEffectivelyReadOnly = isSessionReadOnly || isEditLocked;
+
               return (
                 <SessionDragWrapper
                   key={session.sessionId}
@@ -928,7 +1046,7 @@ export default function TrainingPlanPage() {
                   // Drag-out + drop-over rejected when this session is
                   // read-only (finished session OR past day) — reordering
                   // a historical session has no clinical value.
-                  disabled={isSessionReadOnly}
+                  disabled={isSessionEffectivelyReadOnly}
                 >
                   <div
                     className="rounded-md border border-border bg-bg transition-all duration-100 hover:border-border-md overflow-hidden"
@@ -971,11 +1089,11 @@ export default function TrainingPlanPage() {
                         value={session.name}
                         onChange={(e) => updateSessionName(selectedWeek, session.sessionId, e.target.value)}
                         placeholder={t('training.sessionNamePlaceholder')}
-                        readOnly={isSessionReadOnly}
+                        readOnly={isSessionEffectivelyReadOnly}
                         className={cn(
                           'w-full bg-transparent text-[13px] font-semibold text-text outline-none placeholder:text-text3 rounded-sm',
                           invalidIds.has(session.sessionId) && 'ring-1 ring-red',
-                          isSessionReadOnly && 'cursor-default',
+                          isSessionEffectivelyReadOnly && 'cursor-default',
                         )}
                         style={{ fontFamily: 'inherit' }}
                       />
@@ -1014,6 +1132,63 @@ export default function TrainingPlanPage() {
                         );
                       })()}
                     </span>
+                    {/* ── Edit-lock affordances (published sessions only) ─────────
+                        Live   → in-progress badge + disabled affordance with tooltip
+                        Stable → "Unlock to edit" button
+                        Editing → "Relock" button
+                    ──────────────────────────────────────────────────────────── */}
+                    {isPublishedSession && isLive && (
+                      <span
+                        className={cn(
+                          'shrink-0 inline-flex items-center gap-1 rounded-sm border px-2 py-[2px]',
+                          'text-[10px] font-medium',
+                          'border-orange/50 text-orange bg-orange/10',
+                        )}
+                        title={t('training.lock.liveTooltip')}
+                        aria-label={t('training.lock.liveTooltip')}
+                      >
+                        <span aria-hidden="true">●</span>
+                        {t('training.lock.liveLabel')}
+                      </span>
+                    )}
+                    {isPublishedSession && !isLive && !isEditing && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleUnlock(session.sessionId);
+                        }}
+                        disabled={isLockPending}
+                        className={cn(
+                          'shrink-0 rounded-sm border px-2 py-[2px] text-[10px] font-medium transition-colors',
+                          'border-accent/50 text-accent bg-accent-bg',
+                          'hover:bg-accent/10 hover:border-accent',
+                          'disabled:opacity-40 disabled:cursor-not-allowed',
+                        )}
+                        aria-label={t('training.lock.unlockLabel')}
+                      >
+                        {isLockPending ? t('training.lock.unlocking') : t('training.lock.unlockLabel')}
+                      </button>
+                    )}
+                    {isPublishedSession && isEditing && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleRelock(session.sessionId);
+                        }}
+                        disabled={isLockPending}
+                        className={cn(
+                          'shrink-0 rounded-sm border px-2 py-[2px] text-[10px] font-medium transition-colors',
+                          'border-border text-text3 bg-bg2',
+                          'hover:bg-bg3 hover:border-border-md',
+                          'disabled:opacity-40 disabled:cursor-not-allowed',
+                        )}
+                        aria-label={t('training.lock.relockLabel')}
+                      >
+                        {isLockPending ? t('training.lock.relocking') : t('training.lock.relockLabel')}
+                      </button>
+                    )}
                     {/* "Mark finished" retroactive affordance — only shown on
                         past sessions the client did not complete. The button is
                         visually distinct (tinted outline style) to separate it
@@ -1073,15 +1248,15 @@ export default function TrainingPlanPage() {
                           isDirty: true,
                         });
                       }}
-                      disabled={isSessionReadOnly}
+                      disabled={isSessionEffectivelyReadOnly}
                       style={{
                         background: 'none', border: 'none',
-                        cursor: isSessionReadOnly ? 'not-allowed' : 'pointer', padding: '2px 4px',
+                        cursor: isSessionEffectivelyReadOnly ? 'not-allowed' : 'pointer', padding: '2px 4px',
                         fontSize: 11, color: 'var(--text4)', borderRadius: 'var(--radius)',
                         transition: 'color 0.1s',
-                        opacity: isSessionReadOnly ? 0.4 : 1,
+                        opacity: isSessionEffectivelyReadOnly ? 0.4 : 1,
                       }}
-                      onMouseEnter={(e) => { if (!isSessionReadOnly) e.currentTarget.style.color = 'var(--text2)'; }}
+                      onMouseEnter={(e) => { if (!isSessionEffectivelyReadOnly) e.currentTarget.style.color = 'var(--text2)'; }}
                       onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text4)'; }}
                       title={t('training.duplicateSession')}
                     >
@@ -1090,15 +1265,15 @@ export default function TrainingPlanPage() {
                     <button
                       type="button"
                       onClick={(e) => { e.stopPropagation(); removeSession(selectedWeek, session.sessionId); }}
-                      disabled={isSessionReadOnly}
+                      disabled={isSessionEffectivelyReadOnly}
                       style={{
                         background: 'none', border: 'none',
-                        cursor: isSessionReadOnly ? 'not-allowed' : 'pointer', padding: '2px 4px',
+                        cursor: isSessionEffectivelyReadOnly ? 'not-allowed' : 'pointer', padding: '2px 4px',
                         fontSize: 11, color: 'var(--text4)', borderRadius: 'var(--radius)',
                         transition: 'color 0.1s',
-                        opacity: isSessionReadOnly ? 0.4 : 1,
+                        opacity: isSessionEffectivelyReadOnly ? 0.4 : 1,
                       }}
-                      onMouseEnter={(e) => { if (!isSessionReadOnly) e.currentTarget.style.color = 'var(--red)'; }}
+                      onMouseEnter={(e) => { if (!isSessionEffectivelyReadOnly) e.currentTarget.style.color = 'var(--red)'; }}
                       onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text4)'; }}
                       title={t('training.removeSession')}
                     >
@@ -1120,14 +1295,14 @@ export default function TrainingPlanPage() {
                           value={session.notes ?? ''}
                           onChange={(e) => updateSessionNotes(selectedWeek, session.sessionId, e.target.value)}
                           placeholder={t('training.sessionNotesPlaceholder')}
-                          disabled={isSessionReadOnly}
+                          disabled={isSessionEffectivelyReadOnly}
                           style={{
                             width: '100%', border: 'none', outline: 'none', background: 'transparent',
                             fontSize: 11, color: 'var(--text3)', fontFamily: 'inherit', fontStyle: 'italic',
                             padding: '2px 4px', borderRadius: 'var(--radius)', transition: 'background 0.1s',
-                            cursor: isSessionReadOnly ? 'not-allowed' : 'text',
+                            cursor: isSessionEffectivelyReadOnly ? 'not-allowed' : 'text',
                           }}
-                          onFocus={(e) => { if (!isSessionReadOnly) e.target.style.background = 'var(--bg-hover)'; }}
+                          onFocus={(e) => { if (!isSessionEffectivelyReadOnly) e.target.style.background = 'var(--bg-hover)'; }}
                           onBlur={(e) => { e.target.style.background = 'transparent'; }}
                         />
                       </div>
@@ -1136,13 +1311,13 @@ export default function TrainingPlanPage() {
                       <div
                         className="px-2 pt-1"
                         onDragOver={(e) => {
-                          if (isCurrentWeekFinished || isSessionReadOnly) return;
+                          if (isCurrentWeekFinished || isSessionEffectivelyReadOnly) return;
                           if (!e.dataTransfer.types.includes('application/section-json')) return;
                           e.preventDefault();
                           e.dataTransfer.dropEffect = 'move';
                         }}
                         onDrop={(e) => {
-                          if (isCurrentWeekFinished || isSessionReadOnly) return;
+                          if (isCurrentWeekFinished || isSessionEffectivelyReadOnly) return;
                           if (!e.dataTransfer.types.includes('application/section-json')) return;
                           e.preventDefault();
                           try {
@@ -1191,7 +1366,7 @@ export default function TrainingPlanPage() {
                             // the host session is read-only (finished
                             // session OR past day) — reordering historical
                             // workouts has no clinical value.
-                            disabled={isSessionReadOnly}
+                            disabled={isSessionEffectivelyReadOnly}
                           >
                           <SectionCard
                             section={section}
@@ -1205,11 +1380,13 @@ export default function TrainingPlanPage() {
                               //     section finished by the client)
                               //   - the session is a past completed session
                               //     (client formally finished the workout log)
+                              //   - the session has an edit lock (Stable or Live)
                               // NOTE: isSelectedDayInPast alone no longer locks —
                               // past skipped / untouched sessions are editable.
                               planLocks.sectionIds.has(section.sectionId) ||
                               isClientLockedSession ||
-                              isPastCompletedSession
+                              isPastCompletedSession ||
+                              isEditLocked
                             }
                             lockedExerciseIds={new Set(
                               section.exercises
@@ -1280,7 +1457,7 @@ export default function TrainingPlanPage() {
                           by the client) OR the day already passed. Adding
                           new workouts to a completed session — or to any
                           historical day — has no clinical value. */}
-                      {!isSessionReadOnly && (
+                      {!isSessionEffectivelyReadOnly && (
                         <div className="flex items-center gap-3 px-3 py-2 border-t border-border">
                           <button
                             type="button"

--- a/web/src/stores/trainingPlan.ts
+++ b/web/src/stores/trainingPlan.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { AxiosError } from 'axios';
 import type {
   TrainingPlanDetail,
   TrainingSection,
@@ -11,6 +12,7 @@ import type {
   MovementType,
   SetType,
   WodConfig,
+  SessionLockStateDto,
 } from '@/api/training-plan-types';
 import type { SectionTemplateResponse } from '@/api/sectionTemplates';
 import { updateTrainingPlan, publishTrainingWeek, getTrainingPlan } from '@/api/training-plans';
@@ -27,6 +29,25 @@ interface TrainingPlanState {
   selectedWeek: number;
   /** IDs of session/section entities flagged by the last failed pre-save validation. */
   invalidIds: Set<string>;
+  /**
+   * Per-session edit-lock state map keyed by sessionId.
+   * Built from `plan.sessionLockStates` on load; absent entry = "Stable".
+   * Patched by the `sessioneditlockchanged` SignalR event handler (via
+   * `refreshCompletions`, which also refreshes lock state from the server).
+   *
+   * Do NOT conflate with `training-plan-locks.ts` (completion-based exercise
+   * locking — a different concept).
+   */
+  sessionLockMap: Map<string, Pick<SessionLockStateDto, 'lockState' | 'lockHolder'>>;
+  /**
+   * Patch a single session's lock state in the map.
+   * Called by the SignalR `sessioneditlockchanged` handler for live updates.
+   */
+  patchSessionLockState: (
+    sessionId: string,
+    lockState: SessionLockStateDto['lockState'],
+    lockHolder: SessionLockStateDto['lockHolder'],
+  ) => void;
 
   setPlan: (plan: TrainingPlanDetail) => void;
   setSelectedWeek: (week: number) => void;
@@ -108,8 +129,19 @@ interface TrainingPlanState {
    * `completions` on both `plan` and `originalPlan`. Used by the SignalR
    * `trainingprogressupdated` listener so the editor reacts in real time
    * to client-side completions without clobbering unsaved trainer edits.
+   * Also refreshes `sessionLockMap` from the fresh response.
    */
   refreshCompletions: () => Promise<void>;
+
+  /**
+   * Set when a save attempt returns 409 session_locked.
+   * Contains the IDs of sessions that blocked the save (derived UI-side
+   * as published sessions with changes that are NOT in Editing state).
+   * Cleared on the next successful save, plan load, or explicit dismiss.
+   */
+  sessionLockedError: string[] | null;
+  /** Clear the session-locked inline error (e.g. after the trainer unlocks). */
+  clearSessionLockedError: () => void;
 }
 
 function updateSession(
@@ -182,6 +214,17 @@ function makeNewExercise(exercise: { exerciseExternalId: string; exerciseName: s
   };
 }
 
+/** Build the sessionLockMap from the plan's sessionLockStates array. */
+function buildLockMap(
+  lockStates: SessionLockStateDto[] | undefined,
+): Map<string, Pick<SessionLockStateDto, 'lockState' | 'lockHolder'>> {
+  const map = new Map<string, Pick<SessionLockStateDto, 'lockState' | 'lockHolder'>>();
+  for (const s of lockStates ?? []) {
+    map.set(s.sessionId, { lockState: s.lockState, lockHolder: s.lockHolder });
+  }
+  return map;
+}
+
 export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
   plan: null,
   originalPlan: null,
@@ -189,6 +232,9 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
   isSaving: false,
   selectedWeek: 1,
   invalidIds: new Set(),
+  sessionLockMap: new Map(),
+  sessionLockedError: null,
+  clearSessionLockedError: () => set({ sessionLockedError: null }),
 
   setPlan: (rawPlan) => {
     // Normalize exercises helper — fills in defaults for pre-sections legacy exercises.
@@ -275,11 +321,13 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
     };
     // Default the selected week to whichever week contains today, falling back
     // to week 1 when the plan has no startDate or is wholly in the future / past.
+    // Also build the sessionLockMap from the plan's lock state for cold-load rendering.
     set({
       plan,
       originalPlan: structuredClone(plan),
       isDirty: false,
       selectedWeek: currentWeekNumber(plan),
+      sessionLockMap: buildLockMap(rawPlan.sessionLockStates),
     });
   },
   setSelectedWeek: (week) => set({ selectedWeek: week }),
@@ -287,6 +335,19 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
     const { originalPlan } = get();
     if (!originalPlan) return;
     set({ plan: structuredClone(originalPlan), isDirty: false });
+  },
+
+  patchSessionLockState: (sessionId, lockState, lockHolder) => {
+    set((state) => {
+      const next = new Map(state.sessionLockMap);
+      if (lockState === 'Stable') {
+        // Stable = no active lock; remove from the map (absent = Stable).
+        next.delete(sessionId);
+      } else {
+        next.set(sessionId, { lockState, lockHolder });
+      }
+      return { sessionLockMap: next };
+    });
   },
 
   addSession: (weekNumber, dayOfWeek, name) => {
@@ -1319,9 +1380,51 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
       const updated = await updateTrainingPlan(plan.planId, request);
       // Re-run setPlan so sections are normalized (same as initial load).
       get().setPlan(updated);
+      set({ sessionLockedError: null });
       showSuccess('training.saved');
     } catch (err) {
-      showApiError(err, 'training.saveError');
+      // 409 session_locked: derive blocked session IDs UI-side as published
+      // sessions that have changes but are NOT in Editing state.
+      // The 409 ProblemDetails carries the code in `extensions.errorCode`
+      // (camelCase) — NOT in `errors[0].reason` (the FastEndpoints validation
+      // shape). We read `response.data.errorCode` directly.
+      const axiosErr = err instanceof AxiosError ? err : null;
+      const errorCode = axiosErr?.response?.data?.errorCode as string | undefined;
+
+      if (errorCode === 'session_locked') {
+        const { sessionLockMap, originalPlan } = get();
+        // A session is "blocking the save" when it is published AND the trainer
+        // has changed it AND it is not currently in Editing state (i.e. the
+        // lock was not held by the trainer during the update attempt).
+        const blockedSessionIds: string[] = [];
+        if (originalPlan) {
+          for (const week of plan.weeks) {
+            const origWeek = originalPlan.weeks.find(
+              (w) => w.weekNumber === week.weekNumber,
+            );
+            if (!origWeek || origWeek.status !== 'Published') continue;
+            for (const session of week.sessions) {
+              const origSession = origWeek.sessions.find(
+                (s) => s.sessionId === session.sessionId,
+              );
+              // Session is modified when its JSON differs from the original.
+              const isModified =
+                JSON.stringify(session) !== JSON.stringify(origSession);
+              if (!isModified) continue;
+              const lockEntry = sessionLockMap.get(session.sessionId);
+              const isEditing = lockEntry?.lockState === 'Editing';
+              if (!isEditing) {
+                blockedSessionIds.push(session.sessionId);
+              }
+            }
+          }
+        }
+        set({ sessionLockedError: blockedSessionIds.length > 0 ? blockedSessionIds : ['unknown'] });
+        // Show a brief toast to draw attention; inline error has more detail.
+        useToastStore.getState().addToast(i18n.t('apiErrors.session_locked'), 'error');
+      } else {
+        showApiError(err, 'training.saveError');
+      }
     } finally {
       set({ isSaving: false });
     }
@@ -1355,6 +1458,9 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
     try {
       const fresh = await getTrainingPlan(plan.planId);
       const completions = fresh.completions ?? [];
+      // Also pick up the fresh sessionLockStates so lock state stays current
+      // after a SignalR sessioneditlockchanged event that triggers this path.
+      const sessionLockMap = buildLockMap(fresh.sessionLockStates);
       set((state) => ({
         plan: state.plan ? { ...state.plan, completions } : state.plan,
         // originalPlan tracks server-state too, so it must move with the
@@ -1363,6 +1469,7 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
         originalPlan: state.originalPlan
           ? { ...state.originalPlan, completions }
           : state.originalPlan,
+        sessionLockMap,
       }));
     } catch {
       // Non-critical — UI will catch up on the next manual save / load.

--- a/web/src/stores/trainingPlan.ts
+++ b/web/src/stores/trainingPlan.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { AxiosError } from 'axios';
 import type {
   TrainingPlanDetail,
   TrainingSection,
@@ -16,7 +15,7 @@ import type {
 } from '@/api/training-plan-types';
 import type { SectionTemplateResponse } from '@/api/sectionTemplates';
 import { updateTrainingPlan, publishTrainingWeek, getTrainingPlan } from '@/api/training-plans';
-import { showApiError, showSuccess } from '@/lib/api-errors';
+import { showApiError, showSuccess, getRfc7807ErrorCode } from '@/lib/api-errors';
 import { currentWeekNumber } from '@/lib/training-plan-dates';
 import { useToastStore } from '@/stores/toast';
 import i18n from '@/i18n';
@@ -1388,8 +1387,10 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
       // The 409 ProblemDetails carries the code in `extensions.errorCode`
       // (camelCase) — NOT in `errors[0].reason` (the FastEndpoints validation
       // shape). We read `response.data.errorCode` directly.
-      const axiosErr = err instanceof AxiosError ? err : null;
-      const errorCode = axiosErr?.response?.data?.errorCode as string | undefined;
+      // The 409 ProblemDetails carries the code in extensions.errorCode (camelCase),
+      // read via the typed RFC-7807 helper — NOT getErrorCode() which reads the
+      // FastEndpoints errors[].reason validation shape.
+      const errorCode = getRfc7807ErrorCode(err);
 
       if (errorCode === 'session_locked') {
         const { sessionLockMap, originalPlan } = get();
@@ -1460,14 +1461,19 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
       const completions = fresh.completions ?? [];
       // Also pick up the fresh sessionLockStates so lock state stays current
       // after a SignalR sessioneditlockchanged event that triggers this path.
-      const sessionLockMap = buildLockMap(fresh.sessionLockStates);
+      const sessionLockStates = fresh.sessionLockStates ?? [];
+      const sessionLockMap = buildLockMap(sessionLockStates);
       set((state) => ({
-        plan: state.plan ? { ...state.plan, completions } : state.plan,
+        // Keep plan.sessionLockStates in lockstep with sessionLockMap so the
+        // in-memory plan can't diverge from the authoritative live lock state.
+        plan: state.plan
+          ? { ...state.plan, completions, sessionLockStates }
+          : state.plan,
         // originalPlan tracks server-state too, so it must move with the
         // freshly fetched completions — otherwise revert() would surface
         // stale completion data.
         originalPlan: state.originalPlan
-          ? { ...state.originalPlan, completions }
+          ? { ...state.originalPlan, completions, sessionLockStates }
           : state.originalPlan,
         sessionLockMap,
       }));


### PR DESCRIPTION
## Summary

Trainer-portal UI for the training session edit-lock epic (#379): unlock-to-edit / relock, an in-progress badge when a client is Live, and a gated-save 409 inline error. Folded cross-package (backend read-model prerequisite + web UI) plus an incidental p1 bug fix found during QA.

Part of #379. Closes #394.

## Backend
- **Read-model prerequisite** (`696b9d9`): `GetTrainingPlanResponse` now projects per-session lock state via `ISessionLockService` (batched) — `SessionLockStateDto { sessionId, lockState: "Stable"|"Editing"|"Live", lockHolder: "Coach"|"Client"|null }`, exposed as `sessionLockStates[]`. This is what makes the trainer editor show Live/Editing state on a **cold page load** (SignalR is UX-skin only, per spec §8). #381/#382 had wired lock state into client reads + the unlock/relock endpoints but never the trainer read.
- **`#394` StartWorkout ownership fix** (`b6a7411`): a regression from PR #390 (#382). `StartWorkoutEndpoint` compared `plan.ClientId` (a `ClientProfile.PublicId`) against the raw JWT user id, so every plan-bound StartWorkout 403'd and the Live lock was never acquired. Fixed to resolve `ClientProfile.PublicId` for the ownership check (like sibling endpoints), while keeping the lock's stored `ClientId` = the **user id** (so the #383 `sessioneditlockchanged` SignalR fan-out, which targets the NotificationHub user-id group, still reaches the client). Regression tests cover owning→201 and non-owning→403.

## Web (`7c0a95c`)
- `regen-api` to pick up `sessionLockStates` + the unlock/relock endpoint types.
- `useTrainingPlanStore` builds a `sessionLockMap` from `sessionLockStates` on plan load (cold-load correct) and refreshes it on the #383 `sessioneditlockchanged` event.
- Per-session UI: Stable → "Unlock to edit"; Editing → editable content + "Relock & save"; Live → in-progress badge + disabled affordance + tooltip.
- Gated save reads the 409 code from `response.data.errorCode` (camelCase — `getErrorCode()` only reads the FastEndpoints `errors[].reason` path), derives blocked sessions UI-side, and shows an inline error.
- i18n `training.lock.*` + `apiErrors.session_locked` in cs/en/de. Tailwind tokens only.

## Verification
- Backend: `dotnet build` clean; `GetTrainingPlanLockStateTests` 3/3; `StartWorkoutOwnershipTests` 2/2 + sibling StartWorkout/SessionLock suites green.
- Web: `npm run build` ✅ (typecheck included).
- QA gate: ✅ PASS. Static surfaces + **interactive Playwright drive**:
  - **AC3** (unlock→editing→relock cycle) — confirmed live in the trainer editor.
  - **AC4** (Live in-progress badge + disabled affordances + tooltip) — confirmed on a **cold load** with a real Live lock staged via the now-fixed StartWorkout (201).
  - **AC5** (gated-save 409 inline error) — backend 409 emission is backend-tested; web render is static-verified. A live trigger was pre-empted by #383 realtime correctly self-correcting the editor (see bonus).
  - **Bonus**: an out-of-band server relock pushed `sessioneditlockchanged=Stable` over SignalR and the open editor reactively re-locked with no manual refresh — live confirmation of #383 + #384 together.
  - End-to-end confirmation of the #394 fix: plan-bound StartWorkout → 201, trainer read → `lockState: Live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
