### PR TITLE
feat: snapshot planned set values onto WorkoutSet + expose actual vs planned in training read endpoints

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Documents/WorkoutSet.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/WorkoutSet.cs
@@ -4,6 +4,8 @@ namespace FitnessPlatform.Application.Domain.Documents;
 
 /// <summary>
 /// A single set actually performed during a workout with recorded values.
+/// Snapshot-planned fields capture the prescribed values at the time the set was first logged;
+/// they are immutable after initial persistence so later plan edits do not affect them.
 /// </summary>
 public class WorkoutSet
 {
@@ -60,4 +62,56 @@ public class WorkoutSet
     /// </summary>
     [BsonElement("isPR")]
     public bool IsPR { get; set; }
+
+    // ── Snapshot-planned fields ─────────────────────────────────────────────────
+    // Frozen at log time from the plan prescription. Null on legacy documents
+    // (pre-snapshot) — treated as planned == actual / isModified == false.
+
+    /// <summary>
+    /// Prescribed repetitions at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedReps")]
+    [BsonIgnoreIfNull]
+    public int? PlannedReps { get; set; }
+
+    /// <summary>
+    /// Prescribed weight (kg) at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedWeightKg")]
+    [BsonIgnoreIfNull]
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>
+    /// Prescribed RPE at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedRpe")]
+    [BsonIgnoreIfNull]
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>
+    /// Prescribed duration (seconds) at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedDurationSeconds")]
+    [BsonIgnoreIfNull]
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>
+    /// Prescribed distance (meters) at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedDistanceMeters")]
+    [BsonIgnoreIfNull]
+    public decimal? PlannedDistanceMeters { get; set; }
+
+    /// <summary>
+    /// Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+    /// Always false for legacy sets whose planned fields are all null (backward-compatible default).
+    /// Never stored — derived on read.
+    /// </summary>
+    [BsonIgnore]
+    public bool IsModified =>
+        PlannedReps.HasValue && Reps != PlannedReps ||
+        PlannedWeightKg.HasValue && WeightKg != PlannedWeightKg ||
+        PlannedRpe.HasValue && Rpe != PlannedRpe ||
+        PlannedDurationSeconds.HasValue && DurationSeconds != PlannedDurationSeconds ||
+        PlannedDistanceMeters.HasValue && DistanceMeters != PlannedDistanceMeters;
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
@@ -132,6 +132,38 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
         // per set so accidental duplicate logs don't wipe completion state.
         var completedSets = new Dictionary<(Guid sessionId, Guid exerciseId, int setNumber), DateTime>();
 
+        // Extended lookup: (sessionId, exerciseId, setNumber) → WorkoutSet for actual+planned values.
+        // We prefer the most-recently-updated log per session (mirrors the dedup logic used elsewhere).
+        // If two logs for the same session have the set, the one from the "best" log wins.
+        var loggedSets = new Dictionary<(Guid sessionId, Guid exerciseId, int setNumber), WorkoutSet>();
+
+        // Deduplicate logs per sessionId: prefer most-recently-updated FINALISED, else most-recent.
+        var bestLogBySession = workoutLogs
+            .Where(l => l.SessionId.HasValue)
+            .GroupBy(l => l.SessionId!.Value)
+            .Select(g =>
+            {
+                var finalised = g
+                    .Where(l => l.IsCompleted)
+                    .OrderByDescending(l => l.DateUpdated ?? l.DateCreated)
+                    .FirstOrDefault();
+                return finalised ?? g.OrderByDescending(l => l.DateUpdated ?? l.DateCreated).First();
+            })
+            .ToList();
+
+        foreach (var log in bestLogBySession)
+        {
+            var sessionId = log.SessionId!.Value;
+            foreach (var ex in log.Exercises)
+            {
+                foreach (var set in ex.Sets)
+                {
+                    var key = (sessionId, ex.ExerciseExternalId, set.SetNumber);
+                    loggedSets[key] = set;
+                }
+            }
+        }
+
         foreach (var log in workoutLogs)
         {
             if (log.SessionId is null) continue;
@@ -293,6 +325,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                         {
                             var key = (session.SessionId, ex.ExerciseExternalId, set.SetNumber);
                             completedSets.TryGetValue(key, out var completedAt);
+                            loggedSets.TryGetValue(key, out var loggedSet);
 
                             return new SetDto
                             {
@@ -303,12 +336,26 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                                 DurationSeconds = set.DurationSeconds,
                                 DistanceMeters = set.DistanceMeters,
                                 RestSeconds = set.RestSeconds,
-                                CompletedAt = completedAt == default ? null : completedAt
+                                CompletedAt = completedAt == default ? null : completedAt,
+                                // Actual values from the workout log (null when not yet logged).
+                                ActualReps = loggedSet?.Reps,
+                                ActualWeightKg = loggedSet?.WeightKg,
+                                ActualRpe = loggedSet?.Rpe,
+                                ActualDurationSeconds = loggedSet?.DurationSeconds,
+                                ActualDistanceMeters = loggedSet?.DistanceMeters,
+                                // Snapshot-planned values (null on legacy logs → isModified stays false).
+                                PlannedReps = loggedSet?.PlannedReps,
+                                PlannedWeightKg = loggedSet?.PlannedWeightKg,
+                                PlannedRpe = loggedSet?.PlannedRpe,
+                                PlannedDurationSeconds = loggedSet?.PlannedDurationSeconds,
+                                PlannedDistanceMeters = loggedSet?.PlannedDistanceMeters,
+                                IsModified = loggedSet?.IsModified ?? false
                             };
                         }).ToList();
 
                         // An exercise is complete only when every planned set has a log entry.
                         var isCompleted = setDtos.Count > 0 && setDtos.All(s => s.CompletedAt is not null);
+                        var hasModifications = setDtos.Any(s => s.IsModified);
 
                         return new ExerciseDto
                         {
@@ -323,6 +370,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                             MovementType = ex.MovementType.ToString(),
                             MuscleGroups = muscleGroups,
                             IsCompleted = isCompleted,
+                            HasModifications = hasModifications,
                             Sets = setDtos
                         };
                     }).ToList();
@@ -350,6 +398,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                 var exerciseDtos = sectionDtos.SelectMany(s => s.Exercises).ToList();
 
                 var completedExerciseCount = exerciseDtos.Count(e => e.IsCompleted);
+                var sessionHasModifications = exerciseDtos.Any(e => e.HasModifications);
 
                 // Resolve lock state for this session (Stable if no active lock doc).
                 var sessionLockState = "Stable";
@@ -373,7 +422,8 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                     Sections = sectionDtos,
                     Exercises = exerciseDtos,
                     LockState = sessionLockState,
-                    LockHolder = sessionLockHolder
+                    LockHolder = sessionLockHolder,
+                    HasModifications = sessionHasModifications
                 };
             }).ToList();
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
@@ -131,6 +131,12 @@ public class SessionDto
     /// Possible values: "Coach", "Client", or null when the session is Stable.
     /// </summary>
     public string? LockHolder { get; set; }
+
+    /// <summary>
+    /// True when at least one exercise in this session has HasModifications == true.
+    /// Always false when no workout log exists for this session.
+    /// </summary>
+    public bool HasModifications { get; set; }
 }
 
 /// <summary>
@@ -216,12 +222,18 @@ public class ExerciseDto
     /// <summary>True when every planned set has a completed workout log entry.</summary>
     public bool IsCompleted { get; set; }
 
-    /// <summary>Planned sets with per-set completion timestamps.</summary>
+    /// <summary>
+    /// True when at least one set under this exercise has IsModified == true.
+    /// Always false when no workout log exists for this exercise.
+    /// </summary>
+    public bool HasModifications { get; set; }
+
+    /// <summary>Planned sets with per-set completion timestamps and actual-vs-planned delta.</summary>
     public List<SetDto> Sets { get; set; } = [];
 }
 
 /// <summary>
-/// A planned set with its completion state derived from workout logs.
+/// A planned set with its completion state and actual-vs-planned delta derived from workout logs.
 /// </summary>
 public class SetDto
 {
@@ -231,16 +243,16 @@ public class SetDto
     /// <summary>Set type (Normal, Warmup, Dropset, Superset).</summary>
     public string Type { get; set; } = "";
 
-    /// <summary>Target number of repetitions.</summary>
+    /// <summary>Target number of repetitions (from the plan prescription).</summary>
     public int? Reps { get; set; }
 
-    /// <summary>Target weight in kilograms.</summary>
+    /// <summary>Target weight in kilograms (from the plan prescription).</summary>
     public decimal? WeightKg { get; set; }
 
-    /// <summary>Target duration in seconds (for timed exercises).</summary>
+    /// <summary>Target duration in seconds (from the plan prescription).</summary>
     public int? DurationSeconds { get; set; }
 
-    /// <summary>Target distance in meters (for distance-based exercises).</summary>
+    /// <summary>Target distance in meters (from the plan prescription).</summary>
     public decimal? DistanceMeters { get; set; }
 
     /// <summary>Rest time after this set in seconds.</summary>
@@ -248,4 +260,46 @@ public class SetDto
 
     /// <summary>When this set was completed, or null if not yet done.</summary>
     public DateTime? CompletedAt { get; set; }
+
+    // ── Actual logged values (from WorkoutLog) ──────────────────────────────────
+    // Null when no log exists for this set (i.e. set not yet performed).
+
+    /// <summary>Actual repetitions logged. Null when not yet performed.</summary>
+    public int? ActualReps { get; set; }
+
+    /// <summary>Actual weight (kg) logged. Null when not yet performed.</summary>
+    public decimal? ActualWeightKg { get; set; }
+
+    /// <summary>Actual RPE logged. Null when not yet performed.</summary>
+    public decimal? ActualRpe { get; set; }
+
+    /// <summary>Actual duration (seconds) logged. Null when not yet performed.</summary>
+    public int? ActualDurationSeconds { get; set; }
+
+    /// <summary>Actual distance (meters) logged. Null when not yet performed.</summary>
+    public decimal? ActualDistanceMeters { get; set; }
+
+    // ── Snapshot-planned values (frozen on WorkoutLog at log time) ──────────────
+    // Null on legacy logs that pre-date snapshot storage — treat as planned == actual.
+
+    /// <summary>Snapshot-planned repetitions at log time. Null for legacy logs.</summary>
+    public int? PlannedReps { get; set; }
+
+    /// <summary>Snapshot-planned weight (kg) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>Snapshot-planned RPE at log time. Null for legacy logs.</summary>
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>Snapshot-planned duration (seconds) at log time. Null for legacy logs.</summary>
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>Snapshot-planned distance (meters) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedDistanceMeters { get; set; }
+
+    /// <summary>
+    /// Backend-computed flag: true when any actual field differs from its snapshot-planned
+    /// counterpart. Always false for legacy sets (no snapshot → treated as planned == actual).
+    /// </summary>
+    public bool IsModified { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
@@ -5,6 +5,7 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -268,6 +269,9 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
                     completedBySession[log.SessionId.Value] = set = [];
 
                 var setsForExerciseInSession = new Dictionary<Guid, List<int>>();
+                var loggedSetsForExercise = new Dictionary<Guid, List<LoggedSetDto>>();
+                var sessionHasModifications = false;
+
                 foreach (var ex in log.Exercises)
                 {
                     if (ex.Sets.Count == 0) continue;
@@ -280,9 +284,35 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
                         .ToList();
                     if (completedSetNumbers.Count > 0)
                         setsForExerciseInSession[ex.ExerciseExternalId] = completedSetNumbers;
+
+                    // Build value-bearing LoggedSetDto list for every set in this exercise.
+                    var loggedSetDtos = ex.Sets.Select(s => new LoggedSetDto
+                    {
+                        SetNumber = s.SetNumber,
+                        ActualReps = s.Reps,
+                        ActualWeightKg = s.WeightKg,
+                        ActualRpe = s.Rpe,
+                        ActualDurationSeconds = s.DurationSeconds,
+                        ActualDistanceMeters = s.DistanceMeters,
+                        PlannedReps = s.PlannedReps,
+                        PlannedWeightKg = s.PlannedWeightKg,
+                        PlannedRpe = s.PlannedRpe,
+                        PlannedDurationSeconds = s.PlannedDurationSeconds,
+                        PlannedDistanceMeters = s.PlannedDistanceMeters,
+                        IsModified = s.IsModified
+                    }).ToList();
+
+                    loggedSetsForExercise[ex.ExerciseExternalId] = loggedSetDtos;
+
+                    if (loggedSetDtos.Any(s => s.IsModified))
+                        sessionHasModifications = true;
                 }
                 if (setsForExerciseInSession.Count > 0)
                     response.CompletedSetsBySessionExercise[log.SessionId.Value] = setsForExerciseInSession;
+                if (loggedSetsForExercise.Count > 0)
+                    response.LoggedSetsBySessionExercise[log.SessionId.Value] = loggedSetsForExercise;
+                if (sessionHasModifications)
+                    response.HasModificationsBySession[log.SessionId.Value] = true;
             }
 
             foreach (var (sessionId, set) in completedBySession)

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
@@ -1,5 +1,6 @@
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
 
@@ -139,6 +140,23 @@ public class GetTodaySessionResponse
     /// Empty dictionary when no session has a note today (or when no active plan exists).
     /// </summary>
     public Dictionary<Guid, string> NotesBySession { get; set; } = new();
+
+    /// <summary>
+    /// Per-session, per-exercise logged set values for today.
+    /// Keyed by SessionId → ExerciseExternalId → list of <see cref="LoggedSetDto"/> (one per set).
+    /// Carries actual logged values, snapshot-planned values, and the backend-computed isModified flag.
+    /// Replaces the set-number-only <see cref="CompletedSetsBySessionExercise"/> for callers that
+    /// need actual vs planned comparison.
+    /// Empty when no live-training progress has been logged for today.
+    /// </summary>
+    public Dictionary<Guid, Dictionary<Guid, List<LoggedSetDto>>> LoggedSetsBySessionExercise { get; set; } = new();
+
+    /// <summary>
+    /// Per-session hasModifications flag for today, keyed by SessionId.
+    /// True when any set under any exercise in the session has IsModified == true in the latest log.
+    /// Missing entries are treated as false (no modifications / no log).
+    /// </summary>
+    public Dictionary<Guid, bool> HasModificationsBySession { get; set; } = new();
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
@@ -185,7 +185,15 @@ public class FinishSessionEndpoint(
                                 // Stamp all sets as completed at the supplied instant.
                                 // IsPR is left false — the completion service will set it via PR detection.
                                 CompletedAt = completedAt,
-                                IsPR = false
+                                IsPR = false,
+                                // Snapshot: done-as-prescribed → planned == actual.
+                                // When the trainer finishes a session retroactively the actual
+                                // values ARE the prescription, so isModified stays false for every set.
+                                PlannedReps = es.Reps,
+                                PlannedWeightKg = es.WeightKg,
+                                PlannedRpe = es.Rpe,
+                                PlannedDurationSeconds = es.DurationSeconds,
+                                PlannedDistanceMeters = es.DistanceMeters
                             })
                             .ToList()
                     })

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
@@ -5,6 +5,7 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using MongoDB.Driver;
 
@@ -150,6 +151,8 @@ public class GetTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lo
                     // Build the per-exercise map of completed set numbers.
                     // A set is "completed" iff its WorkoutSet.CompletedAt is non-null.
                     var completedSetsByExercise = new Dictionary<Guid, List<int>>();
+                    var loggedSetsByExercise = new Dictionary<Guid, List<LoggedSetDto>>();
+                    var sessionHasModifications = false;
 
                     foreach (var ex in log.Exercises)
                     {
@@ -161,13 +164,38 @@ public class GetTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lo
 
                         if (completedSetNumbers.Count > 0)
                             completedSetsByExercise[ex.ExerciseExternalId] = completedSetNumbers;
+
+                        // Build value-bearing LoggedSetDto list for every set in this exercise.
+                        var loggedSetDtos = ex.Sets.Select(s => new LoggedSetDto
+                        {
+                            SetNumber = s.SetNumber,
+                            ActualReps = s.Reps,
+                            ActualWeightKg = s.WeightKg,
+                            ActualRpe = s.Rpe,
+                            ActualDurationSeconds = s.DurationSeconds,
+                            ActualDistanceMeters = s.DistanceMeters,
+                            PlannedReps = s.PlannedReps,
+                            PlannedWeightKg = s.PlannedWeightKg,
+                            PlannedRpe = s.PlannedRpe,
+                            PlannedDurationSeconds = s.PlannedDurationSeconds,
+                            PlannedDistanceMeters = s.PlannedDistanceMeters,
+                            IsModified = s.IsModified
+                        }).ToList();
+
+                        if (loggedSetDtos.Count > 0)
+                            loggedSetsByExercise[ex.ExerciseExternalId] = loggedSetDtos;
+
+                        if (loggedSetDtos.Any(s => s.IsModified))
+                            sessionHasModifications = true;
                     }
 
                     return new SessionExecutionDto
                     {
                         SessionId = log.SessionId!.Value,
                         IsSessionFinished = log.IsCompleted,
-                        CompletedSetsByExercise = completedSetsByExercise
+                        CompletedSetsByExercise = completedSetsByExercise,
+                        LoggedSetsByExercise = loggedSetsByExercise,
+                        HasModifications = sessionHasModifications
                     };
                 })
                 .ToList();

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
@@ -1,4 +1,5 @@
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 
 namespace FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
 
@@ -69,6 +70,22 @@ public class SessionExecutionDto
     /// An empty list should not occur but is treated identically to an absent key.
     /// </summary>
     public Dictionary<Guid, List<int>> CompletedSetsByExercise { get; set; } = new();
+
+    /// <summary>
+    /// Per-exercise map of per-set actual values, snapshot-planned values, and isModified flags.
+    /// Key = ExerciseExternalId; value = list of <see cref="LoggedSetDto"/> (one per logged set).
+    /// An absent key means no sets for that exercise were logged.
+    /// The web layer uses this together with <see cref="CompletedSetsByExercise"/> to render
+    /// the actual-vs-planned comparison and the upraveno (modified) indicator per set.
+    /// </summary>
+    public Dictionary<Guid, List<LoggedSetDto>> LoggedSetsByExercise { get; set; } = new();
+
+    /// <summary>
+    /// True when at least one set in any exercise under this session has IsModified == true.
+    /// The web layer uses this to show the upraveno badge at the session-header level.
+    /// Always false when the session has no WorkoutLog (or all logs are legacy without snapshots).
+    /// </summary>
+    public bool HasModifications { get; set; }
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/Shared/LoggedSetDto.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/Shared/LoggedSetDto.cs
@@ -1,0 +1,55 @@
+namespace FitnessPlatform.Application.Features.WorkoutLogs.Shared;
+
+/// <summary>
+/// Per-set actual values + snapshot-planned values + backend-computed isModified flag,
+/// sourced from a <see cref="FitnessPlatform.Application.Domain.Documents.WorkoutSet"/>.
+/// Used by training-read endpoints that need to surface actual-vs-planned comparison
+/// (GetTodaySession, GetFullTrainingPlan, and the trainer GetTrainingPlan).
+/// </summary>
+public class LoggedSetDto
+{
+    /// <summary>1-based set number within the exercise.</summary>
+    public int SetNumber { get; set; }
+
+    // ── Actual logged values ────────────────────────────────────────────────────
+
+    /// <summary>Actual repetitions logged. Null when the set has not been performed.</summary>
+    public int? ActualReps { get; set; }
+
+    /// <summary>Actual weight (kg) logged. Null when not performed.</summary>
+    public decimal? ActualWeightKg { get; set; }
+
+    /// <summary>Actual RPE logged. Null when not performed.</summary>
+    public decimal? ActualRpe { get; set; }
+
+    /// <summary>Actual duration (seconds) logged. Null when not performed.</summary>
+    public int? ActualDurationSeconds { get; set; }
+
+    /// <summary>Actual distance (meters) logged. Null when not performed.</summary>
+    public decimal? ActualDistanceMeters { get; set; }
+
+    // ── Snapshot-planned values ─────────────────────────────────────────────────
+    // Frozen at log time from the plan prescription.
+    // Null on legacy documents that pre-date snapshot storage — treat as planned == actual.
+
+    /// <summary>Snapshot-planned repetitions at log time. Null for legacy logs.</summary>
+    public int? PlannedReps { get; set; }
+
+    /// <summary>Snapshot-planned weight (kg) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>Snapshot-planned RPE at log time. Null for legacy logs.</summary>
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>Snapshot-planned duration (seconds) at log time. Null for legacy logs.</summary>
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>Snapshot-planned distance (meters) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedDistanceMeters { get; set; }
+
+    /// <summary>
+    /// Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+    /// Always false for legacy sets (no snapshot → treated as planned == actual).
+    /// </summary>
+    public bool IsModified { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
@@ -96,7 +96,12 @@ public class UpdateWorkoutEndpoint(
                 Rpe = rs.Rpe,
                 DurationSeconds = rs.DurationSeconds,
                 DistanceMeters = rs.DistanceMeters,
-                CompletedAt = rs.CompletedAt
+                CompletedAt = rs.CompletedAt,
+                PlannedReps = rs.PlannedReps,
+                PlannedWeightKg = rs.PlannedWeightKg,
+                PlannedRpe = rs.PlannedRpe,
+                PlannedDurationSeconds = rs.PlannedDurationSeconds,
+                PlannedDistanceMeters = rs.PlannedDistanceMeters
             }).ToList()
         }).ToList();
         // Preserve existing section structure when available; otherwise use a single default section.

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
@@ -77,6 +77,15 @@ public class UpdateWorkoutEndpoint(
                 .Select(s => (e.ExerciseExternalId, s.SetNumber)))
             .ToHashSet();
 
+        // ── Build snapshot lookup from the existing stored sets ──────────────────
+        // Key: (ExerciseExternalId, SetNumber) → stored WorkoutSet.
+        // Used below to freeze Planned* fields on re-PUT: once a Planned* field has
+        // a non-null value in the database it is immutable; later requests cannot
+        // overwrite it even if they supply different planned values.
+        var storedSetLookup = log.Exercises
+            .SelectMany(e => e.Sets.Select(s => (e.ExerciseExternalId, s)))
+            .ToDictionary(x => (x.ExerciseExternalId, x.s.SetNumber), x => x.s);
+
         // ── Build new exercise list from request ──────────────────────────────────
         // The UpdateWorkout API accepts a flat exercise list (offline-first protocol).
         // Exercises are stored inside a single default section named "Hlavní".
@@ -88,20 +97,27 @@ public class UpdateWorkoutEndpoint(
             ExerciseExternalId = re.ExerciseExternalId,
             ExerciseName = re.ExerciseName,
             WodResult = re.WodResult,
-            Sets = re.Sets.Select(rs => new WorkoutSet
+            Sets = re.Sets.Select(rs =>
             {
-                SetNumber = rs.SetNumber,
-                Reps = rs.Reps,
-                WeightKg = rs.WeightKg,
-                Rpe = rs.Rpe,
-                DurationSeconds = rs.DurationSeconds,
-                DistanceMeters = rs.DistanceMeters,
-                CompletedAt = rs.CompletedAt,
-                PlannedReps = rs.PlannedReps,
-                PlannedWeightKg = rs.PlannedWeightKg,
-                PlannedRpe = rs.PlannedRpe,
-                PlannedDurationSeconds = rs.PlannedDurationSeconds,
-                PlannedDistanceMeters = rs.PlannedDistanceMeters
+                // Per-field snapshot freeze: use stored value when it is already non-null,
+                // otherwise take the incoming request value (first-log or extra-set case).
+                storedSetLookup.TryGetValue((re.ExerciseExternalId, rs.SetNumber), out var stored);
+
+                return new WorkoutSet
+                {
+                    SetNumber = rs.SetNumber,
+                    Reps = rs.Reps,
+                    WeightKg = rs.WeightKg,
+                    Rpe = rs.Rpe,
+                    DurationSeconds = rs.DurationSeconds,
+                    DistanceMeters = rs.DistanceMeters,
+                    CompletedAt = rs.CompletedAt,
+                    PlannedReps = stored?.PlannedReps ?? rs.PlannedReps,
+                    PlannedWeightKg = stored?.PlannedWeightKg ?? rs.PlannedWeightKg,
+                    PlannedRpe = stored?.PlannedRpe ?? rs.PlannedRpe,
+                    PlannedDurationSeconds = stored?.PlannedDurationSeconds ?? rs.PlannedDurationSeconds,
+                    PlannedDistanceMeters = stored?.PlannedDistanceMeters ?? rs.PlannedDistanceMeters
+                };
             }).ToList()
         }).ToList();
         // Preserve existing section structure when available; otherwise use a single default section.

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutRequest.cs
@@ -104,4 +104,34 @@ public class UpdateWorkoutSetRequest
     /// When this set was completed.
     /// </summary>
     public DateTime? CompletedAt { get; set; }
+
+    // ── Snapshot-planned fields ─────────────────────────────────────────────────
+    // Clients send these once from the plan prescription when first logging a set;
+    // they are frozen as a snapshot onto WorkoutSet and must not change on subsequent calls.
+    // All are nullable for backward compatibility with clients that do not yet send them.
+
+    /// <summary>
+    /// Prescribed repetitions from the plan prescription.
+    /// </summary>
+    public int? PlannedReps { get; set; }
+
+    /// <summary>
+    /// Prescribed weight (kg) from the plan prescription.
+    /// </summary>
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>
+    /// Prescribed RPE from the plan prescription.
+    /// </summary>
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>
+    /// Prescribed duration (seconds) from the plan prescription.
+    /// </summary>
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>
+    /// Prescribed distance (meters) from the plan prescription.
+    /// </summary>
+    public decimal? PlannedDistanceMeters { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutValidator.cs
@@ -45,6 +45,19 @@ public class UpdateWorkoutValidator : Validator<UpdateWorkoutRequest>
                 set.RuleFor(s => s.Rpe)
                     .InclusiveBetween(1, 10)
                     .When(s => s.Rpe.HasValue);
+
+                // ── Snapshot-planned bounds — mirror actual-value rules ─────────
+                set.RuleFor(s => s.PlannedReps)
+                    .InclusiveBetween(1, 1000)
+                    .When(s => s.PlannedReps.HasValue);
+
+                set.RuleFor(s => s.PlannedWeightKg)
+                    .GreaterThanOrEqualTo(0)
+                    .When(s => s.PlannedWeightKg.HasValue);
+
+                set.RuleFor(s => s.PlannedRpe)
+                    .InclusiveBetween(1, 10)
+                    .When(s => s.PlannedRpe.HasValue);
             });
         });
     }

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionLoggedSetsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionLoggedSetsTests.cs
@@ -1,0 +1,497 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="GetTodaySessionEndpoint"/> — verifies that
+/// <c>LoggedSetsBySessionExercise</c> and <c>HasModificationsBySession</c>
+/// are correctly populated from WorkoutLog data.
+/// </summary>
+public class GetTodaySessionLoggedSetsTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _userIdGuid = Guid.NewGuid(); // ApplicationUser.Id (used in WorkoutLog.ClientId)
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _userIdGuid, PublicId = _clientId })
+            .Build();
+
+    private static int TodayDow()
+    {
+        var dow = (int)DateTime.UtcNow.DayOfWeek;
+        return dow == 0 ? 7 : dow;
+    }
+
+    private static DateTime StartOfCurrentWeek()
+    {
+        var today = DateTime.UtcNow.Date;
+        return today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
+    }
+
+    private IMongoContext CreateMongoWithPlanAndLog(
+        TrainingPlan plan,
+        List<WorkoutLog>? workoutLogs = null)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Plans collection
+        var plans = new List<TrainingPlan> { plan };
+        var planCollection = Substitute.For<IMongoCollection<TrainingPlan>>();
+        planCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+                var moved = false;
+                cursor.Current.Returns(plans);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                return cursor;
+            });
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Exercises collection (empty — muscle groups not needed for these tests)
+        var exerciseCollection = Substitute.For<IMongoCollection<Exercise>>();
+        exerciseCollection.FindAsync(
+                Arg.Any<FilterDefinition<Exercise>>(),
+                Arg.Any<FindOptions<Exercise, Exercise>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<Exercise>>();
+                var moved = false;
+                cursor.Current.Returns(new List<Exercise>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => false);
+                return cursor;
+            });
+        mongo.Exercises.Returns(exerciseCollection);
+
+        // TrainingCompletions collection (empty for these tests)
+        var completionCollection = Substitute.For<IMongoCollection<TrainingCompletion>>();
+        completionCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<FindOptions<TrainingCompletion, TrainingCompletion>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingCompletion>>();
+                var moved = false;
+                cursor.Current.Returns(new List<TrainingCompletion>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => false);
+                return cursor;
+            });
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        // WorkoutLogs collection
+        var logDocs = workoutLogs ?? [];
+        var logCollection = Substitute.For<IMongoCollection<WorkoutLog>>();
+        logCollection.FindAsync(
+                Arg.Any<FilterDefinition<WorkoutLog>>(),
+                Arg.Any<FindOptions<WorkoutLog, WorkoutLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<WorkoutLog>>();
+                var moved = false;
+                cursor.Current.Returns(logDocs);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return logDocs.Count > 0; });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return logDocs.Count > 0; });
+                return cursor;
+            });
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        // SessionLogs collection (empty)
+        var sessionLogCollection = Substitute.For<IMongoCollection<SessionLog>>();
+        sessionLogCollection.FindAsync(
+                Arg.Any<FilterDefinition<SessionLog>>(),
+                Arg.Any<FindOptions<SessionLog, SessionLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<SessionLog>>();
+                var moved = false;
+                cursor.Current.Returns(new List<SessionLog>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => false);
+                return cursor;
+            });
+        mongo.SessionLogs.Returns(sessionLogCollection);
+
+        return mongo;
+    }
+
+    private GetTodaySessionEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    {
+        var lockService = Substitute.For<ISessionLockService>();
+        lockService.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock>() as IReadOnlyList<SessionLock>);
+
+        return Factory.Create<GetTodaySessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_userIdGuid, AppRoles.Client))),
+            mongo, db, lockService);
+    }
+
+    private TrainingPlan BuildPlanWithSession(Guid sessionId, Guid exerciseId, int dow)
+    {
+        var startOfWeek = StartOfCurrentWeek();
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = dow,
+                            Name = "Test Session",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 80m },
+                                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 80m }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = startOfWeek
+        };
+    }
+
+    // ── LoggedSetsBySessionExercise populated from WorkoutLog ──────────────────
+
+    [Fact]
+    public async Task HandleAsync_WithWorkoutLog_PopulatesLoggedSetsBySessionExercise()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 10,
+                                    WeightKg = 80m,
+                                    PlannedReps = 10,
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                },
+                                new WorkoutSet
+                                {
+                                    SetNumber = 2,
+                                    Reps = 8,            // actual differs from plan
+                                    WeightKg = 80m,
+                                    PlannedReps = 10,    // planned was 10
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var response = ep.Response;
+
+        response.LoggedSetsBySessionExercise.Should().ContainKey(sessionId);
+        var exerciseSets = response.LoggedSetsBySessionExercise[sessionId];
+        exerciseSets.Should().ContainKey(exerciseId);
+
+        var sets = exerciseSets[exerciseId];
+        sets.Should().HaveCount(2);
+
+        // Set 1: actual == planned → IsModified = false
+        var set1 = sets.Single(s => s.SetNumber == 1);
+        set1.ActualReps.Should().Be(10);
+        set1.PlannedReps.Should().Be(10);
+        set1.IsModified.Should().BeFalse();
+
+        // Set 2: actual (8) != planned (10) → IsModified = true
+        var set2 = sets.Single(s => s.SetNumber == 2);
+        set2.ActualReps.Should().Be(8);
+        set2.PlannedReps.Should().Be(10);
+        set2.IsModified.Should().BeTrue();
+    }
+
+    // ── HasModificationsBySession set when any set is modified ─────────────────
+
+    [Fact]
+    public async Task HandleAsync_WithModifiedSet_SetsHasModificationsBySession()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 7,         // actual differs
+                                    WeightKg = 80m,
+                                    PlannedReps = 10, // planned
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.HasModificationsBySession.Should().ContainKey(sessionId);
+        ep.Response.HasModificationsBySession[sessionId].Should().BeTrue();
+    }
+
+    // ── HasModificationsBySession absent when all sets are as-planned ──────────
+
+    [Fact]
+    public async Task HandleAsync_WithNoModifiedSets_HasModificationsAbsentOrFalse()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 10,
+                                    WeightKg = 80m,
+                                    PlannedReps = 10,     // matches actual
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        // Should NOT have a true entry for this session
+        if (ep.Response.HasModificationsBySession.TryGetValue(sessionId, out var val))
+            val.Should().BeFalse();
+        // else: absent key is treated as false — pass
+    }
+
+    // ── Backward compatible: legacy sets without planned fields → IsModified false ─
+
+    [Fact]
+    public async Task HandleAsync_WithLegacySetNoPlannedFields_IsModifiedFalse()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 10,
+                                    WeightKg = 80m,
+                                    // No planned fields — simulates legacy document
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.LoggedSetsBySessionExercise.Should().ContainKey(sessionId);
+        var sets = ep.Response.LoggedSetsBySessionExercise[sessionId][exerciseId];
+        sets[0].IsModified.Should().BeFalse();
+        sets[0].PlannedReps.Should().BeNull();
+    }
+
+    // ── No log → empty LoggedSetsBySessionExercise ─────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_WithNoWorkoutLog_LoggedSetsIsEmpty()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var mongo = CreateMongoWithPlanAndLog(plan, []);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.LoggedSetsBySessionExercise.Should().BeEmpty();
+        ep.Response.HasModificationsBySession.Should().BeEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionPlannedSnapshotTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionPlannedSnapshotTests.cs
@@ -1,0 +1,188 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the snapshot-planned-equals-actual behaviour in
+/// <see cref="FinishSessionEndpoint"/>.MaterializeFromTemplate.
+/// When a trainer retroactively finishes a session the log is built from
+/// the prescription: each set's planned values must equal its actual values
+/// so that IsModified == false (done-as-prescribed).
+/// </summary>
+public class FinishSessionPlannedSnapshotTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    private IWorkoutCompletionService StubCompletionService()
+    {
+        var svc = Substitute.For<IWorkoutCompletionService>();
+        svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
+        return svc;
+    }
+
+    private static TrainingPlan CreatePlanWithPrescribedSets(Guid trainerId, Guid sessionId)
+    {
+        var sectionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = DateTime.UtcNow.Date.AddDays(-30),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 100m, Rpe = 7m },
+                                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 100m, Rpe = 8m },
+                                                new ExerciseSet { SetNumber = 3, Reps = 8,  WeightKg = 100m }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+    }
+
+    private static (IMongoContext Mongo, IMongoCollection<WorkoutLog> LogCollection) CreateMockMongoWithInsert(
+        TrainingPlan plan,
+        IReadOnlyList<WorkoutLog> existingLogs)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        var planCollection = TrainingPlanTestHelpers.CreateMockCollection([plan]);
+        mongo.TrainingPlans.Returns(planCollection);
+
+        var logCollection = TrainingPlanTestHelpers.CreateMockWorkoutLogCollection(existingLogs.ToList());
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        return (mongo, logCollection);
+    }
+
+    // ── MaterializeFromTemplate: planned == actual for every set ──────────────
+
+    [Fact]
+    public async Task MaterializeFromTemplate_InsertedLog_HasPlannedEqualsActualOnEachSet()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPrescribedSets(_trainerId, sessionId);
+        var (mongo, logCollection) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        WorkoutLog? insertedLog = null;
+        await logCollection.InsertOneAsync(
+            Arg.Do<WorkoutLog>(l => insertedLog = l),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Re-fetch the log that was inserted (NSubstitute captured it above).
+        // Because NSubstitute Arg.Do fires when the method is called but we set
+        // up the capture after .Returns(), we verify via the completion-service call.
+        await completionService.Received(1).CompleteAsync(
+            Arg.Is<WorkoutLog>(l =>
+                // Every set must have planned == actual and IsModified == false.
+                l.Exercises.All(ex =>
+                    ex.Sets.All(s =>
+                        s.PlannedReps == s.Reps &&
+                        s.PlannedWeightKg == s.WeightKg &&
+                        s.PlannedRpe == s.Rpe &&
+                        s.PlannedDurationSeconds == s.DurationSeconds &&
+                        s.PlannedDistanceMeters == s.DistanceMeters &&
+                        !s.IsModified))),
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Specific values snapshot correctly ────────────────────────────────────
+
+    [Fact]
+    public async Task MaterializeFromTemplate_SetsSnapshotFromPrescribedValues()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPrescribedSets(_trainerId, sessionId);
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Verify the first set of the materialized log has Rpe snapshot set.
+        // (PlannedRpe = 7m for set 1 as prescribed; set 3 has no Rpe → PlannedRpe null)
+        await completionService.Received(1).CompleteAsync(
+            Arg.Is<WorkoutLog>(l =>
+                l.Exercises[0].Sets[0].PlannedRpe == 7m &&
+                l.Exercises[0].Sets[0].PlannedReps == 10 &&
+                l.Exercises[0].Sets[0].PlannedWeightKg == 100m &&
+                l.Exercises[0].Sets[2].PlannedRpe == null),  // set 3 has no Rpe in prescription
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLoggedSetsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLoggedSetsTests.cs
@@ -1,0 +1,288 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
+using FitnessPlatform.Tests.Endpoints;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the <see cref="GetTrainingPlanEndpoint"/> <c>SessionExecutionDto</c>
+/// planned-vs-actual extension (issue #440):
+/// — <c>LoggedSetsByExercise</c> carries actual + snapshot-planned + isModified per set.
+/// — <c>HasModifications</c> is true when any set in the session is modified.
+/// — Backward compatibility: legacy sets without planned fields → isModified=false.
+/// </summary>
+public class GetTrainingPlanLoggedSetsTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _exerciseId = Guid.NewGuid();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    private TrainingPlan BuildPlan()
+    {
+        var session = new TrainingSession
+        {
+            SessionId = _sessionId,
+            Name = "Session 1",
+            DayOfWeek = 1,
+            Sections =
+            [
+                new TrainingSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Name = "Main",
+                    Order = 0,
+                    Exercises =
+                    [
+                        new SessionExercise
+                        {
+                            ExerciseExternalId = _exerciseId,
+                            ExerciseName = "Squat",
+                            Order = 0,
+                            Sets =
+                            [
+                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 80m },
+                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 80m }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        return new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions = [session]
+                }
+            ],
+            Version = 1,
+            DateCreated = _now
+        };
+    }
+
+    private WorkoutLog BuildLog(List<WorkoutSet> sets)
+    {
+        return new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            PlanId = _planId,
+            SessionId = _sessionId,
+            StartedAt = _now.AddMinutes(-30),
+            IsCompleted = true,
+            CompletedAt = _now,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Main",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = _exerciseId,
+                            ExerciseName = "Squat",
+                            Sets = sets
+                        }
+                    ]
+                }
+            ],
+            DateCreated = _now
+        };
+    }
+
+    private async Task<GetTrainingPlanResponse?> ExecuteAsync(
+        TrainingPlan plan,
+        WorkoutLog[] logs)
+    {
+        var mongo = TrainingPlanTestHelpers.CreateMockMongoWithLogs(
+            plans: [plan],
+            workoutLogs: logs);
+
+        var ep = Factory.Create<GetTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
+
+        await ep.HandleAsync(
+            new GetTrainingPlanRequest { PlanId = _planId },
+            TestContext.Current.CancellationToken);
+
+        if (ep.HttpContext.Response.StatusCode != 200)
+            return null;
+
+        return ep.Response;
+    }
+
+    // ── LoggedSetsByExercise populated correctly ────────────────────────────────
+
+    [Fact]
+    public async Task SessionExecution_WithPlannedSnapshot_LoggedSetsByExerciseContainsActualAndPlanned()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 10,
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-20)
+            },
+            new WorkoutSet
+            {
+                SetNumber = 2,
+                Reps = 8,           // fewer than planned
+                WeightKg = 80m,
+                PlannedReps = 10,   // planned was 10
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-15)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().HaveCount(1);
+
+        var exec = response.SessionExecutions.Single();
+        exec.LoggedSetsByExercise.Should().ContainKey(_exerciseId);
+
+        var sets = exec.LoggedSetsByExercise[_exerciseId];
+        sets.Should().HaveCount(2);
+
+        var set1 = sets.Single(s => s.SetNumber == 1);
+        set1.ActualReps.Should().Be(10);
+        set1.PlannedReps.Should().Be(10);
+        set1.IsModified.Should().BeFalse();
+
+        var set2 = sets.Single(s => s.SetNumber == 2);
+        set2.ActualReps.Should().Be(8);
+        set2.PlannedReps.Should().Be(10);
+        set2.IsModified.Should().BeTrue();
+    }
+
+    // ── HasModifications set when any set is modified ──────────────────────────
+
+    [Fact]
+    public async Task SessionExecution_WithModifiedSet_HasModificationsTrue()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 6,           // diverges from plan
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-25)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        var exec = response!.SessionExecutions.Single();
+        exec.HasModifications.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SessionExecution_AllSetsAsPlanned_HasModificationsFalse()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 10,
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-25)
+            },
+            new WorkoutSet
+            {
+                SetNumber = 2,
+                Reps = 10,
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-20)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        var exec = response!.SessionExecutions.Single();
+        exec.HasModifications.Should().BeFalse();
+    }
+
+    // ── Backward compatibility: legacy log without planned fields ──────────────
+
+    [Fact]
+    public async Task SessionExecution_LegacySetWithoutPlannedFields_IsModifiedFalseAndPlannedNull()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 10,
+                WeightKg = 80m,
+                // No planned fields — legacy document
+                CompletedAt = _now.AddMinutes(-25)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        var exec = response!.SessionExecutions.Single();
+        exec.HasModifications.Should().BeFalse();
+
+        exec.LoggedSetsByExercise.Should().ContainKey(_exerciseId);
+        var set = exec.LoggedSetsByExercise[_exerciseId].Single();
+        set.IsModified.Should().BeFalse();
+        set.PlannedReps.Should().BeNull();
+    }
+
+    // ── No log → SessionExecution absent → LoggedSetsByExercise empty ──────────
+
+    [Fact]
+    public async Task SessionExecution_NoLog_LoggedSetsByExerciseIsEmpty()
+    {
+        var plan = BuildPlan();
+        var response = await ExecuteAsync(plan, []);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().BeEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/UpdateWorkoutPlannedSnapshotTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/UpdateWorkoutPlannedSnapshotTests.cs
@@ -262,4 +262,262 @@ public class UpdateWorkoutPlannedSnapshotTests
         var set = new WorkoutSet { SetNumber = 1, DistanceMeters = 450m, PlannedDistanceMeters = 500m };
         set.IsModified.Should().BeTrue();
     }
+
+    // ── Snapshot immutability: re-PUT must not overwrite an existing snapshot ───
+
+    /// <summary>
+    /// A second PUT that supplies different Planned* values must not overwrite
+    /// the snapshot recorded on the first PUT. The stored non-null values win.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RePut_WithDifferentPlannedValues_PreservesOriginalSnapshot()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        // Simulate the document as it exists AFTER the first PUT:
+        // the snapshot fields are already populated.
+        var storedLog = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        storedLog.Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new WorkoutExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Squat",
+                        Sets =
+                        [
+                            new WorkoutSet
+                            {
+                                SetNumber = 1,
+                                Reps = 8,
+                                WeightKg = 100m,
+                                PlannedReps = 10,       // original snapshot
+                                PlannedWeightKg = 105m  // original snapshot
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [storedLog]);
+        var ep = CreateEndpoint(mongo);
+
+        // Second PUT: coach edited the plan — client sends new Planned* values that differ.
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Squat",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 9,                    // actual updated
+                            WeightKg = 102.5m,           // actual updated
+                            PlannedReps = 12,            // attacker/stale value — must be ignored
+                            PlannedWeightKg = 110m       // attacker/stale value — must be ignored
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Snapshot fields must remain at the ORIGINAL values (10, 105m), not the request values (12, 110m).
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedReps == 10 &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == 105m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A second PUT must still update actual (Reps, WeightKg, Rpe, etc.) values —
+    /// only the Planned* snapshot fields are frozen, not the whole set.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RePut_UpdatesActualValuesWhilePreservingSnapshot()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        // Stored state: snapshot already set, actuals from first PUT.
+        var storedLog = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        storedLog.Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new WorkoutExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Bench Press",
+                        Sets =
+                        [
+                            new WorkoutSet
+                            {
+                                SetNumber = 1,
+                                Reps = 5,
+                                WeightKg = 80m,
+                                PlannedReps = 8,
+                                PlannedWeightKg = 80m
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [storedLog]);
+        var ep = CreateEndpoint(mongo);
+
+        // Second PUT: client corrects their actual reps/weight.
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Bench Press",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 7,              // corrected actual
+                            WeightKg = 82.5m,      // corrected actual
+                            PlannedReps = 99,      // should be ignored — stored is 8
+                            PlannedWeightKg = 99m  // should be ignored — stored is 80m
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                // Actuals are updated to the new values.
+                w.Exercises[0].Sets[0].Reps == 7 &&
+                w.Exercises[0].Sets[0].WeightKg == 82.5m &&
+                // Snapshot stays frozen at original values.
+                w.Exercises[0].Sets[0].PlannedReps == 8 &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == 80m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// An extra set added on a re-PUT (index beyond stored count) has no prior snapshot.
+    /// The request's Planned* values flow through without error.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RePut_ExtraSetBeyondStoredCount_TakesRequestPlannedValues()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        // Stored state: only set 1 exists.
+        var storedLog = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        storedLog.Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new WorkoutExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Pull-up",
+                        Sets =
+                        [
+                            new WorkoutSet
+                            {
+                                SetNumber = 1,
+                                Reps = 10,
+                                PlannedReps = 10
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [storedLog]);
+        var ep = CreateEndpoint(mongo);
+
+        // Second PUT: client adds an extra set 2 (no stored snapshot for it).
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Pull-up",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 10,
+                            PlannedReps = 99 // ignored — stored is 10
+                        },
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 2,         // extra set — no stored snapshot
+                            Reps = 8,
+                            PlannedReps = 8        // should flow through (no stored value)
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                // Set 1: snapshot frozen at original 10.
+                w.Exercises[0].Sets[0].PlannedReps == 10 &&
+                // Set 2 (extra): request planned value flows through.
+                w.Exercises[0].Sets[1].PlannedReps == 8),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/UpdateWorkoutPlannedSnapshotTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/UpdateWorkoutPlannedSnapshotTests.cs
@@ -1,0 +1,265 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.UpdateWorkout;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Tests for snapshot-planned field persistence in <see cref="UpdateWorkoutEndpoint"/>.
+/// Covers:
+/// — planned fields are forwarded from request onto WorkoutSet (happy path)
+/// — IsModified computed property reflects actual-vs-planned differences
+/// — backward-compatible: omitting planned fields does not break existing behaviour
+/// </summary>
+public class UpdateWorkoutPlannedSnapshotTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private UpdateWorkoutEndpoint CreateEndpoint(IMongoContext mongo)
+    {
+        var db = Substitute.For<IApplicationDbContext>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+        var logger = Substitute.For<ILogger<UpdateWorkoutEndpoint>>();
+
+        return Factory.Create<UpdateWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, notifier, logger);
+    }
+
+    // ── Happy path: planned values are persisted alongside actuals ─────────────
+
+    [Fact]
+    public async Task HandleAsync_WithPlannedFields_PersistsSnapshotOnWorkoutSet()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var ep = CreateEndpoint(mongo);
+
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Squat",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 8,                 // actual: slightly fewer than prescribed
+                            WeightKg = 100m,
+                            Rpe = 8m,
+                            PlannedReps = 10,         // snapshot-planned
+                            PlannedWeightKg = 100m,
+                            PlannedRpe = 7m
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Verify planned fields are written to the document.
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedReps == 10 &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == 100m &&
+                w.Exercises[0].Sets[0].PlannedRpe == 7m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAllFivePlannedFields_PersistsAll()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var ep = CreateEndpoint(mongo);
+
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Run",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            DurationSeconds = 120,
+                            DistanceMeters = 500m,
+                            PlannedReps = null,
+                            PlannedWeightKg = null,
+                            PlannedRpe = null,
+                            PlannedDurationSeconds = 120,
+                            PlannedDistanceMeters = 500m
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedDurationSeconds == 120 &&
+                w.Exercises[0].Sets[0].PlannedDistanceMeters == 500m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Backward compatibility: no planned fields → existing behaviour unchanged ─
+
+    [Fact]
+    public async Task HandleAsync_WithoutPlannedFields_SetsAreNullAndIsModifiedFalse()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var ep = CreateEndpoint(mongo);
+
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Deadlift",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest { SetNumber = 1, Reps = 5, WeightKg = 150m }
+                        // No planned fields
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedReps == null &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == null &&
+                // IsModified must be false when no snapshot exists
+                !w.Exercises[0].Sets[0].IsModified),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── IsModified computed property ────────────────────────────────────────────
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenRepsDiffer()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 8,
+            PlannedReps = 10
+        };
+
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_FalseWhenActualEqualsPlanned()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 10,
+            WeightKg = 100m,
+            PlannedReps = 10,
+            PlannedWeightKg = 100m
+        };
+
+        set.IsModified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_FalseWhenNoPlannedFieldsSet()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 10,
+            WeightKg = 100m
+            // No planned fields — legacy document
+        };
+
+        set.IsModified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenWeightDiffers()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 10,
+            WeightKg = 90m,
+            PlannedReps = 10,
+            PlannedWeightKg = 100m
+        };
+
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenRpeDiffers()
+    {
+        var set = new WorkoutSet { SetNumber = 1, Rpe = 9m, PlannedRpe = 7m };
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenDurationDiffers()
+    {
+        var set = new WorkoutSet { SetNumber = 1, DurationSeconds = 90, PlannedDurationSeconds = 60 };
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenDistanceDiffers()
+    {
+        var set = new WorkoutSet { SetNumber = 1, DistanceMeters = 450m, PlannedDistanceMeters = 500m };
+        set.IsModified.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 5 nullable snapshot-planned fields (`PlannedReps`, `PlannedWeightKg`, `PlannedRpe`, `PlannedDurationSeconds`, `PlannedDistanceMeters`) to the embedded `WorkoutSet` Mongo document + a backend-computed `IsModified` property (true only when an actual field differs from a *present* planned counterpart).
- Extends `PUT /client/training/logs/{logId}` to accept + persist the per-set snapshot-planned values (validated with the same bounds as actual values); `FinishSession` (MaterializeFromTemplate) sets `planned == actual` so done-as-prescribed sessions never show as modified.
- Surfaces per-set actual + planned + `isModified`, and per-exercise/per-session `hasModifications`, on three read endpoints: `GET /client/training/plan/today`, `GET /client/training/plans/{planId}` (mobile full plan), and the trainer `GET /training/plans/{planId}` `SessionExecutionDto`.
- Backward compatible: legacy `WorkoutSet` docs without snapshot values yield `isModified == false` (no spurious "upraveno" badges). No EF migration — `WorkoutSet` is an embedded Mongo document.

## Related issue
Part of #439 — sub-issue #440.

## Parent epic
Part of epic #439 — base branch: `feature/439-planned-vs-actual-training`.

## Scope
backend

## Downstream contract note
This changes the Swagger contract for three endpoints. The web (#441) and mobile (#442) sub-issues MUST run `regen-api` before consuming the new fields.

## QA verdict (from qa-tester)
OVERALL ✅ PASS — `dotnet build` clean; 272 integration tests green (WorkoutLogs 76, ClientTraining 108, TrainingPlans 88).

## Test plan
- [ ] Nullable PlannedReps/PlannedWeightKg/PlannedRpe/PlannedDurationSeconds/PlannedDistanceMeters added to WorkoutSet.
- [ ] PUT /client/training/logs/{logId} accepts + persists snapshot-planned values per set.
- [ ] FinishSession (MaterializeFromTemplate) sets each WorkoutSet planned == actual.
- [ ] Backend computes isModified per set (any actual field differs from snapshot-planned).
- [ ] Backend computes hasModifications per exercise + per session.
- [ ] GET /client/training/plan/today carries per-set actual + planned + isModified, per session hasModifications.
- [ ] GET /client/training/plans/{planId} carries the same per-set + per-exercise/session fields.
- [ ] Trainer GET /training/plans/{planId} SessionExecutionDto carries loggedSetsByExercise + hasModifications.
- [ ] Backward compatible: legacy WorkoutSet docs without snapshot → planned == actual / isModified == false.
- [ ] dotnet build clean + dotnet test green on WorkoutLogs, ClientTraining, TrainingPlans slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)