### PR TITLE
fix: notify trainer portal on live-session finish; guard unlock of completed sessions (#429)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Extensions/TrainingCompletionExtensions.cs
+++ b/backend/FitnessPlatform.Application/Domain/Extensions/TrainingCompletionExtensions.cs
@@ -1,4 +1,5 @@
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Features.ClientTraining;
 
 namespace FitnessPlatform.Application.Domain.Extensions;
 
@@ -10,9 +11,21 @@ public static class TrainingCompletionExtensions
     /// <summary>
     /// Returns <c>true</c> when every section in the session is done:
     /// <list type="bullet">
-    ///   <item><description>Sections with exercises — every exercise id is in <see cref="TrainingCompletion.CompletedExerciseIds"/>.</description></item>
-    ///   <item><description>Exercise-free sections — the SectionId is in <see cref="TrainingCompletion.CompletedSectionIds"/>.</description></item>
+    ///   <item><description>Sections with exercises — every exercise id is present in the
+    ///     per-section effective map produced by
+    ///     <see cref="TrainingCompletionBackfill.GetEffectiveCompletedExerciseIdsBySection"/>
+    ///     for that specific section instance. This prevents a duplicate exercise id that spans
+    ///     two sections (e.g. the same movement in two AMRAP blocks) from being treated as
+    ///     done in both sections when it was only completed in one.</description></item>
+    ///   <item><description>Exercise-free sections — the SectionId is in
+    ///     <see cref="TrainingCompletion.CompletedSectionIds"/>.</description></item>
     /// </list>
+    /// <para>
+    /// A session with zero sections is <b>never</b> considered complete — callers must ensure
+    /// <see cref="TrainingSession.WithBackfilledSections"/> has been called on
+    /// <paramref name="session"/> before invoking this helper so that legacy flat-exercise
+    /// sessions get their synthetic section, making zero-section the abnormal/corrupt case.
+    /// </para>
     /// Call <see cref="TrainingSession.WithBackfilledSections"/> on <paramref name="session"/> before
     /// passing it here to ensure legacy flat-exercise documents are handled transparently.
     /// </summary>
@@ -20,9 +33,23 @@ public static class TrainingCompletionExtensions
     /// <param name="session">The session definition (already backfilled). Must not be null.</param>
     public static bool IsSessionComplete(this TrainingCompletion completion, TrainingSession session)
     {
+        // Guard: a session with no sections is never complete.
+        // After WithBackfilledSections() a legacy flat-exercise session always has at least one
+        // synthetic section, so zero sections signals an empty/corrupt session definition.
+        if (session.Sections.Count == 0)
+            return false;
+
+        // Build the section-aware effective view using the authoritative per-section dict
+        // (falls back to the legacy flat list via backfill for older documents). This avoids
+        // the false-positive where the same exercise id appears in two sections and the flat
+        // CompletedExerciseIds list treats both as complete when only one was actually done.
+        var effectiveBySection =
+            TrainingCompletionBackfill.GetEffectiveCompletedExerciseIdsBySection(completion, session);
+
         return session.Sections.All(sec =>
             sec.Exercises.Count > 0
-                ? sec.Exercises.All(e => completion.CompletedExerciseIds.Contains(e.ExerciseExternalId))
+                ? effectiveBySection.TryGetValue(sec.SectionId, out var completedInSection)
+                  && sec.Exercises.All(e => completedInSection.Contains(e.ExerciseExternalId))
                 : (completion.CompletedSectionIds ?? []).Contains(sec.SectionId));
     }
 }

--- a/backend/FitnessPlatform.Application/Domain/Extensions/TrainingCompletionExtensions.cs
+++ b/backend/FitnessPlatform.Application/Domain/Extensions/TrainingCompletionExtensions.cs
@@ -1,0 +1,28 @@
+using FitnessPlatform.Application.Domain.Documents;
+
+namespace FitnessPlatform.Application.Domain.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="TrainingCompletion"/> session-level completeness checks.
+/// </summary>
+public static class TrainingCompletionExtensions
+{
+    /// <summary>
+    /// Returns <c>true</c> when every section in the session is done:
+    /// <list type="bullet">
+    ///   <item><description>Sections with exercises — every exercise id is in <see cref="TrainingCompletion.CompletedExerciseIds"/>.</description></item>
+    ///   <item><description>Exercise-free sections — the SectionId is in <see cref="TrainingCompletion.CompletedSectionIds"/>.</description></item>
+    /// </list>
+    /// Call <see cref="TrainingSession.WithBackfilledSections"/> on <paramref name="session"/> before
+    /// passing it here to ensure legacy flat-exercise documents are handled transparently.
+    /// </summary>
+    /// <param name="completion">The completion document to test. Must not be null.</param>
+    /// <param name="session">The session definition (already backfilled). Must not be null.</param>
+    public static bool IsSessionComplete(this TrainingCompletion completion, TrainingSession session)
+    {
+        return session.Sections.All(sec =>
+            sec.Exercises.Count > 0
+                ? sec.Exercises.All(e => completion.CompletedExerciseIds.Contains(e.ExerciseExternalId))
+                : (completion.CompletedSectionIds ?? []).Contains(sec.SectionId));
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/MarkSessionComplete/MarkSessionCompleteEndpoint.cs
@@ -127,13 +127,10 @@ public class MarkSessionCompleteEndpoint(
 
         if (existing is not null)
         {
-            // Idempotency: the session is already complete when every section is "done":
-            //   - sections with exercises: every exercise is in CompletedExerciseIds
-            //   - exercise-free sections: the SectionId is in CompletedSectionIds
-            var alreadyComplete = session.Sections.All(sec =>
-                sec.Exercises.Count > 0
-                    ? sec.Exercises.All(e => existing.CompletedExerciseIds.Contains(e.ExerciseExternalId))
-                    : (existing.CompletedSectionIds ?? []).Contains(sec.SectionId));
+            // Idempotency: the session is already complete when every section is "done".
+            // Uses the shared TrainingCompletionExtensions.IsSessionComplete helper (rule-of-three:
+            // also called from GetTrainingPlan and UnlockTrainingSession).
+            var alreadyComplete = existing.IsSessionComplete(session);
             if (alreadyComplete)
             {
                 await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);
@@ -212,10 +209,8 @@ public class MarkSessionCompleteEndpoint(
                     throw;
                 }
 
-                var retryAlreadyComplete = session.Sections.All(sec =>
-                    sec.Exercises.Count > 0
-                        ? sec.Exercises.All(e => existing.CompletedExerciseIds.Contains(e.ExerciseExternalId))
-                        : (existing.CompletedSectionIds ?? []).Contains(sec.SectionId));
+                // Retry path — same completeness check via shared helper.
+                var retryAlreadyComplete = existing.IsSessionComplete(session);
                 if (retryAlreadyComplete)
                 {
                     await Send.OkAsync(BuildResponse(req.SessionId, targetDate, existing, allExerciseIds.Count), ct);

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
@@ -172,7 +173,63 @@ public class GetTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lo
                 .ToList();
         }
 
-        // ── 3. Batch-fetch session lock state ────────────────────────────────────
+        // ── 3. TrainingCompletion-based finished state fold-in ───────────────────
+        // The mobile "mark whole day complete" checkbox writes a TrainingCompletion document
+        // but NOT a WorkoutLog. Without this step, sessions finished via that path would
+        // never appear as IsSessionFinished=true on the trainer portal (fix for issue #429).
+        //
+        // For each session that has at least one fully-complete TrainingCompletion (any date),
+        // ensure a SessionExecutionDto entry exists with IsSessionFinished=true.
+        // A TrainingCompletion is "fully complete" iff IsSessionComplete() returns true —
+        // that uses the same logic as the MarkSessionComplete idempotency check.
+        //
+        // Date-scoping: we match the most-complete TrainingCompletion per session regardless
+        // of date, mirroring the WorkoutLog dedup which also collapses across dates. The
+        // finished-state is a permanent property of the session — it does not reset between
+        // scheduled occurrences for the same session definition.
+        if (completions.Count > 0)
+        {
+            // sessionLookup sessions are already backfilled by FromDocument() — WithBackfilledSections()
+            // was called there on the same plan object. IsSessionComplete() can be called directly.
+
+            // Find sessions whose TrainingCompletion is fully done (any date — finished state is permanent).
+            var finishedByCompletion = completions
+                .Where(c => sessionLookup.TryGetValue(c.SessionId, out var s) && c.IsSessionComplete(s))
+                .Select(c => c.SessionId)
+                .ToHashSet();
+
+            if (finishedByCompletion.Count > 0)
+            {
+                // Index existing SessionExecutions by SessionId for O(1) lookup.
+                var executionsBySession = response.SessionExecutions
+                    .ToDictionary(e => e.SessionId);
+
+                foreach (var sessionId in finishedByCompletion)
+                {
+                    if (executionsBySession.TryGetValue(sessionId, out var existing))
+                    {
+                        // Session has a WorkoutLog entry — OR-in the completion-based flag
+                        // (covers the edge case where the WorkoutLog isn't finalised but the
+                        // home-checkbox completion says it's done).
+                        if (!existing.IsSessionFinished)
+                            existing.IsSessionFinished = true;
+                    }
+                    else
+                    {
+                        // No WorkoutLog for this session — emit a synthetic entry so the trainer
+                        // portal renders the session as finished and hides the unlock affordance.
+                        response.SessionExecutions.Add(new SessionExecutionDto
+                        {
+                            SessionId = sessionId,
+                            IsSessionFinished = true,
+                            CompletedSetsByExercise = new Dictionary<Guid, List<int>>()
+                        });
+                    }
+                }
+            }
+        }
+
+        // ── 4. Batch-fetch session lock state ────────────────────────────────────
         // Single Mongo round-trip — not one per session. Mirrors the pattern used
         // in GetFullTrainingPlanEndpoint (client read) so the shape is consistent.
         var allSessionIds = plan.Weeks

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
@@ -74,6 +74,21 @@ public class UnlockTrainingSessionEndpoint(
             return;
         }
 
+        // Finished-guard: reject unlock attempts on sessions that already have a completed WorkoutLog.
+        // Checked AFTER ownership/existence guards (404 takes precedence) and BEFORE acquiring the Editing lock.
+        // Reuses the existing SESSION_ALREADY_COMPLETED error code (matches FinishSessionEndpoint pattern).
+        var completedLogFilter = Builders<WorkoutLog>.Filter.Eq(l => l.PlanId, req.PlanId)
+                                 & Builders<WorkoutLog>.Filter.Eq(l => l.SessionId, req.SessionId)
+                                 & Builders<WorkoutLog>.Filter.Eq(l => l.IsCompleted, true);
+        var completedLogCount = await mongo.WorkoutLogs.CountDocumentsAsync(completedLogFilter, cancellationToken: ct);
+
+        if (completedLogCount > 0)
+        {
+            await this.SendProblemAsync(409, ErrorCodes.SessionAlreadyCompleted,
+                "This session has already been completed and cannot be unlocked for editing.", ct);
+            return;
+        }
+
         var ttl = TimeSpan.FromHours(lockOptions.Value.EditingTtlHours);
 
         var result = await lockService.AcquireAsync(

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UnlockTrainingSession/UnlockTrainingSessionEndpoint.cs
@@ -74,15 +74,35 @@ public class UnlockTrainingSessionEndpoint(
             return;
         }
 
-        // Finished-guard: reject unlock attempts on sessions that already have a completed WorkoutLog.
+        // Finished-guard: reject unlock attempts on sessions that are already finished.
+        // Two completion signals must be checked — live path (WorkoutLog.IsCompleted=true) and
+        // home-checkbox path (TrainingCompletion fully complete per IsSessionComplete()).
         // Checked AFTER ownership/existence guards (404 takes precedence) and BEFORE acquiring the Editing lock.
         // Reuses the existing SESSION_ALREADY_COMPLETED error code (matches FinishSessionEndpoint pattern).
+
+        // Signal 1: completed WorkoutLog
         var completedLogFilter = Builders<WorkoutLog>.Filter.Eq(l => l.PlanId, req.PlanId)
                                  & Builders<WorkoutLog>.Filter.Eq(l => l.SessionId, req.SessionId)
                                  & Builders<WorkoutLog>.Filter.Eq(l => l.IsCompleted, true);
         var completedLogCount = await mongo.WorkoutLogs.CountDocumentsAsync(completedLogFilter, cancellationToken: ct);
 
         if (completedLogCount > 0)
+        {
+            await this.SendProblemAsync(409, ErrorCodes.SessionAlreadyCompleted,
+                "This session has already been completed and cannot be unlocked for editing.", ct);
+            return;
+        }
+
+        // Signal 2: fully-complete TrainingCompletion (written by mobile home-checkbox path).
+        // Match any completion for this session regardless of date — finished state is permanent.
+        // Call WithBackfilledSections() first so legacy flat-exercise sessions are handled correctly.
+        session.WithBackfilledSections();
+        var completionFilter = Builders<TrainingCompletion>.Filter.Eq(c => c.ClientId, plan.ClientId)
+                               & Builders<TrainingCompletion>.Filter.Eq(c => c.SessionId, req.SessionId);
+        var completionCursor = await mongo.TrainingCompletions.FindAsync(completionFilter, cancellationToken: ct);
+        var completionDocs = await completionCursor.ToListAsync(ct);
+
+        if (completionDocs.Any(c => c.IsSessionComplete(session)))
         {
             await this.SendProblemAsync(409, ErrorCodes.SessionAlreadyCompleted,
                 "This session has already been completed and cannot be unlocked for editing.", ct);

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/CompleteWorkout/CompleteWorkoutEndpoint.cs
@@ -6,8 +6,10 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
@@ -19,16 +21,21 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
 /// Also releases the <c>Live</c> session lock when the log is plan-bound
 /// (i.e. when the log carries a non-null <c>SessionId</c>).
 /// Emits <c>sessioneditlockchanged</c> (state=Stable) to both client and trainer when a lock is released.
+/// Emits <c>trainingprogressupdated</c> to the trainer so the portal reflects the finished state in real time.
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="completionService">Shared workout completion pipeline (PR detection, fan-out, notification).</param>
 /// <param name="lockService">Session lock service — used to release the Live lock on finish.</param>
 /// <param name="notifier">Realtime notifier for SignalR fan-out.</param>
+/// <param name="compliance">Compliance service for computing today's metrics (used by the broadcaster).</param>
+/// <param name="logger">Logger for swallowing broadcast errors.</param>
 public class CompleteWorkoutEndpoint(
     IMongoContext mongo,
     IWorkoutCompletionService completionService,
     ISessionLockService lockService,
-    IRealtimeNotifier notifier) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
+    IRealtimeNotifier notifier,
+    IComplianceService compliance,
+    ILogger<CompleteWorkoutEndpoint> logger) : Endpoint<CompleteWorkoutRequest, WorkoutLogDetail>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -96,23 +103,40 @@ public class CompleteWorkoutEndpoint(
         {
             var released = await lockService.ReleaseAsync(log.SessionId.Value, LockHolder.Client, LockType.Live, ct);
 
-            if (released && log.PlanId.HasValue)
+            if (log.PlanId.HasValue)
             {
-                // Resolve the trainer to fan out to. Load the plan by ExternalId.
+                // Load the plan once — used for both the lock-changed broadcast and the progress broadcast.
                 var planFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, log.PlanId.Value);
                 using var planCursor = await mongo.TrainingPlans.FindAsync(planFilter, cancellationToken: ct);
                 var plan = await planCursor.FirstOrDefaultAsync(ct);
 
                 if (plan is not null)
                 {
-                    var payload = new SessionLockChangedPayload(
-                        log.PlanId.Value,
-                        log.SessionId.Value,
-                        "Stable",
-                        "Client");
+                    if (released)
+                    {
+                        // Emit sessioneditlockchanged (state=Stable) to both parties.
+                        var lockPayload = new SessionLockChangedPayload(
+                            log.PlanId.Value,
+                            log.SessionId.Value,
+                            "Stable",
+                            "Client");
 
-                    await notifier.NotifyAsync(clientId, "sessioneditlockchanged", payload, ct);
-                    await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", payload, ct);
+                        await notifier.NotifyAsync(clientId, "sessioneditlockchanged", lockPayload, ct);
+                        await notifier.NotifyAsync(plan.TrainerId, "sessioneditlockchanged", lockPayload, ct);
+                    }
+
+                    // Emit trainingprogressupdated so the trainer portal reflects the finished state in real time.
+                    // plan.ClientId is the ClientProfile.PublicId — the same key used by compliance / TrainingCompletion.
+                    // All exercises in the log were stamped as done by completionService; count both sides as totalExercises.
+                    var totalExercises = log.Exercises.Count;
+                    await TrainingProgressBroadcaster.BroadcastSessionAsync(
+                        notifier, compliance, mongo, plan,
+                        clientId: plan.ClientId,
+                        sessionId: log.SessionId.Value,
+                        date: DateOnly.FromDateTime(log.CompletedDate ?? DateTime.UtcNow),
+                        completedExerciseCount: totalExercises,
+                        totalExerciseCount: totalExercises,
+                        logger, ct);
                 }
             }
         }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanCompletionFinishedStateTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanCompletionFinishedStateTests.cs
@@ -1,0 +1,297 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
+using FitnessPlatform.Tests.Endpoints;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the <see cref="GetTrainingPlanEndpoint"/> <c>SessionExecutions</c> fold-in
+/// using <see cref="TrainingCompletion"/> documents (the mobile home-checkbox path).
+///
+/// The live path (WorkoutLog.IsCompleted=true) is already covered by
+/// <see cref="GetTrainingPlanSessionExecutionTests"/>. This class covers the checkbox path.
+///
+/// Issue #429 follow-up: sessions finished via the mobile "mark whole day complete" checkbox
+/// produce a TrainingCompletion document but NOT a WorkoutLog. Without this fix, those sessions
+/// would never appear as IsSessionFinished=true on the trainer portal.
+/// </summary>
+public class GetTrainingPlanCompletionFinishedStateTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _sectionId = Guid.NewGuid();
+    private readonly Guid _exerciseId = Guid.NewGuid();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    // ── Builder helpers ───────────────────────────────────────────────────────
+
+    private TrainingPlan BuildPlan()
+    {
+        return new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = _sessionId,
+                            Name = "Session 1",
+                            DayOfWeek = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = _sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = _exerciseId,
+                                            ExerciseName = "Squat",
+                                            Order = 0,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10 },
+                                                new ExerciseSet { SetNumber = 2, Reps = 10 }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = _now
+        };
+    }
+
+    private TrainingCompletion BuildCompletion(List<Guid> completedExerciseIds)
+    {
+        return new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            Date = _now.Date,
+            SessionId = _sessionId,
+            CompletedExerciseIds = completedExerciseIds,
+            Version = 1,
+            DateCreated = _now
+        };
+    }
+
+    private async Task<GetTrainingPlanResponse?> ExecuteAsync(
+        TrainingPlan plan,
+        WorkoutLog[] logs,
+        TrainingCompletion[] completions)
+    {
+        var mongo = TrainingPlanTestHelpers.CreateMockMongoWithLogs(
+            plans: [plan],
+            workoutLogs: logs,
+            trainingCompletions: completions);
+
+        var ep = Factory.Create<GetTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
+
+        await ep.HandleAsync(
+            new GetTrainingPlanRequest { PlanId = _planId },
+            TestContext.Current.CancellationToken);
+
+        return ep.HttpContext.Response.StatusCode == 200 ? ep.Response : null;
+    }
+
+    // ── Test cases ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A fully-complete TrainingCompletion with no WorkoutLog at all must produce a synthetic
+    /// SessionExecutionDto entry with IsSessionFinished=true and empty CompletedSetsByExercise.
+    /// This is the core home-checkbox path (#429 fix).
+    /// </summary>
+    [Fact]
+    public async Task SessionExecutions_FullyCompleteTrainingCompletion_NoWorkoutLog_IsSessionFinishedTrue()
+    {
+        var plan = BuildPlan();
+        var completion = BuildCompletion([_exerciseId]); // all exercises done
+
+        var response = await ExecuteAsync(plan, logs: [], completions: [completion]);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().HaveCount(1,
+            "a synthetic entry must be emitted for a session with only a TrainingCompletion");
+
+        var exec = response.SessionExecutions.Single();
+        exec.SessionId.Should().Be(_sessionId);
+        exec.IsSessionFinished.Should().BeTrue(
+            "fully-complete TrainingCompletion must set IsSessionFinished=true");
+        exec.CompletedSetsByExercise.Should().BeEmpty(
+            "the checkbox path has no set-level data — CompletedSetsByExercise must be empty");
+    }
+
+    /// <summary>
+    /// A PARTIAL TrainingCompletion (not all exercises done) must NOT produce a finished entry.
+    /// </summary>
+    [Fact]
+    public async Task SessionExecutions_PartialTrainingCompletion_NoWorkoutLog_IsSessionFinishedFalse()
+    {
+        var plan = BuildPlan();
+        // Only half done — the plan has one exercise; partial means empty list here.
+        var partialCompletion = BuildCompletion([]); // no exercises completed
+
+        var response = await ExecuteAsync(plan, logs: [], completions: [partialCompletion]);
+
+        response.Should().NotBeNull();
+        // No entry at all, or an entry with IsSessionFinished=false (either is acceptable;
+        // the important thing is there is no IsSessionFinished=true entry).
+        var finishedEntry = response!.SessionExecutions
+            .FirstOrDefault(e => e.SessionId == _sessionId);
+        if (finishedEntry is not null)
+        {
+            finishedEntry.IsSessionFinished.Should().BeFalse(
+                "a partial TrainingCompletion must not mark the session finished");
+        }
+    }
+
+    /// <summary>
+    /// When BOTH a completed WorkoutLog and a fully-complete TrainingCompletion exist,
+    /// the result must have exactly one entry (no duplicate) with IsSessionFinished=true.
+    /// </summary>
+    [Fact]
+    public async Task SessionExecutions_BothWorkoutLogAndCompletion_NoDuplicateEntry()
+    {
+        var plan = BuildPlan();
+        var completion = BuildCompletion([_exerciseId]);
+
+        var log = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            PlanId = _planId,
+            SessionId = _sessionId,
+            StartedAt = _now.AddMinutes(-30),
+            IsCompleted = true,
+            CompletedAt = _now,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = _exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet { SetNumber = 1, Reps = 10, CompletedAt = _now.AddMinutes(-20) },
+                                new WorkoutSet { SetNumber = 2, Reps = 10, CompletedAt = _now.AddMinutes(-15) }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = _now.AddMinutes(-35)
+        };
+
+        var response = await ExecuteAsync(plan, logs: [log], completions: [completion]);
+
+        response.Should().NotBeNull();
+        // Must be exactly one entry — not two (no duplicate synthesis).
+        response!.SessionExecutions.Should().HaveCount(1,
+            "WorkoutLog entry must not be duplicated when a TrainingCompletion also exists");
+
+        var exec = response.SessionExecutions.Single();
+        exec.SessionId.Should().Be(_sessionId);
+        exec.IsSessionFinished.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// When a WorkoutLog exists but IsCompleted=false, and a fully-complete TrainingCompletion
+    /// also exists, the IsSessionFinished flag must be OR-ed in from the completion.
+    /// </summary>
+    [Fact]
+    public async Task SessionExecutions_InProgressWorkoutLog_FullyCompleteTrainingCompletion_IsSessionFinishedTrue()
+    {
+        var plan = BuildPlan();
+        var completion = BuildCompletion([_exerciseId]); // fully done via checkbox
+
+        // WorkoutLog in-progress (not completed).
+        var log = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            PlanId = _planId,
+            SessionId = _sessionId,
+            StartedAt = _now.AddMinutes(-30),
+            IsCompleted = false,
+            CompletedAt = null,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = _exerciseId,
+                            ExerciseName = "Squat",
+                            Sets = [new WorkoutSet { SetNumber = 1, Reps = 10, CompletedAt = _now.AddMinutes(-20) }]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = _now.AddMinutes(-35)
+        };
+
+        var response = await ExecuteAsync(plan, logs: [log], completions: [completion]);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().HaveCount(1);
+
+        var exec = response.SessionExecutions.Single();
+        exec.IsSessionFinished.Should().BeTrue(
+            "fully-complete TrainingCompletion must OR-in IsSessionFinished=true even when the WorkoutLog is not finalised");
+    }
+
+    /// <summary>
+    /// No TrainingCompletion and no WorkoutLog → SessionExecutions is empty (unchanged baseline).
+    /// </summary>
+    [Fact]
+    public async Task SessionExecutions_NoCompletionAndNoWorkoutLog_IsEmpty()
+    {
+        var plan = BuildPlan();
+
+        var response = await ExecuteAsync(plan, logs: [], completions: []);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().BeEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanCompletionFinishedStateTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanCompletionFinishedStateTests.cs
@@ -294,4 +294,51 @@ public class GetTrainingPlanCompletionFinishedStateTests
         response.Should().NotBeNull();
         response!.SessionExecutions.Should().BeEmpty();
     }
+
+    /// <summary>
+    /// Regression test for Defect 2: a session with zero sections must never be treated as
+    /// vacuously complete — <c>Enumerable.All()</c> over an empty collection returns <c>true</c>,
+    /// which would cause any completion doc (even an empty one) to match.
+    ///
+    /// A zero-section session indicates an empty/corrupt session definition (after
+    /// WithBackfilledSections() a legacy flat-exercise session always gets a synthetic section).
+    /// Even with a non-empty TrainingCompletion document for that session, IsSessionFinished
+    /// must remain false.
+    /// </summary>
+    [Fact]
+    public async Task SessionExecutions_ZeroSectionSession_NonEmptyCompletion_IsSessionFinishedFalse()
+    {
+        // Build a plan where the session has NO sections (empty/corrupt definition).
+        var plan = BuildPlan();
+        plan.Weeks[0].Sessions[0].Sections = []; // zero sections
+
+        // A non-empty completion doc that would match vacuously under the old All() check.
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            Date = _now.Date,
+            SessionId = _sessionId,
+            CompletedExerciseIds = [_exerciseId], // non-empty flat list
+            CompletedExerciseIdsBySection = new Dictionary<string, List<Guid>>
+            {
+                [_sectionId.ToString()] = [_exerciseId]
+            },
+            Version = 1,
+            DateCreated = _now
+        };
+
+        var response = await ExecuteAsync(plan, logs: [], completions: [completion]);
+
+        response.Should().NotBeNull();
+
+        // No IsSessionFinished=true entry must appear for the zero-section session.
+        var finishedEntry = response!.SessionExecutions
+            .FirstOrDefault(e => e.SessionId == _sessionId);
+        if (finishedEntry is not null)
+        {
+            finishedEntry.IsSessionFinished.Should().BeFalse(
+                "a zero-section session must never be reported as finished, even with a non-empty completion");
+        }
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanTestHelpers.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanTestHelpers.cs
@@ -51,11 +51,13 @@ public static class TrainingPlanTestHelpers
         => CreateMockMongoWithLogs(plans: plans, workoutLogs: []);
 
     /// <summary>
-    /// Creates a mocked <see cref="IMongoContext"/> with training plans + workout logs.
+    /// Creates a mocked <see cref="IMongoContext"/> with training plans + workout logs +
+    /// an optional list of training completions. Completions default to an empty collection.
     /// </summary>
     public static IMongoContext CreateMockMongoWithLogs(
         TrainingPlan[] plans,
-        WorkoutLog[] workoutLogs)
+        WorkoutLog[] workoutLogs,
+        TrainingCompletion[]? trainingCompletions = null)
     {
         var mongo = Substitute.For<IMongoContext>();
 
@@ -63,10 +65,52 @@ public static class TrainingPlanTestHelpers
         // "last call" confusion (CouldNotSetReturnDueToNoLastCallException).
         var plansCollection = CreateMockCollection(plans.ToList());
         var logsCollection = CreateMockWorkoutLogCollection(workoutLogs.ToList());
+        var completionsCollection = CreateMockCompletionCollection(
+            (trainingCompletions ?? []).ToList());
 
         mongo.TrainingPlans.Returns(plansCollection);
         mongo.WorkoutLogs.Returns(logsCollection);
+        mongo.TrainingCompletions.Returns(completionsCollection);
         return mongo;
+    }
+
+    /// <summary>
+    /// Creates a mock <see cref="IMongoCollection{TrainingCompletion}"/> that returns the given
+    /// completions from FindAsync.
+    /// </summary>
+    public static IMongoCollection<TrainingCompletion> CreateMockCompletionCollection(
+        List<TrainingCompletion> completions)
+    {
+        var collection = Substitute.For<IMongoCollection<TrainingCompletion>>();
+
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<FindOptions<TrainingCompletion, TrainingCompletion>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCompletionCursor(completions));
+
+        return collection;
+    }
+
+    private static IAsyncCursor<TrainingCompletion> CreateCompletionCursor(
+        List<TrainingCompletion> completions)
+    {
+        var cursor = Substitute.For<IAsyncCursor<TrainingCompletion>>();
+        var moved = false;
+        cursor.Current.Returns(completions);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return completions.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return Task.FromResult(false);
+            moved = true;
+            return Task.FromResult(completions.Count > 0);
+        });
+        return cursor;
     }
 
     /// <summary>

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UnlockSessionFinishedGuardTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UnlockSessionFinishedGuardTests.cs
@@ -373,4 +373,182 @@ public class UnlockSessionFinishedGuardTests
             LockHolder.Coach, LockType.Editing, Arg.Any<TimeSpan>(),
             Arg.Any<CancellationToken>());
     }
+
+    // ── Per-section path tests (Defect 1 regression) ────────────────────────────
+
+    /// <summary>
+    /// Regression test for Defect 1: the same exercise id appears in two different sections
+    /// (e.g. "Bench Press" scheduled in both AMRAP block A and AMRAP block B).
+    /// The client completed it in only one section — the <c>CompletedExerciseIdsBySection</c> dict
+    /// contains it only for section A.
+    ///
+    /// The old flat-list check (CompletedExerciseIds.Contains) would see the exercise id once and
+    /// treat BOTH sections as done → false-positive "session complete" → wrong 409 on unlock.
+    ///
+    /// The per-section check must see section B as NOT done and allow the unlock to proceed (204).
+    /// </summary>
+    [Fact]
+    public async Task Unlock_DuplicateExerciseAcrossSections_CompletedInOnlyOneSection_Returns204()
+    {
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlan(planId, sessionId);
+
+        var sectionIdA = Guid.NewGuid();
+        var sectionIdB = Guid.NewGuid();
+        var sharedExerciseId = Guid.NewGuid(); // same exercise in both sections
+
+        plan.Weeks[0].Sessions[0].Sections =
+        [
+            new TrainingSection
+            {
+                SectionId = sectionIdA,
+                Order = 0,
+                Name = "AMRAP A",
+                Exercises =
+                [
+                    new SessionExercise { ExerciseExternalId = sharedExerciseId, ExerciseName = "Bench Press", Order = 0, Sets = [] }
+                ]
+            },
+            new TrainingSection
+            {
+                SectionId = sectionIdB,
+                Order = 1,
+                Name = "AMRAP B",
+                Exercises =
+                [
+                    new SessionExercise { ExerciseExternalId = sharedExerciseId, ExerciseName = "Bench Press", Order = 0, Sets = [] }
+                ]
+            }
+        ];
+
+        // Client completed section A's exercise but NOT section B's copy.
+        // CompletedExerciseIdsBySection is authoritative — only section A is populated.
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            // Flat list includes the id once — the OLD code used this and would incorrectly
+            // consider section B complete.
+            CompletedExerciseIds = [sharedExerciseId],
+            // Per-section: only section A done.
+            CompletedExerciseIdsBySection = new Dictionary<string, List<Guid>>
+            {
+                [sectionIdA.ToString()] = [sharedExerciseId]
+                // sectionIdB intentionally absent
+            },
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        // No completed WorkoutLog.
+        var mongo = CreateMockMongo(plan, completedLogCount: 0, completions: [completion]);
+        var lockService = LockServiceAcquired(sessionId, planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: session B still incomplete — unlock must proceed, no 409.
+        ep.HttpContext.Response.StatusCode.Should().Be(204,
+            "session with duplicate exercise id completed in only one section must NOT be treated as finished");
+
+        await lockService.Received(1).AcquireAsync(
+            sessionId, planId, _clientId, _trainerId,
+            LockHolder.Coach, LockType.Editing, Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A completion populated via <c>CompletedExerciseIdsBySection</c> where every section is
+    /// fully done should be treated as complete and must block the unlock with 409.
+    /// </summary>
+    [Fact]
+    public async Task Unlock_AllSectionsCompleteViaBySection_Returns409()
+    {
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlan(planId, sessionId);
+
+        var sectionIdA = Guid.NewGuid();
+        var sectionIdB = Guid.NewGuid();
+        var exerciseId1 = Guid.NewGuid();
+        var exerciseId2 = Guid.NewGuid();
+
+        plan.Weeks[0].Sessions[0].Sections =
+        [
+            new TrainingSection
+            {
+                SectionId = sectionIdA,
+                Order = 0,
+                Name = "Section A",
+                Exercises =
+                [
+                    new SessionExercise { ExerciseExternalId = exerciseId1, ExerciseName = "Squat", Order = 0, Sets = [] }
+                ]
+            },
+            new TrainingSection
+            {
+                SectionId = sectionIdB,
+                Order = 1,
+                Name = "Section B",
+                Exercises =
+                [
+                    new SessionExercise { ExerciseExternalId = exerciseId2, ExerciseName = "Deadlift", Order = 0, Sets = [] }
+                ]
+            }
+        ];
+
+        // Both sections fully done — populated via CompletedExerciseIdsBySection only
+        // (no flat CompletedExerciseIds — as new writes would produce).
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = [], // flat list empty — new-write shape
+            CompletedExerciseIdsBySection = new Dictionary<string, List<Guid>>
+            {
+                [sectionIdA.ToString()] = [exerciseId1],
+                [sectionIdB.ToString()] = [exerciseId2]
+            },
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        // No completed WorkoutLog.
+        var mongo = CreateMockMongo(plan, completedLogCount: 0, completions: [completion]);
+        var lockService = LockServiceAcquired(sessionId, planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: all sections done via CompletedExerciseIdsBySection → 409
+        ep.HttpContext.Response.StatusCode.Should().Be(409,
+            "a fully-complete CompletedExerciseIdsBySection completion must block the unlock");
+
+        // Lock must NOT be acquired
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UnlockSessionFinishedGuardTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UnlockSessionFinishedGuardTests.cs
@@ -62,10 +62,13 @@ public class UnlockSessionFinishedGuardTests
         };
 
     /// <summary>
-    /// Creates an IMongoContext where WorkoutLogs.CountDocumentsAsync returns the given count.
-    /// Uses CreateMockMongoWithLogs for the training-plan side to avoid duplicate stub setup.
+    /// Creates an IMongoContext where WorkoutLogs.CountDocumentsAsync returns the given count
+    /// and TrainingCompletions.FindAsync returns the given completions (default empty).
     /// </summary>
-    private IMongoContext CreateMockMongo(TrainingPlan plan, long completedLogCount)
+    private IMongoContext CreateMockMongo(
+        TrainingPlan plan,
+        long completedLogCount,
+        List<TrainingCompletion>? completions = null)
     {
         var mongo = Substitute.For<IMongoContext>();
 
@@ -81,6 +84,11 @@ public class UnlockSessionFinishedGuardTests
                 Arg.Any<CancellationToken>())
             .Returns(completedLogCount);
         mongo.WorkoutLogs.Returns(logCollection);
+
+        // TrainingCompletions — FindAsync returns the given completions (empty by default)
+        var completionCollection = TrainingPlanTestHelpers.CreateMockCompletionCollection(
+            completions ?? []);
+        mongo.TrainingCompletions.Returns(completionCollection);
 
         return mongo;
     }
@@ -190,12 +198,7 @@ public class UnlockSessionFinishedGuardTests
 
         // CreateMockMongo with a plan belonging to a DIFFERENT trainer — query with otherTrainerId returns nothing
         var otherTrainer = Guid.NewGuid();
-        var planBelongingToOtherTrainer = CreatePlan(planId, sessionId); // uses _trainerId
-        // Use the standard CreateMockMongoWithLogs which returns the plan (our endpoint filters by TrainerId in the query)
-        // We need the plan NOT to be returned when queried by otherTrainerId.
-        // The mongo mock returns ALL plans regardless of filter — so we create a plan with a different trainer
-        // and query as if we're otherTrainer (since the plan.TrainerId != otherTrainer, the mongo filter yields empty in prod,
-        // but the mock returns all). Use a separate mongo where plan collection is empty for simplicity.
+        // Use a separate mongo where plan collection is empty for simplicity.
         var mongo = Substitute.For<IMongoContext>();
         var emptyPlanCollection = TrainingPlanTestHelpers.CreateMockCollection([]);
         mongo.TrainingPlans.Returns(emptyPlanCollection);
@@ -207,6 +210,10 @@ public class UnlockSessionFinishedGuardTests
                 Arg.Any<CancellationToken>())
             .Returns(0L);
         mongo.WorkoutLogs.Returns(logCollection);
+
+        // TrainingCompletions not reached (404 fires first) but stub to avoid null ref.
+        var emptyCompletionCollection = TrainingPlanTestHelpers.CreateMockCompletionCollection([]);
+        mongo.TrainingCompletions.Returns(emptyCompletionCollection);
 
         var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
@@ -225,6 +232,145 @@ public class UnlockSessionFinishedGuardTests
         await logCollection.DidNotReceive().CountDocumentsAsync(
             Arg.Any<FilterDefinition<WorkoutLog>>(),
             Arg.Any<CountOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Gap: TrainingCompletion-based finished guard (home-checkbox path) ────────
+
+    /// <summary>
+    /// Session was completed via the mobile home-checkbox (writes TrainingCompletion, no WorkoutLog).
+    /// Unlock must return 409 SESSION_ALREADY_COMPLETED.
+    /// </summary>
+    [Fact]
+    public async Task Unlock_SessionCompletedViaTrainingCompletion_NoWorkoutLog_Returns409()
+    {
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlan(planId, sessionId);
+        // plan.Sections = [] — exercise-free session → IsSessionComplete requires SectionId in CompletedSectionIds.
+        // Use a plan with one exercise in a section to make the test realistic.
+        var sectionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        plan.Weeks[0].Sessions[0].Sections =
+        [
+            new TrainingSection
+            {
+                SectionId = sectionId,
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new SessionExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Squat",
+                        Order = 0,
+                        Sets = []
+                    }
+                ]
+            }
+        ];
+
+        // Fully-complete TrainingCompletion for that session (all exercises marked done).
+        var completion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = [exerciseId],
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        // No completed WorkoutLog.
+        var mongo = CreateMockMongo(plan, completedLogCount: 0, completions: [completion]);
+        var lockService = LockServiceAcquired(sessionId, planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: 409 from TrainingCompletion finished-guard
+        ep.HttpContext.Response.StatusCode.Should().Be(409,
+            "home-checkbox completion must prevent unlock just like a completed WorkoutLog");
+
+        // Lock must NOT be acquired
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Only a PARTIAL TrainingCompletion exists (not all exercises done).
+    /// The finished-guard must NOT fire — unlock should proceed normally.
+    /// </summary>
+    [Fact]
+    public async Task Unlock_SessionPartiallyComplete_NoWorkoutLog_Returns204()
+    {
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlan(planId, sessionId);
+
+        var sectionId = Guid.NewGuid();
+        var exerciseId1 = Guid.NewGuid();
+        var exerciseId2 = Guid.NewGuid();
+        plan.Weeks[0].Sessions[0].Sections =
+        [
+            new TrainingSection
+            {
+                SectionId = sectionId,
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new SessionExercise { ExerciseExternalId = exerciseId1, ExerciseName = "Squat", Order = 0, Sets = [] },
+                    new SessionExercise { ExerciseExternalId = exerciseId2, ExerciseName = "Press", Order = 1, Sets = [] }
+                ]
+            }
+        ];
+
+        // Only exerciseId1 done — partial completion.
+        var partialCompletion = new TrainingCompletion
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            Date = DateTime.UtcNow.Date,
+            SessionId = sessionId,
+            CompletedExerciseIds = [exerciseId1],  // exerciseId2 missing → NOT complete
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMockMongo(plan, completedLogCount: 0, completions: [partialCompletion]);
+        var lockService = LockServiceAcquired(sessionId, planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: 204 — partial completion does not block unlock
+        ep.HttpContext.Response.StatusCode.Should().Be(204,
+            "a partial TrainingCompletion must not trigger the finished-guard");
+
+        await lockService.Received(1).AcquireAsync(
+            sessionId, planId, _clientId, _trainerId,
+            LockHolder.Coach, LockType.Editing, Arg.Any<TimeSpan>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UnlockSessionFinishedGuardTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/UnlockSessionFinishedGuardTests.cs
@@ -1,0 +1,230 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.UnlockTrainingSession;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the finished-guard added to <see cref="UnlockTrainingSessionEndpoint"/> (issue #429).
+/// Verifies that unlocking a session whose WorkoutLog is already completed returns 409 SESSION_ALREADY_COMPLETED,
+/// and that the endpoint still succeeds (204) when no completed log exists.
+/// </summary>
+public class UnlockSessionFinishedGuardTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private IOptions<TrainingLockOptions> DefaultOptions() =>
+        Options.Create(new TrainingLockOptions { EditingTtlHours = 2, LiveTtlHours = 6 });
+
+    /// <summary>Creates a minimal plan with one session.</summary>
+    private TrainingPlan CreatePlan(Guid planId, Guid sessionId) =>
+        new()
+        {
+            ExternalId = planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = TrainingPlanTestHelpers.LastMonday(),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Test Session",
+                            Order = 1,
+                            Sections = []
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+
+    /// <summary>
+    /// Creates an IMongoContext where WorkoutLogs.CountDocumentsAsync returns the given count.
+    /// Uses CreateMockMongoWithLogs for the training-plan side to avoid duplicate stub setup.
+    /// </summary>
+    private IMongoContext CreateMockMongo(TrainingPlan plan, long completedLogCount)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Training plans — FindAsync returns the plan
+        var planCollection = TrainingPlanTestHelpers.CreateMockCollection([plan]);
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // WorkoutLogs — CountDocumentsAsync returns the given count (0 or 1)
+        var logCollection = Substitute.For<IMongoCollection<WorkoutLog>>();
+        logCollection.CountDocumentsAsync(
+                Arg.Any<FilterDefinition<WorkoutLog>>(),
+                Arg.Any<CountOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(completedLogCount);
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        return mongo;
+    }
+
+    /// <summary>Creates a lock service that returns <see cref="AcquireResult.Acquired"/>.</summary>
+    private ISessionLockService LockServiceAcquired(Guid sessionId, Guid planId)
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.AcquireAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+                Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AcquireResult.Acquired(new SessionLock
+            {
+                SessionId = sessionId,
+                PlanId = planId,
+                ClientId = _clientId,
+                TrainerId = _trainerId,
+                Holder = LockHolder.Coach,
+                Type = LockType.Editing,
+                AcquiredAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddHours(2)
+            }));
+        return svc;
+    }
+
+    // ── Gap B: finished-guard rejects unlock on completed sessions ───────────────
+
+    [Fact]
+    public async Task Unlock_SessionAlreadyCompleted_Returns409SessionAlreadyCompleted()
+    {
+        // Arrange: plan exists with the session, but CountDocumentsAsync returns 1 (completed log exists).
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlan(planId, sessionId);
+
+        var mongo = CreateMockMongo(plan, completedLogCount: 1);
+        var lockService = LockServiceAcquired(sessionId, planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: 409 returned for finished session
+        ep.HttpContext.Response.StatusCode.Should().Be(409,
+            "unlocking a finished session must return 409 SESSION_ALREADY_COMPLETED");
+
+        // Lock was NOT acquired (finished-guard fires before AcquireAsync)
+        await lockService.DidNotReceive().AcquireAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(),
+            Arg.Any<LockHolder>(), Arg.Any<LockType>(), Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+
+        // No SignalR events emitted
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Unlock_SessionNotCompleted_Returns204AndAcquiresLock()
+    {
+        // Arrange: plan exists, session exists, CountDocumentsAsync returns 0 → unlock proceeds.
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlan(planId, sessionId);
+
+        var mongo = CreateMockMongo(plan, completedLogCount: 0);
+        var lockService = LockServiceAcquired(sessionId, planId);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, lockService, DefaultOptions(), notifier);
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: 204 success, lock was acquired
+        ep.HttpContext.Response.StatusCode.Should().Be(204,
+            "unlock on a non-finished session must succeed with 204");
+
+        await lockService.Received(1).AcquireAsync(
+            sessionId, planId, _clientId, _trainerId,
+            LockHolder.Coach, LockType.Editing, Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Unlock_PlanNotFound_Returns404_BeforeFinishedGuard()
+    {
+        // Arrange: query returns no plan for this trainer (ownership guard fires first with 404).
+        var planId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        // CreateMockMongo with a plan belonging to a DIFFERENT trainer — query with otherTrainerId returns nothing
+        var otherTrainer = Guid.NewGuid();
+        var planBelongingToOtherTrainer = CreatePlan(planId, sessionId); // uses _trainerId
+        // Use the standard CreateMockMongoWithLogs which returns the plan (our endpoint filters by TrainerId in the query)
+        // We need the plan NOT to be returned when queried by otherTrainerId.
+        // The mongo mock returns ALL plans regardless of filter — so we create a plan with a different trainer
+        // and query as if we're otherTrainer (since the plan.TrainerId != otherTrainer, the mongo filter yields empty in prod,
+        // but the mock returns all). Use a separate mongo where plan collection is empty for simplicity.
+        var mongo = Substitute.For<IMongoContext>();
+        var emptyPlanCollection = TrainingPlanTestHelpers.CreateMockCollection([]);
+        mongo.TrainingPlans.Returns(emptyPlanCollection);
+
+        var logCollection = Substitute.For<IMongoCollection<WorkoutLog>>();
+        logCollection.CountDocumentsAsync(
+                Arg.Any<FilterDefinition<WorkoutLog>>(),
+                Arg.Any<CountOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(0L);
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        var ep = Factory.Create<UnlockTrainingSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(otherTrainer, AppRoles.Trainer))),
+            mongo, Substitute.For<ISessionLockService>(), DefaultOptions(), Substitute.For<IRealtimeNotifier>());
+
+        // Act
+        await ep.HandleAsync(
+            new UnlockTrainingSessionRequest { PlanId = planId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        // Assert: 404 — ownership guard fires before finished-guard
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+
+        // WorkoutLogs.CountDocumentsAsync must NOT be called (404 short-circuits before finished-guard)
+        await logCollection.DidNotReceive().CountDocumentsAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Any<CountOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/CompleteWorkoutEndpointTests.cs
@@ -6,7 +6,9 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining;
 using FitnessPlatform.Application.Features.WorkoutLogs.CompleteWorkout;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -14,8 +16,8 @@ namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
 /// <summary>
 /// Tests for <see cref="CompleteWorkoutEndpoint"/>.
-/// The endpoint now delegates the completion pipeline to <see cref="IWorkoutCompletionService"/>;
-/// these tests verify the HTTP contract and ownership check.
+/// The endpoint delegates the completion pipeline to <see cref="IWorkoutCompletionService"/>;
+/// these tests verify the HTTP contract, ownership check, and the trainingprogressupdated broadcast.
 /// Behavioral tests (TrainingCompletion fan-out, PR detection) live in
 /// <see cref="WorkoutCompletionServiceTests"/>.
 /// </summary>
@@ -39,6 +41,16 @@ public class CompleteWorkoutEndpointTests
         return svc;
     }
 
+    private static IComplianceService StubComplianceService()
+    {
+        var svc = Substitute.For<IComplianceService>();
+        svc.CalculateComplianceAsync(Arg.Any<Guid>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new ComplianceResult { CompliancePercent = 100m });
+        svc.CalculateStreakAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        return svc;
+    }
+
     [Fact]
     public async Task HandleAsync_ValidRequest_CompletesWorkout()
     {
@@ -51,7 +63,8 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>());
+            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>(),
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
@@ -72,7 +85,8 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), StubLockService(), Substitute.For<IRealtimeNotifier>());
+            mongo, StubCompletionService(), StubLockService(), Substitute.For<IRealtimeNotifier>(),
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
@@ -89,7 +103,8 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), StubLockService(), Substitute.For<IRealtimeNotifier>());
+            mongo, StubCompletionService(), StubLockService(), Substitute.For<IRealtimeNotifier>(),
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = Guid.NewGuid() }, TestContext.Current.CancellationToken);
 
@@ -110,7 +125,8 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>());
+            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>(),
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
@@ -138,11 +154,99 @@ public class CompleteWorkoutEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>());
+            mongo, completionService, StubLockService(), Substitute.For<IRealtimeNotifier>(),
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(409,
             "WorkoutAlreadyCompletedException must be surfaced as 409, not 500");
+    }
+
+    // ── Gap A: trainingprogressupdated broadcast ─────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_PlanBoundWorkout_EmitsTrainingProgressUpdated()
+    {
+        // Arrange: a plan-bound log (has both SessionId and PlanId), with a matching plan.
+        var logId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var trainerId = Guid.NewGuid();
+        var clientPublicId = Guid.NewGuid();
+
+        var log = WorkoutLogTestHelpers.CreateLog(
+            externalId: logId,
+            clientId: _clientId,
+            planId: planId,
+            sessionId: sessionId);
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = planId,
+            ClientId = clientPublicId,
+            TrainerId = trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks = [],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-10)
+        };
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log], plans: [plan]);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<CompleteWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, StubCompletionService(), StubLockService(), notifier,
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
+
+        // Act
+        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert: 200 and trainingprogressupdated sent to trainer
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await notifier.Received(1).NotifyAsync(
+            trainerId,
+            TrainingProgressBroadcaster.EventName,
+            Arg.Is<TrainingProgressUpdatedEvent>(e =>
+                e.SessionId == sessionId &&
+                e.ClientId == clientPublicId &&
+                e.SessionComplete),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_AdHocWorkoutNoSessionId_DoesNotEmitTrainingProgressUpdated()
+    {
+        // Arrange: an ad-hoc workout (no SessionId, no PlanId).
+        var logId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        // sessionId and planId are null by default
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var notifier = Substitute.For<IRealtimeNotifier>();
+
+        var ep = Factory.Create<CompleteWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, StubCompletionService(), StubLockService(), notifier,
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
+
+        // Act
+        await ep.HandleAsync(new CompleteWorkoutRequest { LogId = logId }, TestContext.Current.CancellationToken);
+
+        // Assert: 200 and NO trainingprogressupdated (no trainer to notify)
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await notifier.DidNotReceive().NotifyAsync(
+            Arg.Any<Guid>(),
+            TrainingProgressBroadcaster.EventName,
+            Arg.Any<object>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockBroadcastWorkoutTests.cs
@@ -13,6 +13,7 @@ using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 
@@ -102,6 +103,16 @@ public class SessionLockBroadcastWorkoutTests
         var svc = Substitute.For<IWorkoutCompletionService>();
         svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
             .Returns(new List<string>());
+        return svc;
+    }
+
+    private static IComplianceService StubComplianceService()
+    {
+        var svc = Substitute.For<IComplianceService>();
+        svc.CalculateComplianceAsync(Arg.Any<Guid>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new ComplianceResult { CompliancePercent = 100m });
+        svc.CalculateStreakAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(1);
         return svc;
     }
 
@@ -267,7 +278,8 @@ public class SessionLockBroadcastWorkoutTests
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), lockService, notifier);
+            mongo, StubCompletionService(), lockService, notifier,
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         // Act
         await ep.HandleAsync(
@@ -322,7 +334,8 @@ public class SessionLockBroadcastWorkoutTests
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), lockService, notifier);
+            mongo, StubCompletionService(), lockService, notifier,
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         // Act
         await ep.HandleAsync(
@@ -357,7 +370,8 @@ public class SessionLockBroadcastWorkoutTests
         var ep = Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, StubCompletionService(), lockService, notifier);
+            mongo, StubCompletionService(), lockService, notifier,
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
 
         // Act
         await ep.HandleAsync(

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/SessionLockEnforcementTests.cs
@@ -13,6 +13,7 @@ using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -146,6 +147,16 @@ public class SessionLockEnforcementTests
         return svc;
     }
 
+    private static IComplianceService StubComplianceService()
+    {
+        var svc = Substitute.For<IComplianceService>();
+        svc.CalculateComplianceAsync(Arg.Any<Guid>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new ComplianceResult { CompliancePercent = 100m });
+        svc.CalculateStreakAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        return svc;
+    }
+
     private CompleteWorkoutEndpoint CreateCompleteEndpoint(
         IMongoContext mongo,
         IWorkoutCompletionService completionService,
@@ -154,7 +165,8 @@ public class SessionLockEnforcementTests
         return Factory.Create<CompleteWorkoutEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            mongo, completionService, lockService, Substitute.For<IRealtimeNotifier>());
+            mongo, completionService, lockService, Substitute.For<IRealtimeNotifier>(),
+            StubComplianceService(), Substitute.For<ILogger<CompleteWorkoutEndpoint>>());
     }
 
     [Fact]

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -164,8 +164,9 @@ export function AppShell() {
       }
 
       // If the trainer also has THIS client's plan open in the editor,
-      // pull the latest completions so locked fields update in real time.
-      // Only `completions` is replaced — unsaved trainer edits stay intact.
+      // pull the latest completions, session executions, and lock states so
+      // the finished badge and unlock affordance update in real time.
+      // Only server-owned slices are replaced — unsaved trainer edits stay intact.
       const tp = useTrainingPlanStore.getState();
       if (tp.plan && tp.plan.clientId === clientId) {
         void tp.refreshCompletions();

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1066,7 +1066,9 @@
       "unlockError": "Nepodařilo se odemknout trénink.",
       "relockError": "Nepodařilo se zamknout trénink.",
       "sessionLockedError": "Uložení selhalo — tyto tréninky jsou aktuálně uzamčeny klientem:",
-      "unlockToSave": "Odemkněte nebo počkejte na dokončení tréninku"
+      "unlockToSave": "Odemkněte nebo počkejte na dokončení tréninku",
+      "finishedLabel": "Dokončeno klientem",
+      "finishedTooltip": "Klient tento trénink dokončil — úpravy nejsou možné."
     },
     "sidebarVolume": "Objem tréninku",
     "sidebarTotalSets": "sérií celkem",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1052,7 +1052,9 @@
       "unlockError": "Einheit konnte nicht entsperrt werden.",
       "relockError": "Einheit konnte nicht gesperrt werden.",
       "sessionLockedError": "Speichern fehlgeschlagen — diese Einheiten sind durch den Klienten gesperrt:",
-      "unlockToSave": "Entsperren oder warten, bis das Training abgeschlossen ist"
+      "unlockToSave": "Entsperren oder warten, bis das Training abgeschlossen ist",
+      "finishedLabel": "Vom Klienten abgeschlossen",
+      "finishedTooltip": "Der Klient hat diese Einheit abgeschlossen — Bearbeitung ist nicht möglich."
     },
     "sidebarVolume": "Trainingsvolumen",
     "sidebarTotalSets": "Sätze gesamt",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1053,7 +1053,9 @@
       "unlockError": "Failed to unlock session.",
       "relockError": "Failed to relock session.",
       "sessionLockedError": "Save failed — these sessions are locked by the client:",
-      "unlockToSave": "Unlock or wait for the workout to finish"
+      "unlockToSave": "Unlock or wait for the workout to finish",
+      "finishedLabel": "Completed by client",
+      "finishedTooltip": "The client has finished this session — editing is not available."
     },
     "sidebarVolume": "Training volume",
     "sidebarTotalSets": "total sets",

--- a/web/src/lib/api-errors.ts
+++ b/web/src/lib/api-errors.ts
@@ -49,10 +49,17 @@ export function getRfc7807ErrorCode(error: unknown): string | null {
 
 /**
  * Returns a translated error message for an API error.
- * Tries error code translation first, falls back to the provided fallback key.
+ *
+ * Checks error codes in order:
+ *   1. FastEndpoints `errors[0].reason` (e.g. validation errors)
+ *   2. RFC 7807 top-level `errorCode` (e.g. 409 SESSION_ALREADY_COMPLETED
+ *      from UnlockTrainingSession, UpdateTrainingPlan)
+ *
+ * Falls back to the provided fallback key when no code is present or the
+ * code has no translation entry.
  */
 export function getApiErrorMessage(error: unknown, fallbackKey: string): string {
-  const code = getErrorCode(error);
+  const code = getErrorCode(error) ?? getRfc7807ErrorCode(error);
   if (code) {
     const translated = i18n.t(`apiErrors.${code}`, { defaultValue: '' });
     if (translated) return translated;

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -1152,7 +1152,20 @@ export default function TrainingPlanPage() {
                         {t('training.lock.liveLabel')}
                       </span>
                     )}
-                    {isPublishedSession && !isLive && !isEditing && (
+                    {isPublishedSession && !isLive && !isEditing && sessionExec?.isSessionFinished && (
+                      <span
+                        className={cn(
+                          'shrink-0 inline-flex items-center gap-1 rounded-sm border px-2 py-[2px]',
+                          'text-[10px] font-medium',
+                          'border-text3/30 text-text3 bg-bg2',
+                        )}
+                        title={t('training.lock.finishedTooltip')}
+                        aria-label={t('training.lock.finishedTooltip')}
+                      >
+                        {t('training.lock.finishedLabel')}
+                      </span>
+                    )}
+                    {isPublishedSession && !isLive && !isEditing && !sessionExec?.isSessionFinished && (
                       <button
                         type="button"
                         onClick={(e) => {

--- a/web/src/stores/trainingPlan.ts
+++ b/web/src/stores/trainingPlan.ts
@@ -124,11 +124,12 @@ interface TrainingPlanState {
   save: () => Promise<void>;
   publishWeek: (weekNumber: number) => Promise<void>;
   /**
-   * Re-fetch the current plan from the server and overwrite **only**
-   * `completions` on both `plan` and `originalPlan`. Used by the SignalR
-   * `trainingprogressupdated` listener so the editor reacts in real time
-   * to client-side completions without clobbering unsaved trainer edits.
-   * Also refreshes `sessionLockMap` from the fresh response.
+   * Re-fetch the current plan from the server and overwrite `completions`,
+   * `sessionExecutions`, and `sessionLockStates` on both `plan` and
+   * `originalPlan`. Used by the SignalR `trainingprogressupdated` listener
+   * so the editor reacts in real time to client-side completions and
+   * session-finish state without clobbering unsaved trainer edits.
+   * Also rebuilds `sessionLockMap` from the fresh response.
    */
   refreshCompletions: () => Promise<void>;
 
@@ -1464,8 +1465,8 @@ export const useTrainingPlanStore = create<TrainingPlanState>((set, get) => ({
       const sessionLockStates = fresh.sessionLockStates ?? [];
       const sessionLockMap = buildLockMap(sessionLockStates);
       // Also carry fresh sessionExecutions so isSessionFinished badges update
-      // live — the API response includes them but they were previously dropped
-      // during the merge, leaving the finished badge stale until a full reload.
+      // live without a full page reload. The unlock affordance gates on
+      // sessionExec.isSessionFinished, so this is required for AC1/AC4 of #429.
       const sessionExecutions = fresh.sessionExecutions ?? [];
       set((state) => ({
         // Keep plan.sessionLockStates in lockstep with sessionLockMap so the


### PR DESCRIPTION
## Summary
- Backend (live-finish path): `CompleteWorkoutEndpoint` now emits `trainingprogressupdated` via `TrainingProgressBroadcaster.BroadcastSessionAsync` after `WorkoutCompletionService.CompleteAsync` succeeds, so the trainer portal reflects the finished state in real time (no manual reload). Mirrors the existing `MarkSessionComplete` pattern; uses `plan.ClientId` (ClientProfile.PublicId) as the broadcast key.
- Backend (checkbox/home-finish path): `GetTrainingPlan` and `UnlockTrainingSession` now recognize a fully-complete `TrainingCompletion` (home/Today "mark whole day complete" checkbox) as a finished signal — not just a completed `WorkoutLog` — via the new Domain extension `TrainingCompletionExtensions.IsSessionComplete`. The helper computes per-section membership through `TrainingCompletionBackfill.GetEffectiveCompletedExerciseIdsBySection` (canonical path, not the deprecated flat list) and guards zero-section sessions explicitly.
- Backend (unlock guard): `UnlockTrainingSessionEndpoint` rejects unlocking a session that is already finished (completed `WorkoutLog` OR fully-complete `TrainingCompletion`) with HTTP 409 `SESSION_ALREADY_COMPLETED` (reuses existing ErrorCodes constant), placed after the 404 ownership/existence guards and before `AcquireAsync`.
- Web: `TrainingPlanPage` shows a disabled "Completed by client" badge (i18n `training.lock.finishedLabel` / `finishedTooltip`) in place of the unlock button when `sessionExec?.isSessionFinished`. `api-errors.ts` extends `getApiErrorMessage` to fall back to the RFC 7807 top-level `errorCode` so the 409 surfaces as a localized toast. `AppShell` realtime handler refreshes completions + sessionExecutions + lockStates so the badge/affordance update live.
- Tests: `UnlockSessionFinishedGuardTests`, `GetTrainingPlanCompletionFinishedStateTests`, and `CompleteWorkoutEndpointTests` cover both finish paths and the unlock-finished guard, including duplicate-exercise-across-sections, bySection-complete, and zero-section edge cases. Sibling ctor sites updated in `SessionLockBroadcastWorkoutTests` / `SessionLockEnforcementTests`.

## Related issue
Fixes #429

## Scope
cross-cut (backend + web) — single branch / single PR per the cross-package coordination rule

## QA verdict (from qa-tester)
PASS (re-run 2026-06-04). dotnet build clean; WorkoutLogs 66/66, TrainingPlans 81/81, ClientTraining 103/103; web build clean; i18n cs/en/de parity intact. AC1/AC2/AC4 (real-time interactive flows + 409 toast) **user-confirmed via live smoke 2026-06-04** — the checkbox path now flips the trainer portal to finished in real time. AC3/AC5/AC6/AC7 covered by backend tests + static checks. (2 pre-existing `NutritionPlans.UpdatePlanFullStateTests` failures are out-of-scope, not a regression.)

## Code review verdict (from pr-reviewer)
✅ READY FOR MERGE — both passes clean.
- **First-pass self-review:** CLEAN (zero BLOCKING; hard-rule gate clean — no generated-file edits, no hardcoded colors/`any`/URLs, i18n cs/en/de parity, package boundaries respected, new helper is a Domain extension not a re-layered service).
- **Second-pass fresh-eyes review (blind, PR body + diff only):** across two rounds raised 2 real defects on commit `02fa905`, both fixed in `3d4dc37`:
  1. (backend) `IsSessionComplete` read the section-agnostic deprecated flat `CompletedExerciseIds` → false-positive "complete" when an exercise id is duplicated across sections but done in only one. Fixed: now uses `GetEffectiveCompletedExerciseIdsBySection` for per-section membership. Covered by new test (duplicate-across-sections → not finished / 204).
  2. (backend) `Sections.All(...)` vacuously true for a zero-section session → read as complete. Fixed: explicit zero-section guard. Covered by new test (zero-section → not finished).

  No findings remain from either pass.

## Manual verification (live trainer-portal real-time smoke) — ✅ CONFIRMED
Ran live 2026-06-04 against the compose harness (`npm run e2e:up` + web `npm run dev:e2e`, `:5173` → `:5101`). All three previously-deferred interactive ACs confirmed by the user:

- [x] **AC1 — live finish (mobile/client):** Finishing a live training session as the client flips the trainer-portal session to the finished badge **in real time, no reload** (driven by `trainingprogressupdated` from the live-finish backend path). ✅ confirmed
- [x] **AC2 — Home/Today checkbox finish:** Finishing via the **Home/Today checkbox** path updates the trainer portal in real time — the checkbox path now correctly flips the portal to finished (the gap this PR closes). ✅ confirmed
- [x] **AC4 — unlock guard + 409 toast:** On a finished session, the unlock button is replaced by the disabled **"Dokončeno klientem"** badge; a forced stale unlock attempt surfaces the localized **409 `SESSION_ALREADY_COMPLETED`** toast. ✅ confirmed

AC3/AC5/AC6/AC7 verified by backend tests + static checks (build/i18n parity) — see Test plan.

## Test plan (acceptance criteria, verbatim)
- [x] Finishing a live session on mobile causes the trainer portal to reflect the finished state in real time (no manual reload), via a `trainingprogressupdated` event from the live-finish backend path.
- [x] Finishing a session via the Home/Today checkbox continues to update the trainer portal in real time (no regression).
- [x] The backend unlock endpoint rejects unlocking a finished session, returning RFC 7807 Problem Details with a dedicated error code (HTTP 409).
- [x] The web trainer portal disables / hides the unlock-and-edit affordance for finished sessions, and shows a clear message if an unlock attempt is rejected.
- [x] New backend behavior is covered by tests for both finish paths and the unlock-finished-session rejection.
- [x] Any new user-facing strings (error message, read-only label) land in cs/en/de locale files.
- [x] `dotnet build` + relevant `dotnet test` slice clean; `npm run build` (web) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
