### PR TITLE
fix: hide Food category on training-plan photo views (web + mobile)

### DIFF
--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -830,7 +830,7 @@ function NutritionPlanDetail({ plan }: { plan: FullPlanResponse }) {
             style={styles.menuRow}
             onPress={() =>
               selectMenuItem(() =>
-                router.push(hrefParams('/(client)/plan-photos', { planId: plan.planId ?? '' })),
+                router.push(hrefParams('/(client)/plan-photos', { planId: plan.planId ?? '', planType: 'nutrition' })),
               )
             }
           >
@@ -1163,7 +1163,7 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
 
         {planId ? (
           <Pressable
-            onPress={() => router.push(hrefParams('/(client)/plan-photos', { planId }))}
+            onPress={() => router.push(hrefParams('/(client)/plan-photos', { planId, planType: 'training' }))}
             hitSlop={12}
             style={[styles.nutritionMenuBtn, { backgroundColor: colors.fill }]}
             accessibilityRole="button"

--- a/mobile/app/(client)/plan-photos-upload.tsx
+++ b/mobile/app/(client)/plan-photos-upload.tsx
@@ -131,7 +131,9 @@ export default function PlanPhotosUploadScreen() {
   const queryClient = useQueryClient()
   const { width } = useWindowDimensions()
 
-  const { planId } = useLocalSearchParams<{ planId: string }>()
+  const { planId, planType } = useLocalSearchParams<{ planId: string; planType?: string }>()
+  // On training plans, Food is not a valid upload category. Default stays Free.
+  const isTrainingPlan = planType === 'training'
 
   const [photos, dispatch] = useReducer(photosReducer, [])
   const [picking, setPicking] = useState(false)
@@ -348,8 +350,10 @@ export default function PlanPhotosUploadScreen() {
   const GAP = 10
   const tileWidth = (width - MARGIN * 2 - GAP) / 2
 
+  // On training plans, Food is omitted from the selector — it is a nutrition-only
+  // category. The default category 'Free' is always available on both plan types.
   const categoryChips: { key: UiCategory; label: string }[] = [
-    { key: 'Food', label: t('planPhotos.categoryFood') },
+    ...(!isTrainingPlan ? [{ key: 'Food' as UiCategory, label: t('planPhotos.categoryFood') }] : []),
     { key: 'Progress', label: t('planPhotos.categoryProgress') },
     { key: 'Free', label: t('planPhotos.categoryFree') },
   ]

--- a/mobile/app/(client)/plan-photos.tsx
+++ b/mobile/app/(client)/plan-photos.tsx
@@ -86,7 +86,11 @@ export default function PlanPhotosScreen() {
   const { width } = useWindowDimensions()
 
   // planId is required — passed by plans/[planId].tsx via hrefParams.
-  const { planId } = useLocalSearchParams<{ planId: string }>()
+  // planType determines which category chips are shown:
+  //   'training' → Food chip omitted (Food is irrelevant for training plans).
+  //   'nutrition' (or absent) → all four chips shown (backward-safe default).
+  const { planId, planType } = useLocalSearchParams<{ planId: string; planType?: string }>()
+  const isTrainingPlan = planType === 'training'
 
   // ── Active category filter ('All' shows everything) ──
   const [activeFilter, setActiveFilter] = useState<FilterCategory>('All')
@@ -157,8 +161,10 @@ export default function PlanPhotosScreen() {
   // listens for via the SignalR hook above plus its own staleTime.
   const handleFabPress = useCallback(() => {
     if (!planId) return
-    router.push(hrefParams('/(client)/plan-photos-upload', { planId }))
-  }, [planId, router])
+    const params: Record<string, string> = { planId }
+    if (planType) params.planType = planType
+    router.push(hrefParams('/(client)/plan-photos-upload', params))
+  }, [planId, planType, router])
 
   const handleTilePress = useCallback((index: number) => {
     setLightboxIndex(index)
@@ -247,11 +253,14 @@ export default function PlanPhotosScreen() {
       </View>
 
       {/* ── Category filter chips ── */}
+      {/* On training plans the Food chip is omitted — Food is a nutrition-only
+          category. The 'All' tab still includes any pre-existing Food-categorised
+          photos (orphan-photo safety; the All count is unchanged). */}
       <View style={styles.chipsRow}>
         {(
           [
             { key: 'All', label: t('planPhotos.categoryAll'), count: allPhotos.length },
-            { key: 'Food', label: t('planPhotos.categoryFood'), count: foodCount },
+            ...(!isTrainingPlan ? [{ key: 'Food' as FilterCategory, label: t('planPhotos.categoryFood'), count: foodCount }] : []),
             { key: 'Progress', label: t('planPhotos.categoryProgress'), count: progressCount },
             { key: 'Free', label: t('planPhotos.categoryFree'), count: freeCount },
           ] as { key: FilterCategory; label: string; count: number }[]

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1130,16 +1130,16 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
     markAllTrainingDoneMutation.mutate()
   }, [todaySessions, sessionCompleteMap, markAllTrainingDoneMutation])
 
-  /** Navigate to the plan-photos gallery screen. */
+  /** Navigate to the plan-photos gallery screen (nutrition plan). */
   const handlePhotoGridPress = useCallback(() => {
     if (!plan?.planId) return
-    router.push(hrefParams('/(client)/plan-photos', { planId: plan.planId }))
+    router.push(hrefParams('/(client)/plan-photos', { planId: plan.planId, planType: 'nutrition' }))
   }, [router, plan?.planId])
 
-  /** Navigate to the training plan-photos gallery screen. */
+  /** Navigate to the training plan-photos gallery screen (training plan). */
   const handleTrainingPhotoGridPress = useCallback(() => {
     if (!training?.planId) return
-    router.push(hrefParams('/(client)/plan-photos', { planId: training.planId }))
+    router.push(hrefParams('/(client)/plan-photos', { planId: training.planId, planType: 'training' }))
   }, [router, training?.planId])
 
   /** Navigate to the meal-log-photo modal screen for the tapped meal. */

--- a/web/src/components/photos/PlanPhotosTab.tsx
+++ b/web/src/components/photos/PlanPhotosTab.tsx
@@ -35,6 +35,14 @@ interface PlanPhotosTabProps {
    * Sourced from the client-list or client-dashboard API response.
    */
   linkId?: number | null;
+  /**
+   * When false, the Food category chip is hidden from the filter row.
+   * Use for training plans where food photos are not relevant.
+   * Defaults to true (Food chip shown) so NutritionPlanPage needs no change.
+   * Note: the "All" chip is always shown and continues to include any
+   * Food-categorised photos already on the plan (orphan-photo safety).
+   */
+  allowFoodCategory?: boolean;
 }
 
 // Sentinel for the dedicated diaries tab — sits in the same chip row as the
@@ -53,7 +61,7 @@ const CATEGORIES: Array<{ key: PlanPhotoCategory | null; labelKey: string }> = [
 
 const PAGE_SIZE = 60;
 
-export function PlanPhotosTab({ planId, clientId, clientName, linkId }: PlanPhotosTabProps) {
+export function PlanPhotosTab({ planId, clientId, clientName, linkId, allowFoodCategory = true }: PlanPhotosTabProps) {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<ActiveTab>(null);
   const isDiariesTab = activeTab === 'Diaries';
@@ -61,6 +69,13 @@ export function PlanPhotosTab({ planId, clientId, clientName, linkId }: PlanPhot
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [diaryDialogOpen, setDiaryDialogOpen] = useState(false);
+
+  // Filter out the Food chip when the caller explicitly disallows it
+  // (training plans). The "All" entry (key: null) is always kept so orphan
+  // Food-categorised photos remain reachable under All.
+  const visibleCategories = allowFoodCategory
+    ? CATEGORIES
+    : CATEGORIES.filter((c) => c.key !== PlanPhotoCategory.Food);
 
   const resolvedClientName = clientName ?? '';
   const clientInitials = resolvedClientName
@@ -136,7 +151,7 @@ export function PlanPhotosTab({ planId, clientId, clientName, linkId }: PlanPhot
           when the CTA toggles in / out — `h-12` is enough headroom for any
           chip-button height regardless of glyph metrics. */}
       <div className="shrink-0 flex items-center gap-1 px-4 h-12 border-b border-border">
-        {CATEGORIES.map(({ key, labelKey }) => {
+        {visibleCategories.map(({ key, labelKey }) => {
           const isActive = !isDiariesTab && activeCategory === key;
           const count = counts[key === null ? 'All' : key] ?? 0;
           return (

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -731,6 +731,7 @@ export default function TrainingPlanPage() {
             clientId={plan.clientId}
             clientName={clientName ?? undefined}
             linkId={clientEntry?.linkId}
+            allowFoodCategory={false}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Training-plan photo views now hide the **Food / Jídlo** category in both the gallery filter chips and the mobile upload category selector.
- **Web** (`PlanPhotosTab.tsx`): new `allowFoodCategory?: boolean` prop (defaults `true`); `TrainingPlanPage.tsx` passes `allowFoodCategory={false}`. `NutritionPlanPage` needs no change.
- **Mobile**: a `planType` route param (`'training'` / `'nutrition'`) is threaded from `(tabs)/plans/[planId].tsx` and `today/HasTrainerState.tsx` into `plan-photos.tsx` (filter chips) and `plan-photos-upload.tsx` (upload selector). When `planType === 'training'` the Food chip/option is omitted.
- Nutrition-plan photos are **unchanged** — all four chips (Vše, Jídlo, Postup, Volné) still render.
- The **"All / Vše"** tab is deliberately unchanged on both clients, so any pre-existing Food-categorised photo on a training plan stays viewable under All (orphan-photo safety). The All count is unchanged.
- No backend, no migrations, no `generated.ts`, no new i18n keys (reuses the existing `categoryFood` key; rendering is now guarded).

## Related issue
Fixes #397

## Scope
cross-cut (web + mobile) — standalone bug

## QA verdict (from qa-tester)
Static surface GREEN: web build clean, mobile `tsc --noEmit` clean, expo-doctor green (sole item is pre-existing SDK pin drift), scope clean.

## Manual verify (interactive ACs — not driven by qa-tester this turn, per user authorization)
- [ ] Training plan photos (mobile "Fotky z plánu" + web training-plan detail → photos tab): **no** Jídlo/Food chip in the filter bar.
- [ ] Mobile upload selector on a training plan: **no** Food option.
- [ ] Nutrition plan photos still show all four chips.
- [ ] "All / Vše" tab on a training plan still surfaces any pre-existing Food-categorised photo.

## Test plan
- [ ] Open a training plan's photos tab/screen → Food chip absent (web + mobile).
- [ ] Open the mobile training-plan upload selector → Food option absent.
- [ ] Open a nutrition plan's photos → all four chips present (regression check).
- [ ] All/Vše tab unchanged on both plan types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)