### PR TITLE
feat: add time-period caption to weight (VÁHA) stat card

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -266,7 +266,16 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
         ? weights[weights.length - 1].weight - weights[weights.length - 2].weight
         : null
 
-    return { latest: stats.latestWeight, change }
+    const periodDays =
+      weights.length >= 2
+        ? Math.round(
+            (new Date(weights[weights.length - 1].date).getTime() -
+              new Date(weights[weights.length - 2].date).getTime()) /
+              (1000 * 60 * 60 * 24),
+          )
+        : null
+
+    return { latest: stats.latestWeight, change, periodDays }
   }, [statsQuery.data, recentMeasurementsQuery.data])
 
   // Generated GetTodayLogResponse makes totalConsumed optional; normalise here.
@@ -1214,6 +1223,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
         <WeightStatCard
           latestWeight={weightTrend?.latest ?? null}
           weightDelta={weightTrend?.change ?? null}
+          periodDays={weightTrend?.periodDays ?? null}
         />
         <StatCard
           label={t('today.compliance')}

--- a/mobile/src/components/today/WeightStatCard.tsx
+++ b/mobile/src/components/today/WeightStatCard.tsx
@@ -11,11 +11,18 @@ interface WeightStatCardProps {
   latestWeight: number | null
   /** Difference between the latest measurement and the one before it (positive = gain) */
   weightDelta: number | null
+  /**
+   * Number of calendar days between the two most recent measurements.
+   * Null when fewer than two measurements exist (in which case neither
+   * the delta nor the period caption is shown).
+   */
+  periodDays: number | null
 }
 
 export const WeightStatCard = React.memo(function WeightStatCard({
   latestWeight,
   weightDelta,
+  periodDays,
 }: WeightStatCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -60,6 +67,14 @@ export const WeightStatCard = React.memo(function WeightStatCard({
         )}
       </View>
 
+      {/* Period caption — shown only when two measurements exist (periodDays is non-null).
+          Positioned above the delta line so the layout reads: value → period → change. */}
+      {periodDays != null && (
+        <Text style={[styles.periodSub, { color: colors.label3 }]}>
+          {t('today.weightPeriodSub', { count: periodDays })}
+        </Text>
+      )}
+
       {/* Delta between the last two measurements */}
       {deltaText != null && (
         <Text style={[styles.delta, { color: deltaColor ?? colors.label3 }]}>
@@ -101,6 +116,10 @@ const styles = StyleSheet.create({
   },
   unit: {
     ...Type.caption1,
+  },
+  periodSub: {
+    ...Type.caption1,
+    marginTop: 1,
   },
   delta: {
     ...Type.caption2,

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -224,6 +224,7 @@
     "calories": "Kalorie",
     "weight": "Váha",
     "noMeasurements": "žádné měření",
+    "weightPeriodSub": "za posledních {{count}} dní",
     "training": "Trénink",
     "restDay": "Den odpočinku",
     "preparing": "Připravuje se",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -224,6 +224,7 @@
     "calories": "Kalorien",
     "weight": "Gewicht",
     "noMeasurements": "keine Messungen",
+    "weightPeriodSub": "letzte {{count}} Tage",
     "training": "Training",
     "restDay": "Ruhetag",
     "preparing": "In Vorbereitung",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -224,6 +224,7 @@
     "calories": "Calories",
     "weight": "Weight",
     "noMeasurements": "no measurements",
+    "weightPeriodSub": "last {{count}} days",
     "training": "Training",
     "restDay": "Rest day",
     "preparing": "Preparing",


### PR DESCRIPTION
## Summary
- Adds a time-period caption to the VÁHA weight stat card ("za posledních {{count}} dní"), placed between the kg value and the delta line.
- The period is computed as the calendar-day diff between the two most-recent measurement dates (`weightTrend` useMemo in `HasTrainerState.tsx`), passed into `WeightStatCard` via a new `periodDays: number | null` prop.
- Caption styled with the same tokens as `StatCard.sub`: `Type.caption1` / `colors.label3` / `marginTop: 1` — no hardcoded values.
- When fewer than two measurements exist, `periodDays` is null and neither the delta nor the caption renders.

## Related issue
Fixes #410

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — mobile typecheck clean against the worktree.

## Design decisions (flagged per issue)
1. **Simple `{{count}}` interpolation, NOT i18next plural variants** — consistent with existing `today.daysInRow` / `training.streak`. Trade-off: grammatically imperfect singular forms ("1 dní" / "1 Tage") at count=1.
2. **Same-day edge (count=0)** shows "za posledních 0 dní" rather than suppressing the caption — caption renders whenever two measurements exist.

## Test plan
- [ ] VÁHA card shows a caption describing the change window (e.g. "za posledních 5 dní"), computed from the two most recent measurement dates.
- [ ] Caption matches the compliance sub-label styling (`Type.caption1`, `colors.label3`, `marginTop: 1`) — no hardcoded colors/sizes.
- [ ] Caption positioned above the delta line (value → period → delta).
- [ ] Fewer than two measurements → no delta, no caption, no NaN artifact.
- [ ] `today.weightPeriodSub` populated in cs / en / de.
- [ ] Mobile typecheck passes; no `any` introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)