### PR TITLE
fix: auto-apply pending EF migrations on startup behind opt-in flag (#436)

### DIFF
--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -275,20 +275,31 @@ if (args.Contains("--backfill-photo-descriptions"))
     return;
 }
 
-// Auto-apply pending EF Core migrations in Development and the e2e harness.
-// The e2e compose harness also uses ASPNETCORE_ENVIRONMENT=Development, so
-// IsDevelopment() covers both surfaces. Production uses a non-Development
-// environment name and is therefore never touched by this path.
+// Auto-apply pending EF Core migrations — OPT-IN via Database:RunMigrationsOnStartup=true.
 //
-// NEVER remove or weaken the IsDevelopment() guard without explicit sign-off.
-// Auto-migration in production is a deliberate exclusion: schema changes that
-// affect live data must be applied intentionally with a reviewed migration plan.
-if (app.Environment.IsDevelopment())
+// This flag is intentionally OFF by default. It must be set explicitly in the
+// environment where auto-migration is desired:
+//
+//   • Local dev: set in Properties/launchSettings.json (gitignored; never committed)
+//         "Database__RunMigrationsOnStartup": "true"
+//   • e2e compose harness: set in docker-compose.test.yml api service env section
+//         Database__RunMigrationsOnStartup: "true"
+//
+// Render (and any other hosted environment) sets ASPNETCORE_ENVIRONMENT=Development
+// for TLS / certificate reasons — that alone does NOT enable auto-migration.
+// Because Render does not set Database__RunMigrationsOnStartup, the flag stays
+// false and migrations are NEVER auto-applied there.
+//
+// NEVER promote this flag to a default-true value without explicit sign-off.
+// Schema changes that affect live data must be applied intentionally with a
+// reviewed migration plan.
+var runMigrationsOnStartup = app.Configuration.GetValue<bool>("Database:RunMigrationsOnStartup");
+if (runMigrationsOnStartup)
 {
     using var migrationScope = app.Services.CreateScope();
     var migrationDb = migrationScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     await migrationDb.Database.MigrateAsync();
-    app.Logger.LogInformation("EF Core migrations applied (Development environment).");
+    app.Logger.LogInformation("EF Core migrations applied (Database:RunMigrationsOnStartup=true).");
 }
 
 // Middleware pipeline

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -275,6 +275,22 @@ if (args.Contains("--backfill-photo-descriptions"))
     return;
 }
 
+// Auto-apply pending EF Core migrations in Development and the e2e harness.
+// The e2e compose harness also uses ASPNETCORE_ENVIRONMENT=Development, so
+// IsDevelopment() covers both surfaces. Production uses a non-Development
+// environment name and is therefore never touched by this path.
+//
+// NEVER remove or weaken the IsDevelopment() guard without explicit sign-off.
+// Auto-migration in production is a deliberate exclusion: schema changes that
+// affect live data must be applied intentionally with a reviewed migration plan.
+if (app.Environment.IsDevelopment())
+{
+    using var migrationScope = app.Services.CreateScope();
+    var migrationDb = migrationScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await migrationDb.Database.MigrateAsync();
+    app.Logger.LogInformation("EF Core migrations applied (Development environment).");
+}
+
 // Middleware pipeline
 app.UseExceptionHandler();
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -157,6 +157,11 @@ services:
       Cors__AllowedOrigins__2: "http://web:5173"
       Cors__AllowedOrigins__3: "http://mobile-web:8081"
       RateLimiting__Disabled: "true"
+      # Apply pending EF migrations on API boot for the e2e harness (#436).
+      # Gated on this dedicated flag, NOT ASPNETCORE_ENVIRONMENT — Render runs
+      # as Development for TLS reasons and must NOT auto-migrate, so the guard
+      # keys on Database:RunMigrationsOnStartup which Render never sets.
+      Database__RunMigrationsOnStartup: "true"
       # Enables POST /test/reset for Playwright global-setup. The endpoint
       # remains double-gated: this flag is one half; the other is that
       # ASPNETCORE_ENVIRONMENT=Development (above). Both must be true for


### PR DESCRIPTION
## Summary
- Adds an opt-in startup hook in `Program.cs` that runs `Database.MigrateAsync()` only when `Database:RunMigrationsOnStartup=true` (default OFF).
- The guard keys on the dedicated flag, NOT `ASPNETCORE_ENVIRONMENT` — Render runs as Development for TLS reasons but never sets the flag, so production never auto-migrates.
- `docker-compose.test.yml` sets `Database__RunMigrationsOnStartup: "true"` so the e2e harness DB migrates on API boot, preventing recurring `42703 column does not exist` drift.
- No EF model or `Migrations/**` files are added or modified — the migration itself already exists; this is the prevention measure from the issue.

## Related issue
Fixes #436

## Scope
backend + infra (root `docker-compose.test.yml`)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — column created on fresh DB via migrate-on-boot; PUT settings returns 201 persisting `deadlineOffsetHours`.

## Test plan
- [ ] `deadline_offset_hours` column exists on `weekly_check_in_settings` after migrate-on-boot; saving check-in settings no longer 500s.
- [ ] e2e harness DB confirmed migrated on boot via the compose flag.
- [ ] Prevention measure in place (opt-in startup auto-migrate) without enabling it in production.
- [ ] No EF model/migration code changes required for the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)