### PR TITLE
chore: fix qa-fetch-refresh-token.sh ephemeral port + base64 token encoding

### DIFF
--- a/mobile/scripts/qa-fetch-refresh-token.sh
+++ b/mobile/scripts/qa-fetch-refresh-token.sh
@@ -1,37 +1,68 @@
 #!/usr/bin/env bash
-# Fetch a QA refresh token from the compose harness (:5101) by logging in as one
-# of the seeded fixture users.  Prints the token to stdout so callers can pipe
-# it directly into `xcrun simctl openurl`.
+# Fetch a QA refresh token from the compose harness by logging in as one of the
+# seeded fixture users. Prints the token to stdout.
 #
 # Usage:
-#   mobile/scripts/qa-fetch-refresh-token.sh [client|trainer|nutritionist]
+#   mobile/scripts/qa-fetch-refresh-token.sh [client|trainer|nutritionist] [--encode|--deeplink]
 #
-# Default role: client
+# Default role: client. Default output: the RAW refresh token.
+#
+# Output modes:
+#   (default)    Raw refresh token — for web localStorage injection / Bearer use.
+#   --encode     URL-encoded refresh token — safe as a query-string parameter.
+#   --deeplink   Full ready-to-open URL: fitnessplatform://e2e-auth?token=<url-encoded>
+#                — pipe straight into `xcrun simctl openurl <udid> "$(…)"`.
+#
+# WHY --encode/--deeplink exist: refresh tokens are standard base64 and contain
+# `+`, `/`, `=`. Passed RAW in a `fitnessplatform://e2e-auth?token=…` deep link,
+# expo-linking's Linking.parse turns `+`→space and mangles `/`/`=`, so the app's
+# POST /auth/refresh receives a corrupted token and silently logs out. The iOS
+# dev-client auth bypass MUST use --encode or --deeplink.
+#
+# HARNESS URL: resolved from the current branch's stack via `scripts/test-env
+# ports` (JSON .api_url). The harness host port is EPHEMERAL — the old fixed
+# `:5101` mapping is gone (see docs/testing/e2e-fixtures.md).
 #
 # Prerequisites:
 #   - .env.test at the repo root with QA_SEED_PASSWORD set.
-#   - Compose harness running: npm run e2e:up
+#   - Compose harness running: `scripts/test-env up [<branch>]` (or `npm run e2e:up`).
 #   - jq installed.
 #
 # See docs/testing/e2e-fixtures.md for fixture details.
 
 set -euo pipefail
 
-role="${1:-client}"
+# ── Parse args (role + optional output-mode flag, any order) ─────────────────
+role="client"
+output_mode="raw"   # raw | encode | deeplink
+
+for arg in "$@"; do
+  case "$arg" in
+    client|trainer|nutritionist) role="$arg" ;;
+    --encode)   output_mode="encode" ;;
+    --deeplink) output_mode="deeplink" ;;
+    *)
+      echo "Usage: $0 [client|trainer|nutritionist] [--encode|--deeplink]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # ── Resolve email for the requested role ───────────────────────────────────
 case "$role" in
   client)       email="qa.client@fitnessplatform.test" ;;
   trainer)      email="qa.trainer@fitnessplatform.test" ;;
   nutritionist) email="qa.nutri@fitnessplatform.test" ;;
-  *)
-    echo "Usage: $0 [client|trainer|nutritionist]" >&2
-    exit 1
-    ;;
 esac
 
+# ── jq is required (parse login response + URL-encode) ──────────────────────
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is not installed — install it to parse the login response" >&2
+  exit 1
+fi
+
 # ── Load QA_SEED_PASSWORD from .env.test ───────────────────────────────────
-repo_root="$(dirname "$0")/../.."
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 env_file="$repo_root/.env.test"
 
 if [[ ! -f "$env_file" ]]; then
@@ -51,9 +82,19 @@ if [[ -z "$QA_SEED_PASSWORD" ]]; then
   exit 1
 fi
 
-# ── POST to /auth/login on the compose harness ─────────────────────────────
-harness_url="https://localhost:5101"
+# ── Resolve the harness base URL from the current branch's stack ────────────
+# The host port is ephemeral; read it from the test-env JSON envelope.
+harness_url="$(
+  "$repo_root/scripts/test-env" ports 2>/dev/null | jq -r '.api_url // empty'
+)" || harness_url=""
 
+if [[ -z "$harness_url" ]]; then
+  echo "error: no compose stack found for this branch — run \`scripts/test-env up\` first." >&2
+  echo "       (The harness host port is ephemeral; the old fixed :5101 mapping is gone.)" >&2
+  exit 1
+fi
+
+# ── POST to /auth/login on the compose harness ─────────────────────────────
 # Capture body + HTTP status code in one curl call.
 # The status code is appended after a newline separator.
 response="$(
@@ -64,7 +105,7 @@ response="$(
     -d "{\"email\":\"$email\",\"password\":\"$QA_SEED_PASSWORD\"}" \
   2>&1
 )" || {
-  echo "error: harness unreachable on :5101 — run \`npm run e2e:up\`" >&2
+  echo "error: harness unreachable at $harness_url — run \`scripts/test-env up\`" >&2
   exit 1
 }
 
@@ -82,7 +123,7 @@ case "$status_code" in
     exit 1
     ;;
   404)
-    echo "error: /auth/login not found on harness :5101 (HTTP 404) — is the harness running? (\`npm run e2e:up\`)" >&2
+    echo "error: /auth/login not found at $harness_url (HTTP 404) — is the harness running? (\`scripts/test-env up\`)" >&2
     exit 1
     ;;
   5*)
@@ -97,11 +138,6 @@ case "$status_code" in
 esac
 
 # ── Extract refreshToken via jq ────────────────────────────────────────────
-if ! command -v jq &>/dev/null; then
-  echo "error: jq is not installed — install it to parse the login response" >&2
-  exit 1
-fi
-
 refresh_token="$(printf '%s' "$body" | jq -r '.refreshToken // empty')"
 
 if [[ -z "$refresh_token" ]]; then
@@ -109,5 +145,16 @@ if [[ -z "$refresh_token" ]]; then
   exit 1
 fi
 
-# Token to stdout only — never to a log file.
-printf '%s\n' "$refresh_token"
+# ── Emit per output mode (stdout only — never to a log file) ────────────────
+case "$output_mode" in
+  raw)
+    printf '%s\n' "$refresh_token"
+    ;;
+  encode)
+    printf '%s' "$refresh_token" | jq -sRr @uri
+    ;;
+  deeplink)
+    encoded="$(printf '%s' "$refresh_token" | jq -sRr @uri)"
+    printf 'fitnessplatform://e2e-auth?token=%s\n' "$encoded"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Resolve the compose-harness base URL dynamically from `scripts/test-env ports` (`.api_url`) instead of the hardcoded `https://localhost:5101` — the harness host port is now ephemeral, so the fixed mapping no longer exists. Fails with a clear message when no stack is up.
- Add `--encode` / `--deeplink` output modes so the iOS deep-link path gets a URL-encoded token (`jq -sRr @uri`), fixing the `+`/`/`/`=` corruption that `expo-linking` `Linking.parse` introduced (caused silent logout on `POST /auth/refresh`).
- Keep the RAW token as the default output so the web localStorage-injection path is unchanged.
- Document the ephemeral-port resolution and the base64/URL-encoding requirement in the header comment; token still printed to stdout only, never a log file.

## Related issue
Fixes #422

## Scope
mobile (single file: `mobile/scripts/qa-fetch-refresh-token.sh`)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all 5 ACs met.

## Test plan
- [ ] AC1: harness base URL resolved from `scripts/test-env ports` -> `.api_url`; clear failure message when no stack is up.
- [ ] AC2: default output remains the RAW refresh token (web localStorage injection still works).
- [ ] AC3: `--encode` emits the URL-encoded token; `--deeplink` emits the full `fitnessplatform://e2e-auth?token=<url-encoded>` URL.
- [ ] AC4: header comment documents ephemeral-port resolution and the base64/URL-encoding requirement.
- [ ] AC5: token printed to stdout only, never a log file (security note preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)