### PR TITLE
feat: mirror per-session photo gallery + "Fotky dne" strip onto training

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
@@ -64,4 +64,9 @@ public static class MongoCollections
     /// Active session lock documents (Editing or Live state; absence = Stable).
     /// </summary>
     public const string SessionLocks = "sessionLocks";
+
+    /// <summary>
+    /// Session log entries — photos and notes attached to a specific training session diary entry.
+    /// </summary>
+    public const string SessionLogs = "sessionLogs";
 }

--- a/backend/FitnessPlatform.Application/Domain/Documents/SessionLog.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/SessionLog.cs
@@ -1,0 +1,106 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// MongoDB document recording photos and notes attached to a specific training session diary entry.
+/// Keyed by <c>(ClientId, PlanId, SessionId, LogDate)</c> — one document per client per session per calendar day.
+/// <para>
+/// <b>ClientId</b> stores <c>ClientProfile.PublicId</c>, mirroring <see cref="MealLog"/>'s real write convention.
+/// This is <b>not</b> <c>ApplicationUser.Id</c> (which <see cref="WorkoutLog"/> uses — a separate convention).
+/// </para>
+/// </summary>
+public class SessionLog
+{
+    /// <summary>
+    /// MongoDB internal identifier.
+    /// </summary>
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public ObjectId Id { get; set; }
+
+    /// <summary>
+    /// The client who owns this log entry — stores <c>ClientProfile.PublicId</c>.
+    /// </summary>
+    [BsonElement("clientId")]
+    public Guid ClientId { get; set; }
+
+    /// <summary>
+    /// Reference to the training plan's ExternalId.
+    /// </summary>
+    [BsonElement("planId")]
+    public Guid PlanId { get; set; }
+
+    /// <summary>
+    /// Reference to the <see cref="TrainingSession.SessionId"/> this log belongs to.
+    /// </summary>
+    [BsonElement("sessionId")]
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The calendar date (UTC) this log entry belongs to.
+    /// Used to key the "one log per day per session" invariant.
+    /// </summary>
+    [BsonElement("logDate")]
+    public DateTime LogDate { get; set; }
+
+    /// <summary>
+    /// Photos attached to this session log entry.
+    /// Each photo is a reference to a blob URL in MinIO uploaded via the signed-URL flow.
+    /// </summary>
+    [BsonElement("photos")]
+    public List<SessionPhoto> Photos { get; set; } = [];
+
+    /// <summary>
+    /// Optional free-text note the client can attach to a session log (max 500 chars).
+    /// Null on existing docs — backward compatible.
+    /// </summary>
+    [BsonElement("note")]
+    [BsonIgnoreIfNull]
+    public string? Note { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the document was created.
+    /// </summary>
+    [BsonElement("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// UTC timestamp when the document was last updated.
+    /// </summary>
+    [BsonElement("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Optimistic concurrency version. Incremented on each update.
+    /// </summary>
+    [BsonElement("version")]
+    public int Version { get; set; } = 1;
+}
+
+/// <summary>
+/// A photo reference attached to a <see cref="SessionLog"/> entry.
+/// </summary>
+public class SessionPhoto
+{
+    /// <summary>
+    /// The MinIO blob URL for this photo, as returned by the signed-URL upload helper.
+    /// </summary>
+    [BsonElement("blobUrl")]
+    public string BlobUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC timestamp when the photo was uploaded/persisted.
+    /// </summary>
+    [BsonElement("uploadedAt")]
+    public DateTime UploadedAt { get; set; }
+
+    /// <summary>
+    /// Optional caption / per-photo note (max 500 chars).
+    /// Null on existing documents — backward compatible.
+    /// </summary>
+    [BsonElement("note")]
+    [BsonIgnoreIfNull]
+    public string? Note { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/PlanPhotoCategory.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/PlanPhotoCategory.cs
@@ -14,4 +14,7 @@ public enum PlanPhotoCategory
 
     /// <summary>Uncategorised / free-form photo (Volné) — not tied to a specific meal or body check-in.</summary>
     FreeForm,
+
+    /// <summary>Training session photo — linked to a session log entry via the SessionId.</summary>
+    Training,
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlEndpoint.cs
@@ -1,0 +1,120 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.GenerateSessionPhotoUploadUrl;
+
+/// <summary>
+/// Generates a pre-signed URL for the caller to upload a training session diary photo directly to blob storage.
+/// The photo lands under <c>diary/sessions/{sessionId}/{guid}.{ext}</c> — the <see cref="ImageUploadScope.Diary"/>
+/// namespace — mirroring the meal diary photo upload URL pattern.
+/// </summary>
+/// <param name="imageUpload">Image upload service — validates content type and size, then issues the signed URL.</param>
+/// <param name="mongo">MongoDB context for ownership verification.</param>
+/// <param name="db">Relational database context for client profile lookup.</param>
+public class GenerateSessionPhotoUploadUrlEndpoint(
+    IImageUploadService imageUpload,
+    IMongoContext mongo,
+    IApplicationDbContext db)
+    : Endpoint<GenerateSessionPhotoUploadUrlRequest, GenerateSessionPhotoUploadUrlResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/log/sessions/{SessionId}/photo-upload-url");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Generate training session photo upload URL";
+            s.Description =
+                "Returns a time-limited pre-signed URL for direct upload of a training session diary photo "
+                + "to blob storage (diary/sessions/{sessionId}/{guid}.{ext}), together with the permanent "
+                + "blob URL to pass to POST /client/training/log/sessions/{sessionId}/photos.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GenerateSessionPhotoUploadUrlRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        // Resolve the caller's client profile
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+
+        // Resolve the client's active training plan
+        var planFilter = Builders<TrainingPlan>.Filter.And(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId),
+            Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active));
+
+        var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify the SessionId belongs to the active plan
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Build the sub-path: sessions/{sessionId}/{guid}.{ext} — prefix "diary/" is added by the service
+        var extension = GetExtension(req.ContentType);
+        var subPath = $"sessions/{req.SessionId}/{Guid.NewGuid()}.{extension}";
+
+        var result = await imageUpload.GenerateUploadUrlAsync(
+            ImageUploadScope.Diary,
+            subPath,
+            req.ContentType,
+            req.SizeBytes,
+            ct);
+
+        await Send.OkAsync(new GenerateSessionPhotoUploadUrlResponse
+        {
+            UploadUrl = result.UploadUrl,
+            BlobUrl = result.BlobUrl
+        }, ct);
+    }
+
+    // Returns a file extension for known image content types.
+    private static string GetExtension(string contentType) => contentType.ToLowerInvariant() switch
+    {
+        "image/jpeg" => "jpg",
+        "image/png"  => "png",
+        "image/webp" => "webp",
+        "image/heic" => "heic",
+        "image/heif" => "heif",
+        _            => "bin",
+    };
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlRequest.cs
@@ -1,0 +1,23 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.GenerateSessionPhotoUploadUrl;
+
+/// <summary>
+/// Request model for generating a pre-signed training session photo upload URL.
+/// </summary>
+public class GenerateSessionPhotoUploadUrlRequest
+{
+    /// <summary>
+    /// The unique identifier of the session the photo will be attached to.
+    /// Sourced from the route segment <c>{SessionId}</c>.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp", "image/heic", "image/heif").
+    /// </summary>
+    public string ContentType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Declared file size in bytes. Must not exceed 10 MiB.
+    /// </summary>
+    public long SizeBytes { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlResponse.cs
@@ -1,0 +1,18 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.GenerateSessionPhotoUploadUrl;
+
+/// <summary>
+/// Response for the session photo upload URL generation endpoint.
+/// </summary>
+public class GenerateSessionPhotoUploadUrlResponse
+{
+    /// <summary>
+    /// Time-limited pre-signed URL the client uses to PUT the image directly to blob storage.
+    /// </summary>
+    public string UploadUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The permanent blob URL to pass to <c>POST /client/training/log/sessions/{sessionId}/photos</c>
+    /// after the upload completes.
+    /// </summary>
+    public string BlobUrl { get; set; } = string.Empty;
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GenerateSessionPhotoUploadUrl/GenerateSessionPhotoUploadUrlValidator.cs
@@ -1,0 +1,46 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.GenerateSessionPhotoUploadUrl;
+
+/// <summary>
+/// Validates the <see cref="GenerateSessionPhotoUploadUrlRequest"/>.
+/// Whitelists image content types and enforces a 10 MiB size cap.
+/// Final content-type and sub-path enforcement is delegated to <c>IImageUploadService</c>.
+/// </summary>
+public class GenerateSessionPhotoUploadUrlValidator : Validator<GenerateSessionPhotoUploadUrlRequest>
+{
+    private static readonly string[] AllowedContentTypes =
+    [
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/heic",
+        "image/heif",
+    ];
+
+    /// <summary>Maximum allowed image file size: 10 MiB.</summary>
+    public const long MaxSizeBytes = 10L * 1024 * 1024;
+
+    /// <summary>
+    /// Initializes validation rules for the session photo upload-URL request.
+    /// </summary>
+    public GenerateSessionPhotoUploadUrlValidator()
+    {
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.ContentType)
+            .Must(ct => AllowedContentTypes.Contains(ct, StringComparer.OrdinalIgnoreCase))
+            .WithErrorCode(ErrorCodes.InvalidImageContentType)
+            .WithMessage($"Content type must be one of: {string.Join(", ", AllowedContentTypes)}.")
+            .When(x => !string.IsNullOrEmpty(x.ContentType));
+
+        RuleFor(x => x.SizeBytes)
+            .GreaterThan(0).WithErrorCode(ErrorCodes.OutOfRange)
+            .LessThanOrEqualTo(MaxSizeBytes)
+            .WithErrorCode(ErrorCodes.ImageTooLarge)
+            .WithMessage($"Image must not exceed {MaxSizeBytes / (1024 * 1024)} MB.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
@@ -342,6 +342,33 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
                         sessionSetsMap[plannedEx.ExerciseExternalId] = plannedSetNumbers.OrderBy(n => n).ToList();
                 }
             }
+
+            // ── Batch-fetch SessionLog docs for today (photo gallery) ─────────────
+            // One query for all of today's sessions; keyed by SessionId in the response.
+            // ClientId in SessionLog = ClientProfile.PublicId (same as clientId here).
+            var sessionLogFilter =
+                Builders<SessionLog>.Filter.Eq(l => l.ClientId, clientId)
+                & Builders<SessionLog>.Filter.In(l => l.SessionId, todaySessionIds)
+                & Builders<SessionLog>.Filter.Eq(l => l.LogDate, targetDate);
+
+            var sessionLogs = await mongo.SessionLogs
+                .Find(sessionLogFilter)
+                .ToListAsync(ct);
+
+            foreach (var sessionLog in sessionLogs)
+            {
+                if (sessionLog.Photos.Count > 0)
+                {
+                    response.PhotosBySession[sessionLog.SessionId] = sessionLog.Photos
+                        .Select(p => new SessionPhotoDto
+                        {
+                            BlobUrl = p.BlobUrl,
+                            UploadedAt = p.UploadedAt,
+                            Note = p.Note
+                        })
+                        .ToList();
+                }
+            }
         }
 
         await Send.OkAsync(response, ct);

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
@@ -368,6 +368,14 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
                         })
                         .ToList();
                 }
+
+                // Expose the session-level diary note so the mobile client can pre-load
+                // it into its textarea. Without this, re-saving photos always sends null
+                // for the note field, wiping whatever the user previously entered.
+                if (!string.IsNullOrEmpty(sessionLog.Note))
+                {
+                    response.NotesBySession[sessionLog.SessionId] = sessionLog.Note;
+                }
             }
         }
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
@@ -130,6 +130,15 @@ public class GetTodaySessionResponse
     /// Empty dictionary when no photos have been saved for any session today (or when no active plan exists).
     /// </summary>
     public Dictionary<Guid, List<SessionPhotoDto>> PhotosBySession { get; set; } = new();
+
+    /// <summary>
+    /// Per-session diary note for today, keyed by SessionId.
+    /// Only populated for sessions whose <c>SessionLog</c> has a non-null, non-empty <c>Note</c>.
+    /// Allows the mobile client to pre-load the existing note into its textarea so a subsequent
+    /// Save does not overwrite it with null (data-loss prevention).
+    /// Empty dictionary when no session has a note today (or when no active plan exists).
+    /// </summary>
+    public Dictionary<Guid, string> NotesBySession { get; set; } = new();
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
@@ -122,4 +122,27 @@ public class GetTodaySessionResponse
     /// Null / missing when the session is in the Stable state.
     /// </summary>
     public Dictionary<Guid, string?> LockHolderBySession { get; set; } = new();
+
+    /// <summary>
+    /// Per-session photo list for today, keyed by SessionId.
+    /// Each value is an ordered list of photos that were saved to the session log for today's date.
+    /// Sourced from the <c>SessionLog</c> MongoDB document for today.
+    /// Empty dictionary when no photos have been saved for any session today (or when no active plan exists).
+    /// </summary>
+    public Dictionary<Guid, List<SessionPhotoDto>> PhotosBySession { get; set; } = new();
+}
+
+/// <summary>
+/// A photo attached to a session diary entry, as returned in <see cref="GetTodaySessionResponse.PhotosBySession"/>.
+/// </summary>
+public class SessionPhotoDto
+{
+    /// <summary>The MinIO blob URL for this photo.</summary>
+    public string BlobUrl { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when the photo was uploaded/persisted.</summary>
+    public DateTime UploadedAt { get; set; }
+
+    /// <summary>Optional per-photo caption (max 500 chars). Null when none was provided.</summary>
+    public string? Note { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/SaveSessionPhotos/SaveSessionPhotosEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/SaveSessionPhotos/SaveSessionPhotosEndpoint.cs
@@ -1,0 +1,296 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientPlans;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.SaveSessionPhotos;
+
+/// <summary>
+/// Endpoint for saving the complete photo and note state of a training session diary entry.
+/// The Photos list and Note are replaced with exactly what the client sends. Creates the
+/// <see cref="SessionLog"/> document if one does not already exist for today.
+///
+/// <para>
+/// <b>Dual-write:</b> each photo in the replacement list is also mirrored into the
+/// <see cref="PlanPhoto"/> table (Category = Training, PlanType = Training, LinkId = SessionId)
+/// so that unified plan-photo read paths see training session diary photos too.
+/// The write is idempotent: rows are matched by BlobUrl and only inserted when they don't already exist.
+/// </para>
+/// </summary>
+/// <param name="mongo">MongoDB context.</param>
+/// <param name="db">Relational database context.</param>
+/// <param name="notifier">Realtime notifier for pushing the <c>planPhotoUploaded</c> event.</param>
+/// <param name="logger">Logger.</param>
+public class SaveSessionPhotosEndpoint(
+    IMongoContext mongo,
+    IApplicationDbContext db,
+    IRealtimeNotifier notifier,
+    ILogger<SaveSessionPhotosEndpoint> logger)
+    : Endpoint<SaveSessionPhotosRequest>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/client/training/log/sessions/{SessionId}/photos");
+        Roles(AppRoles.Client);
+        Summary(s =>
+        {
+            s.Summary = "Save photos / note for a training session diary entry";
+            s.Description =
+                "Replaces the Photos list and Note on the session log with exactly what the " +
+                "client sends. Each photo may carry its own optional caption (per-photo Note). " +
+                "Existing photo URLs that are re-submitted keep their original UploadedAt " +
+                "timestamp; new URLs receive the current UTC time. Pass an empty Photos list " +
+                "to remove all photos. Creates the log entry if it does not exist yet.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(SaveSessionPhotosRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.UserId == Guid.Parse(userId), ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var clientId = clientProfile.PublicId;
+
+        // Resolve the client's active training plan
+        var planFilter = Builders<TrainingPlan>.Filter.And(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientId),
+            Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active));
+
+        var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
+        var plan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify the SessionId belongs to the active plan
+        var session = plan.Weeks
+            .SelectMany(w => w.Sessions)
+            .FirstOrDefault(s => s.SessionId == req.SessionId);
+
+        if (session is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var todayUtc = now.Date;
+
+        // Key: one log per (client, plan, session, calendar day).
+        var logFilter = Builders<SessionLog>.Filter.And(
+            Builders<SessionLog>.Filter.Eq(l => l.ClientId, clientId),
+            Builders<SessionLog>.Filter.Eq(l => l.PlanId, plan.ExternalId),
+            Builders<SessionLog>.Filter.Eq(l => l.SessionId, req.SessionId),
+            Builders<SessionLog>.Filter.Eq(l => l.LogDate, todayUtc));
+
+        var existingCursor = await mongo.SessionLogs.FindAsync(logFilter, cancellationToken: ct);
+        var existingLog = await existingCursor.FirstOrDefaultAsync(ct);
+
+        // Build the replacement photo list, preserving UploadedAt for unchanged URLs
+        // and persisting the per-photo Note caption from the request.
+        var existingByUrl = (existingLog?.Photos ?? [])
+            .ToDictionary(p => p.BlobUrl, p => p);
+
+        var replacementPhotos = req.Photos
+            .Select(input =>
+            {
+                var perPhotoNote = string.IsNullOrWhiteSpace(input.Note) ? null : input.Note.Trim();
+                var uploadedAt = existingByUrl.TryGetValue(input.BlobUrl, out var existing)
+                    ? existing.UploadedAt
+                    : now;
+                return new SessionPhoto
+                {
+                    BlobUrl = input.BlobUrl,
+                    UploadedAt = uploadedAt,
+                    Note = perPhotoNote
+                };
+            })
+            .ToList();
+
+        // Normalise the note: null clears, whitespace-only becomes null
+        var resolvedNote = req.Note is null
+            ? null
+            : (string.IsNullOrWhiteSpace(req.Note) ? null : req.Note.Trim());
+
+        if (existingLog is null)
+        {
+            // Create a new photo-only log
+            var newLog = new SessionLog
+            {
+                ClientId = clientId,
+                PlanId = plan.ExternalId,
+                SessionId = req.SessionId,
+                LogDate = todayUtc,
+                Photos = replacementPhotos,
+                Note = resolvedNote,
+                CreatedAt = now,
+                UpdatedAt = now,
+                Version = 1
+            };
+
+            await mongo.SessionLogs.InsertOneAsync(newLog, cancellationToken: ct);
+        }
+        else
+        {
+            // Replace Photos and Note entirely; preserve other fields.
+            var updateFilter = Builders<SessionLog>.Filter.Eq(l => l.Id, existingLog.Id);
+            var update = Builders<SessionLog>.Update
+                .Set(l => l.Photos, replacementPhotos)
+                .Set(l => l.Note, resolvedNote)
+                .Set(l => l.UpdatedAt, now)
+                .Inc(l => l.Version, 1);
+
+            await mongo.SessionLogs.UpdateOneAsync(updateFilter, update, cancellationToken: ct);
+        }
+
+        // Dual-write: mirror photos into PlanPhoto table so unified read paths see training photos.
+        // Returns only the newly-inserted PlanPhoto rows so we can emit events for them.
+        var newPhotos = await DualWritePlanPhotosAsync(
+            clientProfile,
+            plan.ExternalId,
+            req.SessionId,
+            replacementPhotos.Select(p => (p.BlobUrl, p.Note)).ToList(),
+            now,
+            ct);
+
+        // Emit planPhotoUploaded to the owning trainer for each newly-created row (best-effort).
+        if (plan.TrainerId != Guid.Empty)
+        {
+            foreach (var newPhoto in newPhotos)
+            {
+                try
+                {
+                    await notifier.NotifyAsync(
+                        plan.TrainerId,
+                        "planPhotoUploaded",
+                        new PlanPhotoUploadedEvent
+                        {
+                            PlanId = newPhoto.PlanId,
+                            PhotoId = newPhoto.PublicId,
+                            Category = newPhoto.Category,
+                            TakenAt = newPhoto.TakenAt
+                        },
+                        ct);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to emit planPhotoUploaded for photo {PhotoId} to trainer {TrainerId}",
+                        newPhoto.PublicId, plan.TrainerId);
+                }
+            }
+        }
+        else if (newPhotos.Count > 0)
+        {
+            logger.LogWarning(
+                "Could not resolve owning trainer for PlanId={PlanId}; planPhotoUploaded events skipped",
+                plan.ExternalId);
+        }
+
+        await Send.NoContentAsync(ct);
+    }
+
+    /// <summary>
+    /// Idempotent dual-write: ensures a <see cref="PlanPhoto"/> row (Category = Training) exists in
+    /// PostgreSQL for each photo in <paramref name="photos"/>. Rows are matched by <c>BlobUrl</c>
+    /// so calling this twice with the same URLs does not create duplicates.
+    /// For new URLs a row is inserted with <c>Description</c> set from the per-photo note.
+    /// For URLs that already have a row, only <c>Description</c> and <c>DateUpdated</c> are
+    /// updated when the note has changed — no other fields are touched.
+    /// Does NOT remove rows that were in a previous save but are absent now.
+    /// Returns the list of newly-inserted <see cref="PlanPhoto"/> rows (used for SignalR events).
+    /// </summary>
+    private async Task<List<PlanPhoto>> DualWritePlanPhotosAsync(
+        ClientProfile clientProfile,
+        Guid planExternalId,
+        Guid sessionId,
+        IReadOnlyList<(string BlobUrl, string? Note)> photos,
+        DateTime now,
+        CancellationToken ct)
+    {
+        if (photos.Count == 0)
+            return [];
+
+        // Load existing PlanPhoto rows for this client + plan + session (Training category).
+        var existingRows = await db.PlanPhotos
+            .Where(p =>
+                p.ClientProfileId == clientProfile.Id &&
+                p.PlanId == planExternalId &&
+                p.Category == PlanPhotoCategory.Training &&
+                p.LinkId == sessionId)
+            .ToListAsync(ct);
+
+        var existingByUrl = existingRows.ToDictionary(
+            p => p.BlobUrl,
+            p => p,
+            StringComparer.OrdinalIgnoreCase);
+
+        var callerUserId = clientProfile.UserId;
+        var inserted = new List<PlanPhoto>();
+
+        foreach (var (blobUrl, note) in photos)
+        {
+            if (existingByUrl.TryGetValue(blobUrl, out var existing))
+            {
+                // Row already exists — only update Description when it has changed.
+                if (existing.Description != note)
+                {
+                    existing.Description = note;
+                    existing.DateUpdated = now;
+                }
+                continue;
+            }
+
+            var photo = new PlanPhoto
+            {
+                PublicId = Guid.NewGuid(),
+                ClientProfileId = clientProfile.Id,
+                PlanId = planExternalId,
+                PlanType = PlanPhotoType.Training,
+                LinkId = sessionId,
+                Category = PlanPhotoCategory.Training,
+                BlobUrl = blobUrl,
+                Description = note,
+                MealLogId = null,
+                TakenAt = now,
+                UploadedByUserId = callerUserId,
+                DateCreated = now,
+                DateUpdated = now
+            };
+            db.PlanPhotos.Add(photo);
+            inserted.Add(photo);
+        }
+
+        await db.SaveChangesAsync(ct);
+        return inserted;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/SaveSessionPhotos/SaveSessionPhotosRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/SaveSessionPhotos/SaveSessionPhotosRequest.cs
@@ -1,0 +1,46 @@
+namespace FitnessPlatform.Application.Features.ClientTraining.SaveSessionPhotos;
+
+/// <summary>
+/// Request model for saving the complete photo and note state of a training session diary entry.
+/// The Photos list and Note are replaced with exactly what the client sends.
+/// </summary>
+public class SaveSessionPhotosRequest
+{
+    /// <summary>
+    /// The unique identifier of the training session whose photos/note are being saved.
+    /// Sourced from the route segment <c>{SessionId}</c>.
+    /// </summary>
+    public Guid SessionId { get; set; }
+
+    /// <summary>
+    /// The complete list of photos to persist on the session log.
+    /// Replaces the existing Photos list entirely — pass an empty list to remove all photos.
+    /// Each item carries the blob URL and an optional per-photo caption.
+    /// Existing URLs that are re-submitted keep their original <c>UploadedAt</c>
+    /// timestamp; new URLs receive the current UTC time.
+    /// </summary>
+    public List<SessionPhotoInput> Photos { get; set; } = [];
+
+    /// <summary>
+    /// Optional free-text note to persist on the session log entry (max 500 chars).
+    /// When non-null, the stored note is replaced with the trimmed value
+    /// (whitespace-only strings are treated as null). When null, the existing note is cleared.
+    /// </summary>
+    public string? Note { get; set; }
+}
+
+/// <summary>
+/// A single photo input in a <see cref="SaveSessionPhotosRequest"/>.
+/// </summary>
+public class SessionPhotoInput
+{
+    /// <summary>
+    /// The MinIO blob URL for this photo, as returned by the signed-URL upload helper.
+    /// </summary>
+    public string BlobUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional per-photo caption (max 500 chars).
+    /// </summary>
+    public string? Note { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/SaveSessionPhotos/SaveSessionPhotosValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/SaveSessionPhotos/SaveSessionPhotosValidator.cs
@@ -1,0 +1,43 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.ClientTraining.SaveSessionPhotos;
+
+/// <summary>
+/// Validator for the <see cref="SaveSessionPhotosRequest"/>.
+/// </summary>
+public class SaveSessionPhotosValidator : Validator<SaveSessionPhotosRequest>
+{
+    /// <summary>
+    /// Initializes validation rules for the save session photos request.
+    /// </summary>
+    public SaveSessionPhotosValidator()
+    {
+        RuleFor(x => x.Note)
+            .MaximumLength(500)
+            .WithMessage("Note must not exceed 500 characters.")
+            .When(x => x.Note is not null);
+
+        RuleForEach(x => x.Photos)
+            .ChildRules(photo =>
+            {
+                // BlobUrl must be non-empty
+                photo.RuleFor(p => p.BlobUrl)
+                    .NotEmpty()
+                    .WithMessage("Photo URL must not be empty.");
+
+                // When BlobUrl is provided, it must be an HTTP/HTTPS URL
+                photo.RuleFor(p => p.BlobUrl)
+                    .Must(url => url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                    .WithMessage("Photo URL must be a valid HTTP/HTTPS URL.")
+                    .When(p => !string.IsNullOrEmpty(p.BlobUrl));
+
+                // Per-photo note is optional but bounded at 500 chars
+                photo.RuleFor(p => p.Note)
+                    .MaximumLength(500)
+                    .WithMessage("Per-photo note must not exceed 500 characters.")
+                    .When(p => p.Note is not null);
+            })
+            .When(x => x.Photos is { Count: > 0 });
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
@@ -69,4 +69,10 @@ public interface IMongoContext
     /// A document present = Editing or Live; absent = Stable.
     /// </summary>
     IMongoCollection<SessionLock> SessionLocks { get; }
+
+    /// <summary>
+    /// Session log entries — photos and notes attached to a specific training session diary entry.
+    /// Keyed by (ClientId = ClientProfile.PublicId, PlanId, SessionId, LogDate).
+    /// </summary>
+    IMongoCollection<SessionLog> SessionLogs { get; }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
@@ -27,6 +27,7 @@ public class MongoContext : IMongoContext
         DayLogs = database.GetCollection<DayLog>(MongoCollections.DayLogs);
         SectionTemplates = database.GetCollection<SectionTemplate>(MongoCollections.SectionTemplates);
         SessionLocks = database.GetCollection<SessionLock>(MongoCollections.SessionLocks);
+        SessionLogs = database.GetCollection<SessionLog>(MongoCollections.SessionLogs);
     }
 
     /// <inheritdoc />
@@ -64,4 +65,7 @@ public class MongoContext : IMongoContext
 
     /// <inheritdoc />
     public IMongoCollection<SessionLock> SessionLocks { get; }
+
+    /// <inheritdoc />
+    public IMongoCollection<SessionLog> SessionLogs { get; }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GenerateSessionPhotoUploadUrlEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GenerateSessionPhotoUploadUrlEndpointTests.cs
@@ -1,0 +1,274 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining.GenerateSessionPhotoUploadUrl;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="GenerateSessionPhotoUploadUrlEndpoint"/>.
+/// </summary>
+public class GenerateSessionPhotoUploadUrlEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly IImageUploadService _imageUpload = Substitute.For<IImageUploadService>();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    private GenerateSessionPhotoUploadUrlEndpoint CreateEndpoint(
+        IMongoContext mongo,
+        IApplicationDbContext db,
+        Guid? callerUserId = null) =>
+        Factory.Create<GenerateSessionPhotoUploadUrlEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(callerUserId ?? _clientId, AppRoles.Client))),
+            _imageUpload, mongo, db);
+
+    private static IMongoContext CreateMongoWithActivePlan(Guid clientId, Guid? sessionId = null, bool addSession = true)
+    {
+        var sid = sessionId ?? Guid.NewGuid();
+        var startOfWeek = DateTime.UtcNow.Date.AddDays(-(int)DateTime.UtcNow.DayOfWeek + 1);
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions = addSession
+                        ?
+                        [
+                            new TrainingSession
+                            {
+                                SessionId = sid,
+                                DayOfWeek = 1,
+                                Name = "Push Day",
+                                Order = 1,
+                                Sections = []
+                            }
+                        ]
+                        : []
+                }
+            ]
+        };
+
+        return TrainingPhotoTestHelpers.CreateMongoWithPlan(plan);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Happy-path tests
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_ValidRequest_ReturnsUploadUrlWithSessionPrefix()
+    {
+        var sessionId = Guid.NewGuid();
+        var mongo = CreateMongoWithActivePlan(_clientId, sessionId, addSession: true);
+        var db = CreateMockDb();
+
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                ImageUploadScope.Diary,
+                Arg.Is<string>(s => s.StartsWith($"sessions/{sessionId}/") && s.EndsWith(".jpg")),
+                "image/jpeg",
+                2048,
+                Arg.Any<CancellationToken>())
+            .Returns(ci => new BlobUploadUrl(
+                "https://storage/upload?token=abc",
+                $"diary/{ci.ArgAt<string>(1)}"));
+
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new GenerateSessionPhotoUploadUrlRequest
+        {
+            SessionId = sessionId,
+            ContentType = "image/jpeg",
+            SizeBytes = 2048
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.UploadUrl.Should().Be("https://storage/upload?token=abc");
+        ep.Response.BlobUrl.Should().StartWith($"diary/sessions/{sessionId}/");
+        ep.Response.BlobUrl.Should().EndWith(".jpg");
+    }
+
+    [Theory]
+    [InlineData("image/jpeg", "jpg")]
+    [InlineData("image/png", "png")]
+    [InlineData("image/webp", "webp")]
+    [InlineData("image/heic", "heic")]
+    public async Task HandleAsync_AllowedContentTypes_CallServiceWithDiaryScopeAndCorrectExtension(
+        string contentType, string expectedExt)
+    {
+        var sessionId = Guid.NewGuid();
+        var mongo = CreateMongoWithActivePlan(_clientId, sessionId, addSession: true);
+        var db = CreateMockDb();
+
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                Arg.Any<ImageUploadScope>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<long>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci => new BlobUploadUrl(
+                "https://storage/upload",
+                $"diary/{ci.ArgAt<string>(1)}"));
+
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new GenerateSessionPhotoUploadUrlRequest
+        {
+            SessionId = sessionId,
+            ContentType = contentType,
+            SizeBytes = 512
+        }, TestContext.Current.CancellationToken);
+
+        await _imageUpload.Received(1).GenerateUploadUrlAsync(
+            ImageUploadScope.Diary,
+            Arg.Is<string>(s => s.StartsWith($"sessions/{sessionId}/") && s.EndsWith($".{expectedExt}")),
+            contentType,
+            512,
+            Arg.Any<CancellationToken>());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Not-found / ownership tests
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SessionNotInPlan_Returns404()
+    {
+        // Plan exists but has no sessions, so any sessionId will be unknown
+        var mongo = CreateMongoWithActivePlan(_clientId, addSession: false);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new GenerateSessionPhotoUploadUrlRequest
+        {
+            SessionId = Guid.NewGuid(),
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+        await _imageUpload.DidNotReceive().GenerateUploadUrlAsync(
+            Arg.Any<ImageUploadScope>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoActivePlan_Returns404()
+    {
+        // No active plan for this client
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(null);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new GenerateSessionPhotoUploadUrlRequest
+        {
+            SessionId = Guid.NewGuid(),
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+        await _imageUpload.DidNotReceive().GenerateUploadUrlAsync(
+            Arg.Any<ImageUploadScope>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoUserClaims_Returns401()
+    {
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(null);
+        var db = CreateMockDb();
+
+        // Create endpoint with no claims principal (unauthenticated)
+        var ep = Factory.Create<GenerateSessionPhotoUploadUrlEndpoint>(_imageUpload, mongo, db);
+
+        await ep.HandleAsync(new GenerateSessionPhotoUploadUrlRequest
+        {
+            SessionId = Guid.NewGuid(),
+            ContentType = "image/jpeg",
+            SizeBytes = 1024
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+        await _imageUpload.DidNotReceive().GenerateUploadUrlAsync(
+            Arg.Any<ImageUploadScope>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Service-level validation errors
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SizeTooLarge_ServiceThrows_PropagatesException()
+    {
+        var sessionId = Guid.NewGuid();
+        var mongo = CreateMongoWithActivePlan(_clientId, sessionId, addSession: true);
+        var db = CreateMockDb();
+
+        const long elevenMb = 11L * 1024 * 1024;
+
+        _imageUpload
+            .GenerateUploadUrlAsync(
+                Arg.Any<ImageUploadScope>(),
+                Arg.Any<string>(),
+                "image/jpeg",
+                elevenMb,
+                Arg.Any<CancellationToken>())
+            .Throws(new ValidationFailureException(
+                [new FluentValidation.Results.ValidationFailure("sizeBytes", "too large")
+                    { ErrorCode = ErrorCodes.ImageTooLarge }],
+                "Image too large."));
+
+        var ep = CreateEndpoint(mongo, db);
+
+        var act = () => ep.HandleAsync(new GenerateSessionPhotoUploadUrlRequest
+        {
+            SessionId = sessionId,
+            ContentType = "image/jpeg",
+            SizeBytes = elevenMb
+        }, TestContext.Current.CancellationToken);
+
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should()
+            .ContainSingle(f => f.ErrorCode == ErrorCodes.ImageTooLarge);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionEndpointTests.cs
@@ -168,6 +168,35 @@ public class GetTodaySessionEndpointTests
             });
         mongo.WorkoutLogs.Returns(logCollection);
 
+        // Stub the SessionLogs collection — used by the PhotosBySession enrichment path.
+        // The endpoint calls .Find().ToListAsync() which internally dispatches to FindAsync.
+        var sessionLogCollection = Substitute.For<IMongoCollection<SessionLog>>();
+        sessionLogCollection.FindAsync(
+                Arg.Any<FilterDefinition<SessionLog>>(),
+                Arg.Any<FindOptions<SessionLog, SessionLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<SessionLog>>();
+                var moved = false;
+                var emptyLogs = new List<SessionLog>();
+                cursor.Current.Returns(emptyLogs);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+                {
+                    if (moved) return false;
+                    moved = true;
+                    return false; // always empty in baseline tests
+                });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+                {
+                    if (moved) return false;
+                    moved = true;
+                    return false;
+                });
+                return cursor;
+            });
+        mongo.SessionLogs.Returns(sessionLogCollection);
+
         return mongo;
     }
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionPhotosTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionPhotosTests.cs
@@ -200,4 +200,78 @@ public class GetTodaySessionPhotosTests
         // Zero-photo logs don't occupy a key in PhotosBySession
         ep.Response.PhotosBySession.Should().NotContainKey(sessionId);
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Read-back: NotesBySession round-trip (data-loss prevention)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SessionLogWithPhotosAndNote_PopulatesNotesBySession()
+    {
+        // Arrange: a session log with both photos and a session-level note.
+        // The mobile client must be able to pre-load this note so that saving photos
+        // with a blank textarea doesn't overwrite the stored value with null.
+        var sessionId = Guid.NewGuid();
+        var uploadedAt = DateTime.UtcNow.AddMinutes(-5);
+
+        var sessionLog = new SessionLog
+        {
+            Id = ObjectId.GenerateNewId(),
+            ClientId = _clientId,
+            SessionId = sessionId,
+            LogDate = DateTime.UtcNow.Date,
+            Photos =
+            [
+                new SessionPhoto { BlobUrl = "https://minio.local/diary/s1/a.jpg", UploadedAt = uploadedAt }
+            ],
+            Note = "Felt strong today"
+        };
+
+        var mongo = CreateMongoWithPlanAndSessionLog(sessionId, [sessionLog]);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        // Photos still present
+        ep.Response.PhotosBySession.Should().ContainKey(sessionId);
+        // Note round-tripped under NotesBySession
+        ep.Response.NotesBySession.Should().ContainKey(sessionId);
+        ep.Response.NotesBySession[sessionId].Should().Be("Felt strong today");
+    }
+
+    [Fact]
+    public async Task HandleAsync_SessionLogWithPhotosAndNoNote_NotInNotesBySession()
+    {
+        // Arrange: a session log with photos but no session-level note.
+        // NotesBySession must NOT contain a key for this session — null / empty notes
+        // are excluded so the mobile client falls back to an empty textarea cleanly.
+        var sessionId = Guid.NewGuid();
+        var uploadedAt = DateTime.UtcNow.AddMinutes(-5);
+
+        var sessionLog = new SessionLog
+        {
+            Id = ObjectId.GenerateNewId(),
+            ClientId = _clientId,
+            SessionId = sessionId,
+            LogDate = DateTime.UtcNow.Date,
+            Photos =
+            [
+                new SessionPhoto { BlobUrl = "https://minio.local/diary/s1/b.jpg", UploadedAt = uploadedAt }
+            ],
+            Note = null   // no note
+        };
+
+        var mongo = CreateMongoWithPlanAndSessionLog(sessionId, [sessionLog]);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.PhotosBySession.Should().ContainKey(sessionId);
+        // No entry for sessions without a note
+        ep.Response.NotesBySession.Should().NotContainKey(sessionId);
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionPhotosTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionPhotosTests.cs
@@ -1,0 +1,203 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="GetTodaySessionEndpoint"/> PhotosBySession enrichment path.
+/// Separate class to keep test concerns isolated; all other GetTodaySession tests are in
+/// <see cref="GetTodaySessionEndpointTests"/>.
+/// </summary>
+public class GetTodaySessionPhotosTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    /// <summary>
+    /// ISO day-of-week (1 = Monday, 7 = Sunday).
+    /// </summary>
+    private static int TodayDow()
+    {
+        var dow = (int)DateTime.UtcNow.DayOfWeek;
+        return dow == 0 ? 7 : dow;
+    }
+
+    private static DateTime StartOfCurrentWeek()
+    {
+        var today = DateTime.UtcNow.Date;
+        return today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
+    }
+
+    private IMongoContext CreateMongoWithPlanAndSessionLog(
+        Guid sessionId,
+        List<SessionLog>? sessionLogs = null)
+    {
+        var todayDow = TodayDow();
+        var startOfWeek = StartOfCurrentWeek();
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = todayDow,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ]
+        };
+
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Build all collections BEFORE calling .Returns() to avoid NSubstitute nesting issues
+        var planCollection = TrainingPhotoTestHelpers.CreateCollection([plan]);
+        var exerciseCollection = TrainingPhotoTestHelpers.CreateCollection<Exercise>([]);
+        var completionCollection = TrainingPhotoTestHelpers.CreateCollection<TrainingCompletion>([]);
+        var workoutLogCollection = TrainingPhotoTestHelpers.CreateCollection<WorkoutLog>([]);
+        var sessionLockCollection = TrainingPhotoTestHelpers.CreateCollection<SessionLock>([]);
+        var sessionLogCollection = TrainingPhotoTestHelpers.CreateSessionLogCollection(sessionLogs ?? []);
+
+        // Assign after all substitutes are created
+        mongo.TrainingPlans.Returns(planCollection);
+        mongo.Exercises.Returns(exerciseCollection);
+        mongo.TrainingCompletions.Returns(completionCollection);
+        mongo.WorkoutLogs.Returns(workoutLogCollection);
+        mongo.SessionLocks.Returns(sessionLockCollection);
+        mongo.SessionLogs.Returns(sessionLogCollection);
+
+        return mongo;
+    }
+
+    private static ISessionLockService CreateStubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock>() as IReadOnlyList<SessionLock>);
+        return svc;
+    }
+
+    private GetTodaySessionEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
+        Factory.Create<GetTodaySessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, CreateStubLockService());
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Read-back: photos saved to SessionLog appear in PhotosBySession
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_SessionLogWithPhotos_PopulatesPhotosBySession()
+    {
+        var sessionId = Guid.NewGuid();
+        var uploadedAt = DateTime.UtcNow.AddMinutes(-10);
+
+        var sessionLog = new SessionLog
+        {
+            Id = ObjectId.GenerateNewId(),
+            ClientId = _clientId,
+            SessionId = sessionId,
+            LogDate = DateTime.UtcNow.Date,
+            Photos =
+            [
+                new SessionPhoto { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg", UploadedAt = uploadedAt, Note = "Note A" },
+                new SessionPhoto { BlobUrl = "https://minio.local/diary/sessions/s1/b.jpg", UploadedAt = uploadedAt, Note = null }
+            ],
+            Note = "Good workout"
+        };
+
+        var mongo = CreateMongoWithPlanAndSessionLog(sessionId, [sessionLog]);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.PhotosBySession.Should().ContainKey(sessionId);
+        var photos = ep.Response.PhotosBySession[sessionId];
+        photos.Should().HaveCount(2);
+        photos[0].BlobUrl.Should().Be("https://minio.local/diary/sessions/s1/a.jpg");
+        photos[0].UploadedAt.Should().Be(uploadedAt);
+        photos[0].Note.Should().Be("Note A");
+        photos[1].BlobUrl.Should().Be("https://minio.local/diary/sessions/s1/b.jpg");
+        photos[1].Note.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleAsync_NoSessionLog_PhotosBySessionIsEmpty()
+    {
+        var sessionId = Guid.NewGuid();
+
+        // No session logs at all
+        var mongo = CreateMongoWithPlanAndSessionLog(sessionId, []);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.PhotosBySession.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_SessionLogWithNoPhotos_SessionIdNotInPhotosBySession()
+    {
+        var sessionId = Guid.NewGuid();
+
+        // Session log exists but has zero photos
+        var sessionLog = new SessionLog
+        {
+            Id = ObjectId.GenerateNewId(),
+            ClientId = _clientId,
+            SessionId = sessionId,
+            LogDate = DateTime.UtcNow.Date,
+            Photos = [],
+            Note = "diary note only"
+        };
+
+        var mongo = CreateMongoWithPlanAndSessionLog(sessionId, [sessionLog]);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        // Zero-photo logs don't occupy a key in PhotosBySession
+        ep.Response.PhotosBySession.Should().NotContainKey(sessionId);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/SaveSessionPhotosEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/SaveSessionPhotosEndpointTests.cs
@@ -1,0 +1,328 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining.SaveSessionPhotos;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="SaveSessionPhotosEndpoint"/>.
+/// </summary>
+public class SaveSessionPhotosEndpointTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly IRealtimeNotifier _notifier = Substitute.For<IRealtimeNotifier>();
+    private readonly ILogger<SaveSessionPhotosEndpoint> _logger =
+        Substitute.For<ILogger<SaveSessionPhotosEndpoint>>();
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+    private TrainingPlan CreateActivePlan(Guid? sessionId = null)
+    {
+        var sid = sessionId ?? Guid.NewGuid();
+        var startOfWeek = DateTime.UtcNow.Date.AddDays(-(int)DateTime.UtcNow.DayOfWeek + 1);
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sid,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ]
+        };
+    }
+
+    private SaveSessionPhotosEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db) =>
+        Factory.Create<SaveSessionPhotosEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, _notifier, _logger);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Happy-path: new log inserted
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NewLog_InsertsSessionLogAndReturns204()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreateActivePlan(sessionId);
+        var inserted = new List<SessionLog>();
+        var logCollection = TrainingPhotoTestHelpers.CreateSessionLogCollection([], captureInserted: inserted);
+
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(plan);
+        mongo.SessionLogs.Returns(logCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveSessionPhotosRequest
+        {
+            SessionId = sessionId,
+            Photos =
+            [
+                new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg" },
+                new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/b.jpg" }
+            ],
+            Note = "Good session"
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        await logCollection.Received(1).InsertOneAsync(
+            Arg.Is<SessionLog>(log =>
+                log.ClientId == _clientId &&
+                log.SessionId == sessionId &&
+                log.Photos.Count == 2 &&
+                log.Note == "Good session"),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+
+        await logCollection.DidNotReceive().UpdateOneAsync(
+            Arg.Any<FilterDefinition<SessionLog>>(),
+            Arg.Any<UpdateDefinition<SessionLog>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Idempotency: re-POST same BlobUrl preserves UploadedAt
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_RePostSameBlobUrl_PreservesUploadedAt()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreateActivePlan(sessionId);
+        const string urlA = "https://minio.local/diary/sessions/s1/a.jpg";
+        const string urlB = "https://minio.local/diary/sessions/s1/b.jpg";
+        var originalUploadedAt = DateTime.UtcNow.AddHours(-3);
+
+        var existingLog = new SessionLog
+        {
+            Id = ObjectId.GenerateNewId(),
+            ClientId = _clientId,
+            PlanId = plan.ExternalId,
+            SessionId = sessionId,
+            LogDate = DateTime.UtcNow.Date,
+            Photos = [new SessionPhoto { BlobUrl = urlA, UploadedAt = originalUploadedAt }],
+            Note = null
+        };
+
+        var logCollection = TrainingPhotoTestHelpers.CreateSessionLogCollection([existingLog]);
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(plan);
+        mongo.SessionLogs.Returns(logCollection);
+
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+        var beforeCall = DateTime.UtcNow;
+
+        // Re-POST urlA (existing) + urlB (new)
+        await ep.HandleAsync(new SaveSessionPhotosRequest
+        {
+            SessionId = sessionId,
+            Photos =
+            [
+                new SessionPhotoInput { BlobUrl = urlA },
+                new SessionPhotoInput { BlobUrl = urlB }
+            ],
+            Note = null
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // Verify update was issued (not insert)
+        await logCollection.Received(1).UpdateOneAsync(
+            Arg.Any<FilterDefinition<SessionLog>>(),
+            Arg.Any<UpdateDefinition<SessionLog>>(),
+            Arg.Any<UpdateOptions>(),
+            Arg.Any<CancellationToken>());
+
+        // Verify UploadedAt preservation logic by replaying the same keying logic as the endpoint
+        var existingByUrl = existingLog.Photos.ToDictionary(p => p.BlobUrl, p => p);
+        var now = DateTime.UtcNow;
+        var inputs = new[] { urlA, urlB };
+        var reproduced = inputs.Select(url =>
+        {
+            var uploadedAt = existingByUrl.TryGetValue(url, out var ex) ? ex.UploadedAt : now;
+            return new SessionPhoto { BlobUrl = url, UploadedAt = uploadedAt };
+        }).ToList();
+
+        reproduced.Should().HaveCount(2);
+        reproduced.First(p => p.BlobUrl == urlA).UploadedAt.Should().Be(originalUploadedAt);
+        reproduced.First(p => p.BlobUrl == urlB).UploadedAt.Should().BeOnOrAfter(beforeCall);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Dual-write idempotency: re-POST same BlobUrl → no duplicate PlanPhoto row
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_RePostSameBlobUrl_NoDuplicatePlanPhotoRow()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreateActivePlan(sessionId);
+        const string blobUrl = "https://minio.local/diary/sessions/s1/photo.jpg";
+
+        // Pre-seed a PlanPhoto row for the same BlobUrl
+        var existingPlanPhoto = new PlanPhoto
+        {
+            PublicId = Guid.NewGuid(),
+            ClientProfileId = 0,
+            PlanId = plan.ExternalId,
+            PlanType = PlanPhotoType.Training,
+            LinkId = sessionId,
+            Category = PlanPhotoCategory.Training,
+            BlobUrl = blobUrl,
+            Description = null,
+            TakenAt = DateTime.UtcNow.AddHours(-1),
+            UploadedByUserId = _clientId,
+            DateCreated = DateTime.UtcNow.AddHours(-1),
+            DateUpdated = DateTime.UtcNow.AddHours(-1)
+        };
+
+        // Existing SessionLog with the photo so the endpoint does an update
+        var existingLog = new SessionLog
+        {
+            Id = ObjectId.GenerateNewId(),
+            ClientId = _clientId,
+            PlanId = plan.ExternalId,
+            SessionId = sessionId,
+            LogDate = DateTime.UtcNow.Date,
+            Photos = [new SessionPhoto { BlobUrl = blobUrl, UploadedAt = DateTime.UtcNow.AddHours(-1) }],
+            Note = null
+        };
+
+        var logCollection = TrainingPhotoTestHelpers.CreateSessionLogCollection([existingLog]);
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(plan);
+        mongo.SessionLogs.Returns(logCollection);
+
+        // DB has the existing PlanPhoto row
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .With(existingPlanPhoto)
+            .Build();
+
+        var ep = CreateEndpoint(mongo, db);
+
+        // Re-POST the same BlobUrl
+        await ep.HandleAsync(new SaveSessionPhotosRequest
+        {
+            SessionId = sessionId,
+            Photos = [new SessionPhotoInput { BlobUrl = blobUrl }],
+            Note = null
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        // No new PlanPhoto row should have been added (idempotent)
+        db.PlanPhotos.DidNotReceive().Add(Arg.Any<PlanPhoto>());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Dual-write: new photo → creates PlanPhoto with Training category
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NewPhoto_CreatesPlanPhotoWithTrainingCategory()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreateActivePlan(sessionId);
+
+        var logCollection = TrainingPhotoTestHelpers.CreateSessionLogCollection([]);
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(plan);
+        mongo.SessionLogs.Returns(logCollection);
+
+        var db = new MockDbBuilder()
+            .With(new ClientProfile { UserId = _clientId, PublicId = _clientId })
+            .Build();
+
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveSessionPhotosRequest
+        {
+            SessionId = sessionId,
+            Photos = [new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/x.jpg", Note = "Great lift" }],
+            Note = null
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+
+        db.PlanPhotos.Received(1).Add(Arg.Is<PlanPhoto>(p =>
+            p.BlobUrl == "https://minio.local/diary/sessions/s1/x.jpg" &&
+            p.Category == PlanPhotoCategory.Training &&
+            p.PlanType == PlanPhotoType.Training &&
+            p.LinkId == sessionId &&
+            p.Description == "Great lift"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Not-found / ownership guard tests
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NoActivePlan_Returns404()
+    {
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(null);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(new SaveSessionPhotosRequest { SessionId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SessionNotInPlan_Returns404()
+    {
+        // Plan exists but the requested SessionId is not in any of its sessions
+        var sessionId = Guid.NewGuid();
+        var plan = CreateActivePlan(Guid.NewGuid()); // a different sessionId
+        var mongo = TrainingPhotoTestHelpers.CreateMongoWithPlan(plan);
+        var db = CreateMockDb();
+        var ep = CreateEndpoint(mongo, db);
+
+        // Request a sessionId that doesn't exist in the plan
+        await ep.HandleAsync(new SaveSessionPhotosRequest { SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingPhotoTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/TrainingPhotoTestHelpers.cs
@@ -1,0 +1,111 @@
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Shared helpers for training session photo endpoint tests.
+/// Mirrors the pattern from <see cref="NutritionPlans.PlanTestHelpers.CreateMockMongo"/>.
+/// </summary>
+public static class TrainingPhotoTestHelpers
+{
+    /// <summary>
+    /// Creates a mock <see cref="IMongoContext"/> backed by a single optional
+    /// <see cref="TrainingPlan"/> and an empty <see cref="SessionLog"/> collection.
+    /// All other collections are stubbed with empty cursors.
+    /// </summary>
+    public static IMongoContext CreateMongoWithPlan(
+        TrainingPlan? plan,
+        List<SessionLog>? sessionLogs = null)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Build all collections BEFORE calling .Returns() to avoid the NSubstitute
+        // "CouldNotSetReturnDueToNoLastCallException" that fires when a Substitute.For<>
+        // call happens inside a .Returns() lambda.
+        var plans = plan is not null ? new List<TrainingPlan> { plan } : new List<TrainingPlan>();
+        var planCollection = CreateCollection(plans);
+        var sessionLogCollection = CreateSessionLogCollection(sessionLogs ?? []);
+        var exerciseCollection = CreateCollection<Exercise>([]);
+        var completionCollection = CreateCollection<TrainingCompletion>([]);
+        var workoutLogCollection = CreateCollection<WorkoutLog>([]);
+        var sessionLockCollection = CreateCollection<SessionLock>([]);
+
+        // Assign after all substitutes are created
+        mongo.TrainingPlans.Returns(planCollection);
+        mongo.SessionLogs.Returns(sessionLogCollection);
+        mongo.Exercises.Returns(exerciseCollection);
+        mongo.TrainingCompletions.Returns(completionCollection);
+        mongo.WorkoutLogs.Returns(workoutLogCollection);
+        mongo.SessionLocks.Returns(sessionLockCollection);
+
+        return mongo;
+    }
+
+    /// <summary>
+    /// Creates a mock <see cref="IMongoCollection{T}"/> whose <c>FindAsync</c> always returns
+    /// <paramref name="docs"/>.
+    /// </summary>
+    internal static IMongoCollection<T> CreateCollection<T>(List<T> docs)
+    {
+        var collection = Substitute.For<IMongoCollection<T>>();
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<T>>(),
+                Arg.Any<FindOptions<T, T>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(docs));
+        return collection;
+    }
+
+    internal static IMongoCollection<SessionLog> CreateSessionLogCollection(
+        List<SessionLog> docs,
+        List<SessionLog>? captureInserted = null)
+    {
+        var collection = Substitute.For<IMongoCollection<SessionLog>>();
+
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<SessionLog>>(),
+                Arg.Any<FindOptions<SessionLog, SessionLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(docs));
+
+        collection.InsertOneAsync(
+                Arg.Do<SessionLog>(log => captureInserted?.Add(log)),
+                Arg.Any<InsertOneOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var updateResult = Substitute.For<UpdateResult>();
+        updateResult.ModifiedCount.Returns(1);
+        collection.UpdateOneAsync(
+                Arg.Any<FilterDefinition<SessionLog>>(),
+                Arg.Any<UpdateDefinition<SessionLog>>(),
+                Arg.Any<UpdateOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(updateResult);
+
+        return collection;
+    }
+
+    private static IAsyncCursor<T> CreateCursor<T>(List<T> docs)
+    {
+        var cursor = Substitute.For<IAsyncCursor<T>>();
+        var moved = false;
+        cursor.Current.Returns(docs);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        return cursor;
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/WorkoutLogCompletionUniquenessTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/WorkoutLogCompletionUniquenessTests.cs
@@ -508,4 +508,5 @@ internal sealed class BackfillTestMongoContext : IMongoContext
     public IMongoCollection<DayLog> DayLogs               => _db.GetCollection<DayLog>("dayLogs");
     public IMongoCollection<SectionTemplate> SectionTemplates => _db.GetCollection<SectionTemplate>("sectionTemplates");
     public IMongoCollection<SessionLock> SessionLocks         => _db.GetCollection<SessionLock>("sessionLocks");
+    public IMongoCollection<SessionLog> SessionLogs           => _db.GetCollection<SessionLog>("sessionLogs");
 }

--- a/backend/FitnessPlatform.Tests/Validators/SaveSessionPhotosValidatorTests.cs
+++ b/backend/FitnessPlatform.Tests/Validators/SaveSessionPhotosValidatorTests.cs
@@ -1,5 +1,5 @@
 using FluentAssertions;
-using FluentValidation;
+using FluentValidation.TestHelper;
 using FitnessPlatform.Application.Features.ClientTraining.SaveSessionPhotos;
 
 namespace FitnessPlatform.Tests.Validators;
@@ -11,110 +11,195 @@ public class SaveSessionPhotosValidatorTests
 {
     private readonly SaveSessionPhotosValidator _validator = new();
 
-    [Fact]
-    public async Task Validate_ValidRequest_IsValid()
+    private static SaveSessionPhotosRequest ValidRequest() => new()
     {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg" }],
-            Note = "Good session"
-        };
+        SessionId = Guid.NewGuid(),
+        Photos = []
+    };
 
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+    // ──────────────────────────────────────────────────────────────────────────
+    // Happy-path
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidRequest_EmptyPhotoList_PassesValidation()
+    {
+        var result = _validator.TestValidate(ValidRequest());
         result.IsValid.Should().BeTrue();
     }
 
     [Fact]
-    public async Task Validate_EmptyPhotoList_IsValid()
+    public void ValidRequest_WithPhotosAndNote_PassesValidation()
     {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [],
-            Note = null
-        };
+        var req = ValidRequest();
+        req.Photos = [new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg" }];
+        req.Note = "Good session";
 
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        var result = _validator.TestValidate(req);
         result.IsValid.Should().BeTrue();
     }
 
     [Fact]
-    public async Task Validate_NoteTooLong_IsInvalid()
+    public void ValidRequest_WithPerPhotoNote_PassesValidation()
     {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [],
-            Note = new string('x', 501)
-        };
+        var req = ValidRequest();
+        req.Photos = [new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg", Note = "Great form" }];
 
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName.Contains("Note"));
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Session-level Note boundary tests (500 / 501 character boundary)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Note_ExactlyFiveHundredChars_PassesValidation()
+    {
+        var req = ValidRequest();
+        req.Note = new string('a', 500);
+
+        _validator.TestValidate(req).ShouldNotHaveValidationErrorFor(x => x.Note);
     }
 
     [Fact]
-    public async Task Validate_EmptyBlobUrl_IsInvalid()
+    public void Note_FiveHundredAndOneChars_FailsValidation()
     {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [new SessionPhotoInput { BlobUrl = "" }],
-            Note = null
-        };
+        var req = ValidRequest();
+        req.Note = new string('a', 501);
 
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
-        result.IsValid.Should().BeFalse();
+        _validator.TestValidate(req).ShouldHaveValidationErrorFor(x => x.Note);
     }
 
     [Fact]
-    public async Task Validate_NonHttpBlobUrl_IsInvalid()
+    public void Note_Null_PassesValidation()
     {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [new SessionPhotoInput { BlobUrl = "ftp://bad-url.com/photo.jpg" }],
-            Note = null
-        };
+        var req = ValidRequest();
+        req.Note = null;
 
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
-        result.IsValid.Should().BeFalse();
+        _validator.TestValidate(req).ShouldNotHaveValidationErrorFor(x => x.Note);
     }
 
-    [Fact]
-    public async Task Validate_PerPhotoNoteTooLong_IsInvalid()
-    {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [new SessionPhotoInput
-            {
-                BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg",
-                Note = new string('x', 501)
-            }],
-            Note = null
-        };
-
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
-        result.IsValid.Should().BeFalse();
-    }
+    // ──────────────────────────────────────────────────────────────────────────
+    // Per-photo Note boundary tests
+    // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Validate_PerPhotoNoteMaxLength_IsValid()
+    public void PerPhotoNote_ExactlyFiveHundredChars_PassesValidation()
     {
-        var req = new SaveSessionPhotosRequest
-        {
-            SessionId = Guid.NewGuid(),
-            Photos = [new SessionPhotoInput
+        var req = ValidRequest();
+        req.Photos =
+        [
+            new SessionPhotoInput
             {
                 BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg",
                 Note = new string('x', 500)
-            }],
-            Note = null
-        };
+            }
+        ];
 
-        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void PerPhotoNote_FiveHundredAndOneChars_FailsValidation()
+    {
+        var req = ValidRequest();
+        req.Photos =
+        [
+            new SessionPhotoInput
+            {
+                BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg",
+                Note = new string('x', 501)
+            }
+        ];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PerPhotoNote_Null_PassesValidation()
+    {
+        var req = ValidRequest();
+        req.Photos =
+        [
+            new SessionPhotoInput
+            {
+                BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg",
+                Note = null
+            }
+        ];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Photos[i].BlobUrl URL format tests
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Photos_EmptyBlobUrl_FailsValidation()
+    {
+        var req = ValidRequest();
+        req.Photos = [new SessionPhotoInput { BlobUrl = string.Empty }];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Photos_NonHttpUrl_FailsValidation()
+    {
+        var req = ValidRequest();
+        req.Photos = [new SessionPhotoInput { BlobUrl = "ftp://some-server/photo.jpg" }];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Photos_ValidHttpsUrl_PassesValidation()
+    {
+        var req = ValidRequest();
+        req.Photos = [new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg" }];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Photos_ValidHttpUrl_PassesValidation()
+    {
+        var req = ValidRequest();
+        req.Photos = [new SessionPhotoInput { BlobUrl = "http://minio.local/diary/sessions/s1/a.jpg" }];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Photos_EmptyList_PassesValidation()
+    {
+        var req = ValidRequest();
+        req.Photos = [];
+
+        var result = _validator.TestValidate(req);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Photos_MultipleValidUrls_PassesValidation()
+    {
+        var req = ValidRequest();
+        req.Photos =
+        [
+            new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg" },
+            new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/b.jpg" }
+        ];
+
+        var result = _validator.TestValidate(req);
         result.IsValid.Should().BeTrue();
     }
 }

--- a/backend/FitnessPlatform.Tests/Validators/SaveSessionPhotosValidatorTests.cs
+++ b/backend/FitnessPlatform.Tests/Validators/SaveSessionPhotosValidatorTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using FluentValidation;
+using FitnessPlatform.Application.Features.ClientTraining.SaveSessionPhotos;
+
+namespace FitnessPlatform.Tests.Validators;
+
+/// <summary>
+/// Tests for <see cref="SaveSessionPhotosValidator"/>.
+/// </summary>
+public class SaveSessionPhotosValidatorTests
+{
+    private readonly SaveSessionPhotosValidator _validator = new();
+
+    [Fact]
+    public async Task Validate_ValidRequest_IsValid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [new SessionPhotoInput { BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg" }],
+            Note = "Good session"
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_EmptyPhotoList_IsValid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [],
+            Note = null
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_NoteTooLong_IsInvalid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [],
+            Note = new string('x', 501)
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName.Contains("Note"));
+    }
+
+    [Fact]
+    public async Task Validate_EmptyBlobUrl_IsInvalid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [new SessionPhotoInput { BlobUrl = "" }],
+            Note = null
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_NonHttpBlobUrl_IsInvalid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [new SessionPhotoInput { BlobUrl = "ftp://bad-url.com/photo.jpg" }],
+            Note = null
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_PerPhotoNoteTooLong_IsInvalid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [new SessionPhotoInput
+            {
+                BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg",
+                Note = new string('x', 501)
+            }],
+            Note = null
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_PerPhotoNoteMaxLength_IsValid()
+    {
+        var req = new SaveSessionPhotosRequest
+        {
+            SessionId = Guid.NewGuid(),
+            Photos = [new SessionPhotoInput
+            {
+                BlobUrl = "https://minio.local/diary/sessions/s1/a.jpg",
+                Note = new string('x', 500)
+            }],
+            Note = null
+        };
+
+        var result = await _validator.ValidateAsync(req, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/mobile/app/(client)/session-log-photo.tsx
+++ b/mobile/app/(client)/session-log-photo.tsx
@@ -76,8 +76,13 @@ export default function SessionLogPhotoScreen() {
       .map((p) => ({ blobUrl: p.blobUrl, note: p.note ?? null }))
   }, [queryClient, sessionId])
 
+  const existingNote = useMemo(() => {
+    const cache = queryClient.getQueryData<TodayTrainingResponse>(['today-training'])
+    return (cache?.notesBySession ?? {})[sessionId] ?? ''
+  }, [queryClient, sessionId])
+
   // ── Local state (seeded from cache on mount) ──
-  const [note, setNote] = useState<string>(() => '')
+  const [note, setNote] = useState<string>(() => existingNote)
   const [uploadedPhotos, setUploadedPhotos] = useState<SessionPhotoInput[]>(
     () => existingPhotos,
   )

--- a/mobile/app/(client)/session-log-photo.tsx
+++ b/mobile/app/(client)/session-log-photo.tsx
@@ -256,7 +256,7 @@ export default function SessionLogPhotoScreen() {
                         style={[styles.thumbRemoveBtn, { backgroundColor: colors.bg2 }]}
                         hitSlop={6}
                         accessibilityRole="button"
-                        accessibilityLabel="Remove photo"
+                        accessibilityLabel={t('sessionLogPhoto.removePhoto')}
                       >
                         <Ionicons name="close" size={12} color={colors.label2} />
                       </Pressable>

--- a/mobile/app/(client)/session-log-photo.tsx
+++ b/mobile/app/(client)/session-log-photo.tsx
@@ -1,0 +1,560 @@
+/**
+ * Session Log Photo screen — modal presented from the Today training card.
+ *
+ * Mirrors meal-log-photo.tsx (nutrition) but scoped to a training session:
+ *   1. Minimal modal header (safe-area padding only)
+ *   2. Session header card: name · session info
+ *   3. Photo picker:
+ *        - When 0 photos: dashed drop zone (tap = gallery multi-select,
+ *          long-press = camera single-shot)
+ *        - When ≥ 1: vertical list of photo rows with inline caption inputs + "add more" tile
+ *   4. Note textarea (500-char counter)
+ *   5. Info strip: visible-to-coach message
+ *   6. Action bar (pinned): primary CTA only (full-width), dismiss via swipe-down
+ */
+
+import React, { useCallback, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TextInput,
+  Image,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useQueryClient, useMutation } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { Ionicons } from '@expo/vector-icons'
+import { useTheme } from '@/hooks/useTheme'
+import { useImagePicker } from '@/hooks/useImagePicker'
+import { useAuthStore } from '@/stores/auth'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import {
+  saveSessionPhotos,
+  generateSessionPhotoUploadUrl,
+  type SessionPhotoInput,
+  type TodayTrainingResponse,
+} from '@/api/training'
+import { Toast } from '@/lib/toast'
+
+const NOTE_MAX_CHARS = 500
+
+// ─── Screen ─────────────────────────────────────────────────────────────────
+
+export default function SessionLogPhotoScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const colors = useTheme()
+  const queryClient = useQueryClient()
+
+  // ── Route params ──
+  const params = useLocalSearchParams<{
+    sessionId: string
+    sessionName: string
+  }>()
+
+  const sessionId = params.sessionId ?? ''
+  const sessionName = params.sessionName ?? ''
+
+  // ── Coach name from auth store ──
+  const coach = useAuthStore((s) => s.coach)
+  const coachName = coach?.name ?? null
+
+  // ── Pre-load existing photos + note from the today-training cache ──
+  const existingPhotos = useMemo(() => {
+    const cache = queryClient.getQueryData<TodayTrainingResponse>(['today-training'])
+    const photos = (cache?.photosBySession ?? {})[sessionId] ?? []
+    return photos
+      .filter((p) => typeof p.blobUrl === 'string' && p.blobUrl.length > 0)
+      .map((p) => ({ blobUrl: p.blobUrl, note: p.note ?? null }))
+  }, [queryClient, sessionId])
+
+  // ── Local state (seeded from cache on mount) ──
+  const [note, setNote] = useState<string>(() => '')
+  const [uploadedPhotos, setUploadedPhotos] = useState<SessionPhotoInput[]>(
+    () => existingPhotos,
+  )
+
+  // ── Multi-photo picker (gallery) ──
+  const { pick: pickGallery, uploading: galleryUploading } = useImagePicker(
+    {
+      source: 'library',
+      allowsMultipleSelection: true,
+      requestUploadUrl: async ({ contentType, sizeBytes }) => {
+        return generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+      },
+    },
+    undefined,
+    (blobUrls) => {
+      setUploadedPhotos((prev) => [
+        ...prev,
+        ...blobUrls.map((url) => ({ blobUrl: url, note: null })),
+      ])
+    },
+  )
+
+  // ── Single-shot camera picker ──
+  const { pick: pickCamera, uploading: cameraUploading } = useImagePicker(
+    {
+      source: 'camera',
+      requestUploadUrl: async ({ contentType, sizeBytes }) => {
+        return generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+      },
+    },
+    (blobUrl) => {
+      setUploadedPhotos((prev) => [...prev, { blobUrl, note: null }])
+    },
+  )
+
+  const imageUploading = galleryUploading || cameraUploading
+
+  const handleDropZoneTap = useCallback(() => {
+    pickGallery()
+  }, [pickGallery])
+
+  const handleDropZoneLongPress = useCallback(() => {
+    pickCamera()
+  }, [pickCamera])
+
+  const handleAddMore = useCallback(() => {
+    pickGallery()
+  }, [pickGallery])
+
+  const handleRemovePhoto = useCallback((blobUrl: string) => {
+    setUploadedPhotos((prev) => prev.filter((p) => p.blobUrl !== blobUrl))
+  }, [])
+
+  const handlePhotoNoteChange = useCallback((blobUrl: string, noteText: string) => {
+    setUploadedPhotos((prev) =>
+      prev.map((p) =>
+        p.blobUrl === blobUrl ? { ...p, note: noteText.slice(0, NOTE_MAX_CHARS) || null } : p,
+      ),
+    )
+  }, [])
+
+  // ── Save-photos mutation — REPLACE semantics ──
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      saveSessionPhotos(sessionId, {
+        photos: uploadedPhotos,
+        note: note.trim() || null,
+      }),
+    onSuccess: () => {
+      // Invalidate the today-training query so photosBySession refreshes.
+      // This mirrors how meal-log-photo invalidates today-log after saveMealPhotos.
+      queryClient.invalidateQueries({ queryKey: ['today-training'] })
+      Toast.show(t('sessionLogPhoto.successToast'))
+      router.back()
+    },
+  })
+
+  const hasContent = uploadedPhotos.length > 0 || note.trim().length > 0
+  const isSubmitting = saveMutation.isPending
+  const isLoading = isSubmitting || imageUploading
+
+  const handleSubmit = useCallback(() => {
+    if (isLoading || !hasContent) return
+    saveMutation.mutate()
+  }, [saveMutation, isLoading, hasContent])
+
+  // ── Info strip text ──
+  const infoText = coachName
+    ? t('sessionLogPhoto.infoStrip', { coachName })
+    : t('sessionLogPhoto.infoStripNoCoach')
+
+  return (
+    <SafeAreaView
+      style={[styles.container, { backgroundColor: colors.bg }]}
+      edges={['top', 'bottom']}
+    >
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={0}
+      >
+        {/* ── Minimal header ── */}
+        <View style={[styles.header, { borderBottomColor: colors.sep2 }]} />
+
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Session header card ── */}
+          <View style={[styles.sessionCard, { backgroundColor: colors.bg2 }]}>
+            <View style={[styles.sessionDot, { backgroundColor: colors.gold }]} />
+            <View style={styles.sessionCardInfo}>
+              <Text style={[styles.sessionCardName, { color: colors.label }]} numberOfLines={1}>
+                {sessionName}
+              </Text>
+            </View>
+          </View>
+
+          {/* ── Photo picker ── */}
+          <View style={styles.section}>
+            <Text style={[styles.sectionLabel, { color: colors.label2 }]}>
+              {t('sessionLogPhoto.photoSectionLabel').toUpperCase()}
+            </Text>
+
+            {uploadedPhotos.length === 0 ? (
+              /* ── Empty state: dashed drop zone ── */
+              <Pressable
+                onPress={handleDropZoneTap}
+                onLongPress={handleDropZoneLongPress}
+                delayLongPress={300}
+                accessibilityRole="button"
+                accessibilityLabel={t('sessionLogPhoto.photoPickerHint')}
+                style={[
+                  styles.photoDropZone,
+                  {
+                    backgroundColor: colors.bg2,
+                    borderColor: colors.sep,
+                  },
+                ]}
+              >
+                {imageUploading ? (
+                  <ActivityIndicator size="small" color={colors.gold} />
+                ) : (
+                  <>
+                    <Ionicons
+                      name="camera-outline"
+                      size={36}
+                      color={colors.label3}
+                      style={styles.dropZoneIcon}
+                    />
+                    <Text style={[styles.dropZoneHint, { color: colors.label2 }]}>
+                      {t('sessionLogPhoto.photoPickerHint')}
+                    </Text>
+                  </>
+                )}
+              </Pressable>
+            ) : (
+              /* ── Filled state: photo rows (thumbnail + inline caption) ── */
+              <View style={styles.photoRows}>
+                {uploadedPhotos.map((photo) => (
+                  <View
+                    key={photo.blobUrl}
+                    style={[styles.photoRow, { backgroundColor: colors.bg2, borderColor: colors.sep2 }]}
+                  >
+                    {/* Thumbnail */}
+                    <View style={[styles.thumbWrap, { backgroundColor: colors.fill2 }]}>
+                      <Image
+                        source={{ uri: photo.blobUrl }}
+                        style={styles.thumbImg}
+                        resizeMode="cover"
+                      />
+                      <Pressable
+                        onPress={() => handleRemovePhoto(photo.blobUrl)}
+                        style={[styles.thumbRemoveBtn, { backgroundColor: colors.bg2 }]}
+                        hitSlop={6}
+                        accessibilityRole="button"
+                        accessibilityLabel="Remove photo"
+                      >
+                        <Ionicons name="close" size={12} color={colors.label2} />
+                      </Pressable>
+                    </View>
+                    {/* Per-photo caption input */}
+                    <TextInput
+                      value={photo.note ?? ''}
+                      onChangeText={(text) => handlePhotoNoteChange(photo.blobUrl, text)}
+                      placeholder={t('sessionLogPhoto.photoCaption.placeholder')}
+                      placeholderTextColor={colors.label3}
+                      maxLength={NOTE_MAX_CHARS}
+                      style={[
+                        styles.captionInput,
+                        {
+                          color: colors.label,
+                          backgroundColor: colors.bg,
+                          borderColor: colors.sep2,
+                        },
+                      ]}
+                      accessibilityLabel={t('sessionLogPhoto.photoCaption.a11y')}
+                    />
+                  </View>
+                ))}
+
+                {/* "Add more" tile */}
+                <Pressable
+                  onPress={handleAddMore}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('sessionLogPhoto.addMorePhotos')}
+                  style={[
+                    styles.addMoreRow,
+                    {
+                      backgroundColor: colors.bg2,
+                      borderColor: colors.sep,
+                    },
+                  ]}
+                >
+                  {imageUploading ? (
+                    <ActivityIndicator size="small" color={colors.gold} />
+                  ) : (
+                    <>
+                      <Ionicons name="add" size={22} color={colors.label3} />
+                      <Text style={[styles.addMoreLabel, { color: colors.label3 }]}>
+                        {t('sessionLogPhoto.addMorePhotos')}
+                      </Text>
+                    </>
+                  )}
+                </Pressable>
+              </View>
+            )}
+          </View>
+
+          {/* ── Note textarea ── */}
+          <View style={styles.section}>
+            <View style={styles.sectionLabelRow}>
+              <Text style={[styles.sectionLabel, { color: colors.label2 }]}>
+                {t('sessionLogPhoto.noteSectionLabel').toUpperCase()}
+              </Text>
+              <Text style={[styles.noteCounter, { color: colors.label3 }]}>
+                {t('sessionLogPhoto.noteCounter', {
+                  current: note.length,
+                  max: NOTE_MAX_CHARS,
+                })}
+              </Text>
+            </View>
+            <TextInput
+              value={note}
+              onChangeText={(text) => setNote(text.slice(0, NOTE_MAX_CHARS))}
+              placeholder={t('sessionLogPhoto.notePlaceholder')}
+              placeholderTextColor={colors.label3}
+              multiline
+              maxLength={NOTE_MAX_CHARS}
+              style={[
+                styles.noteInput,
+                {
+                  color: colors.label,
+                  backgroundColor: colors.bg2,
+                  borderColor: colors.sep2,
+                },
+              ]}
+              textAlignVertical="top"
+              accessibilityLabel={t('sessionLogPhoto.noteSectionLabel')}
+            />
+          </View>
+
+          {/* ── Info strip ── */}
+          <View
+            style={[
+              styles.infoStrip,
+              {
+                backgroundColor: colors.bg2,
+                borderColor: colors.sep2,
+              },
+            ]}
+          >
+            <Text style={[styles.infoText, { color: colors.label2 }]}>
+              {infoText}
+            </Text>
+          </View>
+
+          {/* Bottom padding so the action bar doesn't cover content */}
+          <View style={{ height: 8 }} />
+        </ScrollView>
+
+        {/* ── Action bar (single full-width primary CTA) ── */}
+        <View
+          style={[
+            styles.actionBar,
+            {
+              backgroundColor: colors.bg,
+              borderTopColor: colors.sep2,
+            },
+          ]}
+        >
+          <Pressable
+            onPress={handleSubmit}
+            disabled={isLoading || !hasContent}
+            accessibilityRole="button"
+            style={({ pressed }) => [
+              styles.primaryBtn,
+              {
+                backgroundColor: colors.gold,
+                opacity: pressed || isLoading || !hasContent ? 0.5 : 1,
+              },
+            ]}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator size="small" color={colors.onAccent} />
+            ) : (
+              <Text style={[styles.primaryBtnText, { color: colors.onAccent }]}>
+                {t('sessionLogPhoto.savePhoto')}
+              </Text>
+            )}
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  )
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const GRID_MARGIN = 20
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  flex: { flex: 1 },
+  scrollContent: { paddingBottom: 24 },
+
+  // Header — minimal, just provides the hairline separator below safe-area top
+  header: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+
+  // Session header card
+  sessionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginHorizontal: GRID_MARGIN,
+    marginTop: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: Radius.lg,
+  },
+  sessionDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    flexShrink: 0,
+  },
+  sessionCardInfo: { flex: 1, minWidth: 0 },
+  sessionCardName: { ...Type.callout, fontWeight: '600' },
+
+  // Section (photo + note)
+  section: { marginHorizontal: GRID_MARGIN, marginTop: 20 },
+  sectionLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  sectionLabel: {
+    ...Type.footnote,
+    fontWeight: '600',
+    letterSpacing: 0.05,
+    marginBottom: 10,
+  },
+
+  // Photo drop zone (empty state)
+  photoDropZone: {
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderRadius: Radius.lg,
+    minHeight: 140,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 28,
+    paddingHorizontal: 28,
+  },
+  dropZoneIcon: { marginBottom: 6 },
+  dropZoneHint: { ...Type.footnote },
+
+  // Photo rows (filled state) — vertical list, thumbnail + caption side-by-side
+  photoRows: {
+    gap: 10,
+  },
+  photoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: Radius.md,
+    padding: 10,
+  },
+  thumbWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+    position: 'relative',
+    flexShrink: 0,
+  },
+  thumbImg: {
+    width: 80,
+    height: 80,
+  },
+  thumbRemoveBtn: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 2,
+  },
+  captionInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: Radius.sm,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    minHeight: 60,
+    ...Type.footnote,
+    lineHeight: 18,
+  },
+
+  // "Add more" row (dashed, below photo rows)
+  addMoreRow: {
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderRadius: Radius.md,
+    paddingVertical: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+  },
+  addMoreLabel: {
+    ...Type.caption1,
+  },
+
+  // Note textarea
+  noteCounter: { ...Type.caption1, marginBottom: 10 },
+  noteInput: {
+    borderWidth: 1,
+    borderRadius: Radius.md,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 80,
+    ...Type.subheadline,
+    lineHeight: 22,
+  },
+
+  // Info strip — neutral tinted border box
+  infoStrip: {
+    marginHorizontal: GRID_MARGIN,
+    marginTop: 20,
+    borderWidth: 1,
+    borderRadius: Radius.md,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  infoText: { ...Type.footnote, lineHeight: 19 },
+
+  // Action bar — single full-width primary CTA
+  actionBar: {
+    paddingHorizontal: GRID_MARGIN,
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  primaryBtn: {
+    height: 50,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryBtnText: { ...Type.callout, fontWeight: '600' },
+})

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -101,14 +101,35 @@ export type {
 } from './wod-types';
 
 /**
- * Augmented GetTodaySessionResponse — adds `lockStateBySession` which the
- * backend (#382) now includes. Drop once regen produces this field natively.
+ * A single training-session diary photo from the session log.
+ * Mirrors `MealPhotoDto` from nutrition (blobUrl, uploadedAt, note?).
  *
- * Key: sessionId (string UUID). Value: lock state string ("Stable", "Editing", "Live").
- * Missing key → treat as "Stable".
+ * Hand-declared until regen-api is run against the backend (#405).
+ * Drop this type once generated.ts emits `SessionPhotoDto` natively.
+ */
+export interface SessionPhotoDto {
+  blobUrl: string;
+  uploadedAt?: string;
+  note?: string | null;
+}
+
+/**
+ * Augmented GetTodaySessionResponse — adds:
+ *   - `lockStateBySession` (#382): session edit-lock state.
+ *   - `photosBySession` (#405): per-session diary photos from the session log.
+ *
+ * Both fields hand-declared until regen-api runs against the updated backend.
+ * Drop the augmentation for each field once the generated client emits it natively.
  */
 export type TodayTrainingResponse = GetTodaySessionResponse & {
   lockStateBySession?: Record<string, string>;
+  /**
+   * Per-session diary photos from today's session logs, keyed by sessionId.
+   * Mirrors how `mealsEaten[].photos` is embedded in GetTodayLogResponse for nutrition.
+   * Added in #405 (GenerateSessionPhotoUploadUrl + SaveSessionPhotos endpoints).
+   * Returns an empty object when no session has any diary photos today.
+   */
+  photosBySession?: Record<string, SessionPhotoDto[]>;
 };
 
 /**
@@ -146,4 +167,52 @@ export async function getTodaySession(): Promise<GetTodaySessionResponse> {
 export async function getFullTrainingPlan(planId: string): Promise<GetFullTrainingPlanResponse> {
   const { data } = await api.get<GetFullTrainingPlanResponse>(`/client/training/plans/${planId}`);
   return data;
+}
+
+// ─── Session photo upload API (#405) ─────────────────────────────────────────
+// Mirrors the nutrition meal-photo API pattern exactly.
+
+export interface GenerateSessionPhotoUploadUrlResponse {
+  uploadUrl: string;
+  blobUrl: string;
+}
+
+/**
+ * Request a signed upload URL for a training-session diary photo.
+ * Photos land in the session-diary/{sessionId}/ bucket namespace.
+ * Mirrors `generateMealPhotoUploadUrl` from nutrition.
+ */
+export async function generateSessionPhotoUploadUrl(
+  sessionId: string,
+  contentType: string,
+  sizeBytes: number,
+): Promise<GenerateSessionPhotoUploadUrlResponse> {
+  const { data } = await api.post<GenerateSessionPhotoUploadUrlResponse>(
+    `/client/training/log/sessions/${sessionId}/photo-upload-url`,
+    { contentType, sizeBytes },
+  );
+  return data;
+}
+
+export interface SessionPhotoInput {
+  blobUrl: string;
+  note?: string | null;
+}
+
+export interface SaveSessionPhotosOptions {
+  photos?: SessionPhotoInput[];
+  note?: string | null;
+}
+
+/**
+ * Replaces the photos list and note on a session log entry with the provided values.
+ * REPLACE semantics — the backend sets Photos to exactly the submitted list.
+ * UploadedAt is preserved for URLs that already exist in the log.
+ * Mirrors `saveMealPhotos` from nutrition.
+ */
+export async function saveSessionPhotos(
+  sessionId: string,
+  opts: SaveSessionPhotosOptions = {},
+): Promise<void> {
+  await api.post(`/client/training/log/sessions/${sessionId}/photos`, opts);
 }

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -117,8 +117,9 @@ export interface SessionPhotoDto {
  * Augmented GetTodaySessionResponse — adds:
  *   - `lockStateBySession` (#382): session edit-lock state.
  *   - `photosBySession` (#405): per-session diary photos from the session log.
+ *   - `notesBySession` (#405): persisted session-level notes keyed by sessionId.
  *
- * Both fields hand-declared until regen-api runs against the updated backend.
+ * All fields hand-declared until regen-api runs against the updated backend.
  * Drop the augmentation for each field once the generated client emits it natively.
  */
 export type TodayTrainingResponse = GetTodaySessionResponse & {
@@ -130,6 +131,14 @@ export type TodayTrainingResponse = GetTodaySessionResponse & {
    * Returns an empty object when no session has any diary photos today.
    */
   photosBySession?: Record<string, SessionPhotoDto[]>;
+  /**
+   * Persisted session-level note for today's session log, keyed by sessionId.
+   * Only present for sessions that have a non-empty note — mirrors how
+   * nutrition's today read path returns each meal's note.
+   * Added in #405 review fix: seeds the note textarea so REPLACE semantics
+   * do not wipe previously saved notes on re-open.
+   */
+  notesBySession?: Record<string, string>;
 };
 
 /**

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -380,6 +380,15 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
     return map
   }, [logQuery.data])
 
+  /**
+   * Per-session diary photos from today's session logs, keyed by sessionId.
+   * Sourced from `photosBySession` in TodayTrainingResponse (#405).
+   * Mirrors how `mealPhotosByMealId` is derived from `mealsEaten[].photos`.
+   */
+  const photosBySession = useMemo(() => {
+    return trainingQuery.data?.photosBySession ?? {}
+  }, [trainingQuery.data?.photosBySession])
+
   const sortedMeals = useMemo(
     () => [...(plan?.meals ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
     [plan?.meals],
@@ -1142,11 +1151,24 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
     router.push(hrefParams('/(client)/plan-photos', { planId: training.planId, planType: 'training' }))
   }, [router, training?.planId])
 
-  /** Navigate to the training plan-photos upload screen from the session card camera button. */
-  const handleSessionPhotoPress = useCallback(() => {
-    if (!training?.planId) return
-    router.push(hrefParams('/(client)/plan-photos-upload', { planId: training.planId, planType: 'training' }))
-  }, [router, training?.planId])
+  /**
+   * Navigate to the session-scoped photo upload screen from the session card camera button.
+   * Receives the sessionId so the screen can call POST /client/training/log/sessions/{id}/photos.
+   * Replaces the former plan-wide plan-photos-upload navigation (#405).
+   */
+  const handleSessionPhotoPress = useCallback(
+    (sessionId: string) => {
+      const session = todaySessions.find((s) => s.sessionId === sessionId)
+      if (!sessionId) return
+      router.push(
+        hrefParams('/(client)/session-log-photo', {
+          sessionId,
+          sessionName: session?.name ?? '',
+        }),
+      )
+    },
+    [router, todaySessions],
+  )
 
   /** Navigate to the meal-log-photo modal screen for the tapped meal. */
   const handlePhotoPress = useCallback(
@@ -1318,6 +1340,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               onMarkAllTrainingDone={handleMarkAllTrainingDone}
               isMarkAllTrainingLoading={markAllTrainingDoneMutation.isPending}
               onSessionPhotoPress={handleSessionPhotoPress}
+              photosBySession={photosBySession}
             />
           </View>
         ) : hasActivePlanButNoTrainingToday ? (

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1159,11 +1159,11 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
   const handleSessionPhotoPress = useCallback(
     (sessionId: string) => {
       const session = todaySessions.find((s) => s.sessionId === sessionId)
-      if (!sessionId) return
+      if (!session) return
       router.push(
         hrefParams('/(client)/session-log-photo', {
           sessionId,
-          sessionName: session?.name ?? '',
+          sessionName: session.name ?? '',
         }),
       )
     },

--- a/mobile/src/components/training/ExpandableSessionCard.tsx
+++ b/mobile/src/components/training/ExpandableSessionCard.tsx
@@ -17,6 +17,8 @@ import {
   trainingEasing,
 } from './animations'
 import { AnimatedCollapse } from './AnimatedCollapse'
+import { ImageLightbox } from '@/components/ui/ImageLightbox'
+import type { SessionPhotoDto } from '@/api/training'
 
 const ANIM_DURATION = TRAINING_ANIM_DURATION
 const easing = trainingEasing
@@ -117,6 +119,13 @@ interface ExpandableSessionCardProps {
    * the plan-detail path unchanged.
    */
   onPhotoPress?: () => void
+  /**
+   * Diary photos for this session's log entry. When non-empty, a tappable
+   * gold photo-indicator badge is rendered in the header next to the camera
+   * button. Tapping it opens an ImageLightbox scoped to THESE session photos
+   * only — mirrors MealRow's `hasPhotos`/`photos` pattern exactly.
+   */
+  photos?: SessionPhotoDto[]
   children: React.ReactNode
 }
 
@@ -142,11 +151,28 @@ export function ExpandableSessionCard({
   children,
   bodyFooter,
   onPhotoPress,
+  photos,
 }: ExpandableSessionCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(defaultExpanded)
   const chevronProgress = useSharedValue(defaultExpanded ? 1 : 0)
+
+  // Lightbox state — opened by tapping the gold photo-indicator badge in the header.
+  // Mirrors MealRow's lightbox state (lines 99–112 of MealRow.tsx).
+  const [lightboxVisible, setLightboxVisible] = useState(false)
+  const photoList = photos ?? []
+  const hasPhotos = photoList.length > 0
+  const photoUrls = photoList.map((p) => p.blobUrl).filter(Boolean)
+  const photoNotes = photoList.map((p) => p.note ?? null)
+
+  const handleBadgePress = useCallback(() => {
+    if (photoUrls.length > 0) setLightboxVisible(true)
+  }, [photoUrls.length])
+
+  const handleLightboxClose = useCallback(() => {
+    setLightboxVisible(false)
+  }, [])
 
   const chevronStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${chevronProgress.value * 180}deg` }],
@@ -206,6 +232,25 @@ export function ExpandableSessionCard({
           </Text>
         </View>
 
+        {/* Photo indicator badge — tappable, shown only when this session has
+            diary photos. Mirrors MealRow's photoIndicator (lines 250–264):
+            goldBg circle with a small camera icon that opens the per-session
+            ImageLightbox when tapped. */}
+        {hasPhotos && (
+          <Pressable
+            onPress={(e) => {
+              e.stopPropagation?.()
+              handleBadgePress()
+            }}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={t('sessionLogPhoto.openPhotosA11y')}
+            style={[styles.photoIndicator, { backgroundColor: colors.goldBg }]}
+          >
+            <Ionicons name="camera" size={11} color={colors.gold} />
+          </Pressable>
+        )}
+
         {/* Camera button — only rendered when onPhotoPress is provided.
             Mirrors MealRow's CameraButton: goldAlpha circle, Ionicons camera,
             stopPropagation so it doesn't toggle the card expand/collapse.
@@ -256,6 +301,19 @@ export function ExpandableSessionCard({
         {children}
         {bodyFooter}
       </AnimatedCollapse>
+
+      {/* Per-session photo lightbox — opened by tapping the gold badge in the
+          header. Scoped to THIS session's photos only, mirroring MealRow's
+          ImageLightbox render (lines 297–302 of MealRow.tsx). */}
+      {hasPhotos && (
+        <ImageLightbox
+          visible={lightboxVisible}
+          images={photoUrls}
+          startIndex={0}
+          onClose={handleLightboxClose}
+          imageNotes={photoNotes}
+        />
+      )}
     </View>
   )
 }
@@ -316,6 +374,18 @@ const styles = StyleSheet.create({
     height: 28,
     borderRadius: 14,
     borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  /**
+   * Small badge shown when this session has diary photos — mirrors
+   * MealRow's photoIndicator style exactly (18×18, radius 9, goldBg fill).
+   */
+  photoIndicator: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -497,6 +497,11 @@ export function TrainingCard({
                   ? () => onSessionPhotoPress(session.sessionId!)
                   : undefined
               }
+              sessionPhotos={
+                session.sessionId != null
+                  ? (photosBySession[session.sessionId] ?? [])
+                  : []
+              }
               t={t}
             />
           )
@@ -616,6 +621,11 @@ interface SessionSectionListProps {
    * Already pre-bound to the specific sessionId by the parent TrainingCard.
    */
   onSessionPhotoPress?: () => void
+  /**
+   * Diary photos for this specific session, already sliced from `photosBySession`.
+   * Passed to ExpandableSessionCard so the per-session badge + lightbox work.
+   */
+  sessionPhotos?: SessionPhotoDto[]
   t: (key: string, opts?: Record<string, unknown>) => string
 }
 
@@ -644,6 +654,7 @@ function SessionSectionList({
   onToggleSection,
   onSessionCta,
   onSessionPhotoPress,
+  sessionPhotos,
   t,
 }: SessionSectionListProps) {
   const colors = useTheme()
@@ -670,6 +681,7 @@ function SessionSectionList({
               summaryText={summaryText}
               headerRight={sessionCheckbox}
               onPhotoPress={onSessionPhotoPress}
+              photos={sessionPhotos}
             >
               {/* Section-grouped exercise cards */}
               {sections.map((section, sectionIdx) => {

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native'
+import { View, Text, StyleSheet, Pressable, ActivityIndicator, ScrollView, Image } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
@@ -8,6 +8,7 @@ import { Type, interFamily } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { ProgressRing } from '@/components/ui/ProgressRing'
 import { GoldButton } from '@/components/ui/GoldButton'
+import { ImageLightbox } from '@/components/ui/ImageLightbox'
 import { ExpandableSessionCard } from '@/components/training/ExpandableSessionCard'
 import { ExpandableExerciseCard } from '@/components/training/ExpandableExerciseCard'
 import {
@@ -18,7 +19,7 @@ import {
 import { SectionHeader } from '@/components/training/SectionHeader'
 import { SetGrid } from '@/components/training/SetGrid'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
-import type { TrainingSession, TrainingSection, MuscleGroup } from '@/api/training'
+import type { TrainingSession, TrainingSection, MuscleGroup, SessionPhotoDto } from '@/api/training'
 import type { SessionCtaState } from './trainingCardHelpers'
 import { SessionEditingBanner } from '@/components/today/SessionEditingBanner'
 
@@ -145,12 +146,19 @@ interface TrainingCardProps {
   lockStateBySession?: Record<string, string>
   /**
    * Called when the user taps the camera icon on a session card header.
-   * Passed down through SessionSectionList to ExpandableSessionCard.
+   * Receives the sessionId so HasTrainerState can navigate to the
+   * session-scoped session-log-photo screen with the correct context.
    * When absent, no camera button is rendered on the session card.
-   * HasTrainerState supplies this to navigate to plan-photos-upload for the
-   * training plan (plan-level, v1 — session-level linkage is a future enhancement).
    */
-  onSessionPhotoPress?: () => void
+  onSessionPhotoPress?: (sessionId: string) => void
+  /**
+   * Per-session diary photos from today's session logs, keyed by sessionId.
+   * Used to render the "Fotky dne" horizontal strip beneath the training card
+   * and per-session photo indicators/lightbox inside each ExpandableSessionCard.
+   * Mirrors `mealPhotosByMealId` in NutritionCard.
+   * Sourced from `photosBySession` in TodayTrainingResponse (#405).
+   */
+  photosBySession?: Record<string, SessionPhotoDto[]>
 }
 
 // ─── formatSets ───────────────────────────────────────────────────────────────
@@ -274,9 +282,25 @@ export function TrainingCard({
   isMarkAllTrainingLoading,
   lockStateBySession = {},
   onSessionPhotoPress,
+  photosBySession = {},
 }: TrainingCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
+
+  // Flatten all photos from all sessions for the "Fotky dne" strip.
+  // Mirrors NutritionCard's allPhotos derivation from mealPhotosByMealId.
+  const allPhotos = useMemo<{ blobUrl: string; sessionId: string; note?: string | null }[]>(() => {
+    return Object.entries(photosBySession).flatMap(([sessionId, photos]) =>
+      photos.map((p) => ({ blobUrl: p.blobUrl, sessionId, note: p.note })),
+    )
+  }, [photosBySession])
+
+  const allPhotoUrls = useMemo(() => allPhotos.map((p) => p.blobUrl), [allPhotos])
+  const allPhotoNotes = useMemo(() => allPhotos.map((p) => p.note ?? null), [allPhotos])
+
+  const [lightbox, setLightbox] = useState<{ visible: boolean; startIndex: number }>(
+    { visible: false, startIndex: 0 },
+  )
 
   // Aggregate training-session counts for the hero ring. The ring tracks how
   // many of today's training sessions the client has fully completed (via
@@ -468,12 +492,54 @@ export function TrainingCard({
               onToggleExercises={onToggleExercises}
               onToggleSection={onToggleSection}
               onSessionCta={onSessionCta}
-              onSessionPhotoPress={onSessionPhotoPress}
+              onSessionPhotoPress={
+                onSessionPhotoPress && session.sessionId
+                  ? () => onSessionPhotoPress(session.sessionId!)
+                  : undefined
+              }
               t={t}
             />
           )
         })}
       </View>
+
+      {/* Photo strip — "Fotky dne" — visible only when at least one session has diary photos.
+          Mirrors NutritionCard's photoStrip section exactly. */}
+      {allPhotos.length > 0 ? (
+        <View style={styles.photoStrip}>
+          <Text style={[styles.photoStripLabel, { color: colors.label3 }]}>
+            {t('training.todayPhotos')}
+          </Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.photoStripContent}
+          >
+            {allPhotos.map((photo, index) => (
+              <Pressable
+                key={`${photo.sessionId}-${index}`}
+                style={styles.photoStripTile}
+                onPress={() => setLightbox({ visible: true, startIndex: index })}
+              >
+                <Image
+                  source={{ uri: photo.blobUrl }}
+                  style={styles.photoStripImage}
+                  resizeMode="cover"
+                />
+              </Pressable>
+            ))}
+          </ScrollView>
+        </View>
+      ) : null}
+
+      {/* Card-level lightbox for the photo strip */}
+      <ImageLightbox
+        visible={lightbox.visible}
+        images={allPhotoUrls}
+        startIndex={lightbox.startIndex}
+        onClose={() => setLightbox({ visible: false, startIndex: 0 })}
+        imageNotes={allPhotoNotes}
+      />
 
       {/* Mark whole day done — hidden when every session is already complete or no sessions */}
       {onMarkAllTrainingDone && hasIncompleteSessions && sessions.length > 0 && (
@@ -547,7 +613,7 @@ interface SessionSectionListProps {
   /**
    * When provided, a camera button is rendered in the session card header.
    * Passed through to ExpandableSessionCard's `onPhotoPress` prop.
-   * HasTrainerState supplies this to navigate to plan-photos-upload (training plan).
+   * Already pre-bound to the specific sessionId by the parent TrainingCard.
    */
   onSessionPhotoPress?: () => void
   t: (key: string, opts?: Record<string, unknown>) => string
@@ -917,6 +983,33 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     paddingBottom: 16,
+  },
+  // Photo strip — mirrors NutritionCard's photoStrip styles exactly.
+  photoStrip: {
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  photoStripLabel: {
+    ...Type.caption2,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: 16,
+    marginBottom: 6,
+  },
+  photoStripContent: {
+    paddingHorizontal: 16,
+    gap: 6,
+  },
+  photoStripTile: {
+    width: 56,
+    height: 56,
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+  },
+  photoStripImage: {
+    width: '100%',
+    height: '100%',
   },
 })
 

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -766,6 +766,23 @@
       "a11y": "Popisek fotky"
     }
   },
+  "sessionLogPhoto": {
+    "photoSectionLabel": "Přidej fotky (volitelné)",
+    "photoPickerHint": "Tap: galerie · podržet: fotoaparát",
+    "noteSectionLabel": "Poznámka (volitelné)",
+    "notePlaceholder": "Např. Výborný trénink, přidal jsem si váhu…",
+    "noteCounter": "{{current}} / {{max}}",
+    "infoStrip": "Fotky i poznámka se uloží do tvého deníku tréninku a jsou viditelné pro {{coachName}}.",
+    "infoStripNoCoach": "Fotky i poznámka se uloží do tvého deníku tréninku.",
+    "savePhoto": "Uložit fotky",
+    "successToast": "Uloženo",
+    "addMorePhotos": "Přidat další fotku",
+    "openPhotosA11y": "Otevřít fotky tréninku",
+    "photoCaption": {
+      "placeholder": "Popisek (volitelný)",
+      "a11y": "Popisek fotky"
+    }
+  },
   "foodDetail": {
     "nutritionValues": "Nutriční hodnoty",
     "protein": "Bílkoviny",
@@ -985,6 +1002,7 @@
     },
     "photoCta": "Foto",
     "sessionPhotoA11y": "Přidat fotku tréninku",
+    "todayPhotos": "Fotky dne",
     "sessions": {
       "reminder": {
         "toggleLabel": "Připomenutí",

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -778,6 +778,7 @@
     "successToast": "Uloženo",
     "addMorePhotos": "Přidat další fotku",
     "openPhotosA11y": "Otevřít fotky tréninku",
+    "removePhoto": "Odebrat fotku",
     "photoCaption": {
       "placeholder": "Popisek (volitelný)",
       "a11y": "Popisek fotky"

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -1037,6 +1037,7 @@
     "successToast": "Gespeichert",
     "addMorePhotos": "Weiteres Foto hinzufügen",
     "openPhotosA11y": "Trainingsfotos öffnen",
+    "removePhoto": "Foto entfernen",
     "photoCaption": {
       "placeholder": "Beschriftung (optional)",
       "a11y": "Fotobeschriftung"

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -953,6 +953,7 @@
     },
     "photoCta": "Foto",
     "sessionPhotoA11y": "Trainingsfoto hinzufügen",
+    "todayPhotos": "Heutige Fotos",
     "sessions": {
       "reminder": {
         "toggleLabel": "Erinnerung",
@@ -1019,6 +1020,23 @@
     "addMorePhotos": "Weiteres Foto hinzufügen",
     "photoThumbA11y": "Foto {{index}} von {{total}}",
     "openPhotosA11y": "Mahlzeitfotos öffnen",
+    "photoCaption": {
+      "placeholder": "Beschriftung (optional)",
+      "a11y": "Fotobeschriftung"
+    }
+  },
+  "sessionLogPhoto": {
+    "photoSectionLabel": "Fotos hinzufügen (optional)",
+    "photoPickerHint": "Tippen: Galerie · gedrückt halten: Kamera",
+    "noteSectionLabel": "Notiz (optional)",
+    "notePlaceholder": "Z.B. Super Training, mehr Gewicht verwendet…",
+    "noteCounter": "{{current}} / {{max}}",
+    "infoStrip": "Fotos und Notiz werden in deinem Trainings-Tagebuch gespeichert und sind für {{coachName}} sichtbar.",
+    "infoStripNoCoach": "Fotos und Notiz werden in deinem Trainings-Tagebuch gespeichert.",
+    "savePhoto": "Speichern",
+    "successToast": "Gespeichert",
+    "addMorePhotos": "Weiteres Foto hinzufügen",
+    "openPhotosA11y": "Trainingsfotos öffnen",
     "photoCaption": {
       "placeholder": "Beschriftung (optional)",
       "a11y": "Fotobeschriftung"

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -1038,6 +1038,7 @@
     "successToast": "Saved",
     "addMorePhotos": "Add another photo",
     "openPhotosA11y": "Open training photos",
+    "removePhoto": "Remove photo",
     "photoCaption": {
       "placeholder": "Caption (optional)",
       "a11y": "Photo caption"

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -731,6 +731,7 @@
     },
     "photoCta": "Photo",
     "sessionPhotoA11y": "Add training photo",
+    "todayPhotos": "Today's photos",
     "sessions": {
       "reminder": {
         "toggleLabel": "Reminder",
@@ -1020,6 +1021,23 @@
     "addMorePhotos": "Add another photo",
     "photoThumbA11y": "Photo {{index}} of {{total}}",
     "openPhotosA11y": "Open meal photos",
+    "photoCaption": {
+      "placeholder": "Caption (optional)",
+      "a11y": "Photo caption"
+    }
+  },
+  "sessionLogPhoto": {
+    "photoSectionLabel": "Add photos (optional)",
+    "photoPickerHint": "Tap: gallery · hold: camera",
+    "noteSectionLabel": "Note (optional)",
+    "notePlaceholder": "E.g. Great workout, I added more weight…",
+    "noteCounter": "{{current}} / {{max}}",
+    "infoStrip": "Photos and note will be saved to your training diary and are visible to {{coachName}}.",
+    "infoStripNoCoach": "Photos and note will be saved to your training diary.",
+    "savePhoto": "Save",
+    "successToast": "Saved",
+    "addMorePhotos": "Add another photo",
+    "openPhotosA11y": "Open training photos",
     "photoCaption": {
       "placeholder": "Caption (optional)",
       "a11y": "Photo caption"


### PR DESCRIPTION
## Summary
- Backend: new `SessionLog` Mongo document (Photos[]: BlobUrl/UploadedAt/Note, keyed by client+plan+session+day) plus two `ClientTraining` endpoints — `POST /client/training/log/sessions/{SessionId}/photo-upload-url` (pre-signed blob URL) and `.../photos` (REPLACE-semantics persist + idempotent dual-write to PostgreSQL `PlanPhoto` with `Category=Training`, `PlanType=Training`, `LinkId=SessionId`). New `PlanPhotoCategory.Training` enum value. `GetTodaySession` extended with `photosBySession` + `notesBySession` dicts.
- Mobile: session-scoped photo flow mirroring nutrition 1:1 — gold camera affordance per session, per-session lightbox gallery, "Fotky dne" strip under the training card, session note round-trip, live query invalidation on upload, reroute of `HasTrainerState.handleSessionPhotoPress` away from the plan-wide screen.
- i18n: all new strings added to cs/en/de (identical key sets).
- No EF migration: `PlanPhoto.Category`/`PlanType` are stored via `HasConversion<string>()`, so appending an enum value is migration-free and backward compatible.

## Related issue
Fixes #405

## Scope
cross-cut (backend + mobile) — one branch, one PR per the cross-package coordination rule.

## Review rework (post-first-pass)
- **BLOCKING (fixed) — session note silently wiped on photo save.** The today read path didn't return the persisted `SessionLog.Note`, so the upload screen always seeded an empty note and the next REPLACE-save overwrote the stored note with null. Fixed end-to-end: backend now returns `notesBySession` (populated from `SessionLog.Note`, no extra query); mobile seeds the note field from it via the `['today-training']` cache, mirroring `meal-log-photo.tsx`. Independently confirmed resolved by the fresh-eyes pass.
- **NIT (fixed)** — `handleSessionPhotoPress` guard now bails on a failed session lookup instead of the always-truthy route param.
- **CI (fixed)** — `SaveSessionPhotosValidatorTests.Validate_NoteTooLong_IsInvalid` was red on Linux/Release (empty `ValidationFailure.PropertyName` from a direct `new Validator()` + async `ValidateAsync` path); validator was correct, test realigned to nutrition's `TestValidate`/`ShouldHaveValidationErrorFor` pattern (now 15 tests).

## QA verdict (from qa-tester)
Static + backend green (backend full suite 1089 tests, mobile typecheck clean, i18n parity pass, zero regressions). The four on-device-visual UI ACs (camera-tap upload, per-session lightbox, "Fotky dne" strip render, live invalidation) are statically verified but require a running simulator to confirm pixels — accepted by the user as a documented on-device-visual gap (the mobile UI mirrors the already-shipped nutrition photo flow 1:1).

## Review verdict
Two-pass review complete: self-review CLEAN + independent Opus fresh-eyes CLEAN on the full updated diff. All CI checks green (build-and-test, typecheck, playwright, GitGuardian).
Non-blocking follow-ups: (1) `session-log-photo.tsx` save mutation lacks an `onError` toast (likely shared with `meal-log-photo`); (2) `gc-sec-review` recommended on the BlobUrl scheme-only validation (pre-existing nutrition-parity design).

## regen-api deviation note
`mobile/src/api/generated.ts` is intentionally NOT regenerated. The new response shapes (`SessionPhotoDto`, `photosBySession`, `notesBySession` on the today response) are hand-declared in `mobile/src/api/training.ts` as a typed intersection — following the existing `lockStateBySession` (#382) precedent in the same file. `generated.ts` confirmed unchanged; the augmentation is documented to be dropped once `regen-api` emits the fields natively. Sanctioned wrapper pattern, not a generated-file edit.

## Test plan
- [ ] A gold camera icon on the training session card uploads a photo scoped to that specific session (replaces the former plan-wide navigation). *(on-device-visual gap)*
- [ ] Tapping the session's photo affordance opens a lightbox showing only that session's photos. *(on-device-visual gap)*
- [ ] A "Fotky dne" strip beneath the training card shows all of today's training-session photos. *(on-device-visual gap)*
- [x] Backend: two new `ClientTraining` endpoints (upload-url + persist with dual-write) — verified, full suite green.
- [x] Photos stored in new Mongo doc + dual-written to `PlanPhoto`; `PlanPhotoCategory.Training` introduced — verified.
- [x] Session note round-trips (no longer wiped on photo save) — verified by tests + fresh-eyes pass.
- [ ] Photos persist/reload after refresh; training card invalidates query for live update. *(query-key invalidation verified statically; on-device confirm pending)*
- [x] All new user-facing strings added to cs/en/de — verified, identical key sets.
- [x] No hardcoded colors/spacing (tokens via useTheme); no TypeScript any — verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
