### PR TITLE
fix: finishing a training session on mobile now marks it finished live in the trainer portal (#408)

### DIFF
--- a/web/src/stores/trainingPlan.ts
+++ b/web/src/stores/trainingPlan.ts
@@ -1463,17 +1463,21 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
       // after a SignalR sessioneditlockchanged event that triggers this path.
       const sessionLockStates = fresh.sessionLockStates ?? [];
       const sessionLockMap = buildLockMap(sessionLockStates);
+      // Also carry fresh sessionExecutions so isSessionFinished badges update
+      // live — the API response includes them but they were previously dropped
+      // during the merge, leaving the finished badge stale until a full reload.
+      const sessionExecutions = fresh.sessionExecutions ?? [];
       set((state) => ({
         // Keep plan.sessionLockStates in lockstep with sessionLockMap so the
         // in-memory plan can't diverge from the authoritative live lock state.
         plan: state.plan
-          ? { ...state.plan, completions, sessionLockStates }
+          ? { ...state.plan, completions, sessionLockStates, sessionExecutions }
           : state.plan,
         // originalPlan tracks server-state too, so it must move with the
         // freshly fetched completions — otherwise revert() would surface
         // stale completion data.
         originalPlan: state.originalPlan
-          ? { ...state.originalPlan, completions, sessionLockStates }
+          ? { ...state.originalPlan, completions, sessionLockStates, sessionExecutions }
           : state.originalPlan,
         sessionLockMap,
       }));


### PR DESCRIPTION
## Summary
- `refreshCompletions()` in `web/src/stores/trainingPlan.ts` now also carries `fresh.sessionExecutions` into both the merged `plan` and `originalPlan` objects, alongside the existing `completions` and `sessionLockStates`.
- The trainer-portal finished badge is driven by `plan.sessionExecutions[].isSessionFinished`; previously this field was silently dropped during the `sessioneditlockchanged` refresh merge, leaving the badge stale until a manual reload.
- Web-only, single-file change. The cross-package "non-live completion event" idea from the issue Notes was intentionally left out of scope (would need its own design-review gate).

## Related issue
Fixes #408

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — finishing a live session on mobile updates the trainer-portal finished badge live (no reload); lock-state and completion refresh unchanged.

## Test plan
- [ ] Finishing a live training session on mobile causes the trainer portal's training plan view to show the session as finished live (finished badge appears) without a manual page reload.
- [ ] `refreshCompletions()` updates `plan.sessionExecutions` (and `originalPlan.sessionExecutions`) from the freshly fetched plan, in addition to `completions` and `sessionLockStates`.
- [ ] Lock state and completion records continue to refresh correctly (no regression to existing `sessioneditlockchanged` behaviour).
- [ ] Web build passes (`npm run build`); no `any`, no hardcoded colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)