### PR TITLE
feat: add Detail button to Today nutrition card header

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1386,25 +1386,57 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
             <SectionHeader
               title={t('today.todaysNutrition')}
               action={
-                <Pressable
-                  onPress={handlePhotoGridPress}
-                  hitSlop={8}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('nutrition.photoCta')}
-                  style={styles.photoCtaBtn}
-                >
-                  <View
-                    style={[
-                      styles.photoCtaIconChip,
-                      { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
-                    ]}
-                  >
-                    <Ionicons name="camera" size={13} color={colors.onGoldChip} />
-                  </View>
-                  <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
-                    {t('nutrition.photoCta')}
-                  </Text>
-                </Pressable>
+                <View style={styles.nutritionHeaderActions}>
+                  {plan?.planId ? (
+                    <Pressable
+                      onPress={handlePhotoGridPress}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('nutrition.photoCta')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="camera" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('nutrition.photoCta')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  {plan?.planId ? (
+                    <Pressable
+                      onPress={() => {
+                        router.push(
+                          hrefParams('/(client)/(tabs)/plans/[planId]', {
+                            planId: plan.planId!,
+                            type: 'nutrition',
+                          }),
+                        )
+                      }}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('today.sectionActionDetail')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="chevron-forward" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('today.sectionActionDetail')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                </View>
               }
             />
             <NutritionCard


### PR DESCRIPTION
## Summary
- Adds a "Detail" button to the Today nutrition ("Dnešní jídelníček") section header, in an actions row beside the existing "Foto" button — mirroring the training-header layout.
- Detail navigates to `/(client)/(tabs)/plans/[planId]` with `type: 'nutrition'` and the current nutrition `planId`.
- Reuses #433's shared gold icon-chip treatment (`photoCtaBtn` / `photoCtaIconChip` / `photoCtaLabel`, `goldAlpha` + `colors.gold`/`onGoldChip`, `chevron-forward`) so training and nutrition Detail buttons are visually identical.
- Both buttons guarded on `plan?.planId`, carry accessibility labels, and reuse the existing `today.sectionActionDetail` i18n key (no new strings).

## Related issue
Fixes #434

## Stacked base
Base is `fix/433-detail-foto-align` (PR #433), not `develop` — intentional stacked PR. #434 reuses the shared button styles #433 introduces. GitHub auto-retargets to `develop` when #433 merges.

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — 6/6 ACs met (orchestrator iOS drive on iPhone 16e confirmed Foto+Detail gold buttons render as a matching actions row; tsc --noEmit clean; i18n cs/en/de present). One verification run flagged false: expo-doctor not run (tooling allowlist gap, not a code defect — single TSX file, no manifest/lockfile change).

## Test plan
- [ ] The Today nutrition header shows a "Detail" button next to "Foto", in an actions row matching the training header layout.
- [ ] The Detail button opens `/(client)/(tabs)/plans/[planId]` with `type: 'nutrition'` and the current nutrition `planId`.
- [ ] Foto and Detail use the exact same style as the #433 training header buttons; training and nutrition Detail buttons are visually identical.
- [ ] Both buttons guarded on `plan?.planId` and carry accessibility labels.
- [ ] Design tokens via `useTheme()`; no hardcoded colors/spacing/font sizes; no `any`; reuses `today.sectionActionDetail`.
- [ ] `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)