### PR TITLE
feat: weekly check-in minute-precision time picker (web + backend)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Entities/WeeklyCheckInClientOverride.cs
+++ b/backend/FitnessPlatform.Application/Domain/Entities/WeeklyCheckInClientOverride.cs
@@ -36,7 +36,8 @@ public class WeeklyCheckInClientOverride
     public DayOfWeek? DayOfWeek { get; set; }
 
     /// <summary>
-    /// Override time of day (hour-aligned). Null = inherit from the professional's setting.
+    /// Override time of day. Null = inherit from the professional's setting.
+    /// Must be between 00:00:00 and 23:59:59 when set (enforced at API layer).
     /// </summary>
     public TimeSpan? TimeOfDay { get; set; }
 

--- a/backend/FitnessPlatform.Application/Domain/Entities/WeeklyCheckInSetting.cs
+++ b/backend/FitnessPlatform.Application/Domain/Entities/WeeklyCheckInSetting.cs
@@ -29,8 +29,8 @@ public class WeeklyCheckInSetting
     public DayOfWeek DayOfWeek { get; set; }
 
     /// <summary>
-    /// Hour-aligned local time of day when the reminder fires.
-    /// Minutes, Seconds, and Milliseconds must be zero (enforced at API layer).
+    /// Local time of day when the reminder fires.
+    /// Must be between 00:00:00 and 23:59:59 (enforced at API layer).
     /// </summary>
     public TimeSpan TimeOfDay { get; set; }
 

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetSettings/GetSettingsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/GetSettings/GetSettingsResponse.cs
@@ -23,7 +23,7 @@ public class CheckInSettingDto
     /// <summary>Day of the week (0 = Sunday, 1 = Monday, …, 6 = Saturday).</summary>
     public int DayOfWeek { get; set; }
 
-    /// <summary>Hour-aligned time of day in "HH:mm:ss" format.</summary>
+    /// <summary>Time of day for the reminder in "HH:mm:ss" format. Between 00:00:00 and 23:59:59.</summary>
     public TimeSpan TimeOfDay { get; set; }
 
     /// <summary>Whether the reminder is enabled.</summary>

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutOverride/PutOverrideRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutOverride/PutOverrideRequest.cs
@@ -15,7 +15,7 @@ public class PutOverrideRequest
     /// <summary>Override day of week (0 = Sunday … 6 = Saturday). Null = inherit.</summary>
     public int? DayOfWeek { get; set; }
 
-    /// <summary>Override time of day (hour-aligned). Null = inherit. Minutes/Seconds/Milliseconds must be zero if set.</summary>
+    /// <summary>Override time of day. Null = inherit. Must be between 00:00:00 and 23:59:59 if set.</summary>
     public TimeSpan? TimeOfDay { get; set; }
 
     /// <summary>Override enabled flag. Null = inherit.</summary>

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutOverride/PutOverrideValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutOverride/PutOverrideValidator.cs
@@ -28,10 +28,10 @@ public class PutOverrideValidator : Validator<PutOverrideRequest>
             .WithMessage("DayOfWeek must be between 0 (Sunday) and 6 (Saturday).");
 
         RuleFor(x => x.TimeOfDay)
-            .Must(t => t!.Value.Minutes == 0 && t.Value.Seconds == 0 && t.Value.Milliseconds == 0)
+            .Must(t => t!.Value >= TimeSpan.Zero && t.Value < TimeSpan.FromHours(24))
             .When(x => x.TimeOfDay.HasValue)
             .WithErrorCode(ErrorCodes.InvalidTimeOfDay)
-            .WithMessage("TimeOfDay must be hour-aligned (minutes, seconds, and milliseconds must be zero).");
+            .WithMessage("TimeOfDay must be between 00:00:00 and 23:59:59.");
 
         RuleFor(x => x.Addendum)
             .MaximumLength(200)

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutSettings/PutSettingsRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutSettings/PutSettingsRequest.cs
@@ -17,7 +17,7 @@ public class PutSettingsRequest
     public int DayOfWeek { get; set; }
 
     /// <summary>
-    /// Hour-aligned local time of day for the reminder. Minutes, Seconds, and Milliseconds must all be zero.
+    /// Local time of day for the reminder. Must be between 00:00:00 and 23:59:59.
     /// </summary>
     public TimeSpan TimeOfDay { get; set; }
 

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutSettings/PutSettingsResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutSettings/PutSettingsResponse.cs
@@ -14,7 +14,7 @@ public class PutSettingsResponse
     /// <summary>Day of the week (0 = Sunday … 6 = Saturday).</summary>
     public int DayOfWeek { get; set; }
 
-    /// <summary>Hour-aligned time of day.</summary>
+    /// <summary>Time of day for the reminder. Between 00:00:00 and 23:59:59.</summary>
     public TimeSpan TimeOfDay { get; set; }
 
     /// <summary>Whether the reminder is enabled.</summary>

--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutSettings/PutSettingsValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/PutSettings/PutSettingsValidator.cs
@@ -24,9 +24,9 @@ public class PutSettingsValidator : Validator<PutSettingsRequest>
             .WithMessage("DayOfWeek must be between 0 (Sunday) and 6 (Saturday).");
 
         RuleFor(x => x.TimeOfDay)
-            .Must(t => t.Minutes == 0 && t.Seconds == 0 && t.Milliseconds == 0)
+            .Must(t => t >= TimeSpan.Zero && t < TimeSpan.FromHours(24))
             .WithErrorCode(ErrorCodes.InvalidTimeOfDay)
-            .WithMessage("TimeOfDay must be hour-aligned (minutes, seconds, and milliseconds must be zero).");
+            .WithMessage("TimeOfDay must be between 00:00:00 and 23:59:59.");
 
         RuleFor(x => x.DefaultAddendum)
             .MaximumLength(200)

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/WeeklyCheckInScheduler.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/WeeklyCheckInScheduler.cs
@@ -5,6 +5,7 @@ using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -15,7 +16,7 @@ using Npgsql;
 namespace FitnessPlatform.Application.Infrastructure.Services;
 
 /// <summary>
-/// Background service that fires weekly check-in reminders on an hourly tick.
+/// Background service that fires weekly check-in reminders on a configurable tick interval.
 /// For each enabled <see cref="WeeklyCheckInSetting"/> (with optional per-client overrides),
 /// it checks whether the configured fire time fell within the last tick window and, if so,
 /// inserts a <see cref="WeeklyCheckIn"/> row, creates a push notification, and broadcasts
@@ -25,15 +26,29 @@ namespace FitnessPlatform.Application.Infrastructure.Services;
 /// </summary>
 public class WeeklyCheckInScheduler(
     IServiceScopeFactory scopeFactory,
-    ILogger<WeeklyCheckInScheduler> logger) : BackgroundService
+    ILogger<WeeklyCheckInScheduler> logger,
+    IConfiguration configuration) : BackgroundService
 {
     /// <summary>
     /// Default deadline offset in hours. Applied when neither a per-client override nor
     /// the professional's <see cref="WeeklyCheckInSetting.DeadlineOffsetHours"/> is set.
     /// </summary>
     internal const int DefaultDeadlineOffsetHours = 72;
+
+    /// <summary>
+    /// Default tick interval in minutes. Override via <c>CheckInTickIntervalMinutes</c>
+    /// in configuration (primarily for tests that need deterministic ticks).
+    /// </summary>
+    internal const int DefaultTickIntervalMinutes = 5;
+
     // Exposed for unit/integration tests — drive the scheduler with a virtual clock.
     internal DateTime? OverrideNow { get; set; }
+
+    // Tick interval resolved from configuration. Tests can inject a short interval
+    // (e.g. 1 minute) via IConfiguration to drive ticks deterministically.
+    private TimeSpan TickInterval =>
+        TimeSpan.FromMinutes(
+            configuration.GetValue("CheckInTickIntervalMinutes", DefaultTickIntervalMinutes));
 
     private DateTime _lastTickAt;
     private bool _cursorInitialized;
@@ -81,20 +96,33 @@ public class WeeklyCheckInScheduler(
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Align first tick to the next :00 boundary.
+        var interval = TickInterval;
+
+        // Align first tick to the next interval boundary.
+        // E.g. for a 5-minute interval: tick at :00, :05, :10, … :55 of each hour.
+        // Minimum delay is one full interval to ensure the host and DB are ready.
         var now = UtcNow();
-        var delay = TimeSpan.FromMinutes(60 - now.Minute)
+        var totalMinutes = now.Hour * 60 + now.Minute;
+        var intervalMinutes = (int)interval.TotalMinutes;
+        var minutesToNextBoundary = intervalMinutes == 0
+            ? 0
+            : intervalMinutes - (totalMinutes % intervalMinutes);
+        // If we're already on a boundary, advance one interval so the first tick is not immediate.
+        if (minutesToNextBoundary == 0 || minutesToNextBoundary == intervalMinutes)
+            minutesToNextBoundary = intervalMinutes;
+
+        var delay = TimeSpan.FromMinutes(minutesToNextBoundary)
                             .Subtract(TimeSpan.FromSeconds(now.Second))
                             .Subtract(TimeSpan.FromMilliseconds(now.Millisecond));
 
         if (delay.TotalMilliseconds > 0)
         {
             logger.LogInformation(
-                "WeeklyCheckInScheduler: first tick in {Delay:mm\\:ss} (aligning to :00).", delay);
+                "WeeklyCheckInScheduler: first tick in {Delay:mm\\:ss} (aligning to interval boundary).", delay);
             await Task.Delay(delay, stoppingToken);
         }
 
-        // Seed cursor from DB so a cold start doesn't re-fire the last hour.
+        // Seed cursor from DB so a cold start doesn't re-fire the last interval window.
         using (var scope = scopeFactory.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
@@ -103,7 +131,7 @@ public class WeeklyCheckInScheduler(
 
         _cursorInitialized = true;
 
-        using var timer = new PeriodicTimer(TimeSpan.FromHours(1));
+        using var timer = new PeriodicTimer(interval);
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -139,20 +167,20 @@ public class WeeklyCheckInScheduler(
     private async Task<DateTime> SeedCursorAsync(
         IApplicationDbContext db, DateTime now, CancellationToken ct)
     {
-        // Seed the cursor so that settings whose fire time fell in the last hour
+        // Seed the cursor so that settings whose fire time fell in the last tick window
         // before startup are not re-fired (they already ran, and we would duplicate).
-        // We back off by 1 minute to ensure a setting whose fire time was at :00
-        // is not skipped on the very first tick after startup.
+        // We back off by 1 minute to ensure a setting whose fire time is very close to
+        // the boundary is not skipped on the very first tick after startup.
         var maxSentAt = await db.WeeklyCheckIns
             .AsNoTracking()
             .MaxAsync(c => (DateTime?)c.SentAt, ct);
 
-        var oneHourAgo = now.AddHours(-1);
+        var oneIntervalAgo = now - TickInterval;
 
         if (maxSentAt.HasValue)
         {
             var seedFrom = maxSentAt.Value.AddMinutes(-1);
-            var cursor = seedFrom < oneHourAgo ? oneHourAgo : seedFrom;
+            var cursor = seedFrom < oneIntervalAgo ? oneIntervalAgo : seedFrom;
             logger.LogInformation(
                 "WeeklyCheckInScheduler: seeding cursor to {Cursor:u} (maxSentAt={MaxSentAt:u}).",
                 cursor, maxSentAt.Value);
@@ -160,8 +188,8 @@ public class WeeklyCheckInScheduler(
         }
 
         logger.LogInformation(
-            "WeeklyCheckInScheduler: no previous check-ins; seeding cursor to {Cursor:u}.", oneHourAgo);
-        return oneHourAgo;
+            "WeeklyCheckInScheduler: no previous check-ins; seeding cursor to {Cursor:u}.", oneIntervalAgo);
+        return oneIntervalAgo;
     }
 
     private async Task ProcessTickAsync(

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutOverrideEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutOverrideEndpointTests.cs
@@ -145,8 +145,9 @@ public class PutOverrideEndpointTests(FitnessApiFactory factory)
     // ── Validation ───────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task PutOverride_TimeNotHourAligned_Returns400WithInvalidTimeOfDay()
+    public async Task PutOverride_MinutePrecisionTime_Returns2xx()
     {
+        // AC: non-hour times (e.g. 18:45) must now be accepted in overrides too
         var (http, _, trainerProfileId) = await SetupTrainerAsync();
         var (clientUserId, clientProfileId) = await SetupClientAsync();
         await LinkTrainerToClientAsync(trainerProfileId, clientProfileId);
@@ -154,6 +155,23 @@ public class PutOverrideEndpointTests(FitnessApiFactory factory)
         var response = await http.PutAsJsonAsync(
             $"/trainer/weekly-check-ins/overrides/{clientUserId}/Training",
             new { DayOfWeek = (int?)1, TimeOfDay = "18:45:00", Enabled = (bool?)true, Addendum = (string?)null },
+            TestContext.Current.CancellationToken);
+
+        ((int)response.StatusCode).Should().BeInRange(200, 299,
+            "minute-precision times must now be accepted in overrides");
+    }
+
+    [Fact]
+    public async Task PutOverride_TimeOf1Day_Returns400()
+    {
+        // AC: a TimeSpan ≥ 24h (using "1.00:00:00" = 1 day = 24h) must still be rejected
+        var (http, _, trainerProfileId) = await SetupTrainerAsync();
+        var (clientUserId, clientProfileId) = await SetupClientAsync();
+        await LinkTrainerToClientAsync(trainerProfileId, clientProfileId);
+
+        var response = await http.PutAsJsonAsync(
+            $"/trainer/weekly-check-ins/overrides/{clientUserId}/Training",
+            new { DayOfWeek = (int?)1, TimeOfDay = "1.00:00:00", Enabled = (bool?)true, Addendum = (string?)null },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutOverrideValidatorTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutOverrideValidatorTests.cs
@@ -93,13 +93,13 @@ public class PutOverrideValidatorTests
     }
 
     [Fact]
-    public void TimeOfDay_WithMinutes_Fails_WithInvalidTimeOfDayCode()
+    public void TimeOfDay_WithMinutes_Passes()
     {
+        // AC: minute-precision times must be accepted (e.g. 14:15)
         var req = ValidRequest();
         req.TimeOfDay = new TimeSpan(0, 14, 15, 0); // 14:15:00
         var result = _validator.TestValidate(req);
-        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
-              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
+        result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
     }
 
     [Fact]
@@ -112,12 +112,42 @@ public class PutOverrideValidatorTests
     }
 
     [Fact]
+    public void TimeOfDay_NonHour_18h45_Passes()
+    {
+        var req = ValidRequest();
+        req.TimeOfDay = new TimeSpan(0, 18, 45, 0); // 18:45:00
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
+    }
+
+    [Fact]
     public void TimeOfDay_Null_PassesValidation()
     {
         var req = ValidRequest();
         req.TimeOfDay = null;
         var result = _validator.TestValidate(req);
         result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
+    }
+
+    [Fact]
+    public void TimeOfDay_ExactlyTwentyFourHours_Fails_WithInvalidTimeOfDayCode()
+    {
+        // AC: >= 24:00 must be rejected even in override
+        var req = ValidRequest();
+        req.TimeOfDay = TimeSpan.FromHours(24);
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
+              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
+    }
+
+    [Fact]
+    public void TimeOfDay_Negative_Fails_WithInvalidTimeOfDayCode()
+    {
+        var req = ValidRequest();
+        req.TimeOfDay = TimeSpan.FromHours(-1);
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
+              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
     }
 
     [Fact]

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutSettingsEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutSettingsEndpointTests.cs
@@ -50,8 +50,9 @@ public class PutSettingsEndpointTests(FitnessApiFactory factory)
     // ── Validation ───────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task PutSettings_TimeNotHourAligned_Returns400WithInvalidTimeOfDay()
+    public async Task PutSettings_MinutePrecisionTime_Returns2xx()
     {
+        // AC: non-hour times (e.g. 18:30) must now be accepted — endpoint returns 200 or 201
         var client = factory.CreateClient();
         var email = UniqueEmail();
 
@@ -62,6 +63,28 @@ public class PutSettingsEndpointTests(FitnessApiFactory factory)
         var response = await client.PutAsJsonAsync(
             "/trainer/weekly-check-ins/settings",
             new { Profession = "Training", DayOfWeek = 1, TimeOfDay = "18:30:00", Enabled = true },
+            TestContext.Current.CancellationToken);
+
+        ((int)response.StatusCode).Should().BeInRange(200, 299,
+            "minute-precision times must now be accepted");
+    }
+
+    [Fact]
+    public async Task PutSettings_TimeOf1Day_Returns400()
+    {
+        // AC: a TimeSpan value ≥ 24h (e.g. 1.00:00:00 = 1 day) must be rejected.
+        // "24:00:00" is not a valid .NET TimeSpan string, so we use the day-format "1.00:00:00"
+        // which .NET parses to TimeSpan.FromDays(1) = 24 h, triggering the upper-bound rule.
+        var client = factory.CreateClient();
+        var email = UniqueEmail();
+
+        await TestHelpers.RegisterAsync(client, email, "TestPass1!", "Trainer", "Val2", "Trainer");
+        var (accessToken, _) = await TestHelpers.LoginAsync(client, email, "TestPass1!");
+        TestHelpers.SetBearerToken(client, accessToken);
+
+        var response = await client.PutAsJsonAsync(
+            "/trainer/weekly-check-ins/settings",
+            new { Profession = "Training", DayOfWeek = 1, TimeOfDay = "1.00:00:00", Enabled = true },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutSettingsValidatorTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/PutSettingsValidatorTests.cs
@@ -87,23 +87,23 @@ public class PutSettingsValidatorTests
     }
 
     [Fact]
-    public void TimeOfDay_WithMinutes_Fails_WithInvalidTimeOfDayCode()
+    public void TimeOfDay_WithMinutes_Passes()
     {
+        // AC: minute-precision times must be accepted (e.g. 18:30)
         var req = ValidRequest();
         req.TimeOfDay = new TimeSpan(0, 18, 30, 0); // 18:30:00
         var result = _validator.TestValidate(req);
-        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
-              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
+        result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
     }
 
     [Fact]
-    public void TimeOfDay_WithSeconds_Fails_WithInvalidTimeOfDayCode()
+    public void TimeOfDay_WithSeconds_Passes()
     {
+        // AC: sub-minute precision must also be accepted (e.g. 18:00:45)
         var req = ValidRequest();
         req.TimeOfDay = new TimeSpan(0, 18, 0, 45); // 18:00:45
         var result = _validator.TestValidate(req);
-        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
-              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
+        result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
     }
 
     [Fact]
@@ -113,6 +113,49 @@ public class PutSettingsValidatorTests
         req.TimeOfDay = TimeSpan.FromHours(9);
         var result = _validator.TestValidate(req);
         result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
+    }
+
+    [Theory]
+    [InlineData(0, 9, 15, 0)]    // 09:15:00
+    [InlineData(0, 23, 59, 59)]  // 23:59:59 — boundary accepted
+    [InlineData(0, 0, 0, 0)]     // 00:00:00 — midnight accepted
+    public void TimeOfDay_ValidMinutePrecision_Passes(int days, int hours, int minutes, int seconds)
+    {
+        var req = ValidRequest();
+        req.TimeOfDay = new TimeSpan(days, hours, minutes, seconds);
+        var result = _validator.TestValidate(req);
+        result.ShouldNotHaveValidationErrorFor(x => x.TimeOfDay);
+    }
+
+    [Fact]
+    public void TimeOfDay_ExactlyTwentyFourHours_Fails_WithInvalidTimeOfDayCode()
+    {
+        // AC: >= 24:00 must be rejected
+        var req = ValidRequest();
+        req.TimeOfDay = TimeSpan.FromHours(24);
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
+              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
+    }
+
+    [Fact]
+    public void TimeOfDay_GreaterThanTwentyFourHours_Fails_WithInvalidTimeOfDayCode()
+    {
+        var req = ValidRequest();
+        req.TimeOfDay = TimeSpan.FromHours(25);
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
+              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
+    }
+
+    [Fact]
+    public void TimeOfDay_Negative_Fails_WithInvalidTimeOfDayCode()
+    {
+        var req = ValidRequest();
+        req.TimeOfDay = TimeSpan.FromHours(-1);
+        var result = _validator.TestValidate(req);
+        result.ShouldHaveValidationErrorFor(x => x.TimeOfDay)
+              .WithErrorCode(ErrorCodes.InvalidTimeOfDay);
     }
 
     [Fact]

--- a/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/WeeklyCheckInSchedulerTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WeeklyCheckIns/WeeklyCheckInSchedulerTests.cs
@@ -239,6 +239,129 @@ public class WeeklyCheckInSchedulerTests(FitnessApiFactory factory)
             "scheduler must broadcast exactly one newnotification to the client");
     }
 
+    // ── Sub-hour precision tests ──────────────────────────────────────────────
+
+    /// <summary>
+    /// AC: a setting configured at a non-hour time (18:30) fires when the scheduler
+    /// ticks past that minute boundary.
+    /// </summary>
+    [Fact]
+    public async Task Tick_NonHourFireTime_18h30_CreatesCheckIn()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Wednesday,
+            new TimeSpan(18, 30, 0), // 18:30:00 UTC
+            "UTC");
+
+        var utcNow = DateTime.UtcNow;
+        var daysToLastWed = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Wednesday + 7) % 7;
+        var lastWed1830 = utcNow.Date.AddDays(-daysToLastWed)
+                                     .AddHours(18).AddMinutes(30);
+        if (lastWed1830 >= utcNow) lastWed1830 = lastWed1830.AddDays(-7);
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        // Position cursor just before the fire time so 18:30 is in the upcoming window.
+        scheduler.SetLastTickAt(lastWed1830.AddMinutes(-10));
+
+        // Tick just after 18:30 — scheduler must fire.
+        scheduler.OverrideNow = lastWed1830.AddMinutes(3);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var checkIns = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientUserId && c.ProfessionalUserId == trainerUserId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        checkIns.Should().HaveCount(1,
+            "a non-hour fire time (18:30) must trigger exactly one check-in when the window crosses it");
+    }
+
+    /// <summary>
+    /// AC: a setting configured at 09:15 fires correctly.
+    /// </summary>
+    [Fact]
+    public async Task Tick_NonHourFireTime_09h15_CreatesCheckIn()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Thursday,
+            new TimeSpan(9, 15, 0), // 09:15:00 UTC
+            "UTC");
+
+        var utcNow = DateTime.UtcNow;
+        var daysToLastThu = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Thursday + 7) % 7;
+        var lastThu0915 = utcNow.Date.AddDays(-daysToLastThu)
+                                      .AddHours(9).AddMinutes(15);
+        if (lastThu0915 >= utcNow) lastThu0915 = lastThu0915.AddDays(-7);
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        scheduler.SetLastTickAt(lastThu0915.AddMinutes(-10));
+        scheduler.OverrideNow = lastThu0915.AddMinutes(5);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var checkIns = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientUserId && c.ProfessionalUserId == trainerUserId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        checkIns.Should().HaveCount(1,
+            "a non-hour fire time (09:15) must trigger exactly one check-in when the window crosses it");
+    }
+
+    /// <summary>
+    /// AC: multiple sub-hour ticks within the same fire window do NOT produce duplicate check-ins.
+    /// The unique-key dedup (23505 catch) must hold even when ticking every few minutes.
+    /// </summary>
+    [Fact]
+    public async Task Tick_MultipleSubHourTicksAcrossSameFireMinute_DoesNotDuplicate()
+    {
+        var (trainerUserId, clientUserId) = await SetupTrainerAndClientWithSettingAsync(
+            DayOfWeek.Monday,
+            new TimeSpan(14, 30, 0), // 14:30:00 UTC
+            "UTC");
+
+        var utcNow = DateTime.UtcNow;
+        var daysToLastMon = ((int)utcNow.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+        var lastMon1430 = utcNow.Date.AddDays(-daysToLastMon)
+                                      .AddHours(14).AddMinutes(30);
+        if (lastMon1430 >= utcNow) lastMon1430 = lastMon1430.AddDays(-7);
+
+        var scheduler = factory.Services.GetRequiredService<WeeklyCheckInScheduler>();
+
+        // Tick before fire time — nothing should fire.
+        scheduler.SetLastTickAt(lastMon1430.AddMinutes(-10));
+        scheduler.OverrideNow = lastMon1430.AddMinutes(-5);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // First tick past 14:30 — fires once.
+        scheduler.OverrideNow = lastMon1430.AddMinutes(1);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Second tick — still within same week's window; unique key prevents duplicate.
+        scheduler.OverrideNow = lastMon1430.AddMinutes(6);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        // Third tick — still same week.
+        scheduler.OverrideNow = lastMon1430.AddMinutes(11);
+        await scheduler.TickAsync(scheduler.OverrideNow.Value, TestContext.Current.CancellationToken);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var checkIns = await db.WeeklyCheckIns
+            .Where(c => c.ClientUserId == clientUserId && c.ProfessionalUserId == trainerUserId)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        checkIns.Should().HaveCount(1,
+            "multiple sub-hour ticks across the same fire minute must produce exactly one check-in " +
+            "— the half-open window + unique-key dedup together prevent duplication");
+    }
+
     /// <summary>
     /// Regression test for the EF Core change-tracker cascade (issue #280).
     ///

--- a/web/src/api/weekly-checkins.ts
+++ b/web/src/api/weekly-checkins.ts
@@ -14,10 +14,9 @@ export type DayOfWeekInt = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 /**
  * C# TimeSpan serializes to "HH:mm:ss" by System.Text.Json.
- * The backend enforces hour-aligned times (minutes/seconds = 0), so values will
- * always be of the form "HH:00:00".
+ * Values follow the form "HH:mm:ss" (minute precision; seconds are always 0).
  */
-export type TimeSpanString = string; // e.g. "18:00:00"
+export type TimeSpanString = string; // e.g. "18:30:00"
 
 /* ─────────────────────── WeeklyCheckInStatus ────────────────────────────────────── */
 
@@ -47,7 +46,7 @@ export interface CheckInSettingDto {
   profession: Profession;
   /** 0 = Sunday, 1 = Monday, …, 6 = Saturday */
   dayOfWeek: DayOfWeekInt;
-  /** "HH:mm:ss", always hour-aligned */
+  /** "HH:mm:ss" — minute precision; seconds always 0 */
   timeOfDay: TimeSpanString;
   enabled: boolean;
   defaultAddendum: string | null;
@@ -77,7 +76,7 @@ export interface PutSettingsRequest {
   profession: Profession;
   /** 0 = Sunday … 6 = Saturday */
   dayOfWeek: DayOfWeekInt;
-  /** "HH:mm:ss" — must be hour-aligned */
+  /** "HH:mm:ss" — minute precision; seconds always 0 */
   timeOfDay: TimeSpanString;
   enabled: boolean;
   defaultAddendum: string | null;
@@ -154,7 +153,7 @@ export async function getCheckInOverrides(): Promise<GetOverridesResponse> {
 export interface PutOverrideRequest {
   /** Null = inherit */
   dayOfWeek: DayOfWeekInt | null;
-  /** "HH:mm:ss" — must be hour-aligned. Null = inherit. */
+  /** "HH:mm:ss" — minute precision; seconds always 0. Null = inherit. */
   timeOfDay: TimeSpanString | null;
   /** Null = inherit */
   enabled: boolean | null;

--- a/web/src/components/profile/OverrideDialog.tsx
+++ b/web/src/components/profile/OverrideDialog.tsx
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Button, Toggle, Select, Dialog } from '@/components/ui';
+import { TimePicker } from '@/components/ui/TimePicker';
 import { useToastStore } from '@/stores/toast';
 import { getApiErrorMessage } from '@/lib/api-errors';
 import {
@@ -24,12 +25,6 @@ import type {
 
 /* ─────────────────────── Constants ─────────────────────── */
 
-/** Hour options from 06:00 to 22:00, rendered as "HH:mm". */
-const HOUR_OPTIONS: string[] = Array.from({ length: 17 }, (_, i) => {
-  const h = i + 6;
-  return `${String(h).padStart(2, '0')}:00`;
-});
-
 const DEFAULT_DAY: DayOfWeekInt = 1;
 const DEFAULT_HOUR = '09:00';
 
@@ -48,7 +43,8 @@ const overrideSchema = z.object({
   useDefaultDay: z.boolean(),
   dayOfWeek: dayOfWeekSchema.nullable(),
   useDefaultTime: z.boolean(),
-  timeOfDay: z.string().nullable(),
+  /** "HH:mm" when set — converted to "HH:mm:ss" before sending. Null = inherit. */
+  timeOfDay: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Invalid time').nullable(),
   useDefaultEnabled: z.boolean(),
   enabled: z.boolean().nullable(),
   useDefaultAddendum: z.boolean(),
@@ -316,16 +312,10 @@ export function OverrideDialog({ override, settings, onClose }: OverrideDialogPr
               name="timeOfDay"
               control={control}
               render={({ field }) => (
-                <Select
+                <TimePicker
                   value={field.value ?? ''}
                   onChange={(e) => field.onChange(e.target.value)}
-                >
-                  {HOUR_OPTIONS.map((h) => (
-                    <option key={h} value={h}>
-                      {h}
-                    </option>
-                  ))}
-                </Select>
+                />
               )}
             />
           )}

--- a/web/src/components/profile/WeeklyCheckInTab.tsx
+++ b/web/src/components/profile/WeeklyCheckInTab.tsx
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { CSSProperties } from 'react';
 import { Select } from '@/components/ui';
+import { TimePicker } from '@/components/ui/TimePicker';
 import { useToastStore } from '@/stores/toast';
 import {
   getCheckInSettings,
@@ -44,12 +45,6 @@ const innerRowStyle: CSSProperties = {
 
 /* ─────────────────────── Other Constants ─────────────────────── */
 
-/** Hour options from 06:00 to 22:00, rendered as "HH:mm". Wire value is "HH:mm:ss". */
-const HOUR_OPTIONS: string[] = Array.from({ length: 17 }, (_, i) => {
-  const h = i + 6;
-  return `${String(h).padStart(2, '0')}:00`;
-});
-
 /** Default hour:minute string used when no setting exists yet. */
 const DEFAULT_HOUR = '09:00';
 
@@ -72,7 +67,7 @@ const settingSchema = z.object({
   /** DayOfWeek as int (0=Sunday…6=Saturday) */
   dayOfWeek: dayOfWeekSchema,
   /** "HH:mm" — converted to "HH:mm:ss" before sending */
-  timeOfDay: z.string().regex(/^\d{2}:00$/, 'Invalid time'),
+  timeOfDay: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Invalid time'),
   defaultAddendum: z.string().max(200, 'Max 200 characters').nullable(),
   /** Hours until check-in expires; must be one of DEADLINE_OFFSET_OPTIONS. */
   deadlineOffsetHours: deadlineOffsetSchema,
@@ -271,13 +266,10 @@ const ProfessionBlock = forwardRef<ProfessionBlockHandle, ProfessionBlockProps>(
                 name="timeOfDay"
                 control={control}
                 render={({ field }) => (
-                  <Select value={field.value} onChange={(e) => field.onChange(e.target.value)}>
-                    {HOUR_OPTIONS.map((h) => (
-                      <option key={h} value={h}>
-                        {h}
-                      </option>
-                    ))}
-                  </Select>
+                  <TimePicker
+                    value={field.value}
+                    onChange={(e) => field.onChange(e.target.value)}
+                  />
                 )}
               />
               {errors.timeOfDay && (

--- a/web/src/components/ui/TimePicker.tsx
+++ b/web/src/components/ui/TimePicker.tsx
@@ -1,0 +1,37 @@
+/**
+ * TimePicker — thin wrapper around <input type="time"> following the
+ * auth-input / form-input styling convention used in PlanDialogs.tsx.
+ *
+ * Renders a native browser time picker that accepts any HH:mm value
+ * (minute-level precision). The caller is responsible for converting
+ * the "HH:mm" value to the "HH:mm:ss" wire format via toTimeSpanString().
+ */
+import { forwardRef } from 'react';
+
+export interface TimePickerProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Current value in "HH:mm" format */
+  value?: string;
+  /** Called with the new "HH:mm" value when the user changes the time */
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+export const TimePicker = forwardRef<HTMLInputElement, TimePickerProps>(
+  function TimePicker({ className, style, ...rest }, ref) {
+    return (
+      <input
+        ref={ref}
+        type="time"
+        className={className ?? 'auth-input'}
+        style={{
+          fontSize: 13,
+          padding: '7px 10px',
+          cursor: 'pointer',
+          width: '100%',
+          ...style,
+        }}
+        {...rest}
+      />
+    );
+  },
+);


### PR DESCRIPTION
## Summary
- Backend: `PutSettings` / `PutOverride` validators now accept any `HH:mm:ss` in `[00:00:00, 24:00:00)` — dropped the hour-alignment (`minutes == 0`) constraint while keeping the `< 24:00` sanity bound and `ErrorCodes.InvalidTimeOfDay`.
- Backend: weekly check-in scheduler tick is now configurable (default 5 min, aligned to the interval boundary instead of `:00`); `ComputeNextFireAt` already supported minute precision, and weekly dedup `(ClientUserId, ProfessionalUserId, Profession, WeekStartDate)` is unaffected by the finer cadence.
- Backend: dropped "hour-aligned" wording from request/response DTO + entity comments. No DB migration (the `time_of_day` `interval` column already stores minutes).
- Web: new reusable `ui/TimePicker.tsx` (native `<input type="time">`) replaces the hour-only `<Select>` in `WeeklyCheckInTab` and `OverrideDialog`; Zod relaxed from `/^\d{2}:00$/` to a full `HH:mm` validator. Wire contract unchanged (`toTimeSpanString` still appends `:00`).

## Related issue
Fixes #437

## Scope
cross-cut (backend + web — one branch, one PR per `rules/scope-boundaries.md#cross-package-coordination`)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — 8/8 acceptance criteria; includes orchestrator web form-drive saving 09:30 / 14:45 end-to-end. WeeklyCheckIns backend slice 141/141.

## Test plan
- [ ] Web check-in settings editor and per-client override dialog expose a minute-capable time picker (not whole-hours only).
- [ ] Saving a non-hour time (e.g. 09:30) succeeds end-to-end (Zod accepts, API accepts, persists).
- [ ] Scheduler fires at the configured non-hour time within the tick interval and does not double-send (weekly dedup intact at finer cadence).
- [ ] Backend tests updated: validators accept minute-precision times; scheduler tests cover a non-hour fire time + dedup across sub-hour ticks. Web build passes.
- [ ] Hour-aligned wording removed from request DTO/entity comments; a sane upper-bound (`< 24:00`) validation remains.
- [ ] No DB migration introduced; no `generated.ts` hand-edits.
- [ ] No `any` / hardcoded colors added on web; any new strings land in cs/en/de locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)