### PR TITLE
fix: live training session 'Probíhá trénink' state machine (go-live on Start, clear on finish + discard)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutEndpoint.cs
@@ -1,0 +1,117 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.WorkoutLogs.AbandonWorkout;
+
+/// <summary>
+/// Abandons (discards) a draft workout session by releasing the Live session lock.
+/// Does NOT mark the log as completed and does NOT delete it — the caller (mobile)
+/// owns clearing local state. The log remains as an incomplete draft in Mongo.
+///
+/// Idempotent: if no Live lock is held (already released, expired, or session was ad-hoc),
+/// returns 200 with no broadcast. Only emits <c>sessioneditlockchanged</c> (state=Stable)
+/// to both client and trainer when a lock was actually released (ReleaseAsync returns true)
+/// AND the log's PlanId resolves a training plan (avoids spurious fan-out).
+///
+/// Broadcast failure is non-fatal — the release is authoritative.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="lockService">Session lock service.</param>
+/// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
+public class AbandonWorkoutEndpoint(
+    IMongoContext mongo,
+    ISessionLockService lockService,
+    IRealtimeNotifier notifier) : Endpoint<AbandonWorkoutRequest, AbandonWorkoutResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/logs/{logId}/abandon");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Abandon a workout";
+            s.Description = "Releases the Live session lock for a draft workout log. " +
+                            "Idempotent: returns 200 when no lock is held. " +
+                            "Does not delete the log or mark it completed.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(AbandonWorkoutRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientUserIdGuid = Guid.Parse(userId);
+
+        // Load the log — must belong to the caller and be incomplete.
+        var logFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ExternalId, req.LogId)
+                        & Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserIdGuid)
+                        & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, false);
+
+        using var logCursor = await mongo.WorkoutLogs.FindAsync(logFilter, cancellationToken: ct);
+        var log = await logCursor.FirstOrDefaultAsync(ct);
+
+        if (log is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // For ad-hoc workouts or logs without a session, no lock was ever acquired.
+        // Return idempotent success immediately — no broadcast.
+        if (!log.SessionId.HasValue)
+        {
+            await Send.OkAsync(new AbandonWorkoutResponse { Released = false }, ct);
+            return;
+        }
+
+        // Release the Live lock. ReleaseAsync is idempotent — returns false when no lock
+        // was held (already released, expired, or 6h TTL elapsed). Not an error.
+        var released = await lockService.ReleaseAsync(log.SessionId.Value, LockHolder.Client, LockType.Live, ct);
+
+        // Only emit sessioneditlockchanged when we actually released a lock AND the plan resolves
+        // a trainer to fan out to. Spurious Stable broadcasts on unlocked sessions are wrong.
+        if (released && log.PlanId.HasValue)
+        {
+            // Resolve the training plan to get the trainer ID for fan-out.
+            var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
+            using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+            var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+            if (plan is not null)
+            {
+                // Broadcast is best-effort — failure must NOT fail the request.
+                try
+                {
+                    var payload = new SessionLockChangedPayload(
+                        log.PlanId.Value,
+                        log.SessionId.Value,
+                        "Stable",
+                        "Client");
+
+                    await notifier.NotifyAsync(clientUserIdGuid, "sessioneditlockchanged", payload, ct);
+                    await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
+                }
+                catch
+                {
+                    // Fan-out is best-effort — the lock release is authoritative.
+                }
+            }
+        }
+
+        await Send.OkAsync(new AbandonWorkoutResponse { Released = released }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.WorkoutLogs.AbandonWorkout;
+
+/// <summary>
+/// Request to abandon (discard) a draft workout session and release the Live lock.
+/// </summary>
+public class AbandonWorkoutRequest
+{
+    /// <summary>
+    /// The external ID of the workout log to abandon.
+    /// Bound from the route segment {logId}.
+    /// </summary>
+    public Guid LogId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutResponse.cs
@@ -1,0 +1,12 @@
+namespace FitnessPlatform.Application.Features.WorkoutLogs.AbandonWorkout;
+
+/// <summary>
+/// Response returned when an abandon request is processed (including idempotent no-op case).
+/// </summary>
+public class AbandonWorkoutResponse
+{
+    /// <summary>
+    /// Whether a Live lock was actually released. False when the lock was already gone (idempotent).
+    /// </summary>
+    public bool Released { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/AbandonWorkout/AbandonWorkoutValidator.cs
@@ -1,0 +1,18 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.WorkoutLogs.AbandonWorkout;
+
+/// <summary>
+/// Validator for <see cref="AbandonWorkoutRequest"/>.
+/// </summary>
+public class AbandonWorkoutValidator : Validator<AbandonWorkoutRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="AbandonWorkoutValidator"/>.
+    /// </summary>
+    public AbandonWorkoutValidator()
+    {
+        RuleFor(x => x.LogId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveEndpoint.cs
@@ -1,0 +1,149 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.WorkoutLogs.GoLive;
+
+/// <summary>
+/// Transitions an existing draft workout log to Live state by acquiring the Live session lock.
+/// This endpoint is called when the client presses the Start button on the session intro page —
+/// NOT on page mount. Separating log creation (POST /client/training/logs) from lock acquisition
+/// fixes the timing issue where the "Probíhá trénink" badge fired on intro-page entry rather
+/// than on Start press.
+///
+/// Requires that the log already exists (created by StartWorkout) and that the session is
+/// plan-bound (non-null PlanId + SessionId on the log).
+///
+/// Returns 409 <c>session_locked</c> when the session is already in Editing state.
+/// Emits <c>sessioneditlockchanged</c> (state=Live) to both client and trainer on successful acquire.
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="lockService">Session lock service.</param>
+/// <param name="lockOptions">Training lock TTL configuration.</param>
+/// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
+public class GoLiveEndpoint(
+    IMongoContext mongo,
+    ISessionLockService lockService,
+    IOptions<TrainingLockOptions> lockOptions,
+    IRealtimeNotifier notifier) : Endpoint<GoLiveRequest, GoLiveResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/logs/{logId}/go-live");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Go live with a workout";
+            s.Description = "Acquires the Live session lock for an existing draft workout log. " +
+                            "Call this when the client actually presses Start, not on page mount.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GoLiveRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientUserIdGuid = Guid.Parse(userId);
+
+        // Load the log and verify ownership.
+        var logFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ExternalId, req.LogId)
+                        & Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserIdGuid)
+                        & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, false);
+
+        using var logCursor = await mongo.WorkoutLogs.FindAsync(logFilter, cancellationToken: ct);
+        var log = await logCursor.FirstOrDefaultAsync(ct);
+
+        if (log is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // go-live is only meaningful for plan-bound sessions — ad-hoc workouts have no lock to acquire.
+        if (!log.PlanId.HasValue || !log.SessionId.HasValue)
+        {
+            // Ad-hoc workout — no lock needed; return success so the client can proceed.
+            await Send.OkAsync(new GoLiveResponse
+            {
+                LogId = log.ExternalId,
+                LiveAt = DateTime.UtcNow
+            }, ct);
+            return;
+        }
+
+        // Resolve the training plan to get the trainer ID for fan-out.
+        var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
+        using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var liveTtl = TimeSpan.FromHours(lockOptions.Value.LiveTtlHours);
+
+        // AcquireAsync clientId must be the ApplicationUser.Id — SignalR groups by user id,
+        // not by ClientProfile.PublicId.
+        var acquireResult = await lockService.AcquireAsync(
+            log.SessionId.Value,
+            log.PlanId.Value,
+            clientUserIdGuid,
+            plan.TrainerId,
+            LockHolder.Client,
+            LockType.Live,
+            liveTtl,
+            ct);
+
+        if (acquireResult is AcquireResult.LockConflict)
+        {
+            // Session is currently in Editing state — emit nothing; no transition occurred.
+            await this.SendProblemAsync(409, ErrorCodes.SessionLocked,
+                "This session is locked and cannot be started right now.", ct);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+
+        // Broadcast state=Live AFTER the lock is acquired (and the log already exists in Mongo).
+        // Best-effort: broadcast failure must NOT fail the request.
+        try
+        {
+            var payload = new SessionLockChangedPayload(
+                log.PlanId.Value,
+                log.SessionId.Value,
+                "Live",
+                "Client");
+
+            await notifier.NotifyAsync(clientUserIdGuid, "sessioneditlockchanged", payload, ct);
+            await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
+        }
+        catch
+        {
+            // Fan-out is best-effort — the lock acquire is authoritative.
+        }
+
+        await Send.OkAsync(new GoLiveResponse
+        {
+            LogId = log.ExternalId,
+            LiveAt = now
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveRequest.cs
@@ -1,0 +1,13 @@
+namespace FitnessPlatform.Application.Features.WorkoutLogs.GoLive;
+
+/// <summary>
+/// Request to transition an existing draft workout log to Live state.
+/// </summary>
+public class GoLiveRequest
+{
+    /// <summary>
+    /// The external ID of the workout log to go live with.
+    /// Bound from the route segment {logId}.
+    /// </summary>
+    public Guid LogId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveResponse.cs
@@ -1,0 +1,17 @@
+namespace FitnessPlatform.Application.Features.WorkoutLogs.GoLive;
+
+/// <summary>
+/// Response returned when a workout log transitions to Live state.
+/// </summary>
+public class GoLiveResponse
+{
+    /// <summary>
+    /// The external ID of the workout log now in Live state.
+    /// </summary>
+    public Guid LogId { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the Live lock was acquired.
+    /// </summary>
+    public DateTime LiveAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/GoLive/GoLiveValidator.cs
@@ -1,0 +1,18 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.WorkoutLogs.GoLive;
+
+/// <summary>
+/// Validator for <see cref="GoLiveRequest"/>.
+/// </summary>
+public class GoLiveValidator : Validator<GoLiveRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="GoLiveValidator"/>.
+    /// </summary>
+    public GoLiveValidator()
+    {
+        RuleFor(x => x.LogId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/StartWorkout/StartWorkoutEndpoint.cs
@@ -2,37 +2,25 @@ using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
-using FitnessPlatform.Application.Domain.Enums;
-using FitnessPlatform.Application.Domain.Extensions;
-using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
-using FitnessPlatform.Application.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 
 /// <summary>
 /// Starts a new workout session for the authenticated client.
-/// When the request references a plan + session (non-ad-hoc workouts),
-/// acquires a <c>Live</c> lock on the session before creating the log.
-/// Returns 409 <c>session_locked</c> when the session is in <c>Editing</c> state.
-/// Ad-hoc workouts (null PlanId or null SessionId) skip the lock entirely.
-/// Emits <c>sessioneditlockchanged</c> (state=Live) to both client and trainer on successful acquire.
+/// Creates a draft workout log and returns its ID for progressive logging.
+/// Does NOT acquire a Live lock — the client must call POST .../go-live after pressing Start
+/// to transition the session to Live state.
+/// Ad-hoc workouts (null PlanId or null SessionId) skip plan/ownership validation entirely.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="db">Relational database context — used to resolve the caller's ClientProfile.PublicId.</param>
-/// <param name="lockService">Session lock service.</param>
-/// <param name="lockOptions">Training lock TTL configuration.</param>
-/// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
 public class StartWorkoutEndpoint(
     IMongoContext mongo,
-    IApplicationDbContext db,
-    ISessionLockService lockService,
-    IOptions<TrainingLockOptions> lockOptions,
-    IRealtimeNotifier notifier) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
+    IApplicationDbContext db) : Endpoint<StartWorkoutRequest, StartWorkoutResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -41,9 +29,9 @@ public class StartWorkoutEndpoint(
         Roles(AppRoles.Client);
         Summary(s =>
         {
-            s.Summary = "Start a workout";
+            s.Summary = "Start a workout (create draft log)";
             s.Description = "Creates a new empty workout log and returns its ID for progressive logging. " +
-                            "Acquires a Live lock on the session when PlanId and SessionId are provided.";
+                            "Does NOT acquire a Live lock — call POST .../go-live when the client presses Start.";
         });
     }
 
@@ -59,15 +47,12 @@ public class StartWorkoutEndpoint(
         }
 
         // clientUserIdGuid is the ApplicationUser.Id (what JWT AppClaims.UserId stores).
-        // It is used for:
-        //   1. WorkoutLog.ClientId — the log is owned by the user id.
-        //   2. AcquireAsync clientId arg — SignalR groups connections by ApplicationUser.Id,
-        //      so realtime events (sessioneditlockchanged) must target the user id, not the profile id.
+        // WorkoutLog.ClientId is set to this value.
         var clientUserIdGuid = Guid.Parse(userId);
         var now = DateTime.UtcNow;
 
-        // ── Live lock acquisition (plan-bound workouts only) ──────────────────────
-        // Ad-hoc workouts (null PlanId or null SessionId) skip the lock entirely —
+        // ── Ownership validation (plan-bound workouts only) ───────────────────────
+        // Ad-hoc workouts (null PlanId or null SessionId) skip plan lookup entirely —
         // there is no session to gate and no trainer who could be editing.
         if (req.PlanId.HasValue && req.SessionId.HasValue)
         {
@@ -85,7 +70,7 @@ public class StartWorkoutEndpoint(
 
             var profilePublicId = clientProfile.PublicId;
 
-            // Load the plan to resolve trainerId and validate ownership.
+            // Load the plan to validate ownership.
             var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, req.PlanId.Value);
             using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
             var plan = await planCursor.FirstOrDefaultAsync(ct);
@@ -102,43 +87,6 @@ public class StartWorkoutEndpoint(
             {
                 await Send.ForbiddenAsync(ct);
                 return;
-            }
-
-            var liveTtl = TimeSpan.FromHours(lockOptions.Value.LiveTtlHours);
-            // AcquireAsync clientId must be the ApplicationUser.Id (clientUserIdGuid), not the
-            // profile PublicId — SessionLock.ClientId feeds SignalR fan-out via IRealtimeNotifier
-            // which routes by ApplicationUser.Id (NotificationHub groups connections by user id).
-            var acquireResult = await lockService.AcquireAsync(
-                req.SessionId.Value,
-                req.PlanId.Value,
-                clientUserIdGuid,
-                plan.TrainerId,
-                LockHolder.Client,
-                LockType.Live,
-                liveTtl,
-                ct);
-
-            if (acquireResult is AcquireResult.LockConflict)
-            {
-                // 409 conflict path — emit nothing; no state transition occurred.
-                await this.SendProblemAsync(409, ErrorCodes.SessionLocked,
-                    "This session is locked and cannot be started right now.", ct);
-                return;
-            }
-
-            // Emit sessioneditlockchanged (state=Live) to both parties on successful acquire.
-            // Broadcast after the lock is held but before the log is persisted so clients
-            // see the state update as soon as the lock is confirmed.
-            if (acquireResult is AcquireResult.Acquired)
-            {
-                var payload = new SessionLockChangedPayload(
-                    req.PlanId!.Value,
-                    req.SessionId!.Value,
-                    "Live",
-                    "Client");
-
-                await notifier.NotifyAsync(clientUserIdGuid, "sessioneditlockchanged", payload, ct);
-                await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
             }
         }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/AbandonWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/AbandonWorkoutEndpointTests.cs
@@ -1,0 +1,237 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.AbandonWorkout;
+using FitnessPlatform.Tests.Endpoints;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Tests for <see cref="AbandonWorkoutEndpoint"/> (issue #401 — Defect 3 fix).
+/// Abandon releases the Live lock and broadcasts state=Stable, or returns idempotent 200
+/// when no lock is held (already released / expired).
+/// </summary>
+public class AbandonWorkoutEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private TrainingPlan MakePlan() =>
+        new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+    private static ISessionLockService ReleasedLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(true);
+        return svc;
+    }
+
+    private static ISessionLockService NoLockHeldService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.ReleaseAsync(Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(),
+            Arg.Any<CancellationToken>()).Returns(false); // idempotent — lock already gone
+        return svc;
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Abandon_WithActiveLiveLock_Returns200_ReleasesLock_BroadcastsStable()
+    {
+        // Arrange — plan-bound log, Live lock held → release + broadcast Stable
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+        var lockService = ReleasedLockService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<AbandonWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(new AbandonWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert — 200 and lock released
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await lockService.Received(1).ReleaseAsync(
+            _sessionId,
+            LockHolder.Client,
+            LockType.Live,
+            Arg.Any<CancellationToken>());
+
+        // Broadcast state=Stable to BOTH client and trainer
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Stable" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Abandon_NoActiveLock_Returns200_IdempotentNoBroadcast()
+    {
+        // Arrange — ReleaseAsync returns false (lock already gone / expired)
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+        var lockService = NoLockHeldService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<AbandonWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, notifier);
+
+        // Act
+        await ep.HandleAsync(new AbandonWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert — 200 idempotent success, NO broadcast (lock wasn't held)
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            "sessioneditlockchanged",
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Abandon_NoClaims_Returns401()
+    {
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+
+        var ep = Factory.Create<AbandonWorkoutEndpoint>(
+            mongo, Substitute.For<ISessionLockService>(), Substitute.For<IRealtimeNotifier>());
+
+        await ep.HandleAsync(
+            new AbandonWorkoutRequest { LogId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task Abandon_LogNotFound_Returns404()
+    {
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: []);
+        var lockService = Substitute.For<ISessionLockService>();
+
+        var ep = Factory.Create<AbandonWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, Substitute.For<IRealtimeNotifier>());
+
+        await ep.HandleAsync(
+            new AbandonWorkoutRequest { LogId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+
+        await lockService.DidNotReceive().ReleaseAsync(
+            Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Abandon_AdHocLog_Returns200_NoBroadcast()
+    {
+        // Ad-hoc log with no SessionId — no lock was ever acquired, success immediately
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var lockService = Substitute.For<ISessionLockService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<AbandonWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, notifier);
+
+        await ep.HandleAsync(new AbandonWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No release call and no broadcast for ad-hoc (no-session) workouts
+        await lockService.DidNotReceive().ReleaseAsync(
+            Arg.Any<Guid>(), Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<CancellationToken>());
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Abandon_BroadcastFailure_StillReturns200()
+    {
+        // Broadcast failure must NOT fail the request — release is authoritative.
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+        var lockService = ReleasedLockService();
+
+        var notifier = Substitute.For<IRealtimeNotifier>();
+        notifier.NotifyAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("hub unavailable (simulated)"));
+
+        var ep = Factory.Create<AbandonWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, notifier);
+
+        // Act — should not throw despite notifier failure
+        await ep.HandleAsync(new AbandonWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert — 200; lock was released, broadcast was best-effort
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await lockService.Received(1).ReleaseAsync(
+            _sessionId, LockHolder.Client, LockType.Live, Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/GoLiveEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/GoLiveEndpointTests.cs
@@ -1,0 +1,265 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.GoLive;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Tests for <see cref="GoLiveEndpoint"/> (issue #401 — Defect 1 fix).
+/// GoLive acquires the Live lock and broadcasts state=Live ONLY when the client presses
+/// Start on the session intro page. The draft log already exists at that point.
+/// </summary>
+public class GoLiveEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+
+    private static readonly IOptions<TrainingLockOptions> LockOptions =
+        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private TrainingPlan MakePlan() =>
+        new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+    private ISessionLockService AcquiredLiveService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(new SessionLock
+            {
+                SessionId = _sessionId, PlanId = _planId,
+                ClientId = _clientId, TrainerId = _trainerId,
+                Holder = LockHolder.Client, Type = LockType.Live,
+                AcquiredAt = DateTime.UtcNow, ExpiresAt = DateTime.UtcNow.AddHours(6)
+            }));
+        return svc;
+    }
+
+    private static ISessionLockService ConflictLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.LockConflict());
+        return svc;
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GoLive_ValidPlanBoundLog_Returns200_AcquiresLock_BroadcastsLive()
+    {
+        // Arrange — draft log exists, plan exists, lock acquisition succeeds
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+        var lockService = AcquiredLiveService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        // Act
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert — 200 and lock acquired with correct args
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await lockService.Received(1).AcquireAsync(
+            _sessionId,
+            _planId,
+            _clientId,
+            _trainerId,
+            LockHolder.Client,
+            LockType.Live,
+            TimeSpan.FromHours(6),
+            Arg.Any<CancellationToken>());
+
+        // Broadcast state=Live to BOTH client and trainer
+        await notifier.Received(1).NotifyAsync(
+            _clientId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Live" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+
+        await notifier.Received(1).NotifyAsync(
+            _trainerId,
+            "sessioneditlockchanged",
+            Arg.Is<SessionLockChangedPayload>(p =>
+                p.PlanId == _planId &&
+                p.SessionId == _sessionId &&
+                p.State == "Live" &&
+                p.Holder == "Client"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GoLive_NoClaims_Returns401()
+    {
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            mongo, Substitute.For<ISessionLockService>(), LockOptions, Substitute.For<IRealtimeNotifier>());
+
+        await ep.HandleAsync(new GoLiveRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task GoLive_LogNotFound_Returns404()
+    {
+        // No log in Mongo matching the request
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: []);
+        var lockService = Substitute.For<ISessionLockService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        await ep.HandleAsync(new GoLiveRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GoLive_OtherClientsLog_Returns404()
+    {
+        // Log belongs to a different client — ownership check via ClientId filter
+        var differentClientId = Guid.NewGuid();
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: differentClientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: []); // filter returns empty for this caller
+        var lockService = Substitute.For<ISessionLockService>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, Substitute.For<IRealtimeNotifier>());
+
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task GoLive_SessionInEditingState_Returns409_EmitsNothing()
+    {
+        // Session is currently Editing-locked by the trainer — go-live is blocked
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+        var lockService = ConflictLockService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+
+        // No broadcast when acquisition failed — no state transition occurred
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GoLive_AdHocLog_NoSessionId_Returns200_NoLockAcquired()
+    {
+        // Ad-hoc workouts have no session — go-live is a no-op success
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var lockService = Substitute.For<ISessionLockService>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GoLive_PlanNotFound_Returns404()
+    {
+        // Log exists with PlanId but the plan has been deleted
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        // Plan collection is empty
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: []);
+        var lockService = Substitute.For<ISessionLockService>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, Substitute.For<IRealtimeNotifier>());
+
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
@@ -7,6 +7,7 @@ using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
+using FitnessPlatform.Application.Features.WorkoutLogs.GoLive;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Services;
@@ -19,11 +20,12 @@ namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
 /// <summary>
 /// Tests that verify the <c>sessioneditlockchanged</c> SignalR broadcast behaviour
-/// for the workout-log endpoints (issue #383).
+/// for the workout-log endpoints (issues #383, #401).
 /// Covers:
-///   - StartWorkout: acquire Live lock → emits state=Live to BOTH clientId and trainerId
-///   - StartWorkout: 409 conflict (session in Editing) → emits NOTHING
-///   - StartWorkout: ad-hoc (no SessionId) → emits NOTHING
+///   - StartWorkout: creates draft log WITHOUT any broadcast (issue #401 fix)
+///   - GoLive: acquire Live lock → emits state=Live to BOTH clientId and trainerId
+///   - GoLive: 409 conflict (session in Editing) → emits NOTHING
+///   - GoLive: ad-hoc log (no SessionId on log) → 200, emits NOTHING
 ///   - CompleteWorkout: plan-bound log, ReleaseAsync=true → emits state=Stable to BOTH parties
 ///   - CompleteWorkout: plan-bound log, ReleaseAsync=false (already gone) → emits NOTHING
 ///   - CompleteWorkout: ad-hoc log (no SessionId) → emits NOTHING
@@ -103,28 +105,51 @@ public class SessionLockBroadcastWorkoutTests
         return svc;
     }
 
-    // ── StartWorkout: Live lock acquired → emits state=Live to BOTH parties ─────
+    // ── StartWorkout: creates draft log WITHOUT any broadcast (issue #401) ───────
 
     [Fact]
-    public async Task StartWorkout_LiveLockAcquired_EmitsLiveToBothClientAndTrainer()
+    public async Task StartWorkout_PlanBound_EmitsNothing_LiveLockMovedToGoLive()
     {
-        // Arrange — plan exists, lock acquisition succeeds (Acquired)
+        // StartWorkout must NOT emit sessioneditlockchanged — that is GoLive's job (issue #401).
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
-        var lockService = AcquiredLiveService();
-        var notifier = Substitute.For<IRealtimeNotifier>();
 
         var ep = Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, CreateDbWithProfile(), lockService, LockOptions, notifier);
+            mongo, CreateDbWithProfile());
 
-        // Act
         await ep.HandleAsync(
             new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
             TestContext.Current.CancellationToken);
 
-        // Assert — 201 created
+        // 201 created — but zero notifications (no lock acquired yet)
         ep.HttpContext.Response.StatusCode.Should().Be(201);
+    }
+
+    // ── GoLive: Live lock acquired → emits state=Live to BOTH parties ────────────
+
+    [Fact]
+    public async Task GoLive_LiveLockAcquired_EmitsLiveToBothClientAndTrainer()
+    {
+        // Arrange — draft log exists, lock acquisition succeeds
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
+        var lockService = AcquiredLiveService();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<GoLiveEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, lockService, LockOptions, notifier);
+
+        // Act
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert — 200 OK
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
 
         // Must emit to the CLIENT's user id
         await notifier.Received(1).NotifyAsync(
@@ -156,27 +181,26 @@ public class SessionLockBroadcastWorkoutTests
             Arg.Any<CancellationToken>());
     }
 
-    // ── StartWorkout: 409 conflict → emits NOTHING ──────────────────────────────
+    // ── GoLive: 409 conflict (Editing lock held) → emits NOTHING ─────────────────
 
     [Fact]
-    public async Task StartWorkout_LockConflict_Returns409_EmitsNothing()
+    public async Task GoLive_LockConflict_Returns409_EmitsNothing()
     {
-        // Arrange — session is currently in Editing; acquire fails with LockConflict
-        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId, clientId: _clientId, planId: _planId, sessionId: _sessionId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [MakePlan()]);
         var lockService = ConflictLockService();
         var notifier = Substitute.For<IRealtimeNotifier>();
 
-        var ep = Factory.Create<StartWorkoutEndpoint>(
+        var ep = Factory.Create<GoLiveEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, CreateDbWithProfile(), lockService, LockOptions, notifier);
+            mongo, lockService, LockOptions, notifier);
 
-        // Act
-        await ep.HandleAsync(
-            new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
-            TestContext.Current.CancellationToken);
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
-        // Assert — 409 and zero notifications
         ep.HttpContext.Response.StatusCode.Should().Be(409);
 
         await notifier.DidNotReceive().NotifyAsync(
@@ -186,26 +210,33 @@ public class SessionLockBroadcastWorkoutTests
             Arg.Any<CancellationToken>());
     }
 
-    // ── StartWorkout: ad-hoc workout (no SessionId) → emits NOTHING ─────────────
+    // ── GoLive: ad-hoc log (no SessionId) → 200, emits NOTHING ──────────────────
 
     [Fact]
-    public async Task StartWorkout_AdHoc_NoSessionId_EmitsNothing()
+    public async Task GoLive_AdHocLog_NoSessionId_Returns200_EmitsNothing()
     {
-        // Arrange — no SessionId in request; lock path is bypassed entirely
-        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+        var logId = Guid.NewGuid();
+        // Ad-hoc log — no PlanId or SessionId on the log
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
         var lockService = Substitute.For<ISessionLockService>();
         var notifier = Substitute.For<IRealtimeNotifier>();
 
-        var ep = Factory.Create<StartWorkoutEndpoint>(
+        var ep = Factory.Create<GoLiveEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, Substitute.For<IApplicationDbContext>(), lockService, LockOptions, notifier);
+            mongo, lockService, LockOptions, notifier);
 
-        // Act — ad-hoc workout (no PlanId, no SessionId) — db is never queried on ad-hoc path
-        await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
+        await ep.HandleAsync(new GoLiveRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
-        // Assert — 201 and no lock-change notifications
-        ep.HttpContext.Response.StatusCode.Should().Be(201);
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // No lock acquired and no broadcast for ad-hoc workouts
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
 
         await notifier.DidNotReceive().NotifyAsync(
             Arg.Any<Guid>(),

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
@@ -13,14 +13,21 @@ using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
 namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
 /// <summary>
-/// Tests for session-lock enforcement in StartWorkout and CompleteWorkout endpoints (issue #382).
+/// Tests for session-lock enforcement around StartWorkout and CompleteWorkout endpoints (issue #382).
+///
+/// Design note (#401): StartWorkout no longer acquires the Live lock — that responsibility
+/// moved to GoLiveEndpoint (see GoLiveEndpointTests for the lock-state-machine coverage).
+/// StartWorkout now ONLY creates the draft log. Lock-enforcement tests that previously targeted
+/// StartWorkout have been relocated here to GoLive (or deleted where GoLiveEndpointTests already
+/// provides equivalent coverage). The remaining StartWorkout tests assert that:
+///   - Ad-hoc workouts (null PlanId or null SessionId) create a draft log without touching the lock service.
+///   - Plan-bound workouts create a draft log without touching the lock service (GoLive handles the lock).
 /// </summary>
 public class SessionLockEnforcementTests
 {
@@ -28,12 +35,6 @@ public class SessionLockEnforcementTests
     private readonly Guid _trainerId = Guid.NewGuid();
     private readonly Guid _planId = Guid.NewGuid();
     private readonly Guid _sessionId = Guid.NewGuid();
-
-    private IOptions<TrainingLockOptions> DefaultLockOptions()
-    {
-        var opts = new TrainingLockOptions { LiveTtlHours = 6, EditingTtlHours = 2 };
-        return Options.Create(opts);
-    }
 
     private TrainingPlan MakePlan(Guid? clientId = null)
     {
@@ -50,38 +51,6 @@ public class SessionLockEnforcementTests
         };
     }
 
-    private ISessionLockService AcquiredLockService()
-    {
-        var svc = Substitute.For<ISessionLockService>();
-        svc.AcquireAsync(
-                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new AcquireResult.Acquired(new SessionLock
-            {
-                SessionId = _sessionId,
-                PlanId = _planId,
-                ClientId = _clientId,
-                TrainerId = _trainerId,
-                Holder = LockHolder.Client,
-                Type = LockType.Live,
-                AcquiredAt = DateTime.UtcNow,
-                ExpiresAt = DateTime.UtcNow.AddHours(6)
-            }));
-        return svc;
-    }
-
-    private ISessionLockService LockedLockService()
-    {
-        var svc = Substitute.For<ISessionLockService>();
-        svc.AcquireAsync(
-                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new AcquireResult.LockConflict());
-        return svc;
-    }
-
     /// <summary>
     /// Builds a mock IApplicationDbContext with a ClientProfile for _clientId.
     /// PublicId = _clientId (test shortcut — plan.ClientId uses _clientId so it still matches).
@@ -91,64 +60,36 @@ public class SessionLockEnforcementTests
             .With(new ClientProfile { Id = 1, UserId = _clientId, PublicId = _clientId })
             .Build();
 
-    private StartWorkoutEndpoint CreateStartEndpoint(
-        IMongoContext mongo,
-        ISessionLockService lockService)
+    private StartWorkoutEndpoint CreateStartEndpoint(IMongoContext mongo)
     {
         return Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, CreateDbWithProfile(), lockService, DefaultLockOptions(), Substitute.For<IRealtimeNotifier>());
+            mongo, CreateDbWithProfile());
     }
 
     // ── StartWorkout tests ────────────────────────────────────────────────────
+    // StartWorkout creates the draft log only; it does NOT interact with ISessionLockService.
+    // Lock acquisition (Live lock) and the 409-on-Editing enforcement live in GoLiveEndpoint
+    // (see GoLiveEndpointTests.GoLive_ValidPlanBoundLog_Returns200_AcquiresLock_BroadcastsLive
+    //  and GoLiveEndpointTests.GoLive_SessionInEditingState_Returns409_EmitsNothing).
 
     [Fact]
-    public async Task StartWorkout_SessionInEditingState_Returns409SessionLocked()
+    public async Task StartWorkout_PlanBoundSession_CreatesDraftLogAndReturns201()
     {
-        // Arrange — plan exists, lock acquisition fails (session is Editing)
+        // Arrange — plan-bound workout: StartWorkout should create the draft and return 201
+        // WITHOUT acquiring any lock (GoLive owns that step).
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
-        var lockService = LockedLockService();
-        var ep = CreateStartEndpoint(mongo, lockService);
+        var ep = CreateStartEndpoint(mongo);
 
         var req = new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId };
 
         // Act
         await ep.HandleAsync(req, TestContext.Current.CancellationToken);
 
-        // Assert
-        ep.HttpContext.Response.StatusCode.Should().Be(409);
-        // No WorkoutLog must have been inserted
-        await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
-            Arg.Any<WorkoutLog>(),
-            Arg.Any<InsertOneOptions>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task StartWorkout_StableSession_AcquiresLockAndReturns201()
-    {
-        // Arrange — plan exists, lock acquisition succeeds
-        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
-        var lockService = AcquiredLockService();
-        var ep = CreateStartEndpoint(mongo, lockService);
-
-        var req = new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId };
-
-        // Act
-        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
-
-        // Assert
+        // Assert — draft log created
         ep.HttpContext.Response.StatusCode.Should().Be(201);
 
-        // Lock must have been acquired with Client/Live
-        await lockService.Received(1).AcquireAsync(
-            _sessionId, _planId, _clientId, _trainerId,
-            LockHolder.Client, LockType.Live,
-            TimeSpan.FromHours(6),
-            Arg.Any<CancellationToken>());
-
-        // WorkoutLog must have been inserted
         await mongo.WorkoutLogs.Received(1).InsertOneAsync(
             Arg.Is<WorkoutLog>(w => w.ClientId == _clientId && w.SessionId == _sessionId),
             Arg.Any<InsertOneOptions>(),
@@ -156,12 +97,11 @@ public class SessionLockEnforcementTests
     }
 
     [Fact]
-    public async Task StartWorkout_NullPlanId_SkipsLockAndReturns201()
+    public async Task StartWorkout_NullPlanId_CreatesDraftLogAndReturns201()
     {
-        // Arrange — ad-hoc workout: no PlanId
+        // Arrange — ad-hoc workout: no PlanId, no SessionId
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
-        var lockService = Substitute.For<ISessionLockService>();
-        var ep = CreateStartEndpoint(mongo, lockService);
+        var ep = CreateStartEndpoint(mongo);
 
         // Act
         await ep.HandleAsync(new StartWorkoutRequest { PlanId = null, SessionId = null },
@@ -170,12 +110,6 @@ public class SessionLockEnforcementTests
         // Assert
         ep.HttpContext.Response.StatusCode.Should().Be(201);
 
-        // Lock must NOT have been acquired
-        await lockService.DidNotReceive().AcquireAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-            Arg.Any<CancellationToken>());
-
         await mongo.WorkoutLogs.Received(1).InsertOneAsync(
             Arg.Is<WorkoutLog>(w => w.ClientId == _clientId && w.PlanId == null && w.SessionId == null),
             Arg.Any<InsertOneOptions>(),
@@ -183,12 +117,11 @@ public class SessionLockEnforcementTests
     }
 
     [Fact]
-    public async Task StartWorkout_NullSessionIdOnly_SkipsLockAndReturns201()
+    public async Task StartWorkout_NullSessionIdOnly_CreatesDraftLogAndReturns201()
     {
         // Arrange — PlanId provided but SessionId is null: ad-hoc relative to a plan
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
-        var lockService = Substitute.For<ISessionLockService>();
-        var ep = CreateStartEndpoint(mongo, lockService);
+        var ep = CreateStartEndpoint(mongo);
 
         // Act
         await ep.HandleAsync(new StartWorkoutRequest { PlanId = _planId, SessionId = null },
@@ -197,9 +130,9 @@ public class SessionLockEnforcementTests
         // Assert
         ep.HttpContext.Response.StatusCode.Should().Be(201);
 
-        await lockService.DidNotReceive().AcquireAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+        await mongo.WorkoutLogs.Received(1).InsertOneAsync(
+            Arg.Is<WorkoutLog>(w => w.ClientId == _clientId && w.PlanId == _planId && w.SessionId == null),
+            Arg.Any<InsertOneOptions>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutEndpointTests.cs
@@ -5,14 +5,11 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
-using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
-using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
-using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -20,29 +17,12 @@ namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
 /// <summary>
 /// Tests for <see cref="StartWorkoutEndpoint"/>.
+/// StartWorkout now only creates a draft log — no Live lock acquisition or broadcast.
+/// Lock acquisition happens in the separate GoLive endpoint (issue #401).
 /// </summary>
 public class StartWorkoutEndpointTests
 {
     private readonly Guid _clientId = Guid.NewGuid();
-    private static readonly IOptions<TrainingLockOptions> LockOptions =
-        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
-
-    private static ISessionLockService CreateNoOpLockService()
-    {
-        var svc = Substitute.For<ISessionLockService>();
-        svc.AcquireAsync(
-                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new AcquireResult.Acquired(new SessionLock
-            {
-                SessionId = Guid.NewGuid(), PlanId = Guid.NewGuid(),
-                ClientId = Guid.NewGuid(), TrainerId = Guid.NewGuid(),
-                Holder = LockHolder.Client, Type = LockType.Live,
-                AcquiredAt = DateTime.UtcNow, ExpiresAt = DateTime.UtcNow.AddHours(6)
-            }));
-        return svc;
-    }
 
     /// <summary>
     /// Builds a mock IApplicationDbContext containing a ClientProfile for _clientId
@@ -55,21 +35,20 @@ public class StartWorkoutEndpointTests
 
     private StartWorkoutEndpoint CreateEndpointWithUser(
         IMongoContext mongo,
-        ISessionLockService lockService,
         IApplicationDbContext? db = null)
     {
         var dbContext = db ?? CreateDbWithProfile();
         return Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, dbContext, lockService, LockOptions, Substitute.For<IRealtimeNotifier>());
+            mongo, dbContext);
     }
 
     [Fact]
     public async Task HandleAsync_ValidRequest_CreatesLog()
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
-        var ep = CreateEndpointWithUser(mongo, CreateNoOpLockService());
+        var ep = CreateEndpointWithUser(mongo);
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
@@ -89,8 +68,7 @@ public class StartWorkoutEndpointTests
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
         // No user claims — endpoint returns 401 before any db/lock lookup.
         var ep = Factory.Create<StartWorkoutEndpoint>(
-            mongo, Substitute.For<IApplicationDbContext>(), CreateNoOpLockService(),
-            LockOptions, Substitute.For<IRealtimeNotifier>());
+            mongo, Substitute.For<IApplicationDbContext>());
 
         await ep.HandleAsync(new StartWorkoutRequest(), TestContext.Current.CancellationToken);
 
@@ -106,19 +84,12 @@ public class StartWorkoutEndpointTests
 
         // Empty plan collection — plan does not exist.
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: []);
-        var lockService = Substitute.For<ISessionLockService>();
-        var ep = CreateEndpointWithUser(mongo, lockService);
+        var ep = CreateEndpointWithUser(mongo);
 
         await ep.HandleAsync(new StartWorkoutRequest { PlanId = planId, SessionId = sessionId },
             TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(404);
-
-        // Lock must not have been acquired and no log inserted.
-        await lockService.DidNotReceive().AcquireAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-            Arg.Any<CancellationToken>());
 
         await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
             Arg.Any<WorkoutLog>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
@@ -145,21 +116,53 @@ public class StartWorkoutEndpointTests
         };
 
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [plan]);
-        var lockService = Substitute.For<ISessionLockService>();
-        var ep = CreateEndpointWithUser(mongo, lockService);
+        var ep = CreateEndpointWithUser(mongo);
 
         await ep.HandleAsync(new StartWorkoutRequest { PlanId = planId, SessionId = sessionId },
             TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(403);
 
-        // Lock must not have been acquired and no log inserted.
-        await lockService.DidNotReceive().AcquireAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-            Arg.Any<CancellationToken>());
-
         await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
             Arg.Any<WorkoutLog>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_PlanBound_CreatesLog_WithoutBroadcast()
+    {
+        // StartWorkout no longer fires a Live broadcast — GoLive endpoint does that.
+        // This test asserts the log is created and no SignalR fan-out occurs from StartWorkout.
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "My Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [plan]);
+        var ep = CreateEndpointWithUser(mongo);
+
+        await ep.HandleAsync(new StartWorkoutRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // 201 created — draft log exists but no lock was acquired
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.WorkoutLogs.Received(1).InsertOneAsync(
+            Arg.Is<WorkoutLog>(w =>
+                w.ClientId == _clientId &&
+                w.PlanId == planId &&
+                w.SessionId == sessionId &&
+                !w.IsCompleted),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutOwnershipTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/StartWorkoutOwnershipTests.cs
@@ -5,41 +5,33 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
-using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.WorkoutLogs.StartWorkout;
 using FitnessPlatform.Application.Infrastructure.Data;
-using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
-using Microsoft.Extensions.Options;
 using NSubstitute;
 
 namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
 /// <summary>
-/// Regression tests for the StartWorkout ownership identity bug (issue #382/PR-#390 regression).
+/// Regression tests for the StartWorkout ownership identity pattern (issue #382).
 ///
-/// Root cause: the endpoint previously compared <c>plan.ClientId != Guid.Parse(userId)</c>
-/// where <c>userId</c> is the <c>ApplicationUser.Id</c>. But <c>TrainingPlan.ClientId</c> stores
-/// the <c>ClientProfile.PublicId</c>, which is a different GUID. The comparison never matched,
-/// so every plan-bound StartWorkout returned 403 and the Live lock was never acquired.
+/// StartWorkout (POST /client/training/logs) now only creates a draft log — lock acquisition
+/// and the Live broadcast have moved to the separate GoLive endpoint (issue #401).
 ///
-/// The fix resolves <c>ClientProfile.PublicId</c> via EF for the ownership comparison while
-/// keeping <c>ApplicationUser.Id</c> (the JWT user id) as the lock's <c>clientId</c> — because
-/// <c>NotificationHub</c> groups SignalR connections by <c>ApplicationUser.Id</c>, so realtime
-/// events must target the user id.
+/// Root-cause note (preserved for history): the endpoint previously compared
+/// plan.ClientId against ApplicationUser.Id but TrainingPlan.ClientId stores
+/// ClientProfile.PublicId. This file verifies the ownership resolution still uses the
+/// profile public id for the plan check while storing the user id on WorkoutLog.ClientId.
 /// </summary>
 public class StartWorkoutOwnershipTests
 {
     // Two distinct GUIDs to prove neither side of the identity split is collapsed.
-    private readonly Guid _clientUserId = Guid.NewGuid();   // ApplicationUser.Id (from JWT)
+    private readonly Guid _clientUserId = Guid.NewGuid();          // ApplicationUser.Id (from JWT)
     private readonly Guid _clientProfilePublicId = Guid.NewGuid(); // ClientProfile.PublicId
     private readonly Guid _trainerId = Guid.NewGuid();
     private readonly Guid _planId = Guid.NewGuid();
     private readonly Guid _sessionId = Guid.NewGuid();
-
-    private static readonly IOptions<TrainingLockOptions> LockOptions =
-        Options.Create(new TrainingLockOptions { LiveTtlHours = 6 });
 
     // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -68,51 +60,24 @@ public class StartWorkoutOwnershipTests
             .With(new ClientProfile { Id = 1, UserId = _clientUserId, PublicId = _clientProfilePublicId })
             .Build();
 
-    private static ISessionLockService AcquiredLockService(
-        Guid expectedClientId,
-        Guid expectedTrainerId,
-        Guid expectedSessionId,
-        Guid expectedPlanId)
-    {
-        var svc = Substitute.For<ISessionLockService>();
-        svc.AcquireAsync(
-                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new AcquireResult.Acquired(new SessionLock
-            {
-                SessionId = expectedSessionId,
-                PlanId = expectedPlanId,
-                ClientId = expectedClientId,
-                TrainerId = expectedTrainerId,
-                Holder = LockHolder.Client,
-                Type = LockType.Live,
-                AcquiredAt = DateTime.UtcNow,
-                ExpiresAt = DateTime.UtcNow.AddHours(6)
-            }));
-        return svc;
-    }
-
     // ── Tests ────────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// The owning client (JWT user id → ClientProfile.PublicId == plan.ClientId) starts a
-    /// plan-bound workout.
-    /// Expected: 201, Live lock acquired with clientId = ApplicationUser.Id (not the profile id),
-    /// WorkoutLog.ClientId = ApplicationUser.Id.
+    /// The owning client (JWT user id → ClientProfile.PublicId == plan.ClientId) creates a
+    /// plan-bound draft log.
+    /// Expected: 201, WorkoutLog.ClientId = ApplicationUser.Id (not profile id).
+    /// No lock acquisition here — that happens in GoLive.
     /// </summary>
     [Fact]
-    public async Task StartWorkout_OwningClient_Returns201_LockClientIdIsUserId()
+    public async Task StartWorkout_OwningClient_Returns201_LogClientIdIsUserId()
     {
         // Arrange
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
-        var lockService = AcquiredLockService(_clientUserId, _trainerId, _sessionId, _planId);
-        var notifier = Substitute.For<IRealtimeNotifier>();
 
         var ep = Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientUserId, AppRoles.Client))),
-            mongo, MakeDbWithOwnerProfile(), lockService, LockOptions, notifier);
+            mongo, MakeDbWithOwnerProfile());
 
         // Act
         await ep.HandleAsync(
@@ -122,19 +87,7 @@ public class StartWorkoutOwnershipTests
         // Assert — 201 created
         ep.HttpContext.Response.StatusCode.Should().Be(201);
 
-        // Lock must be acquired with the LOCK clientId = ApplicationUser.Id (not profile id).
-        // This is critical — NotificationHub routes events by ApplicationUser.Id.
-        await lockService.Received(1).AcquireAsync(
-            _sessionId,
-            _planId,
-            _clientUserId,    // must be user id — NOT _clientProfilePublicId
-            _trainerId,
-            LockHolder.Client,
-            LockType.Live,
-            TimeSpan.FromHours(6),
-            Arg.Any<CancellationToken>());
-
-        // WorkoutLog.ClientId must also be the ApplicationUser.Id
+        // WorkoutLog.ClientId must be the ApplicationUser.Id (not profile id).
         await mongo.WorkoutLogs.Received(1).InsertOneAsync(
             Arg.Is<WorkoutLog>(w =>
                 w.ClientId == _clientUserId &&   // user id, not profile id
@@ -142,29 +95,12 @@ public class StartWorkoutOwnershipTests
                 w.SessionId == _sessionId),
             Arg.Any<MongoDB.Driver.InsertOneOptions>(),
             Arg.Any<CancellationToken>());
-
-        // SignalR events must be sent to the user id (not profile id)
-        await notifier.Received(1).NotifyAsync(
-            _clientUserId,   // ApplicationUser.Id — what NotificationHub groups on
-            "sessioneditlockchanged",
-            Arg.Is<SessionLockChangedPayload>(p =>
-                p.PlanId == _planId &&
-                p.SessionId == _sessionId &&
-                p.State == "Live" &&
-                p.Holder == "Client"),
-            Arg.Any<CancellationToken>());
-
-        await notifier.Received(1).NotifyAsync(
-            _trainerId,
-            "sessioneditlockchanged",
-            Arg.Any<object>(),
-            Arg.Any<CancellationToken>());
     }
 
     /// <summary>
-    /// A different client (JWT user id → a profile whose PublicId != plan.ClientId) tries to start
-    /// a plan that belongs to another client.
-    /// Expected: 403, no lock acquired, no log created.
+    /// A different client (JWT user id → a profile whose PublicId != plan.ClientId) tries to create
+    /// a log for a plan that belongs to another client.
+    /// Expected: 403, no log created.
     /// </summary>
     [Fact]
     public async Task StartWorkout_NonOwningClient_Returns403()
@@ -178,36 +114,23 @@ public class StartWorkoutOwnershipTests
             .Build();
 
         var mongo = WorkoutLogTestHelpers.CreateMockMongo(plans: [MakePlan()]);
-        var lockService = Substitute.For<ISessionLockService>();
-        var notifier = Substitute.For<IRealtimeNotifier>();
 
         var ep = Factory.Create<StartWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(attackerUserId, AppRoles.Client))),
-            mongo, attackerDb, lockService, LockOptions, notifier);
+            mongo, attackerDb);
 
         // Act
         await ep.HandleAsync(
             new StartWorkoutRequest { PlanId = _planId, SessionId = _sessionId },
             TestContext.Current.CancellationToken);
 
-        // Assert — 403, nothing acquired, nothing created
+        // Assert — 403, nothing created
         ep.HttpContext.Response.StatusCode.Should().Be(403);
-
-        await lockService.DidNotReceive().AcquireAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
-            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
-            Arg.Any<CancellationToken>());
 
         await mongo.WorkoutLogs.DidNotReceive().InsertOneAsync(
             Arg.Any<WorkoutLog>(),
             Arg.Any<MongoDB.Driver.InsertOneOptions>(),
-            Arg.Any<CancellationToken>());
-
-        await notifier.DidNotReceive().NotifyAsync(
-            Arg.Any<Guid>(),
-            Arg.Any<string>(),
-            Arg.Any<object>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -41,7 +41,7 @@ import { href } from '@/lib/navigation'
 import { useNetworkStatus } from '@/hooks/useNetworkStatus'
 
 import axios from 'axios'
-import { startWorkout, updateWorkout, completeWorkout } from '@/api/workouts'
+import { startWorkout, updateWorkout, completeWorkout, goLive, abandonWorkout } from '@/api/workouts'
 import type { UpdateWorkoutRequest } from '@/api/workouts'
 import { Toast } from '@/lib/toast'
 import type {
@@ -2515,7 +2515,25 @@ export default function WorkoutLogScreen() {
       prefillForm(0, 0, exercises)
       // (showWodHero removed in #338)
     }
-  }, [storeStart, storeAdvanceSection, loadedLogId, activeLogId, exercises, sections, sessionId, planId, prefillForm, sessionFormat, sessionFormatConfig])
+
+    // Acquire the Live lock now that the user has explicitly started.
+    // The draft log was created on mount (startNew effect) — this is the
+    // second step that broadcasts state=Live to trainers. Best-effort:
+    // a 409 (session_locked) surfaces as a toast; other errors are logged.
+    if (logId) {
+      void goLive(logId).catch((err: unknown) => {
+        if (
+          axios.isAxiosError(err) &&
+          err.response?.status === 409 &&
+          (err.response.data as { errorCode?: string } | undefined)?.errorCode === 'session_locked'
+        ) {
+          Toast.show(t('training.sessionEditing.startBlockedToast'))
+        } else {
+          console.warn('[handleStart] goLive failed', err)
+        }
+      })
+    }
+  }, [storeStart, storeAdvanceSection, loadedLogId, activeLogId, exercises, sections, sessionId, planId, prefillForm, sessionFormat, sessionFormatConfig, t])
 
   const handleSetDone = useCallback(() => {
     const ex = exercises[currentExerciseIdx]
@@ -2704,6 +2722,15 @@ export default function WorkoutLogScreen() {
         await updateMutation.mutateAsync({ logId, req })
       } catch {
         // Offline path is handled inside updateMutation.onError; proceed anyway.
+      }
+      // Release the Live lock — the session is being abandoned mid-run.
+      // completeWorkout would have released it on normal completion; since
+      // the user is leaving early we do it explicitly here. Best-effort:
+      // the server-side TTL (6h) cleans up if this call fails.
+      try {
+        await abandonWorkout(logId)
+      } catch (err) {
+        console.warn('[handleClose] abandonWorkout failed', err)
       }
     }
     storeClose()

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -2159,6 +2159,13 @@ export default function WorkoutLogScreen() {
 
   // ── Confirm sheet ──
 
+  // ── goLive in-flight guard ──
+  // Tracks the in-flight goLive() promise so handleClose can await it before
+  // calling abandonWorkout. Without this guard, a rapid Start→Close tap sends
+  // abandonWorkout BEFORE the AcquireAsync completes, leaving the Live lock
+  // permanently held until the 6h TTL expires. (#401)
+  const goLivePromiseRef = useRef<Promise<unknown> | null>(null)
+
   // ── Elapsed timer (local interval, drives display only) ──
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const elapsedIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -2520,18 +2527,27 @@ export default function WorkoutLogScreen() {
     // The draft log was created on mount (startNew effect) — this is the
     // second step that broadcasts state=Live to trainers. Best-effort:
     // a 409 (session_locked) surfaces as a toast; other errors are logged.
+    //
+    // The promise is stored in goLivePromiseRef so handleClose can await it
+    // before calling abandonWorkout, preventing the Start→Close race where
+    // abandon reaches the server before acquire does. (#401)
     if (logId) {
-      void goLive(logId).catch((err: unknown) => {
-        if (
-          axios.isAxiosError(err) &&
-          err.response?.status === 409 &&
-          (err.response.data as { errorCode?: string } | undefined)?.errorCode === 'session_locked'
-        ) {
-          Toast.show(t('training.sessionEditing.startBlockedToast'))
-        } else {
-          console.warn('[handleStart] goLive failed', err)
-        }
-      })
+      const promise = goLive(logId)
+        .catch((err: unknown) => {
+          if (
+            axios.isAxiosError(err) &&
+            err.response?.status === 409 &&
+            (err.response.data as { errorCode?: string } | undefined)?.errorCode === 'session_locked'
+          ) {
+            Toast.show(t('training.sessionEditing.startBlockedToast'))
+          } else {
+            console.warn('[handleStart] goLive failed', err)
+          }
+        })
+        .finally(() => {
+          goLivePromiseRef.current = null
+        })
+      goLivePromiseRef.current = promise
     }
   }, [storeStart, storeAdvanceSection, loadedLogId, activeLogId, exercises, sections, sessionId, planId, prefillForm, sessionFormat, sessionFormatConfig, t])
 
@@ -2727,6 +2743,17 @@ export default function WorkoutLogScreen() {
       // completeWorkout would have released it on normal completion; since
       // the user is leaving early we do it explicitly here. Best-effort:
       // the server-side TTL (6h) cleans up if this call fails.
+      //
+      // Wait for any in-flight goLive() to settle first. If the user tapped
+      // Start and then Close before the acquire completed, we must let the
+      // AcquireAsync land before we call ReleaseAsync, otherwise the release
+      // no-ops and the lock is held until the 6h TTL. (#401)
+      try {
+        await goLivePromiseRef.current
+      } catch {
+        // goLive rejection was already handled in handleStart; swallow here
+        // so we still proceed to abandon regardless.
+      }
       try {
         await abandonWorkout(logId)
       } catch (err) {

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -164,7 +164,7 @@ export class ApiClient {
     }
 
     /**
-     * Start a workout
+     * Start a workout (create draft log)
      * @return Success
      */
     startWorkoutEndpoint(startWorkoutRequest: StartWorkoutRequest, signal?: AbortSignal): Promise<StartWorkoutResponse> {
@@ -298,6 +298,78 @@ export class ApiClient {
     }
 
     /**
+     * Go live with a workout
+     * @param logId The external ID of the workout log to go live with.
+    Bound from the route segment {logId}.
+     * @return Success
+     */
+    goLiveEndpoint(logId: string, signal?: AbortSignal): Promise<GoLiveResponse> {
+        let url_ = this.baseUrl + "/client/training/logs/{logId}/go-live";
+        if (logId === undefined || logId === null)
+            throw new globalThis.Error("The parameter 'logId' must be defined.");
+        url_ = url_.replace("{logId}", encodeURIComponent("" + logId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGoLiveEndpoint(_response);
+        });
+    }
+
+    protected processGoLiveEndpoint(response: AxiosResponse): Promise<GoLiveResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GoLiveResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GoLiveResponse>(null as any);
+    }
+
+    /**
      * Get exercise progress
      * @param clientId Client's public user identifier.
      * @param exerciseId Exercise's public identifier.
@@ -427,6 +499,78 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<WorkoutLogDetail>(null as any);
+    }
+
+    /**
+     * Abandon a workout
+     * @param logId The external ID of the workout log to abandon.
+    Bound from the route segment {logId}.
+     * @return Success
+     */
+    abandonWorkoutEndpoint(logId: string, signal?: AbortSignal): Promise<AbandonWorkoutResponse> {
+        let url_ = this.baseUrl + "/client/training/logs/{logId}/abandon";
+        if (logId === undefined || logId === null)
+            throw new globalThis.Error("The parameter 'logId' must be defined.");
+        url_ = url_.replace("{logId}", encodeURIComponent("" + logId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAbandonWorkoutEndpoint(_response);
+        });
+    }
+
+    protected processAbandonWorkoutEndpoint(response: AxiosResponse): Promise<AbandonWorkoutResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<AbandonWorkoutResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<AbandonWorkoutResponse>(null as any);
     }
 
     /**
@@ -1910,6 +2054,148 @@ export class ApiClient {
     }
 
     /**
+     * Unlock a training session for editing
+     * @param planId Training plan identifier.
+     * @param sessionId Session identifier to unlock for editing.
+     * @return No Content
+     */
+    unlockTrainingSessionEndpoint(planId: string, sessionId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/training/plans/{planId}/sessions/{sessionId}/unlock";
+        if (planId === undefined || planId === null)
+            throw new globalThis.Error("The parameter 'planId' must be defined.");
+        url_ = url_.replace("{planId}", encodeURIComponent("" + planId));
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUnlockTrainingSessionEndpoint(_response);
+        });
+    }
+
+    protected processUnlockTrainingSessionEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Relock a training session (release the Editing lock)
+     * @param planId Training plan identifier.
+     * @param sessionId Session identifier to relock.
+     * @return No Content
+     */
+    relockTrainingSessionEndpoint(planId: string, sessionId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/training/plans/{planId}/sessions/{sessionId}/relock";
+        if (planId === undefined || planId === null)
+            throw new globalThis.Error("The parameter 'planId' must be defined.");
+        url_ = url_.replace("{planId}", encodeURIComponent("" + planId));
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRelockTrainingSessionEndpoint(_response);
+        });
+    }
+
+    protected processRelockTrainingSessionEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Publish a week of a training plan
      * @param planId Plan identifier.
      * @param weekNumber Week number to publish.
@@ -2201,6 +2487,85 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<TrainingPlanSummaryDto>(null as any);
+    }
+
+    /**
+     * Finish a session on behalf of a client
+     * @param planId The training plan ExternalId (route parameter).
+     * @param sessionId The session identifier within the plan's weeks (route parameter).
+     * @return Success
+     */
+    finishSessionEndpoint(planId: string, sessionId: string, finishSessionRequest: FinishSessionRequest, signal?: AbortSignal): Promise<FinishSessionResponse> {
+        let url_ = this.baseUrl + "/trainer/training/plans/{planId}/sessions/{sessionId}/finish";
+        if (planId === undefined || planId === null)
+            throw new globalThis.Error("The parameter 'planId' must be defined.");
+        url_ = url_.replace("{planId}", encodeURIComponent("" + planId));
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(finishSessionRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processFinishSessionEndpoint(_response);
+        });
+    }
+
+    protected processFinishSessionEndpoint(response: AxiosResponse): Promise<FinishSessionResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<FinishSessionResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<FinishSessionResponse>(null as any);
     }
 
     /**
@@ -12529,6 +12894,18 @@ export interface StartWorkoutRequest {
     sessionId?: string | undefined;
 }
 
+/** Response returned when a workout log transitions to Live state. */
+export interface GoLiveResponse {
+    /** The external ID of the workout log now in Live state. */
+    logId?: string;
+    /** UTC timestamp when the Live lock was acquired. */
+    liveAt?: string;
+}
+
+/** Request to transition an existing draft workout log to Live state. */
+export interface GoLiveRequest {
+}
+
 /** Paginated response with workout log summaries. */
 export interface GetWorkoutLogsResponse {
     /** List of workout log summaries. */
@@ -12601,6 +12978,16 @@ export interface GetExerciseProgressRequest {
 export interface CompleteWorkoutRequest {
 }
 
+/** Response returned when an abandon request is processed (including idempotent no-op case). */
+export interface AbandonWorkoutResponse {
+    /** Whether a Live lock was actually released. False when the lock was already gone (idempotent). */
+    released?: boolean;
+}
+
+/** Request to abandon (discard) a draft workout session and release the Live lock. */
+export interface AbandonWorkoutRequest {
+}
+
 /** Response for POST /client/weekly-check-ins/{id}/respond. */
 export interface RespondToCheckInResponse {
     /** Check-in identifier. */
@@ -12645,6 +13032,8 @@ export interface PutSettingsResponse {
     enabled?: boolean;
     /** Optional addendum. */
     defaultAddendum?: string | undefined;
+    /** Hours after dispatch before the check-in expires. */
+    deadlineOffsetHours?: number;
 }
 
 /** Request body for PUT /trainer/weekly-check-ins/settings. */
@@ -12660,6 +13049,10 @@ Accepted values: "Training", "Nutrition". */
     enabled?: boolean;
     /** Optional addendum appended to the default reminder message. ≤ 200 characters. */
     defaultAddendum?: string | undefined;
+    /** Number of hours after the check-in is sent before it expires.
+Must be one of: 24, 48, 72, 120, 168.
+Defaults to 72 (3 days) when not specified. */
+    deadlineOffsetHours?: number;
 }
 
 /** Response for PUT /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. */
@@ -12678,6 +13071,8 @@ export interface PutOverrideResponse {
     enabled?: boolean | undefined;
     /** Override addendum. Null = inherit. */
     addendum?: string | undefined;
+    /** Override deadline offset in hours. Null = inherit. */
+    deadlineOffsetHours?: number | undefined;
 }
 
 /** Request model for PUT /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. Route params identify the override; body provides the values (null = inherit from setting). */
@@ -12690,6 +13085,9 @@ export interface PutOverrideRequest {
     enabled?: boolean | undefined;
     /** Override addendum (≤ 200 chars). Null = inherit. */
     addendum?: string | undefined;
+    /** Override deadline offset in hours. Null = inherit from the professional's setting.
+When set, must be one of 24, 48, 72, 120, or 168. */
+    deadlineOffsetHours?: number | undefined;
 }
 
 /** Response for POST /trainer/weekly-check-ins/{id}/mark-reviewed. */
@@ -12734,6 +13132,10 @@ export interface TrainerCheckInDto {
     dismissedByClientAt?: string | undefined;
     /** When the trainer marked this reviewed. Null if not reviewed. */
     reviewedByTrainerAt?: string | undefined;
+    /** Lifecycle status of the check-in. */
+    status?: string;
+    /** UTC deadline by which the client must respond. Null for rows created before v1 deadline feature. */
+    dueAt?: string | undefined;
 }
 
 /** Query parameters for GET /trainer/weekly-check-ins. */
@@ -12760,6 +13162,8 @@ export interface CheckInSettingDto {
     enabled?: boolean;
     /** Optional addendum appended to the default reminder message. */
     defaultAddendum?: string | undefined;
+    /** Hours after dispatch before the check-in expires. */
+    deadlineOffsetHours?: number;
 }
 
 /** Response model for GET /trainer/weekly-check-ins/overrides. */
@@ -12788,6 +13192,8 @@ export interface CheckInOverrideDto {
     enabled?: boolean | undefined;
     /** Override addendum. Null = inherit. */
     addendum?: string | undefined;
+    /** Override deadline offset in hours. Null = inherit. */
+    deadlineOffsetHours?: number | undefined;
 }
 
 /** Response for GET /client/weekly-check-ins/current. Returns 0–2 active (not responded, not dismissed) check-ins for the current ISO week. */
@@ -12871,6 +13277,10 @@ export interface GetCheckInDetailResponse {
     dismissedByClientAt?: string | undefined;
     /** When the trainer marked this reviewed. Null if not reviewed. */
     reviewedByTrainerAt?: string | undefined;
+    /** Lifecycle status of the check-in. */
+    status?: string;
+    /** UTC deadline by which the client must respond. Null for rows created before v1 deadline feature. */
+    dueAt?: string | undefined;
 }
 
 /** Request for GET /trainer/weekly-check-ins/{id}. */
@@ -13016,6 +13426,18 @@ Null if no questionnaire is linked to this plan. */
 Populated by the endpoint after loading the plan; the client side should filter
 to dates that fall within the plan's active weeks. */
     completions?: TrainingPlanCompletionDto[];
+    /** Per-session workout-log execution data for the plan's client.
+One entry per session that has at least one WorkoutLog record.
+Sessions with no log entry are absent (equivalent to all sets being not-yet-reached).
+The web layer uses this together with Completions to render per-set,
+per-exercise, and per-session completed/skipped/unreached state indicators. */
+    sessionExecutions?: SessionExecutionDto[];
+    /** Per-session edit-lock state for all sessions in the plan.
+Only sessions with an active (non-expired) lock appear here; a session absent from
+this list is implicitly Stable.
+The web editor uses this on initial load to show the Live in-progress badge and gate
+the unlock affordance — SignalR events update this state while the page is open. */
+    sessionLockStates?: SessionLockStateDto[];
 }
 
 /** A single week within a training plan. */
@@ -13182,6 +13604,34 @@ completion documents are transparently migrated. */
     version?: number;
 }
 
+/** Per-set execution data returned by the trainer endpoint. Lets the web layer derive completed / skipped / not-yet-reached states without storing those as flags on the document. */
+export interface SessionExecutionDto {
+    /** The SessionId this execution belongs to. */
+    sessionId?: string;
+    /** Whether the workout was finalised by the client (IsCompleted was true). */
+    isSessionFinished?: boolean;
+    /** Per-exercise map of which set numbers were completed (i.e. had a non-null
+CompletedAt). Key = ExerciseExternalId; value = sorted list
+of 1-based set numbers that were stamped as complete in the WorkoutLog.
+An absent key means no sets for that exercise were logged.
+An empty list should not occur but is treated identically to an absent key. */
+    completedSetsByExercise?: { [key: string]: number[]; };
+}
+
+/** Per-session edit-lock state projected into the trainer read model. A session with no active lock document reports Stable with a null holder. */
+export interface SessionLockStateDto {
+    /** The SessionId this lock state belongs to. */
+    sessionId?: string;
+    /** Current lock state of this session.
+Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+"Live" (client has an in-progress workout lock).
+Populated via a batch GetStateAsync call on the session lock service. */
+    lockState?: string;
+    /** Who currently holds the lock, if any.
+Possible values: "Coach", "Client", or null when the session is Stable. */
+    lockHolder?: string | undefined;
+}
+
 /** Request for a full-state update of a training plan. */
 export interface UpdateTrainingPlanRequest {
     /** Updated display name. */
@@ -13287,6 +13737,14 @@ export interface UpdateExerciseSetRequest {
     restSeconds?: number | undefined;
 }
 
+/** Request to acquire an Editing lock on a published training session. */
+export interface UnlockTrainingSessionRequest {
+}
+
+/** Request to release the Editing lock on a training session (relock it to Stable). */
+export interface RelockTrainingSessionRequest {
+}
+
 /** Request to publish a specific week of a training plan. */
 export interface PublishTrainingWeekRequest {
     /** Optimistic concurrency version. */
@@ -13355,6 +13813,26 @@ export enum TrainingPlanStatus {
 
 /** Request to retrieve a single training plan. */
 export interface GetTrainingPlanRequest {
+}
+
+/** Response after a trainer successfully finishes a session. */
+export interface FinishSessionResponse {
+    /** The workout log ExternalId that was created or completed. */
+    workoutLogId?: string;
+    /** The plan ExternalId. */
+    planId?: string;
+    /** The session identifier within the plan. */
+    sessionId?: string;
+    /** The instant the session was marked as completed (the effective completedAt value used). */
+    completedAt?: string;
+}
+
+/** Request for the trainer to retroactively finish a skipped or untouched session. */
+export interface FinishSessionRequest {
+    /** Optional backdated completion instant.
+When omitted the server uses UtcNow.
+Must be in the past (or present) and not before the plan's start date. */
+    completedAt?: string | undefined;
 }
 
 /** Request to delete a training plan. */
@@ -14674,6 +15152,14 @@ export interface GetPlanResponse {
     /** Linked questionnaire response (cross-DB reference to PostgreSQL QuestionnaireResponse.PublicId).
 Null if no questionnaire is linked to this plan. */
     questionnaireResponseId?: string | undefined;
+    /** Per-meal eaten state for all MealLog documents associated with this plan.
+One entry per (MealId, LogDate) pair that has a log record; meals without a log entry
+are absent (equivalent to not-touched / no badge).
+Populated by the endpoint after loading the plan. Ownership is guaranteed by the
+plan ownership gate above the MealLog query — filtering by PlanId is safe. */
+    mealLogs?: MealLogDto[];
+    /** Supplement recommendations attached to this plan. */
+    supplements?: SupplementDto[];
 }
 
 /** Global daily nutrition targets for a plan. */
@@ -14761,7 +15247,35 @@ export interface MealRecipe {
     foodCategories?: string[] | undefined;
 }
 
-/** Request for a full-state update of a nutrition plan: replaces name, settings, and all weeks/days/meals/foods. */
+/** Per-meal eaten state derived from a MealLog document. Lets the web layer render eaten/not-touched indicators and lock editing affordances on meals the client has already confirmed as eaten. */
+export interface MealLogDto {
+    /** The MealId this log belongs to. */
+    mealId?: string;
+    /** The calendar date (UTC) this log entry belongs to, as a date-only value.
+Matches LogDate truncated to day precision. */
+    logDate?: string;
+    /** Whether the meal has been confirmed as eaten by the client.
+true iff EatenAt was non-null in the document.
+A log with EatenAt == null is a photo-only or note-only stub —
+it is NOT considered eaten. */
+    isEaten?: boolean;
+    /** When the meal was eaten, if eaten. Null for photo-only / note-only stubs. */
+    eatenAt?: string | undefined;
+}
+
+/** A supplement entry in a nutrition plan response DTO. */
+export interface SupplementDto {
+    /** Stable public identifier for the supplement. */
+    externalId?: string;
+    /** Name of the supplement. */
+    name?: string;
+    /** Optional dosage instruction. */
+    dose?: string | undefined;
+    /** Optional additional notes. */
+    notes?: string | undefined;
+}
+
+/** Request for a full-state update of a nutrition plan: replaces name, settings, weeks/days/meals/foods, and supplements. */
 export interface UpdatePlanRequest {
     /** Updated display name. */
     name: string;
@@ -14774,6 +15288,9 @@ export interface UpdatePlanRequest {
     /** Updated start date. Must be a Monday and not in the past.
 Null clears the start date (only if it hasn't arrived and no weeks are published). */
     startDate?: string | undefined;
+    /** Full supplement list to persist. Replaces all existing supplements.
+Omitting an entry removes that supplement (full-state replace pattern). */
+    supplements?: UpdateSupplementRequest[];
 }
 
 /** Represents a single week submitted in a full-state plan update. */
@@ -14849,6 +15366,20 @@ export interface UpdateMealRecipeRequest {
     note?: string | undefined;
     /** Distinct food categories from the recipe's ingredients (snapshot). */
     foodCategories?: string[] | undefined;
+}
+
+/** Represents a single supplement entry submitted in a full-state plan update. */
+export interface UpdateSupplementRequest {
+    /** Stable public identifier for this supplement. Clients generate this on creation
+and send it back unchanged on subsequent updates so mobile reminder keys survive round-trips.
+When empty, the endpoint generates a new Guid. */
+    externalId?: string | undefined;
+    /** Name of the supplement (e.g. "Vitamin D3"). Required. */
+    name?: string;
+    /** Optional dosage instruction in free text (e.g. "1 capsule with breakfast"). */
+    dose?: string | undefined;
+    /** Optional additional notes for the client. */
+    notes?: string | undefined;
 }
 
 /** Request to publish a specific week of a nutrition plan. */
@@ -15723,6 +16254,16 @@ Empty when no live-training progress has been logged for today.
 Keeps per-set state out of the planning-document tree (Sessions) which
 represents prescription, not actuals. */
     completedSetsBySessionExercise?: { [key: string]: { [key: string]: number[]; }; };
+    /** Per-session lock state, keyed by SessionId.
+Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+"Live" (client has an in-progress workout lock).
+Missing entries are treated as "Stable".
+Populated via a single batch GetStateAsync call on the session lock service. */
+    lockStateBySession?: { [key: string]: string; };
+    /** Per-session lock holder, keyed by SessionId.
+Possible values: "Coach" (trainer/nutritionist holds the lock) or "Client".
+Null / missing when the session is in the Stable state. */
+    lockHolderBySession?: { [key: string]: string; };
 }
 
 /** Full training plan response for the client mobile view. Contains all published weeks enriched with completion state and muscle group data. */
@@ -15795,6 +16336,14 @@ Schema-on-read: legacy documents with only flat exercises are backfilled into a 
     /** Flat list of all exercises across all sections, in section order.
 Kept for backward-compatibility with callers that don't yet read Sections. */
     exercises?: ExerciseDto[];
+    /** Current lock state of this session.
+Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+"Live" (client has an in-progress workout lock).
+Populated via a batch GetStateAsync call on the session lock service. */
+    lockState?: string;
+    /** Who currently holds the lock, if any.
+Possible values: "Coach", "Client", or null when the session is Stable. */
+    lockHolder?: string | undefined;
 }
 
 /** An ordered section within a session (e.g. "Hlavní", "Warm-up", "Cool-down"). */
@@ -16166,7 +16715,7 @@ export interface GetTodayPlanResponse {
 /** Response model for the client's meal log for today. */
 export interface GetTodayLogResponse {
     /** Meals eaten today. */
-    mealsEaten?: MealLogDto[];
+    mealsEaten?: MealLogDto2[];
     /** Total nutrients consumed across all meals today. */
     totalConsumed?: NutrientTotals;
     /** Remaining nutrients to reach the daily target.
@@ -16175,7 +16724,7 @@ Null if the active plan has no global settings. */
 }
 
 /** DTO representing a single logged meal with computed nutrient totals. */
-export interface MealLogDto {
+export interface MealLogDto2 {
     /** Identifier of the meal that was eaten. */
     mealId?: string;
     /** Display name of the meal (resolved from the plan). */
@@ -16279,6 +16828,9 @@ export interface GetFullPlanResponse {
     /** Set of meal IDs that the client has logged as eaten.
 Meal IDs are unique across the plan, so a flat set covers all days. */
     eatenMealIds?: string[];
+    /** Supplement recommendations for this plan. Clients use this list to configure
+local reminder notifications; the list is read-only on the client side. */
+    supplements?: SupplementDto[];
 }
 
 /** A published week with pre-computed start/end dates. */

--- a/mobile/src/api/workouts.ts
+++ b/mobile/src/api/workouts.ts
@@ -10,6 +10,8 @@ import type {
   UpdateWorkoutRequest,
   GetExerciseProgressResponse,
   ExerciseProgressPoint,
+  GoLiveResponse,
+  AbandonWorkoutResponse,
 } from './generated';
 
 // Re-export generated types so consumer imports (`from '@/api/workouts'`) still work.
@@ -23,6 +25,8 @@ export type {
   UpdateWorkoutExerciseRequest,
   UpdateWorkoutRequest,
   ExerciseProgressPoint,
+  GoLiveResponse,
+  AbandonWorkoutResponse,
 };
 
 /**
@@ -50,6 +54,26 @@ export async function updateWorkout(
 
 export async function completeWorkout(logId: string): Promise<WorkoutLogDetail> {
   const { data } = await api.post<WorkoutLogDetail>(`/client/training/logs/${logId}/complete`);
+  return data;
+}
+
+/**
+ * Acquires the Live lock for an existing draft log.
+ * Call this when the user taps "Start" — NOT on mount (draft creation).
+ * Returns 409 with errorCode "session_locked" if another editor holds the lock.
+ */
+export async function goLive(logId: string): Promise<GoLiveResponse> {
+  const { data } = await api.post<GoLiveResponse>(`/client/training/logs/${logId}/go-live`);
+  return data;
+}
+
+/**
+ * Releases the Live lock for a log. Idempotent: succeeds (200) even when
+ * no lock is currently held (e.g. it already expired or was never acquired).
+ * Call on discard or when leaving an in-progress session without completing.
+ */
+export async function abandonWorkout(logId: string): Promise<AbandonWorkoutResponse> {
+  const { data } = await api.post<AbandonWorkoutResponse>(`/client/training/logs/${logId}/abandon`);
   return data;
 }
 

--- a/mobile/src/components/training/ResumeTrainingBanner.tsx
+++ b/mobile/src/components/training/ResumeTrainingBanner.tsx
@@ -5,6 +5,7 @@ import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { useTranslation } from 'react-i18next'
 import { useLiveSessionStore } from '@/stores/liveSessionStore'
+import { abandonWorkout } from '@/api/workouts'
 
 interface ResumeTrainingBannerProps {
   /** Exercise name at the current position in the session */
@@ -27,6 +28,7 @@ export function ResumeTrainingBanner({
   const colors = useTheme()
   const { t } = useTranslation()
   const discard = useLiveSessionStore((s) => s.discard)
+  const activeLogId = useLiveSessionStore((s) => s.activeLogId)
 
   const handleDiscard = useCallback(() => {
     Alert.alert(
@@ -37,11 +39,21 @@ export function ResumeTrainingBanner({
         {
           text: t('training.live.discardConfirm'),
           style: 'destructive',
-          onPress: () => discard(),
+          onPress: () => {
+            // Release the Live lock on the backend before clearing local state.
+            // Best-effort: if the call fails we still discard locally so the user
+            // is never trapped. The server-side TTL (6h) cleans up orphaned locks.
+            if (activeLogId) {
+              void abandonWorkout(activeLogId).catch((err: unknown) => {
+                console.warn('[ResumeTrainingBanner] abandonWorkout failed', err)
+              })
+            }
+            discard()
+          },
         },
       ],
     )
-  }, [t, discard])
+  }, [t, discard, activeLogId])
 
   return (
     <View


### PR DESCRIPTION
## Summary
Fixes the three defects in the `Live` training-session lock that drives the trainer-portal "Probíhá trénink" badge (part of epic #379, shipped via `56061cf`).

- **Defect 1 — badge fired on intro-page entry, not on Start.** `Live` lock acquisition was moved out of `StartWorkout` (which ran on intro-page mount) into a new dedicated `GoLive` endpoint, invoked from the mobile Start-button press. `StartWorkout` now only creates the draft log; it no longer acquires `LockType.Live` or broadcasts `Live`.
- **Defect 2 — badge never cleared after finishing.** Mobile `handleBackToToday()` now awaits the completion mutation (which releases the lock via `CompleteWorkoutEndpoint` → `Stable` broadcast) before navigating away, closing the navigate-before-release race.
- **Defect 3 — badge never cleared on discard.** New `AbandonWorkout` endpoint releases the `Live` lock and broadcasts `Stable`; mobile discard (`ResumeTrainingBanner.handleDiscard()` / `liveSessionStore.discard()`) now calls it before clearing local MMKV state.

## Related issue
Fixes #401

## Scope
cross-cut — backend + mobile (no web, no migrations)

## QA verdict (from qa-tester)
Static + regression surface GREEN: backend build clean, WorkoutLogs tests 27/27 pass, mobile `tsc --noEmit` clean, scope boundaries clean, `generated.ts` machine-regenerated (not hand-edited).

## Manual verification still required
- [ ] Cross-device realtime badge: with the trainer portal open on a client's plan page, drive the mobile session through Start → finish → discard and confirm the "Probíhá trénink" badge appears only on Start and clears on both finish and discard. This is interactive-only and was authorized to proceed to review without the interactive drive.

## Test plan
- [ ] Badge appears on trainer portal only when client presses Start (not on intro-page entry).
- [ ] Badge reverts to Stable after client completes the session and returns to Today.
- [ ] Badge reverts to Stable when client discards from the resume banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)