### PR TITLE
fix: live session finalizes on whole-session summary, not last-section interstitial (#409)

### DIFF
--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -3184,14 +3184,6 @@ export default function WorkoutLogScreen() {
                         })
                         persistUpdate()
                         setPhase('sectionFinished')
-                        if (nextSectionIdx >= sections.length) {
-                          // Last section — mark the session finished + flush
-                          // the log so the backend matches the UI; the CTA
-                          // will hop to the session summary on tap.
-                          storeFinish()
-                          const logId = loadedLogId ?? activeLogId
-                          if (logId) void finalizeWorkout(logId)
-                        }
                         return
                       }
 
@@ -3636,14 +3628,6 @@ export default function WorkoutLogScreen() {
                   })
                   persistUpdate()
                   setPhase('sectionFinished')
-                  if (nextSectionIdx >= sections.length) {
-                    // Last section — mark the session finished + flush the
-                    // log so the backend sees the completed state. The
-                    // pinned CTA will close the session on tap.
-                    storeFinish()
-                    const logId = loadedLogId ?? activeLogId
-                    if (logId) void finalizeWorkout(logId)
-                  }
                 }}
                 onCancel={handleWodCancel}
                 onRoundChange={setCurrentWodRound}
@@ -3852,12 +3836,16 @@ export default function WorkoutLogScreen() {
             <Pressable
               style={[styles.pinnedCtaBtn, { backgroundColor: colors.gold }]}
               onPress={() => {
-                // No next workout — this was the last section. Hop to the
-                // session-summary (`'finished'`) screen; storeFinish +
-                // finalizeWorkout already ran in the onFinish that brought
-                // us here, so the backend is in sync. LiveFinishedSummary
-                // owns the "Back to today" exit from there.
+                // No next workout — this was the last section. Mark the
+                // session finished here (not in onFinish) so that the
+                // backend only receives the complete signal once the client
+                // explicitly taps through to the session-summary screen.
+                // This prevents the web portal from flipping state while
+                // the client is still on the last-section interstitial.
                 if (!nextSec) {
+                  storeFinish()
+                  const logId = loadedLogId ?? activeLogId
+                  if (logId) void finalizeWorkout(logId)
                   setFinishedSectionInfo(null)
                   setPhase('finished')
                   return


### PR DESCRIPTION
## Summary
- Live training session was releasing the Live lock + broadcasting `sessioneditlockchanged` (Stable) one screen too early — on the last-workout section-finished interstitial instead of the whole-session summary.
- Removed `storeFinish()` + `finalizeWorkout(logId)` from the two last-section `onFinish` branches (WOD path + exercise-free WOD path); these now only `persistUpdate()` + `setPhase('sectionFinished')`.
- Moved `storeFinish()` + `finalizeWorkout(logId)` into the pinned-CTA `!nextSec` branch, immediately before `setPhase('finished')`, so the lock release / SignalR fire happens only when the client taps through to the session summary.
- Direct-to-`finished` paths and `handleWodFinish` left unchanged (they already finalize at the correct time). The `finished`-phase restore-on-remount guard verified unaffected.

## Related issue
Fixes #409

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS (relayed by orchestrator). Mobile typecheck clean against the worktree.

## Test plan
- [ ] Finishing the last workout/section lands on the section-finished interstitial WITHOUT releasing the Live lock or changing the web portal state.
- [ ] Tapping Continue on that interstitial enters the whole-session summary AND that is when the session finalizes (lock released, web portal updates).
- [ ] The web trainer portal live-state change is observed only at the whole-session summary, not at the last-workout section interstitial.
- [ ] Section/workout data still persists on each section finish (no regression to completion data on the backend).
- [ ] Single-section sessions and the direct-to-`finished` paths still finalize correctly (no regression).
- [ ] Mobile typecheck passes (`npx tsc --noEmit`); no `any`, no hardcoded colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)