### PR TITLE
feat: move hydration card into Today stat strip (middle slot) when enabled

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1332,8 +1332,19 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
                         )
                       }}
                       hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('today.sectionActionDetail')}
+                      style={styles.photoCtaBtn}
                     >
-                      <Text style={[styles.trainingDetailAction, { color: colors.gold }]}>
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="chevron-forward" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
                         {t('today.sectionActionDetail')}
                       </Text>
                     </Pressable>
@@ -1460,9 +1471,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
-  },
-  trainingDetailAction: {
-    ...Type.subheadline,
   },
   mealsProgress: {
     ...Type.footnote,

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1386,25 +1386,57 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
             <SectionHeader
               title={t('today.todaysNutrition')}
               action={
-                <Pressable
-                  onPress={handlePhotoGridPress}
-                  hitSlop={8}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('nutrition.photoCta')}
-                  style={styles.photoCtaBtn}
-                >
-                  <View
-                    style={[
-                      styles.photoCtaIconChip,
-                      { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
-                    ]}
-                  >
-                    <Ionicons name="camera" size={13} color={colors.onGoldChip} />
-                  </View>
-                  <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
-                    {t('nutrition.photoCta')}
-                  </Text>
-                </Pressable>
+                <View style={styles.nutritionHeaderActions}>
+                  {plan?.planId ? (
+                    <Pressable
+                      onPress={handlePhotoGridPress}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('nutrition.photoCta')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="camera" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('nutrition.photoCta')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  {plan?.planId ? (
+                    <Pressable
+                      onPress={() => {
+                        router.push(
+                          hrefParams('/(client)/(tabs)/plans/[planId]', {
+                            planId: plan.planId!,
+                            type: 'nutrition',
+                          }),
+                        )
+                      }}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('today.sectionActionDetail')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="chevron-forward" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('today.sectionActionDetail')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                </View>
               }
             />
             <NutritionCard

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -17,7 +17,7 @@ import { SectionHeader } from '@/components/ui/SectionHeader'
 import { TrainingCard } from '@/components/training/TrainingCard'
 import { NutritionCard } from '@/components/nutrition/NutritionCard'
 import { WaitingForPlanCard } from '@/components/today/WaitingForPlanCard'
-import { HydrationCard } from '@/components/hydration/HydrationCard'
+import { HydrationStatCard } from '@/components/today/HydrationStatCard'
 import { useHydrationStore } from '@/stores/hydrationStore'
 import { ShoppingPrepBanner } from '@/components/today/ShoppingPrepBanner'
 import {
@@ -1229,14 +1229,18 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
           weightDelta={weightTrend?.change ?? null}
           periodDays={weightTrend?.periodDays ?? null}
         />
-        <StatCard
-          label={t('today.compliance')}
-          value={`${compliancePercent}%`}
-          sub={t('today.complianceSub')}
-          color={complianceColor}
-          progress={compliancePercent / 100}
-          progressColor={complianceColor}
-        />
+        {hydrationEnabled ? (
+          <HydrationStatCard />
+        ) : (
+          <StatCard
+            label={t('today.compliance')}
+            value={`${compliancePercent}%`}
+            sub={t('today.complianceSub')}
+            color={complianceColor}
+            progress={compliancePercent / 100}
+            progressColor={complianceColor}
+          />
+        )}
         <StatCard
           label={t('today.streak')}
           value={streak}
@@ -1275,13 +1279,6 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
       {showShoppingBanner !== null && (
         <View style={[styles.section, { marginBottom: -8 }]}>
           <ShoppingPrepBanner week={showShoppingBanner} />
-        </View>
-      )}
-
-      {/* Hydration card — sits ABOVE the training card, gated on enabled flag */}
-      {hydrationEnabled && (
-        <View style={styles.section}>
-          <HydrationCard />
         </View>
       )}
 

--- a/mobile/src/components/today/HydrationStatCard.tsx
+++ b/mobile/src/components/today/HydrationStatCard.tsx
@@ -1,0 +1,161 @@
+/**
+ * HydrationStatCard — compact stat-tile variant of the hydration tracker (#432).
+ *
+ * Occupies the middle slot of the Today stat strip when the hydration feature
+ * is enabled (replaces the Plnění compliance StatCard in that slot).
+ *
+ * Visual shape mirrors StatCard exactly:
+ *   - Short uppercase label ("Pití") in the top-left
+ *   - Gold plus button in the top-right (24 px circle, like StatCard's headerIcon)
+ *   - Big value: today's logged ml
+ *   - Sub line: "z {target} ml"
+ *   - Gold progress bar at the bottom (capped at 100%)
+ *
+ * Tapping anywhere on the card OR the plus button opens HydrationQuickLogSheet.
+ * State is read from hydrationStore (Zustand reactive selectors) — no TanStack
+ * Query needed (purely local MMKV-backed state).
+ */
+
+import React, { useState, useCallback } from 'react'
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { useTranslation } from 'react-i18next'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { Radius } from '@/constants/radius'
+import { useHydrationStore, selectTodayTotalMl } from '@/stores/hydrationStore'
+import { HydrationQuickLogSheet } from '@/components/hydration/HydrationQuickLogSheet'
+
+export function HydrationStatCard(): React.ReactElement {
+  const { t } = useTranslation()
+  const colors = useTheme()
+
+  // Reactive Zustand selectors — updates immediately when addDrink is called.
+  const log = useHydrationStore((s) => s.log)
+  const targetMl = useHydrationStore((s) => s.targetMl)
+  const addDrink = useHydrationStore((s) => s.addDrink)
+
+  const todayTotal = selectTodayTotalMl(log)
+
+  const [sheetVisible, setSheetVisible] = useState(false)
+
+  const openSheet = useCallback(() => setSheetVisible(true), [])
+
+  const handleLog = useCallback(
+    (amountMl: number) => {
+      addDrink(amountMl)
+      setSheetVisible(false)
+    },
+    [addDrink],
+  )
+
+  const progress = targetMl > 0 ? Math.min(todayTotal / targetMl, 1) : 0
+
+  const styles = makeStyles(colors)
+
+  return (
+    <>
+      <Pressable
+        style={({ pressed }) => [
+          styles.card,
+          { backgroundColor: colors.bg2, opacity: pressed ? 0.85 : 1 },
+        ]}
+        onPress={openSheet}
+        accessibilityRole="button"
+        accessibilityLabel={t('hydration.card.addButtonA11y')}
+      >
+        {/* Top row: label + gold plus */}
+        <View style={styles.headerRow}>
+          <Text style={[styles.label, { color: colors.label2 }]}>
+            {t('today.hydration')}
+          </Text>
+          <Pressable
+            hitSlop={8}
+            onPress={openSheet}
+            style={[styles.plusBtn, { backgroundColor: colors.gold }]}
+            accessibilityRole="button"
+            accessibilityLabel={t('hydration.card.addButtonA11y')}
+          >
+            <Ionicons name="add" size={13} color={colors.onAccent} />
+          </Pressable>
+        </View>
+
+        {/* Value row */}
+        <Text style={[styles.value, { color: colors.label }]}>
+          {todayTotal}
+        </Text>
+
+        {/* Sub line */}
+        <Text style={[styles.sub, { color: colors.label3 }]}>
+          {t('today.hydrationSub', { target: targetMl })}
+        </Text>
+
+        {/* Gold progress bar */}
+        <View style={[styles.track, { backgroundColor: colors.fill, marginTop: 6 }]}>
+          <View
+            style={[
+              styles.fill,
+              { width: `${progress * 100}%`, backgroundColor: colors.gold },
+            ]}
+          />
+        </View>
+      </Pressable>
+
+      <HydrationQuickLogSheet
+        visible={sheetVisible}
+        onLog={handleLog}
+        onDismiss={() => setSheetVisible(false)}
+      />
+    </>
+  )
+}
+
+export default HydrationStatCard
+
+type Colors = ReturnType<typeof useTheme>
+
+function makeStyles(colors: Colors) {
+  return StyleSheet.create({
+    card: {
+      flex: 1,
+      borderRadius: Radius.md,
+      padding: 12,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 4,
+    },
+    label: {
+      ...Type.caption2,
+      fontWeight: '500',
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    plusBtn: {
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+    },
+    value: {
+      ...Type.title2,
+    },
+    sub: {
+      ...Type.caption1,
+      marginTop: 1,
+    },
+    track: {
+      height: 4,
+      borderRadius: Radius.full,
+      overflow: 'hidden',
+    },
+    fill: {
+      height: 4,
+      borderRadius: Radius.full,
+    },
+  })
+}

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -348,7 +348,9 @@
       "sessionInProgress": "Jiný trénink už běží"
     },
     "noNutritionPlanForToday": "Na dnes nemáte naplánovaný jídelníček",
-    "noTrainingForToday": "Na dnes nemáte naplánovaný trénink"
+    "noTrainingForToday": "Na dnes nemáte naplánovaný trénink",
+    "hydration": "Pití",
+    "hydrationSub": "z {{target}} ml"
   },
   "questionnaire": {
     "allDone": "Hotovo!",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -343,7 +343,9 @@
       "sessionInProgress": "Trainingseinheit läuft bereits"
     },
     "noNutritionPlanForToday": "Heute ist kein Ernährungsplan geplant",
-    "noTrainingForToday": "Heute ist kein Training geplant"
+    "noTrainingForToday": "Heute ist kein Training geplant",
+    "hydration": "Trinken",
+    "hydrationSub": "von {{target}} ml"
   },
   "questionnaire": {
     "allDone": "Fertig!",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -343,7 +343,9 @@
       "sessionInProgress": "Session already in progress"
     },
     "noNutritionPlanForToday": "No nutrition plan for today",
-    "noTrainingForToday": "No training planned for today"
+    "noTrainingForToday": "No training planned for today",
+    "hydration": "Water",
+    "hydrationSub": "of {{target}} ml"
   },
   "questionnaire": {
     "allDone": "All done!",


### PR DESCRIPTION
## Summary
- When the hydration (Pitný režim) feature is **enabled**, a new `HydrationStatCard` occupies the **middle** Today stat slot, replacing the PLNĚNÍ compliance `StatCard`.
- The standalone hydration card that previously sat above the training card is **removed**.
- When the feature is **disabled**, the PLNĚNÍ compliance `StatCard` renders in the middle slot unchanged — no hydration UI on Today.
- New `HydrationStatCard` reuses `HydrationQuickLogSheet`; tapping the card or the gold plus opens the sheet and logging updates the tile immediately (reactive Zustand selectors).

## Related issue
Fixes #432

## Stacked base
Base is `feature/434-nutrition-detail-button` (intentional stacked PR for a minimal diff). GitHub auto-retargets to `develop` when the parent merges. Not an epic sub-issue.

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — iOS-sim drive verified middle PITÍ tile (value + `z 3500 ml` sub + gold bar + gold plus), quick-log updates the card immediately; i18n cs/en/de pass; prototype fidelity pass.

## Test plan
- [ ] Enabled: hydration card renders in MIDDLE stat slot (replacing PLNĚNÍ); standalone hydration card above training is gone.
- [ ] Disabled: PLNĚNÍ compliance card renders in middle slot unchanged; no hydration UI on Today.
- [ ] Hydration stat card shows today's logged ml value, `z {target} ml` sub, gold progress bar (todayTotal/target capped 100%), gold plus affordance.
- [ ] Tapping the card or the plus opens HydrationQuickLogSheet; logged amount updates the card's value and bar immediately.
- [ ] Uses design tokens via useTheme() (no hardcoded colors/spacing, no any); StatCard's compliance/streak/weight usages visually unchanged.
- [ ] New user-facing strings added in all three cs/en/de locale files.
- [ ] Plus button retains an accessibility label; the card is an accessible pressable.
- [ ] npx tsc --noEmit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)