### PR TITLE
chore: localize plan-detail back-button + Plan-not-found, remove dead styles

### DIFF
--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -500,7 +500,7 @@ function NutritionPlanDetail({
           style={styles.nutritionBackBtn}
         >
           <Ionicons name="chevron-back" size={24} color={colors.gold} />
-          <Text style={[Type.body, { color: colors.gold }]}>Plans</Text>
+          <Text style={[Type.body, { color: colors.gold }]}>{t('plans.title')}</Text>
         </Pressable>
         <TouchableOpacity
           onPress={() => handleStepWeek(-1)}
@@ -1126,7 +1126,7 @@ function TrainingPlanDetail({
           style={styles.nutritionBackBtn}
         >
           <Ionicons name="chevron-back" size={24} color={colors.gold} />
-          <Text style={[Type.body, { color: colors.gold }]}>Plans</Text>
+          <Text style={[Type.body, { color: colors.gold }]}>{t('plans.title')}</Text>
         </Pressable>
         <TouchableOpacity
           onPress={() => handleStepWeek(-1)}
@@ -1618,6 +1618,7 @@ export default function PlanDetailScreen() {
     day?: string
   }>()
   const colors = useTheme()
+  const { t } = useTranslation()
   const router = useRouter()
 
   const isNutrition = type === 'nutrition'
@@ -1675,7 +1676,7 @@ export default function PlanDetailScreen() {
           />
         ) : (
           <View style={styles.centered}>
-            <Text style={[Type.headline, { color: colors.label3 }]}>Plan not found</Text>
+            <Text style={[Type.headline, { color: colors.label3 }]}>{t('plans.planNotFound')}</Text>
           </View>
         )}
       </SafeAreaView>
@@ -1686,21 +1687,6 @@ export default function PlanDetailScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  navBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 8,
-    paddingVertical: 8,
-  },
-  backBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 2,
-  },
-  titleBar: {
-    paddingHorizontal: 16,
-    paddingBottom: 12,
   },
   centered: {
     flex: 1,
@@ -1876,13 +1862,6 @@ const styles = StyleSheet.create({
     paddingTop: 40,
     alignItems: 'center',
   },
-  emptyDay: {
-    margin: 16,
-    borderRadius: Radius.md,
-    padding: 32,
-    alignItems: 'center',
-  },
-
   // Training plan detail — no horizontal padding; standalone ExpandableSessionCard
   // carries its own marginHorizontal: 16 in standalone mode.
   sessionsWrap: {

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -460,7 +460,8 @@
     "sessions_other": "{{count}} cvičení",
     "meals_one": "{{count}} jídlo",
     "meals_few": "{{count}} jídla",
-    "meals_other": "{{count}} jídel"
+    "meals_other": "{{count}} jídel",
+    "planNotFound": "Plán nebyl nalezen"
   },
   "pendingQuestionnaires": {
     "title": "Čekající dotazníky",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -452,7 +452,8 @@
     "sessions_one": "{{count}} Übung",
     "sessions_other": "{{count}} Übungen",
     "meals_one": "{{count}} Mahlzeit",
-    "meals_other": "{{count}} Mahlzeiten"
+    "meals_other": "{{count}} Mahlzeiten",
+    "planNotFound": "Plan nicht gefunden"
   },
   "pendingQuestionnaires": {
     "title": "Ausstehende Fragebögen",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -454,7 +454,8 @@
     "sessions_other": "{{count}} exercises",
     "meals_one": "{{count}} meal",
     "meals_few": "{{count}} meals",
-    "meals_other": "{{count}} meals"
+    "meals_other": "{{count}} meals",
+    "planNotFound": "Plan not found"
   },
   "pendingQuestionnaires": {
     "title": "Pending Questionnaires",


### PR DESCRIPTION
## Summary
- Localize both detail back-button labels (`NutritionPlanDetail`, `TrainingPlanDetail`) to `t('plans.title')` — no more hardcoded "Plans".
- Localize the "Plan not found" fallback via new `plans.planNotFound` key (added to cs/en/de).
- Remove unreferenced `navBar` / `backBtn` / `titleBar` / `emptyDay` styles from the `StyleSheet.create`.

## Related issue
Fixes #425

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all 4 ACs met; `npx tsc --noEmit` clean on ccd5f03; i18n_check: pass.

## Test plan
- [ ] AC1: Both detail back-button labels use `t('plans.title')` (no hardcoded "Plans").
- [ ] AC2: The "Plan not found" fallback uses an i18n key present in cs/en/de.
- [ ] AC3: Confirm-and-remove the unreferenced `navBar`/`backBtn`/`titleBar`/`emptyDay` styles.
- [ ] AC4: `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)