### PR TITLE
feat: add camera affordance to training session card (replace 0/3 pill)

### DIFF
--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -1377,15 +1377,6 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
                     summaryParts.push(t('training.workoutUntimedCount', { count: untimedCount }))
                   }
 
-                  // Session pill: count workouts (sections), not exercises.
-                  // Uses section.isCompleted from the backend (#260 fix) so
-                  // empty-exercise sections are counted correctly via
-                  // TrainingCompletion.CompletedSectionIds.
-                  const totalWorkouts = sections.length
-                  const completedWorkouts = sections.filter(
-                    (sec) => sec.isCompleted === true,
-                  ).length
-
                   // Read-only session completion indicator for headerRight.
                   // A session is complete IFF every section (workout) within it
                   // is complete. Empty-exercise sections are flagged complete by
@@ -1419,8 +1410,6 @@ function TrainingPlanDetail({ plan }: { plan: GetFullTrainingPlanResponse }) {
                       key={session.sessionId ?? index}
                       name={session.name ?? ''}
                       summaryText={summaryParts.join(' · ')}
-                      completedCount={completedWorkouts}
-                      totalCount={totalWorkouts}
                       defaultExpanded={isSessionExpanded}
                       standalone
                       headerRight={sessionCheckIndicator}

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1142,6 +1142,12 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
     router.push(hrefParams('/(client)/plan-photos', { planId: training.planId, planType: 'training' }))
   }, [router, training?.planId])
 
+  /** Navigate to the training plan-photos upload screen from the session card camera button. */
+  const handleSessionPhotoPress = useCallback(() => {
+    if (!training?.planId) return
+    router.push(hrefParams('/(client)/plan-photos-upload', { planId: training.planId, planType: 'training' }))
+  }, [router, training?.planId])
+
   /** Navigate to the meal-log-photo modal screen for the tapped meal. */
   const handlePhotoPress = useCallback(
     (mealId: string) => {
@@ -1311,6 +1317,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               lockStateBySession={trainingQuery.data?.lockStateBySession ?? {}}
               onMarkAllTrainingDone={handleMarkAllTrainingDone}
               isMarkAllTrainingLoading={markAllTrainingDoneMutation.isPending}
+              onSessionPhotoPress={handleSessionPhotoPress}
             />
           </View>
         ) : hasActivePlanButNoTrainingToday ? (

--- a/mobile/src/components/training/ExpandableSessionCard.tsx
+++ b/mobile/src/components/training/ExpandableSessionCard.tsx
@@ -6,8 +6,10 @@ import Animated, {
   useAnimatedStyle,
   withTiming,
 } from 'react-native-reanimated'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { type ColorScheme } from '@/constants/colors'
+import { goldAlpha } from '@/constants/colors'
 import { Type, interFamily } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import {
@@ -63,8 +65,6 @@ interface ExpandableSessionCardProps {
   name: string
   /** Short descriptor e.g. "4 cviky · 45 min" */
   summaryText: string
-  completedCount: number
-  totalCount: number
   /**
    * Hour component (0–23) of the session's scheduled start time.
    * Used to pick a time-of-day accent color for the left bar and expanded
@@ -87,7 +87,7 @@ interface ExpandableSessionCardProps {
   isFirst?: boolean
   /**
    * Optional node injected at the right side of the header row, between the
-   * progress pill and the chevron. Use this to render a session-level checkbox.
+   * camera button and the chevron. Use this to render a session-level checkbox.
    * Tapping the injected element should call `event.stopPropagation()` so it
    * does NOT collapse/expand the card.
    */
@@ -107,6 +107,16 @@ interface ExpandableSessionCardProps {
    * screen (no chrome, hairline top divider between siblings).
    */
   standalone?: boolean
+  /**
+   * When provided, renders a camera icon button in the header slot where the
+   * progress pill previously appeared. The button fires `onPhotoPress` without
+   * collapsing/expanding the card (uses `e.stopPropagation()`).
+   *
+   * When absent (e.g. plan-detail screen renders `ExpandableSessionCard`
+   * directly with no photo handler), no camera button is rendered — keeping
+   * the plan-detail path unchanged.
+   */
+  onPhotoPress?: () => void
   children: React.ReactNode
 }
 
@@ -123,8 +133,6 @@ interface ExpandableSessionCardProps {
 export function ExpandableSessionCard({
   name,
   summaryText,
-  completedCount,
-  totalCount,
   startHour,
   index = 0,
   defaultExpanded = false,
@@ -133,8 +141,10 @@ export function ExpandableSessionCard({
   standalone = false,
   children,
   bodyFooter,
+  onPhotoPress,
 }: ExpandableSessionCardProps) {
   const colors = useTheme()
+  const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(defaultExpanded)
   const chevronProgress = useSharedValue(defaultExpanded ? 1 : 0)
 
@@ -152,10 +162,6 @@ export function ExpandableSessionCard({
       return next
     })
   }, [chevronProgress])
-
-  const allDone = totalCount > 0 && completedCount === totalCount
-  const pillColor = allDone ? colors.green : colors.label2
-  const pillBg = allDone ? colors.green + '1E' : colors.fill
 
   // Left-bar accent color — derived from session start hour, matches prototype kind palette.
   const kindColor = sessionKindColor(startHour, colors, index)
@@ -200,12 +206,30 @@ export function ExpandableSessionCard({
           </Text>
         </View>
 
-        {/* Done/total pill */}
-        <View style={[styles.progressPill, { backgroundColor: pillBg }]}>
-          <Text style={[Type.caption1, { color: pillColor, fontFamily: interFamily('600'), fontWeight: '600' }]}>
-            {completedCount}/{totalCount}
-          </Text>
-        </View>
+        {/* Camera button — only rendered when onPhotoPress is provided.
+            Mirrors MealRow's CameraButton: goldAlpha circle, Ionicons camera,
+            stopPropagation so it doesn't toggle the card expand/collapse.
+            Absent on plan-detail screen (no prop passed) — that path unchanged. */}
+        {onPhotoPress != null && (
+          <Pressable
+            onPress={(e) => {
+              e.stopPropagation?.()
+              onPhotoPress()
+            }}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('training.sessionPhotoA11y')}
+            style={[
+              styles.cameraBtn,
+              {
+                backgroundColor: goldAlpha['12'],
+                borderColor: goldAlpha['35'],
+              },
+            ]}
+          >
+            <Ionicons name="camera" size={15} color={colors.onGoldChip} />
+          </Pressable>
+        )}
 
         {/* Optional header-right slot (e.g. session-level checkbox).
             Rendered directly — all three levels now use the same 24×24 checkbox
@@ -283,10 +307,17 @@ const styles = StyleSheet.create({
     flex: 1,
     minWidth: 0,
   },
-  progressPill: {
-    paddingHorizontal: 10,
-    paddingVertical: 3,
-    borderRadius: 99,
+  /**
+   * Gold-tinted circular camera button — mirrors MealRow's cameraBtn style.
+   * 28×28 to match the prototype spec exactly.
+   */
+  cameraBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
     flexShrink: 0,
   },
   chevron: {

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -143,6 +143,14 @@ interface TrainingCardProps {
    * Sourced from GetTodaySessionResponse.lockStateBySession (#382).
    */
   lockStateBySession?: Record<string, string>
+  /**
+   * Called when the user taps the camera icon on a session card header.
+   * Passed down through SessionSectionList to ExpandableSessionCard.
+   * When absent, no camera button is rendered on the session card.
+   * HasTrainerState supplies this to navigate to plan-photos-upload for the
+   * training plan (plan-level, v1 — session-level linkage is a future enhancement).
+   */
+  onSessionPhotoPress?: () => void
 }
 
 // ─── formatSets ───────────────────────────────────────────────────────────────
@@ -265,6 +273,7 @@ export function TrainingCard({
   onMarkAllTrainingDone,
   isMarkAllTrainingLoading,
   lockStateBySession = {},
+  onSessionPhotoPress,
 }: TrainingCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -459,6 +468,7 @@ export function TrainingCard({
               onToggleExercises={onToggleExercises}
               onToggleSection={onToggleSection}
               onSessionCta={onSessionCta}
+              onSessionPhotoPress={onSessionPhotoPress}
               t={t}
             />
           )
@@ -534,6 +544,12 @@ interface SessionSectionListProps {
   onToggleExercises?: (sessionId: string, sectionId: string, exerciseIds: string[], complete: boolean) => void
   onToggleSection?: (sessionId: string, sectionId: string) => void
   onSessionCta?: (session: TrainingSession, state: SessionCtaState) => void
+  /**
+   * When provided, a camera button is rendered in the session card header.
+   * Passed through to ExpandableSessionCard's `onPhotoPress` prop.
+   * HasTrainerState supplies this to navigate to plan-photos-upload (training plan).
+   */
+  onSessionPhotoPress?: () => void
   t: (key: string, opts?: Record<string, unknown>) => string
 }
 
@@ -561,6 +577,7 @@ function SessionSectionList({
   onToggleExercises,
   onToggleSection,
   onSessionCta,
+  onSessionPhotoPress,
   t,
 }: SessionSectionListProps) {
   const colors = useTheme()
@@ -578,23 +595,6 @@ function SessionSectionList({
     setExpandedSections((prev) => ({ ...prev, [sectionKey]: !prev[sectionKey] }))
   }, [])
 
-  // Session-header progress is by workouts (sections), not exercises.
-  // A workout counts as finished when:
-  //   - it has trackable exercises AND every one is in that section's per-section
-  //     completed set (uses `sectionCompletionMap` to avoid cross-section bleed), OR
-  //   - it has no trackable exercises (e.g. ForTime "Running") AND its
-  //     sectionId is in `completedSectionIds`.
-  const totalWorkouts = sections.length
-  const completedWorkouts = sections.filter((sec) => {
-    const trackable = (sec.exercises ?? []).filter((e) => e.exerciseExternalId != null)
-    if (trackable.length > 0) {
-      const sectionCompletedIds =
-        sec.sectionId != null ? (sectionCompletionMap.get(sec.sectionId) ?? new Set<string>()) : new Set<string>()
-      return trackable.every((e) => sectionCompletedIds.has(e.exerciseExternalId!))
-    }
-    return sec.sectionId != null && completedSectionIds.has(sec.sectionId)
-  }).length
-
   return (
             <ExpandableSessionCard
               key={sessionId}
@@ -602,9 +602,8 @@ function SessionSectionList({
               isFirst={isFirst}
               name={name}
               summaryText={summaryText}
-              completedCount={completedWorkouts}
-              totalCount={totalWorkouts}
               headerRight={sessionCheckbox}
+              onPhotoPress={onSessionPhotoPress}
             >
               {/* Section-grouped exercise cards */}
               {sections.map((section, sectionIdx) => {

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -984,6 +984,7 @@
       "amrapExerciseDone": "Hotovo {{rounds}}× · {{total}} opak."
     },
     "photoCta": "Foto",
+    "sessionPhotoA11y": "Přidat fotku tréninku",
     "sessions": {
       "reminder": {
         "toggleLabel": "Připomenutí",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -952,6 +952,7 @@
       "amrapExerciseDone": "{{rounds}}× erledigt · {{total}} Wdh."
     },
     "photoCta": "Foto",
+    "sessionPhotoA11y": "Trainingsfoto hinzufügen",
     "sessions": {
       "reminder": {
         "toggleLabel": "Erinnerung",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -730,6 +730,7 @@
       "amrapExerciseDone": "Done {{rounds}}× · {{total}} reps"
     },
     "photoCta": "Photo",
+    "sessionPhotoA11y": "Add training photo",
     "sessions": {
       "reminder": {
         "toggleLabel": "Reminder",


### PR DESCRIPTION
## Summary
- Today-screen training session card header gains a camera-icon affordance (gold-tinted 28×28 circle, mirrors the meal card's `CameraButton`) that opens the training-plan photo-upload flow.
- The `0/3` progress pill is removed from the shared `ExpandableSessionCard` header **everywhere** (Today + plan-detail) — user-approved, not scope creep.
- Camera button is gated behind `onPhotoPress` truthiness, so the plan-detail reuse of the shared card renders **no** camera.
- New localized a11y key `training.sessionPhotoA11y` in cs/en/de.

## Related issue
Fixes #399

## Scope
mobile

## QA verdict (from qa-tester)
Static GREEN — mobile `tsc --noEmit` clean, expo-doctor green (one pre-existing SDK-drift advisory), i18n parity confirmed in cs/en/de, scope clean.

## Manual verify (interactive ACs not driven this round — user authorized proceeding)
- [ ] Camera icon **appears** in the Today training session card header (styled like the meal card camera button).
- [ ] Camera icon is **absent** on the plan-detail session cards.
- [ ] Tapping it opens `plan-photos-upload` for the training plan (Food category hidden — tracked in #397).
- [ ] No layout regression in the remaining header elements after pill removal.

## Notes
- `plans/[planId].tsx` is touched only as the necessary consequence of removing the `completedCount`/`totalCount` props from the shared `ExpandableSessionCard`; the plan-detail pill removal is intended (user explicitly authorized removing the 0/3 pill everywhere).

## Test plan
- [ ] Training session card header on the Today screen shows a camera-icon button styled identically to the meal card's `CameraButton` (Ionicons camera size 15, 28×28 circle, `goldAlpha['12']` bg, `goldAlpha['35']` border, borderWidth 1.5, icon `colors.onGoldChip`) — design tokens only.
- [ ] The `0/3` progress pill is removed from the training session card header; no layout regression.
- [ ] Tapping the camera button opens `plan-photos-upload` for the training plan, passing the plan's `planId`.
- [ ] The camera button's a11y label is the localized key `training.sessionPhotoA11y`, populated in cs/en/de.
- [ ] No `any`; no hardcoded colors; all new strings localized in cs/en/de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)