### PR TITLE
feat(#434): nutrition Today header Detail button

### DIFF
--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1332,8 +1332,19 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
                         )
                       }}
                       hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('today.sectionActionDetail')}
+                      style={styles.photoCtaBtn}
                     >
-                      <Text style={[styles.trainingDetailAction, { color: colors.gold }]}>
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="chevron-forward" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
                         {t('today.sectionActionDetail')}
                       </Text>
                     </Pressable>
@@ -1460,9 +1471,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
-  },
-  trainingDetailAction: {
-    ...Type.subheadline,
   },
   mealsProgress: {
     ...Type.footnote,

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1386,25 +1386,57 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
             <SectionHeader
               title={t('today.todaysNutrition')}
               action={
-                <Pressable
-                  onPress={handlePhotoGridPress}
-                  hitSlop={8}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('nutrition.photoCta')}
-                  style={styles.photoCtaBtn}
-                >
-                  <View
-                    style={[
-                      styles.photoCtaIconChip,
-                      { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
-                    ]}
-                  >
-                    <Ionicons name="camera" size={13} color={colors.onGoldChip} />
-                  </View>
-                  <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
-                    {t('nutrition.photoCta')}
-                  </Text>
-                </Pressable>
+                <View style={styles.nutritionHeaderActions}>
+                  {plan?.planId ? (
+                    <Pressable
+                      onPress={handlePhotoGridPress}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('nutrition.photoCta')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="camera" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('nutrition.photoCta')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  {plan?.planId ? (
+                    <Pressable
+                      onPress={() => {
+                        router.push(
+                          hrefParams('/(client)/(tabs)/plans/[planId]', {
+                            planId: plan.planId!,
+                            type: 'nutrition',
+                          }),
+                        )
+                      }}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('today.sectionActionDetail')}
+                      style={styles.photoCtaBtn}
+                    >
+                      <View
+                        style={[
+                          styles.photoCtaIconChip,
+                          { backgroundColor: goldAlpha['12'], borderColor: goldAlpha['35'] },
+                        ]}
+                      >
+                        <Ionicons name="chevron-forward" size={13} color={colors.onGoldChip} />
+                      </View>
+                      <Text style={[styles.photoCtaLabel, { color: colors.gold }]}>
+                        {t('today.sectionActionDetail')}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                </View>
               }
             />
             <NutritionCard


### PR DESCRIPTION
Adds a "Detail" button to the Today nutrition ("Dnešní jídelníček") header, beside the existing "Foto" button, opening the nutrition plan detail. Reuses #433's shared gold icon-chip treatment.

QA: PASS (interactive iOS — Foto+Detail gold buttons confirmed). Two-pass review clean (was PR #444, reopened as new PR after develop reconcile — squash-merging the parent #433 required merging develop back into this branch; force-push is disallowed so the original PR could not be retargeted).

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)