### PR TITLE
feat: coach plan detail — show client actual vs planned set values + modified badges

### DIFF
--- a/web/src/api/training-plan-types.ts
+++ b/web/src/api/training-plan-types.ts
@@ -150,6 +150,51 @@ export interface TrainingPlanCompletion {
 }
 
 /**
+ * Per-set actual + snapshot-planned values and the backend-computed isModified flag.
+ * Sourced from a WorkoutSet document. Key fields are null for legacy sets without
+ * snapshot storage — treat as planned == actual / isModified == false.
+ *
+ * Hand-written (not from generated.ts) — the plan response is consumed via the
+ * hand-written TrainingPlanDetail type, not the NSwag-generated client.
+ */
+export interface LoggedSetDto {
+  /** 1-based set number within the exercise. */
+  setNumber: number;
+
+  // ── Actual logged values ─────────────────────────────────────────────────────
+  /** Actual repetitions logged. Null when the set has not been performed. */
+  actualReps: number | null;
+  /** Actual weight (kg) logged. Null when not performed. */
+  actualWeightKg: number | null;
+  /** Actual RPE logged. Null when not performed. */
+  actualRpe: number | null;
+  /** Actual duration (seconds) logged. Null when not performed. */
+  actualDurationSeconds: number | null;
+  /** Actual distance (meters) logged. Null when not performed. */
+  actualDistanceMeters: number | null;
+
+  // ── Snapshot-planned values ──────────────────────────────────────────────────
+  // Frozen at log time from the plan prescription.
+  // Null on legacy documents that pre-date snapshot storage.
+  /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+  plannedReps: number | null;
+  /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+  plannedWeightKg: number | null;
+  /** Snapshot-planned RPE at log time. Null for legacy logs. */
+  plannedRpe: number | null;
+  /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+  plannedDurationSeconds: number | null;
+  /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+  plannedDistanceMeters: number | null;
+
+  /**
+   * Backend-computed flag: true when any actual field differs from its snapshot-planned
+   * counterpart. Always false for legacy sets (no snapshot → treated as planned == actual).
+   */
+  isModified: boolean;
+}
+
+/**
  * Per-session workout-log execution data returned by the trainer endpoint.
  * Used to derive completed / skipped / not-yet-reached states per set.
  *
@@ -169,6 +214,19 @@ export interface SessionExecutionDto {
    * An absent key means no sets for that exercise were logged.
    */
   completedSetsByExercise: Record<string, number[]>;
+  /**
+   * Key = exerciseExternalId (matches SessionExercise.exerciseExternalId).
+   * Value = list of LoggedSetDto (one per logged set), carrying actual values,
+   * snapshot-planned values, and the isModified flag.
+   * An absent key means no sets for that exercise were logged.
+   */
+  loggedSetsByExercise: Record<string, LoggedSetDto[]>;
+  /**
+   * True when at least one set in any exercise under this session has isModified === true.
+   * The web layer uses this to show the "upraveno" badge at the session-header level.
+   * Always false when the session has no WorkoutLog (or all logs are legacy without snapshots).
+   */
+  hasModifications: boolean;
 }
 
 /**

--- a/web/src/components/common/CompletionBadge.tsx
+++ b/web/src/components/common/CompletionBadge.tsx
@@ -147,12 +147,26 @@ type DayBadgeProps = {
   counts?: DayCompletionCounts;
 };
 
+/**
+ * Training: "upraveno" (modified) roll-up badge.
+ * Shown at exercise-header and session-header level when any set under the
+ * exercise / session has isModified === true.
+ * false → nothing rendered (returns null).
+ * true  → accent pill with a small pencil-edit icon + t('training.completionState.modified') label.
+ */
+type ModifiedBadgeProps = {
+  kind: 'modified';
+  state: boolean;
+  counts?: undefined;
+};
+
 export type CompletionBadgeProps =
   | SetBadgeProps
   | ExerciseBadgeProps
   | SessionBadgeProps
   | MealBadgeProps
-  | DayBadgeProps;
+  | DayBadgeProps
+  | ModifiedBadgeProps;
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -184,6 +198,9 @@ export function CompletionBadge(props: CompletionBadgeProps) {
   }
   if (props.kind === 'day') {
     return <DayBadge state={props.state} counts={props.counts} t={t} />;
+  }
+  if (props.kind === 'modified') {
+    return <ModifiedBadge state={props.state} t={t} />;
   }
   return <SessionBadge state={props.state} counts={props.counts} t={t} />;
 }
@@ -322,6 +339,44 @@ function DayBadge({
       title={label}
     >
       <IconCheckCircle2 size={12} />
+      {label}
+    </span>
+  );
+}
+
+// ── Modified (upraveno) badge ────────────────────────────────────────────────
+
+function ModifiedBadge({
+  state,
+  t,
+}: {
+  state: boolean;
+  t: ReturnType<typeof useTranslation>['t'];
+}) {
+  if (!state) return null;
+  const label = t('training.completionState.modified');
+  return (
+    <span
+      className={accentPill}
+      aria-label={label}
+      title={label}
+    >
+      {/* Inline pencil-edit SVG — same pattern as other micro-icons above */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={10}
+        height={10}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+      </svg>
       {label}
     </span>
   );

--- a/web/src/components/training/ExerciseCardHeader.tsx
+++ b/web/src/components/training/ExerciseCardHeader.tsx
@@ -37,6 +37,11 @@ interface ExerciseCardHeaderProps {
   exerciseCompletionState?: ExerciseCompletionState;
   /** Counts for the aggregate badge (required when exerciseCompletionState is set). */
   exerciseCounts?: ExerciseCounts;
+  /**
+   * True when any set under this exercise has isModified === true (derived client-side).
+   * Shows the "upraveno" roll-up badge next to the completion badge.
+   */
+  hasModifications?: boolean;
 }
 
 export function ExerciseCardHeader({
@@ -56,6 +61,7 @@ export function ExerciseCardHeader({
   disabled,
   exerciseCompletionState,
   exerciseCounts,
+  hasModifications,
 }: ExerciseCardHeaderProps) {
   const { t } = useTranslation();
 
@@ -114,6 +120,12 @@ export function ExerciseCardHeader({
               kind="exercise"
               state={exerciseCompletionState}
               counts={exerciseCounts}
+            />
+          )}
+          {hasModifications && (
+            <CompletionBadge
+              kind="modified"
+              state={hasModifications}
             />
           )}
         </div>

--- a/web/src/components/training/SectionCard.tsx
+++ b/web/src/components/training/SectionCard.tsx
@@ -15,6 +15,7 @@ import type { ExerciseSet } from '@/api/training-plan-types';
 import {
   deriveSetCompletionState,
   deriveExerciseCompletionState,
+  deriveExerciseModificationState,
 } from '@/lib/completionState';
 
 /**
@@ -328,6 +329,21 @@ export function SectionCard({
                   ex.sets.length,
                 );
 
+              // Derive modification state: true when any logged set under this
+              // exercise has isModified === true. Backend has no per-exercise flag —
+              // we derive client-side mirroring deriveExerciseCompletionState.
+              const exHasModifications = deriveExerciseModificationState(
+                sessionExecution,
+                ex.exerciseExternalId,
+              );
+
+              // Logged sets for this exercise, keyed by 1-based setNumber.
+              const loggedSetsMap = sessionExecution?.loggedSetsByExercise[ex.exerciseExternalId]
+                ? Object.fromEntries(
+                    sessionExecution.loggedSetsByExercise[ex.exerciseExternalId].map((ls) => [ls.setNumber, ls])
+                  )
+                : undefined;
+
               return (
                 <div
                   key={exKey}
@@ -374,6 +390,9 @@ export function SectionCard({
                     // Completion state (additive, display-only).
                     exerciseCompletionState={exCompletionState}
                     exerciseCounts={exCounts}
+                    // Modification roll-up: true when any set under this exercise
+                    // has isModified === true (derived client-side).
+                    hasModifications={exHasModifications || undefined}
                   />
 
                   <div className="collapse-grid" data-open={isExOpen}>
@@ -411,6 +430,7 @@ export function SectionCard({
                                 movementType={ex.movementType}
                                 sectionFormat={section.format}
                                 onUpdate={(updates) => onUpdateSet(exIdx, 0, updates)}
+                                loggedSet={loggedSetsMap?.[ex.sets[0].setNumber]}
                               />
                             </div>
                           )
@@ -441,7 +461,7 @@ export function SectionCard({
                               <span />
                             </div>
 
-                            {/* Set rows */}
+                            {/* Set rows (planned sets) */}
                             {ex.sets.map((s, sIdx) => (
                               <SetRow
                                 key={sIdx}
@@ -460,8 +480,37 @@ export function SectionCard({
                                       )
                                     : undefined
                                 }
+                                // Logged-set actual/planned overlay when available
+                                loggedSet={loggedSetsMap?.[s.setNumber]}
                               />
                             ))}
+                            {/* Extra sets — sets logged beyond the plan count.
+                                These have set numbers > ex.sets.length. */}
+                            {loggedSetsMap &&
+                              Object.values(loggedSetsMap)
+                                .filter((ls) => !ex.sets.some((s) => s.setNumber === ls.setNumber))
+                                .sort((a, b) => a.setNumber - b.setNumber)
+                                .map((ls) => (
+                                  <SetRow
+                                    key={`extra-${ls.setNumber}`}
+                                    set={{
+                                      setNumber: ls.setNumber,
+                                      type: 'Normal',
+                                      reps: null,
+                                      weightKg: null,
+                                      durationSeconds: null,
+                                      rpe: null,
+                                      distanceMeters: null,
+                                      restSeconds: null,
+                                    }}
+                                    movementType="Reps"
+                                    onUpdate={() => {/* extra sets are read-only */}}
+                                    onRemove={() => {/* extra sets are read-only */}}
+                                    completionState="completed"
+                                    loggedSet={ls}
+                                    isExtraSet
+                                  />
+                                ))}
 
                             {/* Add set — hidden when the section is locked
                                 (also covers session-locked + day-in-past per

--- a/web/src/components/training/SetRow.tsx
+++ b/web/src/components/training/SetRow.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import type { ExerciseSet, MovementType } from '@/api/training-plan-types';
+import type { ExerciseSet, MovementType, LoggedSetDto } from '@/api/training-plan-types';
 import type { SetCompletionState } from '@/lib/completionState';
 import { CompletionBadge } from '@/components/common/CompletionBadge';
 
@@ -11,6 +11,20 @@ interface SetRowProps {
   onRemove: () => void;
   /** Completion state for this set (additive display-only; omit to render nothing). */
   completionState?: SetCompletionState;
+  /**
+   * Logged-set actual + snapshot-planned values from the client's workout log.
+   * When present, the set is rendered in read-view (Treatment B):
+   *   - Actual value as the headline number
+   *   - Snapshot-planned as a quiet "plán…" caption below
+   *   - Gold accent change-indicator dot when isModified === true
+   * When absent (no workout log for this set), the editable plan inputs render as normal.
+   */
+  loggedSet?: LoggedSetDto;
+  /**
+   * When true, the set is an extra set performed beyond the plan count
+   * (actual only, no planned value). Shown in gold + "navíc" caption.
+   */
+  isExtraSet?: boolean;
 }
 
 /**
@@ -21,7 +35,7 @@ interface SetRowProps {
  *   Distance    → distance + duration + rest
  *   RepsForTime → reps + rest
  */
-export function SetRow({ set, movementType, onUpdate, onDuplicate, onRemove, completionState }: SetRowProps) {
+export function SetRow({ set, movementType, onUpdate, onDuplicate, onRemove, completionState, loggedSet, isExtraSet }: SetRowProps) {
   const { t } = useTranslation();
 
   // Shared input styling. Values are centered in their columns so that the
@@ -69,9 +83,96 @@ export function SetRow({ set, movementType, onUpdate, onDuplicate, onRemove, com
     />
   );
 
+  /**
+   * Renders a single value cell in "logged view" (Treatment B):
+   *   - actual value as headline (gold if isExtraSet, else default text color)
+   *   - snapshot-planned as a quiet "plán X" caption below (hidden for extra sets)
+   *   - gold dot change indicator when isModified === true
+   *
+   * Returns null when both actual and planned are null (set not performed).
+   */
+  const loggedCell = (
+    actual: number | null | undefined,
+    planned: number | null | undefined,
+    isModifiedField: boolean,
+  ) => {
+    const actualDisplay = actual != null ? String(actual) : '–';
+    const plannedDisplay = planned != null ? String(planned) : null;
+    return (
+      <div className="flex flex-col items-center gap-0" style={{ minWidth: 0 }}>
+        {/* Actual headline */}
+        <span
+          className={
+            isExtraSet
+              ? 'text-[12px] font-semibold text-accent tabular-nums'
+              : 'text-[12px] font-semibold text-text tabular-nums'
+          }
+        >
+          {actualDisplay}
+          {isModifiedField && !isExtraSet && (
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full bg-accent ml-[2px] align-middle"
+              aria-label={t('training.completionState.modified')}
+            />
+          )}
+        </span>
+        {/* Snapshot-planned caption */}
+        {!isExtraSet && plannedDisplay != null && (
+          <span className="text-[9px] text-text4 tabular-nums leading-none">
+            {t('training.completionState.plan')} {plannedDisplay}
+          </span>
+        )}
+        {/* Extra-set "navíc" caption */}
+        {isExtraSet && (
+          <span className="text-[9px] text-accent tabular-nums leading-none">
+            {t('training.completionState.navic')}
+          </span>
+        )}
+      </div>
+    );
+  };
+
   // Determine grid template based on movementType.
   // Columns: # | type-specific fields | rest | remove
   const renderColumns = () => {
+    // When loggedSet is present, render actual/planned overlay instead of editable inputs
+    if (loggedSet) {
+      switch (movementType) {
+        case 'Time':
+          return (
+            <>
+              {loggedCell(loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified)}
+              {/* Rest is plan-only — no logged "actual rest" in the contract */}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+        case 'Distance':
+          return (
+            <>
+              {loggedCell(loggedSet.actualDistanceMeters, loggedSet.plannedDistanceMeters, loggedSet.isModified)}
+              {loggedCell(loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified)}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+        case 'RepsForTime':
+          return (
+            <>
+              {loggedCell(loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+        // Reps (default)
+        default:
+          return (
+            <>
+              {loggedCell(loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified)}
+              {loggedCell(loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+      }
+    }
+
     switch (movementType) {
       case 'Time':
         return (

--- a/web/src/components/training/WodExerciseRow.tsx
+++ b/web/src/components/training/WodExerciseRow.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import type { ExerciseSet, MovementType, WorkoutFormat } from '@/api/training-plan-types';
+import type { ExerciseSet, MovementType, WorkoutFormat, LoggedSetDto } from '@/api/training-plan-types';
 
 interface WodExerciseRowProps {
   /** The single set holding the WOD round prescription. */
@@ -13,6 +13,11 @@ interface WodExerciseRowProps {
   sectionFormat: WorkoutFormat;
   /** Patches the single set in the store. */
   onUpdate: (updates: Partial<ExerciseSet>) => void;
+  /**
+   * Logged-set actual + snapshot-planned values from the client's workout log.
+   * When present, renders actual as headline + snapshot-planned as caption + change dot.
+   */
+  loggedSet?: LoggedSetDto;
 }
 
 /**
@@ -29,12 +34,47 @@ interface WodExerciseRowProps {
  *   Distance    → distance (m) + duration (s)
  *   RepsForTime → reps
  */
-export function WodExerciseRow({ set, movementType, sectionFormat, onUpdate }: WodExerciseRowProps) {
+export function WodExerciseRow({ set, movementType, sectionFormat, onUpdate, loggedSet }: WodExerciseRowProps) {
   const { t } = useTranslation();
   // Tabata sets work duration at the section level (`formatConfig.workSeconds`),
   // so per-exercise reps don't make sense — the trainer prescribes load and
   // movement; the rep count is whatever the client achieves in the work window.
   const hideReps = sectionFormat === 'Tabata';
+
+  /**
+   * Renders a single WOD field in "logged view" (Treatment B):
+   *   - actual value as headline
+   *   - snapshot-planned as quiet "plán X" caption
+   *   - gold dot change indicator when isModifiedField is true
+   */
+  const loggedWodField = (
+    label: string,
+    actual: number | null | undefined,
+    planned: number | null | undefined,
+    isModifiedField: boolean,
+    unit?: string,
+  ) => (
+    <span className="inline-flex items-start gap-1.5">
+      <span className="text-[11px] font-medium text-text3 uppercase">{label}</span>
+      <span className="inline-flex flex-col items-end">
+        <span className="text-[12px] font-semibold text-text tabular-nums">
+          {actual != null ? String(actual) : '–'}
+          {isModifiedField && (
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full bg-accent ml-[2px] align-middle"
+              aria-label={t('training.completionState.modified')}
+            />
+          )}
+        </span>
+        {planned != null && (
+          <span className="text-[9px] text-text4 tabular-nums leading-none">
+            {t('training.completionState.plan')} {planned}
+          </span>
+        )}
+      </span>
+      {unit && <span className="text-[11px] text-text4">{unit}</span>}
+    </span>
+  );
 
   const inputStyle: React.CSSProperties = {
     border: 'none',
@@ -93,6 +133,42 @@ export function WodExerciseRow({ set, movementType, sectionFormat, onUpdate }: W
     numInput(set.weightKg, (v) => onUpdate({ weightKg: v })),
     'kg',
   );
+
+  // When a logged set is present, render actual/planned overlay instead of editable inputs
+  if (loggedSet) {
+    switch (movementType) {
+      case 'Time':
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {loggedWodField(t('training.wod.durationLabel'), loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified, 's')}
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+          </div>
+        );
+      case 'Distance':
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {loggedWodField(t('training.wod.distanceLabel'), loggedSet.actualDistanceMeters, loggedSet.plannedDistanceMeters, loggedSet.isModified, 'm')}
+            {loggedWodField(t('training.wod.durationLabel'), loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified, 's')}
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+          </div>
+        );
+      case 'RepsForTime':
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {!hideReps && loggedWodField(t('training.repsLabel'), loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+          </div>
+        );
+      // Reps (default)
+      default:
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+            {!hideReps && loggedWodField(t('training.repsLabel'), loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+          </div>
+        );
+    }
+  }
 
   switch (movementType) {
     case 'Time':

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1215,7 +1215,10 @@
       "exerciseCompleted": "{{done}}/{{total}} dokončeno",
       "exerciseSkippedSuffix": "{{count}} vynecháno",
       "sessionAllComplete": "Vše dokončeno",
-      "sessionMixed": "{{completed}} dokončeno · {{skipped}} vynecháno"
+      "sessionMixed": "{{completed}} dokončeno · {{skipped}} vynecháno",
+      "modified": "upraveno",
+      "plan": "plán",
+      "navic": "navíc"
     },
     "retroactiveFinish": {
       "buttonLabel": "Označit jako dokončeno",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1199,7 +1199,10 @@
       "exerciseCompleted": "{{done}}/{{total}} abgeschlossen",
       "exerciseSkippedSuffix": "{{count}} übersprungen",
       "sessionAllComplete": "Alles erledigt",
-      "sessionMixed": "{{completed}} abgeschlossen · {{skipped}} übersprungen"
+      "sessionMixed": "{{completed}} abgeschlossen · {{skipped}} übersprungen",
+      "modified": "geändert",
+      "plan": "Plan",
+      "navic": "extra"
     },
     "retroactiveFinish": {
       "buttonLabel": "Als abgeschlossen markieren",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1200,7 +1200,10 @@
       "exerciseCompleted": "{{done}}/{{total}} completed",
       "exerciseSkippedSuffix": "{{count}} skipped",
       "sessionAllComplete": "All complete",
-      "sessionMixed": "{{completed}} completed · {{skipped}} skipped"
+      "sessionMixed": "{{completed}} completed · {{skipped}} skipped",
+      "modified": "modified",
+      "plan": "plan",
+      "navic": "extra"
     },
     "retroactiveFinish": {
       "buttonLabel": "Mark finished",

--- a/web/src/lib/completionState.ts
+++ b/web/src/lib/completionState.ts
@@ -22,6 +22,29 @@
 import type { SessionExecutionDto } from '@/api/training-plan-types';
 import type { MealLogDto } from '@/api/plan-types';
 
+// ── Per-exercise modification state ─────────────────────────────────────────
+
+/**
+ * Derive whether an exercise has any set-level modifications.
+ *
+ * The backend only surfaces session-level hasModifications and per-set isModified
+ * flags. There is no per-exercise hasModifications on the DTO — we derive it
+ * client-side by checking whether any LoggedSetDto under the exercise has
+ * isModified === true.
+ *
+ * @param sessionExecution  The execution record for the session (may be undefined)
+ * @param exerciseExternalId The exercise to check
+ */
+export function deriveExerciseModificationState(
+  sessionExecution: SessionExecutionDto | undefined,
+  exerciseExternalId: string,
+): boolean {
+  if (!sessionExecution) return false;
+  const loggedSets = sessionExecution.loggedSetsByExercise[exerciseExternalId];
+  if (!loggedSets || loggedSets.length === 0) return false;
+  return loggedSets.some((s) => s.isModified);
+}
+
 // ── Per-set state ────────────────────────────────────────────────────────────
 
 export type SetCompletionState = 'completed' | 'skipped' | 'not-reached';

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -1132,6 +1132,15 @@ export default function TrainingPlanPage() {
                           />
                         );
                       })()}
+                      {/* Session-level "upraveno" badge — shown when the client
+                          performed at least one set that differs from the plan.
+                          hasModifications is backend-computed on the SessionExecutionDto. */}
+                      {sessionExec?.hasModifications && (
+                        <CompletionBadge
+                          kind="modified"
+                          state={sessionExec.hasModifications}
+                        />
+                      )}
                     </span>
                     {/* ── Edit-lock affordances (published sessions only) ─────────
                         Live   → in-progress badge + disabled affordance with tooltip


### PR DESCRIPTION
## Summary
- Coach plan-detail consumes the #440 `SessionExecutionDto` (`loggedSetsByExercise` per-set planned+actual+isModified, session-level `hasModifications`).
- `SetRow` / `WodExerciseRow` render Treatment B: actual headline + quiet "plán …" snapshot caption + gold change-indicator dot when `isModified`.
- "upraveno" roll-up badge (`CompletionBadge kind="modified"`) at session-header and exercise-header level.
- Edge cases: skipped (blank actual), extra/"navíc" (gold, no plan), swapped/ad-hoc (whole exercise flagged). i18n `modified`/`plan`/`navic` in cs/en/de.

## Related issue
Fixes #442

## Parent epic (sub-issue PR)
Part of epic #439 — base branch: `feature/439-planned-vs-actual-training`.

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — "upraveno" badges (session + exercise) verified live; skipped-set blank-actual + extra-set "navíc" verified live; trainer API `loggedSetsByExercise` confirmed carrying planned+actual+isModified. "plán <snapshot> caption + gold dot on a plan-paired modified set" static-verified only (seed plan has 0 prescribed sets; completed session can't be unlocked) — deferred to review.

## Test plan
- [ ] Treatment B in SetRow: actual headline, quiet "plán …" caption, gold change indicator when isModified; editable plan input still shows current plan value.
- [ ] "upraveno" roll-up badge at session-header and exercise-header when hasModifications.
- [ ] WOD rows get the same treatment.
- [ ] Skipped set: planned caption present, actual blank.
- [ ] Extra set: actual in gold, "navíc" caption, no planned value.
- [ ] Swapped/ad-hoc exercise: shown as performed, whole exercise flagged modified.
- [ ] i18n keys (modified/plan/navic) in cs/en/de.
- [ ] No hardcoded colors; no `any`; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)