### PR TITLE
refactor: remove "Fotky dne" photo strip from Today training & nutrition cards

### DIFF
--- a/mobile/src/components/nutrition/NutritionCard.tsx
+++ b/mobile/src/components/nutrition/NutritionCard.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useCallback } from 'react'
-import { View, StyleSheet, ScrollView, Pressable, Image, Text } from 'react-native'
+import { View, StyleSheet } from 'react-native'
 import { useTheme } from '@/hooks/useTheme'
 import { Radius } from '@/constants/radius'
-import { Type } from '@/constants/typography'
 import { NutritionCardHero } from '@/components/nutrition/NutritionCardHero'
 import { MealRow } from '@/components/nutrition/MealRow'
 import { NoteBanner } from '@/components/ui/NoteBanner'
 import { GoldButton } from '@/components/ui/GoldButton'
-import { ImageLightbox } from '@/components/ui/ImageLightbox'
 import { useTranslation } from 'react-i18next'
 import type { NutrientTotals, PlanMeal } from '@/api/nutrition'
 
@@ -93,20 +91,6 @@ export function NutritionCard({
     () => new Set(),
   )
 
-  const [lightbox, setLightbox] = useState<{ visible: boolean; startIndex: number }>(
-    { visible: false, startIndex: 0 },
-  )
-
-  // Flatten all photos from all meals into a single ordered list for the strip
-  const allPhotos: { blobUrl: string; mealId: string; note?: string | null }[] =
-    mealPhotosByMealId
-      ? Object.entries(mealPhotosByMealId).flatMap(([mealId, photos]) =>
-          photos.map((p) => ({ blobUrl: p.blobUrl, mealId, note: p.note })),
-        )
-      : []
-  const allPhotoUrls = allPhotos.map((p) => p.blobUrl)
-  const allPhotoNotes = allPhotos.map((p) => p.note ?? null)
-
   const toggle = useCallback(
     (mealId: string) =>
       setExpandedMealIds((cur) => {
@@ -164,43 +148,6 @@ export function NutritionCard({
         ))}
       </View>
 
-      {/* Photo strip — visible only when at least one meal has diary photos */}
-      {allPhotos.length > 0 ? (
-        <View style={styles.photoStrip}>
-          <Text style={[styles.photoStripLabel, { color: colors.label3 }]}>
-            {t('nutrition.todayPhotos')}
-          </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.photoStripContent}
-          >
-            {allPhotos.map((photo, index) => (
-              <Pressable
-                key={`${photo.mealId}-${index}`}
-                style={styles.photoStripTile}
-                onPress={() => setLightbox({ visible: true, startIndex: index })}
-              >
-                <Image
-                  source={{ uri: photo.blobUrl }}
-                  style={styles.photoStripImage}
-                  resizeMode="cover"
-                />
-              </Pressable>
-            ))}
-          </ScrollView>
-        </View>
-      ) : null}
-
-      {/* Card-level lightbox for the photo strip */}
-      <ImageLightbox
-        visible={lightbox.visible}
-        images={allPhotoUrls}
-        startIndex={lightbox.startIndex}
-        onClose={() => setLightbox({ visible: false, startIndex: 0 })}
-        imageNotes={allPhotoNotes}
-      />
-
       {/* Mark whole day as eaten — hidden when every meal is already logged */}
       {onMarkAllEaten && eatenMealIds.size < meals.length && meals.length > 0 ? (
         <View style={styles.ctaWrap}>
@@ -229,32 +176,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     paddingBottom: 16,
-  },
-  photoStrip: {
-    marginTop: 12,
-    marginBottom: 4,
-  },
-  photoStripLabel: {
-    ...Type.caption2,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    paddingHorizontal: 16,
-    marginBottom: 6,
-  },
-  photoStripContent: {
-    paddingHorizontal: 16,
-    gap: 6,
-  },
-  photoStripTile: {
-    width: 56,
-    height: 56,
-    borderRadius: Radius.sm,
-    overflow: 'hidden',
-  },
-  photoStripImage: {
-    width: '100%',
-    height: '100%',
   },
 })
 

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import { View, Text, StyleSheet, Pressable, ActivityIndicator, ScrollView, Image } from 'react-native'
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native'
 import { Ionicons } from '@expo/vector-icons'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
@@ -8,7 +8,6 @@ import { Type, interFamily } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { ProgressRing } from '@/components/ui/ProgressRing'
 import { GoldButton } from '@/components/ui/GoldButton'
-import { ImageLightbox } from '@/components/ui/ImageLightbox'
 import { ExpandableSessionCard } from '@/components/training/ExpandableSessionCard'
 import { ExpandableExerciseCard } from '@/components/training/ExpandableExerciseCard'
 import {
@@ -287,21 +286,6 @@ export function TrainingCard({
   const colors = useTheme()
   const { t } = useTranslation()
 
-  // Flatten all photos from all sessions for the "Fotky dne" strip.
-  // Mirrors NutritionCard's allPhotos derivation from mealPhotosByMealId.
-  const allPhotos = useMemo<{ blobUrl: string; sessionId: string; note?: string | null }[]>(() => {
-    return Object.entries(photosBySession).flatMap(([sessionId, photos]) =>
-      photos.map((p) => ({ blobUrl: p.blobUrl, sessionId, note: p.note })),
-    )
-  }, [photosBySession])
-
-  const allPhotoUrls = useMemo(() => allPhotos.map((p) => p.blobUrl), [allPhotos])
-  const allPhotoNotes = useMemo(() => allPhotos.map((p) => p.note ?? null), [allPhotos])
-
-  const [lightbox, setLightbox] = useState<{ visible: boolean; startIndex: number }>(
-    { visible: false, startIndex: 0 },
-  )
-
   // Aggregate training-session counts for the hero ring. The ring tracks how
   // many of today's training sessions the client has fully completed (via
   // the per-session checkbox / live runner finish flow).
@@ -507,44 +491,6 @@ export function TrainingCard({
           )
         })}
       </View>
-
-      {/* Photo strip — "Fotky dne" — visible only when at least one session has diary photos.
-          Mirrors NutritionCard's photoStrip section exactly. */}
-      {allPhotos.length > 0 ? (
-        <View style={styles.photoStrip}>
-          <Text style={[styles.photoStripLabel, { color: colors.label3 }]}>
-            {t('training.todayPhotos')}
-          </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.photoStripContent}
-          >
-            {allPhotos.map((photo, index) => (
-              <Pressable
-                key={`${photo.sessionId}-${index}`}
-                style={styles.photoStripTile}
-                onPress={() => setLightbox({ visible: true, startIndex: index })}
-              >
-                <Image
-                  source={{ uri: photo.blobUrl }}
-                  style={styles.photoStripImage}
-                  resizeMode="cover"
-                />
-              </Pressable>
-            ))}
-          </ScrollView>
-        </View>
-      ) : null}
-
-      {/* Card-level lightbox for the photo strip */}
-      <ImageLightbox
-        visible={lightbox.visible}
-        images={allPhotoUrls}
-        startIndex={lightbox.startIndex}
-        onClose={() => setLightbox({ visible: false, startIndex: 0 })}
-        imageNotes={allPhotoNotes}
-      />
 
       {/* Mark whole day done — hidden when every session is already complete or no sessions */}
       {onMarkAllTrainingDone && hasIncompleteSessions && sessions.length > 0 && (
@@ -995,33 +941,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     paddingBottom: 16,
-  },
-  // Photo strip — mirrors NutritionCard's photoStrip styles exactly.
-  photoStrip: {
-    marginTop: 12,
-    marginBottom: 4,
-  },
-  photoStripLabel: {
-    ...Type.caption2,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    paddingHorizontal: 16,
-    marginBottom: 6,
-  },
-  photoStripContent: {
-    paddingHorizontal: 16,
-    gap: 6,
-  },
-  photoStripTile: {
-    width: 56,
-    height: 56,
-    borderRadius: Radius.sm,
-    overflow: 'hidden',
-  },
-  photoStripImage: {
-    width: '100%',
-    height: '100%',
   },
 })
 

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -723,7 +723,6 @@
     "tip": "Pozn:",
     "dayNoteLabel": "Pozn k dni:",
     "mealNoteLabel": "Pozn k jídlu:",
-    "todayPhotos": "Fotky dne",
     "recipe": "Recept",
     "serving_one": "{{count}}× porce",
     "serving_other": "{{count}}× porce",
@@ -1035,7 +1034,6 @@
     },
     "photoCta": "Foto",
     "sessionPhotoA11y": "Přidat fotku tréninku",
-    "todayPhotos": "Fotky dne",
     "sessions": {
       "reminder": {
         "toggleLabel": "Připomenutí",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -741,7 +741,6 @@
     "tip": "Tipp:",
     "dayNoteLabel": "Tagesnotiz:",
     "mealNoteLabel": "Mahlzeitennotiz:",
-    "todayPhotos": "Heutige Fotos",
     "recipe": "Rezept",
     "serving_one": "{{count}}× Portion",
     "serving_other": "{{count}}× Portionen",
@@ -982,7 +981,6 @@
     },
     "photoCta": "Foto",
     "sessionPhotoA11y": "Trainingsfoto hinzufügen",
-    "todayPhotos": "Heutige Fotos",
     "sessions": {
       "reminder": {
         "toggleLabel": "Erinnerung",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -756,7 +756,6 @@
     },
     "photoCta": "Photo",
     "sessionPhotoA11y": "Add training photo",
-    "todayPhotos": "Today's photos",
     "sessions": {
       "reminder": {
         "toggleLabel": "Reminder",
@@ -982,7 +981,6 @@
     "tip": "Tip:",
     "dayNoteLabel": "Day note:",
     "mealNoteLabel": "Meal note:",
-    "todayPhotos": "Today's photos",
     "recipe": "Recipe",
     "serving_one": "{{count}}× serving",
     "serving_other": "{{count}}× servings",


### PR DESCRIPTION
## Summary
- Pure-deletion refactor: removes the aggregate "Fotky dne" horizontal photo strip from both the Today **Training** card (`TrainingCard.tsx`) and **Nutrition** card (`NutritionCard.tsx`).
- Cleans up the dead plumbing the strip fed: the card-level `ImageLightbox`, the `allPhotos`/`allPhotoUrls`/`allPhotoNotes` aggregates, the strip-only `lightbox` state, the `photoStrip*` styles, and the imports that became unused (`ScrollView`, `Image`, `Pressable`, `Text`, `Type`, `ImageLightbox`).
- Removes the now-unused `training.todayPhotos` and `nutrition.todayPhotos` i18n keys from all three locale files (`cs`, `en`, `de`).
- No new UI introduced. Per-meal and per-session photo affordances (meal-row / session photo press and their own lightboxes) are untouched.

## Related issue
Fixes #427

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS (static). `npx tsc --noEmit` clean. The two visual ACs ("strip no longer renders on training/nutrition card") are conclusively satisfied at the code level: the strip was the only consumer of the deleted data-gated JSX block, so removing the block removes the render path entirely — no data state can re-introduce it.

## Test plan
- [ ] The "Fotky dne" photo strip no longer renders on the Today training card.
- [ ] The "Fotky dne" photo strip no longer renders on the Today nutrition card.
- [ ] Dead code cleaned up: card-level photo-strip `ImageLightbox`, the `allPhotos`/`allPhotoUrls`/`allPhotoNotes` aggregates, strip-only `lightbox` state, `photoStrip*` styles, and now-unused imports.
- [ ] Per-meal and per-session photo affordances remain fully intact and untouched.
- [ ] The unused `training.todayPhotos` and `nutrition.todayPhotos` i18n keys removed from all three locale files (cs, en, de).
- [ ] `npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)