### PR TITLE
fix: plan photo uploads now appear live in plan detail (SignalR query-key invalidation)

### DIFF
--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -207,9 +207,14 @@ export function AppShell() {
       const data = payload as { planId?: string } | undefined;
       const planId = data?.planId;
       if (planId) {
-        queryClient.invalidateQueries({ queryKey: ['planPhotos', planId] });
+        // Key shape: ['planPhotos', clientId, planId] — planId lives at index 2.
+        // Use a predicate so we match regardless of clientId (not in the payload).
+        queryClient.invalidateQueries({
+          predicate: (q) =>
+            q.queryKey[0] === 'planPhotos' && q.queryKey[2] === planId,
+        });
       } else {
-        // Broad invalidation if planId is missing
+        // Broad invalidation if planId is missing from the payload
         queryClient.invalidateQueries({ queryKey: ['planPhotos'] });
       }
     },

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -250,8 +250,14 @@ export function AppShell() {
       // grid; here we also refresh the diary request status (InProgress count).
       const data = payload as { planId?: string } | undefined;
       if (data?.planId) {
+        // ['diary-requests', planId] — correct 2-element key; unchanged.
         queryClient.invalidateQueries({ queryKey: ['diary-requests', data.planId] });
-        queryClient.invalidateQueries({ queryKey: ['planPhotos', data.planId] });
+        // Key shape: ['planPhotos', clientId, planId] — planId lives at index 2.
+        // Use a predicate so we match regardless of clientId (not in the payload).
+        queryClient.invalidateQueries({
+          predicate: (q) =>
+            q.queryKey[0] === 'planPhotos' && q.queryKey[2] === data.planId,
+        });
       } else {
         queryClient.invalidateQueries({ queryKey: ['diary-requests'] });
         queryClient.invalidateQueries({ queryKey: ['planPhotos'] });


### PR DESCRIPTION
## Summary
- Fixes the `planphotouploaded` SignalR handler in `web/src/components/layout/AppShell.tsx`: it invalidated `['planPhotos', planId]` (2-element key, `planId` landing in the `clientId` slot), which never matched the registered query `['planPhotos', clientId, planId]` under TanStack Query prefix matching. The handler now uses a predicate (`q.queryKey[0] === 'planPhotos' && q.queryKey[2] === planId`) so the open photo grid refetches regardless of `clientId` (which is not in the event payload).
- Folds in the identical sibling bug in the `photodiaryphotouploaded` handler: its `planPhotos` invalidation used the same wrong 2-element key and now uses the same predicate. Its other invalidation, `['diary-requests', planId]`, was verified correct (2-element key matching the four sibling diary handlers and the `['diary-requests', planId]` queries in `DiaryViewerPanel.tsx`, `PlanPhotosTab.tsx`, `NutritionPlanPage.tsx`) and left unchanged.
- No backend change needed — the backend already broadcasts the correct payload (`{ planId, photoId, category, takenAt }`). No i18n strings affected.

## Related issue
Fixes #398

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — static + build surface clean (`npm run build` passes). The live realtime path requires manual two-session verification (see Test plan) which the static build gate cannot cover.

## Manual verification note
The live SignalR invalidation path cannot be exercised by the static build gate. It needs a manual two-session check against the compose harness (`:5101`):
1. Trainer web session open on a client's plan-detail Photos section.
2. As that client, upload a photo to the same plan from the mobile app.
3. The photo grid in the trainer portal should refresh live (no manual page reload). Repeat for the photo-diary upload path (`photodiaryphotouploaded`).

## Test plan
- [ ] Open a client's plan detail in the trainer portal and switch to the Photos section.
- [ ] As that client, upload a photo to the same plan from the mobile app.
- [ ] Confirm the web photo grid updates live — the new photo appears without a full page refresh.
- [ ] Repeat for a photo-diary upload (the `photodiaryphotouploaded` path) — confirm both the photo grid and the diary-request status (InProgress count) refresh live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)