### PR TITLE
feat: planned-vs-actual set values + modified badges across training surfaces

### DIFF
--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -1437,6 +1437,7 @@ function TrainingPlanDetail({
                       standalone
                       headerRight={sessionCheckIndicator}
                       bodyFooter={<SessionReminderRow session={session} planId={planId} />}
+                      hasModifications={session.hasModifications ?? false}
                     >
                       {/* Section-grouped exercise cards (read-only) */}
                       {sections.map((section, sectionIdx) => {

--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -42,6 +42,7 @@ import {
   type SectionDto,
   type WorkoutFormat,
   type MuscleGroup,
+  type LoggedSetDto,
 } from '@/api/training'
 import {
   getSubmittedQuestionnairesByCoach,
@@ -1529,6 +1530,28 @@ function TrainingPlanDetail({
                                     ? getMuscleGroupColor(primaryMg, colors)
                                     : colors.gold
 
+                                // Build LoggedSetDto array from FullPlanSet (#441).
+                                // FullPlanSet carries actual + planned + isModified after
+                                // backend #440. Sets without actual data (never performed)
+                                // have all actual* === null and isModified === false.
+                                const planLoggedSets: LoggedSetDto[] | undefined =
+                                  sets.some((s) => s.isModified != null)
+                                    ? sets.map((s, si) => ({
+                                        setNumber: s.setNumber ?? si + 1,
+                                        actualReps: s.actualReps ?? undefined,
+                                        actualWeightKg: s.actualWeightKg ?? undefined,
+                                        actualRpe: s.actualRpe ?? undefined,
+                                        actualDurationSeconds: s.actualDurationSeconds ?? undefined,
+                                        actualDistanceMeters: s.actualDistanceMeters ?? undefined,
+                                        plannedReps: s.plannedReps ?? undefined,
+                                        plannedWeightKg: s.plannedWeightKg ?? undefined,
+                                        plannedRpe: s.plannedRpe ?? undefined,
+                                        plannedDurationSeconds: s.plannedDurationSeconds ?? undefined,
+                                        plannedDistanceMeters: s.plannedDistanceMeters ?? undefined,
+                                        isModified: s.isModified ?? false,
+                                      }))
+                                    : undefined
+
                                 return (
                                   <ExpandableExerciseCard
                                     key={exId ?? exIdx}
@@ -1542,6 +1565,7 @@ function TrainingPlanDetail({
                                     nonExpandable={isWodFormat}
                                     hideCompletionIndicator={isWodFormat}
                                     notes={exercise.notes}
+                                    hasModifications={exercise.hasModifications ?? false}
                                   >
                                     <SetGrid
                                       sets={sets}
@@ -1549,6 +1573,7 @@ function TrainingPlanDetail({
                                         .filter((s) => s.completedAt != null)
                                         .map((s) => s.setNumber ?? 0)
                                         .filter((n) => n > 0)}
+                                      loggedSets={planLoggedSets}
                                     />
                                   </ExpandableExerciseCard>
                                 )

--- a/mobile/app/(client)/plan-photos.tsx
+++ b/mobile/app/(client)/plan-photos.tsx
@@ -61,8 +61,13 @@ import { ImageLightbox } from '@/components/ui/ImageLightbox'
 type UiCategory = 'Food' | 'Progress' | 'Free'
 type FilterCategory = 'All' | UiCategory
 
-/** Map from PlanPhotoCategory wire value back to UI category for display. */
-const WIRE_TO_UI: Record<PlanPhotoCategory, UiCategory> = {
+/**
+ * Map from PlanPhotoCategory wire value back to UI category for display.
+ * Partial by design: wire categories without a dedicated chip (e.g. Training,
+ * which is surfaced on session-scoped screens, not this plan-photos filter)
+ * fall back to 'Free' at the call site via `?? 'Free'`.
+ */
+const WIRE_TO_UI: Partial<Record<PlanPhotoCategory, UiCategory>> = {
   [PlanPhotoCategory.Food]: 'Food',
   [PlanPhotoCategory.Body]: 'Progress',
   [PlanPhotoCategory.FreeForm]: 'Free',

--- a/mobile/app/(client)/session-log-photo.tsx
+++ b/mobile/app/(client)/session-log-photo.tsx
@@ -72,7 +72,9 @@ export default function SessionLogPhotoScreen() {
     const cache = queryClient.getQueryData<TodayTrainingResponse>(['today-training'])
     const photos = (cache?.photosBySession ?? {})[sessionId] ?? []
     return photos
-      .filter((p) => typeof p.blobUrl === 'string' && p.blobUrl.length > 0)
+      .filter((p): p is typeof p & { blobUrl: string } =>
+        typeof p.blobUrl === 'string' && p.blobUrl.length > 0,
+      )
       .map((p) => ({ blobUrl: p.blobUrl, note: p.note ?? null }))
   }, [queryClient, sessionId])
 
@@ -93,7 +95,9 @@ export default function SessionLogPhotoScreen() {
       source: 'library',
       allowsMultipleSelection: true,
       requestUploadUrl: async ({ contentType, sizeBytes }) => {
-        return generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        const res = await generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        // Generated type marks these optional; the API always returns them.
+        return { uploadUrl: res.uploadUrl ?? '', blobUrl: res.blobUrl ?? '' }
       },
     },
     undefined,
@@ -110,7 +114,9 @@ export default function SessionLogPhotoScreen() {
     {
       source: 'camera',
       requestUploadUrl: async ({ contentType, sizeBytes }) => {
-        return generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        const res = await generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        // Generated type marks these optional; the API always returns them.
+        return { uploadUrl: res.uploadUrl ?? '', blobUrl: res.blobUrl ?? '' }
       },
     },
     (blobUrl) => {

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -58,6 +58,7 @@ import type {
   WodResult,
   UpdateWorkoutWodRequest,
   UpdateWodExerciseRequest,
+  LoggedSetDto,
 } from '@/api/wod-types'
 import { SectionHeader } from '@/components/training/SectionHeader'
 import { ExpandableExerciseCard } from '@/components/training/ExpandableExerciseCard'
@@ -2415,6 +2416,14 @@ export default function WorkoutLogScreen() {
           // so sending completedAt for skipped sets caused them to show as '✓'
           // on the Today-screen TrainingCard SetGrid (bug #322).
           completedAt: isDone ? new Date().toISOString() : undefined,
+          // Snapshot-planned values (#441): the backend stores these on the
+          // WorkoutLog so the isModified flag can be computed on read. Send
+          // the original plan values from the exercise's planned sets.
+          plannedReps: planned.reps ?? null,
+          plannedWeightKg: planned.weightKg ?? null,
+          plannedRpe: planned.rpe ?? null,
+          plannedDurationSeconds: planned.durationSeconds ?? null,
+          plannedDistanceMeters: planned.distanceMeters ?? null,
         }
       })
       // Per-exercise WOD result (only present when the exercise has a format override).
@@ -2893,11 +2902,53 @@ export default function WorkoutLogScreen() {
           (si) => plannedSets[si]?.setNumber ?? si + 1,
         )
         if (plannedSets.length > 0) {
+          // Build client-side LoggedSetDto from the live session store (#441).
+          // The backend computes isModified server-side (stored in WorkoutLog),
+          // but for the local finished summary we derive it from the plan vs
+          // the user's actual inputs (formOverrides). This gives immediate
+          // visual feedback in the LiveFinishedSummary before the PUT/GET cycle.
+          const loggedSets: LoggedSetDto[] = plannedSets.map((planned, si) => {
+            const override = formOverrides[exId]?.[si]
+            const isDone = doneIndices.includes(si)
+            const actualReps = isDone ? (override?.reps ?? planned.reps ?? null) : null
+            const actualWeightKg = isDone ? (override?.weightKg ?? planned.weightKg ?? null) : null
+            const actualDurationSeconds = isDone ? (override?.durationSeconds ?? null) : null
+            const actualDistanceMeters = isDone ? (override?.distanceMeters ?? null) : null
+            // isModified: true when the user changed reps or weight vs. plan.
+            const repsModified =
+              isDone &&
+              actualReps != null &&
+              planned.reps != null &&
+              actualReps !== planned.reps
+            const weightModified =
+              isDone &&
+              actualWeightKg != null &&
+              planned.weightKg != null &&
+              actualWeightKg !== planned.weightKg
+            const durationModified =
+              isDone &&
+              actualDurationSeconds != null &&
+              planned.durationSeconds != null &&
+              actualDurationSeconds !== planned.durationSeconds
+            return {
+              setNumber: planned.setNumber ?? si + 1,
+              actualReps: actualReps ?? undefined,
+              actualWeightKg: actualWeightKg ?? undefined,
+              actualDurationSeconds: actualDurationSeconds ?? undefined,
+              actualDistanceMeters: actualDistanceMeters ?? undefined,
+              plannedReps: planned.reps ?? undefined,
+              plannedWeightKg: planned.weightKg ?? undefined,
+              plannedDurationSeconds: planned.durationSeconds ?? undefined,
+              plannedDistanceMeters: planned.distanceMeters ?? undefined,
+              isModified: repsModified || weightModified || durationModified,
+            }
+          })
           exerciseSets.push({
             exerciseName: ex.exerciseName ?? '',
             sets: plannedSets,
             completedSetNumbers: completedSetNums,
             skippedSetNumbers: skippedSetNums,
+            loggedSets,
           })
         }
       }

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -2407,9 +2407,10 @@ export default function WorkoutLogScreen() {
           reps: isDone ? (override?.reps ?? planned.reps) : undefined,
           weightKg: isDone ? (override?.weightKg ?? planned.weightKg) : undefined,
           // Time-movement actuals: durationSeconds replaces the reps slot.
-          durationSeconds: isDone ? (override?.durationSeconds ?? null) : undefined,
+          // Use undefined (not null) to match UpdateWorkoutSetRequest's field type.
+          durationSeconds: isDone ? (override?.durationSeconds ?? undefined) : undefined,
           // Distance-movement actuals: distanceMeters replaces the weightKg slot.
-          distanceMeters: isDone ? (override?.distanceMeters ?? null) : undefined,
+          distanceMeters: isDone ? (override?.distanceMeters ?? undefined) : undefined,
           // Only truly completed sets carry completedAt. Skipped sets must NOT
           // receive a completedAt timestamp — the backend (GetTodaySession)
           // uses CompletedAt != null to populate completedSetsBySessionExercise,
@@ -2419,11 +2420,12 @@ export default function WorkoutLogScreen() {
           // Snapshot-planned values (#441): the backend stores these on the
           // WorkoutLog so the isModified flag can be computed on read. Send
           // the original plan values from the exercise's planned sets.
-          plannedReps: planned.reps ?? null,
-          plannedWeightKg: planned.weightKg ?? null,
-          plannedRpe: planned.rpe ?? null,
-          plannedDurationSeconds: planned.durationSeconds ?? null,
-          plannedDistanceMeters: planned.distanceMeters ?? null,
+          // Use undefined (not null) to match UpdateWorkoutSetRequest's field type.
+          plannedReps: planned.reps ?? undefined,
+          plannedWeightKg: planned.weightKg ?? undefined,
+          plannedRpe: planned.rpe ?? undefined,
+          plannedDurationSeconds: planned.durationSeconds ?? undefined,
+          plannedDistanceMeters: planned.distanceMeters ?? undefined,
         }
       })
       // Per-exercise WOD result (only present when the exercise has a format override).

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web",
     "test": "jest",
     "typecheck": "tsc --noEmit",
+    "expo-doctor": "npx expo-doctor",
     "generate-api": "cd ../backend && curl -sk https://localhost:5001/swagger/v1/swagger.json -o swagger.json && dotnet nswag run nswag.mobile.json && sed -i '' 's|/\\* eslint-disable \\*/|/* eslint-disable */\\n// @ts-nocheck|' ../mobile/src/api/generated.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -20,7 +20,7 @@ export class ApiClient {
 
         this.instance = instance || axios.create();
 
-        this.baseUrl = baseUrl ?? "https://localhost:61551";
+        this.baseUrl = baseUrl ?? "https://localhost:5001";
 
     }
 

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -20,7 +20,7 @@ export class ApiClient {
 
         this.instance = instance || axios.create();
 
-        this.baseUrl = baseUrl ?? "https://localhost:5001";
+        this.baseUrl = baseUrl ?? "https://localhost:61551";
 
     }
 
@@ -8750,6 +8750,78 @@ export class ApiClient {
     }
 
     /**
+     * Save photos / note for a training session diary entry
+     * @param sessionId The unique identifier of the training session whose photos/note are being saved.
+    Sourced from the route segment {SessionId}.
+     * @return No Content
+     */
+    saveSessionPhotosEndpoint(sessionId: string, saveSessionPhotosRequest: SaveSessionPhotosRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/client/training/log/sessions/{sessionId}/photos";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(saveSessionPhotosRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSaveSessionPhotosEndpoint(_response);
+        });
+    }
+
+    protected processSaveSessionPhotosEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Mark all training sessions for a day complete
      * @return Success
      */
@@ -9407,6 +9479,82 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetFullTrainingPlanResponse>(null as any);
+    }
+
+    /**
+     * Generate training session photo upload URL
+     * @param sessionId The unique identifier of the session the photo will be attached to.
+    Sourced from the route segment {SessionId}.
+     * @return Success
+     */
+    generateSessionPhotoUploadUrlEndpoint(sessionId: string, generateSessionPhotoUploadUrlRequest: GenerateSessionPhotoUploadUrlRequest, signal?: AbortSignal): Promise<GenerateSessionPhotoUploadUrlResponse> {
+        let url_ = this.baseUrl + "/client/training/log/sessions/{sessionId}/photo-upload-url";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateSessionPhotoUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateSessionPhotoUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateSessionPhotoUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateSessionPhotoUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateSessionPhotoUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateSessionPhotoUploadUrlResponse>(null as any);
     }
 
     /**
@@ -12790,7 +12938,7 @@ export interface WodResult {
     repsByRound?: number[] | undefined;
 }
 
-/** A single set actually performed during a workout with recorded values. */
+/** A single set actually performed during a workout with recorded values. Snapshot-planned fields capture the prescribed values at the time the set was first logged; they are immutable after initial persistence so later plan edits do not affect them. */
 export interface WorkoutSet {
     /** Set number within the exercise (1-based). */
     setNumber?: number;
@@ -12808,6 +12956,20 @@ export interface WorkoutSet {
     completedAt?: string | undefined;
     /** Whether this set is a personal record for this exercise. */
     isPR?: boolean;
+    /** Prescribed repetitions at the time this set was first logged. */
+    plannedReps?: number | undefined;
+    /** Prescribed weight (kg) at the time this set was first logged. */
+    plannedWeightKg?: number | undefined;
+    /** Prescribed RPE at the time this set was first logged. */
+    plannedRpe?: number | undefined;
+    /** Prescribed duration (seconds) at the time this set was first logged. */
+    plannedDurationSeconds?: number | undefined;
+    /** Prescribed distance (meters) at the time this set was first logged. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+Always false for legacy sets whose planned fields are all null (backward-compatible default).
+Never stored — derived on read. */
+    isModified?: boolean;
 }
 
 /** Request to progressively update a workout log with exercise data. Designed for offline-first: client sends all exercises/sets accumulated so far. */
@@ -12852,29 +13014,32 @@ export interface UpdateWorkoutSetRequest {
     distanceMeters?: number | undefined;
     /** When this set was completed. */
     completedAt?: string | undefined;
+    /** Prescribed repetitions from the plan prescription. */
+    plannedReps?: number | undefined;
+    /** Prescribed weight (kg) from the plan prescription. */
+    plannedWeightKg?: number | undefined;
+    /** Prescribed RPE from the plan prescription. */
+    plannedRpe?: number | undefined;
+    /** Prescribed duration (seconds) from the plan prescription. */
+    plannedDurationSeconds?: number | undefined;
+    /** Prescribed distance (meters) from the plan prescription. */
+    plannedDistanceMeters?: number | undefined;
 }
 
-/** RFC7807 compatible problem details/ error response class. this can be used by configuring startup like so: app.UseFastEndpoints(c => c.Errors.UseProblemDetails()) */
 export interface ProblemDetails {
     type?: string;
     title?: string;
     status?: number;
     instance?: string;
     traceId?: string;
-    /** the details of the error */
     detail?: string | undefined;
     errors?: ProblemDetails_Error[];
 }
 
-/** the error details object */
 export interface ProblemDetails_Error {
-    /** the name of the error or property of the dto that caused the error */
     name?: string;
-    /** the reason for the error */
     reason?: string;
-    /** the code of the error */
     code?: string | undefined;
-    /** the severity of the error */
     severity?: string | undefined;
 }
 
@@ -13026,7 +13191,7 @@ export interface PutSettingsResponse {
     profession?: string;
     /** Day of the week (0 = Sunday … 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned time of day. */
+    /** Time of day for the reminder. Between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
@@ -13043,7 +13208,7 @@ Accepted values: "Training", "Nutrition". */
     profession: string;
     /** Day of the week on which the reminder fires (0 = Sunday … 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned local time of day for the reminder. Minutes, Seconds, and Milliseconds must all be zero. */
+    /** Local time of day for the reminder. Must be between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
@@ -13079,7 +13244,7 @@ export interface PutOverrideResponse {
 export interface PutOverrideRequest {
     /** Override day of week (0 = Sunday … 6 = Saturday). Null = inherit. */
     dayOfWeek?: number | undefined;
-    /** Override time of day (hour-aligned). Null = inherit. Minutes/Seconds/Milliseconds must be zero if set. */
+    /** Override time of day. Null = inherit. Must be between 00:00:00 and 23:59:59 if set. */
     timeOfDay?: string | undefined;
     /** Override enabled flag. Null = inherit. */
     enabled?: boolean | undefined;
@@ -13156,7 +13321,7 @@ export interface CheckInSettingDto {
     profession?: string;
     /** Day of the week (0 = Sunday, 1 = Monday, …, 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned time of day in "HH:mm:ss" format. */
+    /** Time of day for the reminder in "HH:mm:ss" format. Between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
@@ -13616,6 +13781,45 @@ of 1-based set numbers that were stamped as complete in the WorkoutLog.
 An absent key means no sets for that exercise were logged.
 An empty list should not occur but is treated identically to an absent key. */
     completedSetsByExercise?: { [key: string]: number[]; };
+    /** Per-exercise map of per-set actual values, snapshot-planned values, and isModified flags.
+Key = ExerciseExternalId; value = list of LoggedSetDto (one per logged set).
+An absent key means no sets for that exercise were logged.
+The web layer uses this together with CompletedSetsByExercise to render
+the actual-vs-planned comparison and the upraveno (modified) indicator per set. */
+    loggedSetsByExercise?: { [key: string]: LoggedSetDto[]; };
+    /** True when at least one set in any exercise under this session has IsModified == true.
+The web layer uses this to show the upraveno badge at the session-header level.
+Always false when the session has no WorkoutLog (or all logs are legacy without snapshots). */
+    hasModifications?: boolean;
+}
+
+/** Per-set actual values + snapshot-planned values + backend-computed isModified flag, sourced from a WorkoutSet. Used by training-read endpoints that need to surface actual-vs-planned comparison (GetTodaySession, GetFullTrainingPlan, and the trainer GetTrainingPlan). */
+export interface LoggedSetDto {
+    /** 1-based set number within the exercise. */
+    setNumber?: number;
+    /** Actual repetitions logged. Null when the set has not been performed. */
+    actualReps?: number | undefined;
+    /** Actual weight (kg) logged. Null when not performed. */
+    actualWeightKg?: number | undefined;
+    /** Actual RPE logged. Null when not performed. */
+    actualRpe?: number | undefined;
+    /** Actual duration (seconds) logged. Null when not performed. */
+    actualDurationSeconds?: number | undefined;
+    /** Actual distance (meters) logged. Null when not performed. */
+    actualDistanceMeters?: number | undefined;
+    /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+    plannedReps?: number | undefined;
+    /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+    plannedWeightKg?: number | undefined;
+    /** Snapshot-planned RPE at log time. Null for legacy logs. */
+    plannedRpe?: number | undefined;
+    /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+    plannedDurationSeconds?: number | undefined;
+    /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+Always false for legacy sets (no snapshot → treated as planned == actual). */
+    isModified?: boolean;
 }
 
 /** Per-session edit-lock state projected into the trainer read model. A session with no active lock document reports Stable with a null holder. */
@@ -16003,6 +16207,28 @@ export interface CreateExerciseRequest {
     techniqueNotes?: string | undefined;
 }
 
+/** Request model for saving the complete photo and note state of a training session diary entry. The Photos list and Note are replaced with exactly what the client sends. */
+export interface SaveSessionPhotosRequest {
+    /** The complete list of photos to persist on the session log.
+Replaces the existing Photos list entirely — pass an empty list to remove all photos.
+Each item carries the blob URL and an optional per-photo caption.
+Existing URLs that are re-submitted keep their original UploadedAt
+timestamp; new URLs receive the current UTC time. */
+    photos?: SessionPhotoInput[];
+    /** Optional free-text note to persist on the session log entry (max 500 chars).
+When non-null, the stored note is replaced with the trimmed value
+(whitespace-only strings are treated as null). When null, the existing note is cleared. */
+    note?: string | undefined;
+}
+
+/** A single photo input in a SaveSessionPhotosRequest. */
+export interface SessionPhotoInput {
+    /** The MinIO blob URL for this photo, as returned by the signed-URL upload helper. */
+    blobUrl?: string;
+    /** Optional per-photo caption (max 500 chars). */
+    note?: string | undefined;
+}
+
 /** Response for marking all training sessions on a day complete. */
 export interface MarkWholeDayCompleteResponse {
     /** The date that was marked complete. */
@@ -16264,6 +16490,38 @@ Populated via a single batch GetStateAsync call on the session lock service. */
 Possible values: "Coach" (trainer/nutritionist holds the lock) or "Client".
 Null / missing when the session is in the Stable state. */
     lockHolderBySession?: { [key: string]: string; };
+    /** Per-session photo list for today, keyed by SessionId.
+Each value is an ordered list of photos that were saved to the session log for today's date.
+Sourced from the SessionLog MongoDB document for today.
+Empty dictionary when no photos have been saved for any session today (or when no active plan exists). */
+    photosBySession?: { [key: string]: SessionPhotoDto[]; };
+    /** Per-session diary note for today, keyed by SessionId.
+Only populated for sessions whose SessionLog has a non-null, non-empty Note.
+Allows the mobile client to pre-load the existing note into its textarea so a subsequent
+Save does not overwrite it with null (data-loss prevention).
+Empty dictionary when no session has a note today (or when no active plan exists). */
+    notesBySession?: { [key: string]: string; };
+    /** Per-session, per-exercise logged set values for today.
+Keyed by SessionId → ExerciseExternalId → list of LoggedSetDto (one per set).
+Carries actual logged values, snapshot-planned values, and the backend-computed isModified flag.
+Replaces the set-number-only CompletedSetsBySessionExercise for callers that
+need actual vs planned comparison.
+Empty when no live-training progress has been logged for today. */
+    loggedSetsBySessionExercise?: { [key: string]: { [key: string]: LoggedSetDto[]; }; };
+    /** Per-session hasModifications flag for today, keyed by SessionId.
+True when any set under any exercise in the session has IsModified == true in the latest log.
+Missing entries are treated as false (no modifications / no log). */
+    hasModificationsBySession?: { [key: string]: boolean; };
+}
+
+/** A photo attached to a session diary entry, as returned in PhotosBySession. */
+export interface SessionPhotoDto {
+    /** The MinIO blob URL for this photo. */
+    blobUrl?: string;
+    /** UTC timestamp when the photo was uploaded/persisted. */
+    uploadedAt?: string;
+    /** Optional per-photo caption (max 500 chars). Null when none was provided. */
+    note?: string | undefined;
 }
 
 /** Full training plan response for the client mobile view. Contains all published weeks enriched with completion state and muscle group data. */
@@ -16344,6 +16602,9 @@ Populated via a batch GetStateAsync call on the session lock service. */
     /** Who currently holds the lock, if any.
 Possible values: "Coach", "Client", or null when the session is Stable. */
     lockHolder?: string | undefined;
+    /** True when at least one exercise in this session has HasModifications == true.
+Always false when no workout log exists for this session. */
+    hasModifications?: boolean;
 }
 
 /** An ordered section within a session (e.g. "Hlavní", "Warm-up", "Cool-down"). */
@@ -16398,28 +16659,71 @@ Empty list when the exercise no longer exists in the database. */
     muscleGroups?: MuscleGroup[];
     /** True when every planned set has a completed workout log entry. */
     isCompleted?: boolean;
-    /** Planned sets with per-set completion timestamps. */
+    /** True when at least one set under this exercise has IsModified == true.
+Always false when no workout log exists for this exercise. */
+    hasModifications?: boolean;
+    /** Planned sets with per-set completion timestamps and actual-vs-planned delta. */
     sets?: SetDto[];
 }
 
-/** A planned set with its completion state derived from workout logs. */
+/** A planned set with its completion state and actual-vs-planned delta derived from workout logs. */
 export interface SetDto {
     /** 1-based set number within the exercise. */
     setNumber?: number;
     /** Set type (Normal, Warmup, Dropset, Superset). */
     type?: string;
-    /** Target number of repetitions. */
+    /** Target number of repetitions (from the plan prescription). */
     reps?: number | undefined;
-    /** Target weight in kilograms. */
+    /** Target weight in kilograms (from the plan prescription). */
     weightKg?: number | undefined;
-    /** Target duration in seconds (for timed exercises). */
+    /** Target duration in seconds (from the plan prescription). */
     durationSeconds?: number | undefined;
-    /** Target distance in meters (for distance-based exercises). */
+    /** Target distance in meters (from the plan prescription). */
     distanceMeters?: number | undefined;
     /** Rest time after this set in seconds. */
     restSeconds?: number | undefined;
     /** When this set was completed, or null if not yet done. */
     completedAt?: string | undefined;
+    /** Actual repetitions logged. Null when not yet performed. */
+    actualReps?: number | undefined;
+    /** Actual weight (kg) logged. Null when not yet performed. */
+    actualWeightKg?: number | undefined;
+    /** Actual RPE logged. Null when not yet performed. */
+    actualRpe?: number | undefined;
+    /** Actual duration (seconds) logged. Null when not yet performed. */
+    actualDurationSeconds?: number | undefined;
+    /** Actual distance (meters) logged. Null when not yet performed. */
+    actualDistanceMeters?: number | undefined;
+    /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+    plannedReps?: number | undefined;
+    /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+    plannedWeightKg?: number | undefined;
+    /** Snapshot-planned RPE at log time. Null for legacy logs. */
+    plannedRpe?: number | undefined;
+    /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+    plannedDurationSeconds?: number | undefined;
+    /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned
+counterpart. Always false for legacy sets (no snapshot → treated as planned == actual). */
+    isModified?: boolean;
+}
+
+/** Response for the session photo upload URL generation endpoint. */
+export interface GenerateSessionPhotoUploadUrlResponse {
+    /** Time-limited pre-signed URL the client uses to PUT the image directly to blob storage. */
+    uploadUrl?: string;
+    /** The permanent blob URL to pass to POST /client/training/log/sessions/{sessionId}/photos
+after the upload completes. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed training session photo upload URL. */
+export interface GenerateSessionPhotoUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 10 MiB. */
+    sizeBytes?: number;
 }
 
 /** Response model returned after sending a client request. */
@@ -16493,6 +16797,7 @@ export enum PlanPhotoCategory {
     Food = "Food",
     Body = "Body",
     FreeForm = "FreeForm",
+    Training = "Training",
 }
 
 /** Identifies whether a PlanPhoto is associated with a nutrition plan or a training plan. */

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -19,6 +19,7 @@ import type {
   SetDto,
   WodConfig,
 } from './generated';
+import type { LoggedSetDto } from './wod-types';
 
 // Re-export generated types and enums so consumer imports (`from '@/api/training'`) still work.
 export { SetType, MuscleGroup, WorkoutFormat, MovementType };
@@ -46,15 +47,21 @@ export type SectionDto = Omit<GeneratedSectionDto, 'exercises'> & {
    * For sections without exercises: the section id is in
    * TrainingCompletion.CompletedSectionIds (#260 fix). */
   isCompleted?: boolean;
-  exercises?: GeneratedSectionDto['exercises'];
+  /**
+   * Exercises in this section. Uses `FullPlanExercise` so call sites can
+   * read `hasModifications` and augmented `sets` (actual + planned + isModified)
+   * without extra casts. The generated shape is a subset, so the widening is safe.
+   * (#440 — drop cast once regen surfaces these fields in generated.ts natively).
+   */
+  exercises?: FullPlanExercise[];
 };
 
 /**
  * Augmented SessionDto — propagates SectionDto augmentation so
  * `response.weeks[i].sessions[j].sections[k].formatConfig` is typed correctly
  * without per-call casts.
- * Also adds `lockState` which the backend (#382) now includes in GetFullTrainingPlan
- * responses. Drop once regen produces this field natively.
+ * Also adds `lockState` (#382) and `hasModifications` (#440).
+ * Drop once regen produces these fields natively.
  */
 export type SessionDto = Omit<GeneratedSessionDto, 'sections'> & {
   sections?: SectionDto[];
@@ -66,6 +73,12 @@ export type SessionDto = Omit<GeneratedSessionDto, 'sections'> & {
    * Defaults to "Stable" when the field is absent (pre-#382 response shape).
    */
   lockState?: string;
+  /**
+   * True when at least one exercise in this session has hasModifications == true.
+   * Always false when no workout log exists for this session.
+   * Hand-declared until regen-api surfaces this field natively (#440).
+   */
+  hasModifications?: boolean;
 };
 
 /**
@@ -98,6 +111,8 @@ export type TrainingSection = Omit<GeneratedTrainingSection, 'notes'> & {
 export type {
   WodResult,
   WodSessionExercise,
+  LoggedSetDto,
+  UpdateWorkoutSetWithPlannedRequest,
 } from './wod-types';
 
 /**
@@ -118,6 +133,9 @@ export interface SessionPhotoDto {
  *   - `lockStateBySession` (#382): session edit-lock state.
  *   - `photosBySession` (#405): per-session diary photos from the session log.
  *   - `notesBySession` (#405): persisted session-level notes keyed by sessionId.
+ *   - `loggedSetsBySessionExercise` (#440): per-session, per-exercise logged sets
+ *     with actual values, snapshot-planned values, and isModified flag.
+ *   - `hasModificationsBySession` (#440): per-session roll-up modification flag.
  *
  * All fields hand-declared until regen-api runs against the updated backend.
  * Drop the augmentation for each field once the generated client emits it natively.
@@ -139,6 +157,19 @@ export type TodayTrainingResponse = GetTodaySessionResponse & {
    * do not wipe previously saved notes on re-open.
    */
   notesBySession?: Record<string, string>;
+  /**
+   * Per-session, per-exercise logged sets with actual values, snapshot-planned
+   * values, and backend-computed isModified flag.
+   * Outer key = sessionId (string UUID), inner key = exerciseExternalId (string UUID).
+   * Hand-declared until regen-api surfaces LoggedSetsBySessionExercise natively (#440).
+   */
+  loggedSetsBySessionExercise?: Record<string, Record<string, LoggedSetDto[]>>;
+  /**
+   * Per-session roll-up modification flag: true when the session has at least one
+   * exercise with at least one isModified set.
+   * Hand-declared until regen-api surfaces HasModificationsBySession natively (#440).
+   */
+  hasModificationsBySession?: Record<string, boolean>;
 };
 
 /**
@@ -157,14 +188,61 @@ export type FullPlanWeek = WeekDto;
 export type FullPlanSession = SessionDto;
 
 /**
- * @deprecated Use `ExerciseDto` from generated. Kept as alias for backward compatibility.
+ * Augmented ExerciseDto — adds hasModifications from #440, and widens
+ * `sets` from `SetDto[]` to `FullPlanSet[]` (a superset with actual values,
+ * snapshot-planned values, and the isModified flag).
+ *
+ * Uses `Omit` to replace the generated `sets` property so TypeScript resolves
+ * the narrower `FullPlanSet[]` type unambiguously (plain intersection would
+ * produce `SetDto[] & FullPlanSet[]`, which TypeScript cannot narrow at call sites).
+ *
+ * Hand-declared until regen-api produces these fields natively.
  */
-export type FullPlanExercise = ExerciseDto;
+export type FullPlanExercise = Omit<ExerciseDto, 'sets'> & {
+  /**
+   * True when at least one set under this exercise has isModified == true.
+   * Always false when no workout log exists for this exercise.
+   */
+  hasModifications?: boolean;
+  /** Augmented sets with actual + planned values and isModified (#440). */
+  sets?: FullPlanSet[];
+};
 
 /**
- * @deprecated Use `SetDto` from generated. Kept as alias for backward compatibility.
+ * Augmented SetDto — adds actual values, snapshot-planned values, and
+ * the backend-computed isModified flag introduced in #440.
+ * Hand-declared until regen-api produces these fields natively in generated.ts.
+ * Drop augmentation once generated.ts emits the full shape.
  */
-export type FullPlanSet = SetDto;
+export type FullPlanSet = SetDto & {
+  // ── Actual logged values ────────────────────────────────────────────────────
+  /** Actual reps completed. Null when set has not been performed. */
+  actualReps?: number | null;
+  /** Actual weight (kg) logged. Null when not performed. */
+  actualWeightKg?: number | null;
+  /** Actual RPE logged. Null when not performed. */
+  actualRpe?: number | null;
+  /** Actual duration (seconds) logged. Null when not performed. */
+  actualDurationSeconds?: number | null;
+  /** Actual distance (meters) logged. Null when not performed. */
+  actualDistanceMeters?: number | null;
+  // ── Snapshot-planned values ─────────────────────────────────────────────────
+  /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+  plannedReps?: number | null;
+  /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+  plannedWeightKg?: number | null;
+  /** Snapshot-planned RPE at log time. Null for legacy logs. */
+  plannedRpe?: number | null;
+  /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+  plannedDurationSeconds?: number | null;
+  /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+  plannedDistanceMeters?: number | null;
+  /**
+   * Backend-computed: true when any actual field differs from its snapshot-planned
+   * counterpart. Always false for legacy sets (no snapshot).
+   */
+  isModified?: boolean;
+};
 
 // --- API calls ---
 

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -11,15 +11,16 @@ import type {
   TrainingSection as GeneratedTrainingSection,
   TrainingSession,
   GetTodaySessionResponse,
-  GetFullTrainingPlanResponse as GeneratedFullTrainingPlanResponse,
-  WeekDto as GeneratedWeekDto,
-  SessionDto as GeneratedSessionDto,
-  SectionDto as GeneratedSectionDto,
+  GetFullTrainingPlanResponse,
+  WeekDto,
+  SessionDto,
+  SectionDto,
   ExerciseDto,
   SetDto,
   WodConfig,
+  SessionPhotoDto,
+  GenerateSessionPhotoUploadUrlResponse,
 } from './generated';
-import type { LoggedSetDto } from './wod-types';
 
 // Re-export generated types and enums so consumer imports (`from '@/api/training'`) still work.
 export { SetType, MuscleGroup, WorkoutFormat, MovementType };
@@ -28,71 +29,15 @@ export type {
   SessionExercise,
   TrainingSession,
   GetTodaySessionResponse,
+  GetFullTrainingPlanResponse,
+  WeekDto,
+  SessionDto,
+  SectionDto,
   ExerciseDto,
   SetDto,
   WodConfig,
-};
-
-/**
- * Augmented SectionDto — adds `formatConfig`, `notes`, and `isCompleted` that
- * the backend now emits but NSwag hasn't been re-run for yet.
- * Drop the augmentation fields once the generated client is regenerated
- * and the fields appear on GeneratedSectionDto directly.
- */
-export type SectionDto = Omit<GeneratedSectionDto, 'exercises'> & {
-  formatConfig?: WodConfig | null;
-  notes?: string | null;
-  /** True when the backend considers this section fully complete.
-   * For sections with exercises: every exercise has IsCompleted=true.
-   * For sections without exercises: the section id is in
-   * TrainingCompletion.CompletedSectionIds (#260 fix). */
-  isCompleted?: boolean;
-  /**
-   * Exercises in this section. Uses `FullPlanExercise` so call sites can
-   * read `hasModifications` and augmented `sets` (actual + planned + isModified)
-   * without extra casts. The generated shape is a subset, so the widening is safe.
-   * (#440 — drop cast once regen surfaces these fields in generated.ts natively).
-   */
-  exercises?: FullPlanExercise[];
-};
-
-/**
- * Augmented SessionDto — propagates SectionDto augmentation so
- * `response.weeks[i].sessions[j].sections[k].formatConfig` is typed correctly
- * without per-call casts.
- * Also adds `lockState` (#382) and `hasModifications` (#440).
- * Drop once regen produces these fields natively.
- */
-export type SessionDto = Omit<GeneratedSessionDto, 'sections'> & {
-  sections?: SectionDto[];
-  /**
-   * Session edit-lock state from the backend.
-   * "Stable"  — no active lock; normal operation.
-   * "Editing" — a trainer currently holds the edit lock; banner should be shown.
-   * "Live"    — the client's own live session is in progress; no banner.
-   * Defaults to "Stable" when the field is absent (pre-#382 response shape).
-   */
-  lockState?: string;
-  /**
-   * True when at least one exercise in this session has hasModifications == true.
-   * Always false when no workout log exists for this session.
-   * Hand-declared until regen-api surfaces this field natively (#440).
-   */
-  hasModifications?: boolean;
-};
-
-/**
- * Augmented WeekDto — propagates SessionDto augmentation up the chain.
- */
-export type WeekDto = Omit<GeneratedWeekDto, 'sessions'> & {
-  sessions?: SessionDto[];
-};
-
-/**
- * Augmented GetFullTrainingPlanResponse — propagates WeekDto augmentation up the chain.
- */
-export type GetFullTrainingPlanResponse = Omit<GeneratedFullTrainingPlanResponse, 'weeks'> & {
-  weeks?: WeekDto[];
+  SessionPhotoDto,
+  GenerateSessionPhotoUploadUrlResponse,
 };
 
 /**
@@ -107,70 +52,25 @@ export type TrainingSection = Omit<GeneratedTrainingSection, 'notes'> & {
   notes?: string | null;
 }
 
-// Re-export WodResult from wod-types (hand-declared until fully superseded by generated).
+// Re-export WOD types from wod-types (UpdateWodExerciseRequest and UpdateWorkoutWodRequest
+// are still hand-maintained; WodResult, WodConfig, LoggedSetDto are re-exported
+// from generated via wod-types).
 export type {
   WodResult,
   WodSessionExercise,
   LoggedSetDto,
-  UpdateWorkoutSetWithPlannedRequest,
+  UpdateWodExerciseRequest,
+  UpdateWorkoutWodRequest,
 } from './wod-types';
 
 /**
- * A single training-session diary photo from the session log.
- * Mirrors `MealPhotoDto` from nutrition (blobUrl, uploadedAt, note?).
- *
- * Hand-declared until regen-api is run against the backend (#405).
- * Drop this type once generated.ts emits `SessionPhotoDto` natively.
+ * `TodayTrainingResponse` is now a direct alias for `GetTodaySessionResponse`.
+ * After the #440 regen all previously-augmented fields
+ * (`lockStateBySession`, `photosBySession`, `notesBySession`,
+ * `loggedSetsBySessionExercise`, `hasModificationsBySession`)
+ * are emitted natively by generated.ts.
  */
-export interface SessionPhotoDto {
-  blobUrl: string;
-  uploadedAt?: string;
-  note?: string | null;
-}
-
-/**
- * Augmented GetTodaySessionResponse — adds:
- *   - `lockStateBySession` (#382): session edit-lock state.
- *   - `photosBySession` (#405): per-session diary photos from the session log.
- *   - `notesBySession` (#405): persisted session-level notes keyed by sessionId.
- *   - `loggedSetsBySessionExercise` (#440): per-session, per-exercise logged sets
- *     with actual values, snapshot-planned values, and isModified flag.
- *   - `hasModificationsBySession` (#440): per-session roll-up modification flag.
- *
- * All fields hand-declared until regen-api runs against the updated backend.
- * Drop the augmentation for each field once the generated client emits it natively.
- */
-export type TodayTrainingResponse = GetTodaySessionResponse & {
-  lockStateBySession?: Record<string, string>;
-  /**
-   * Per-session diary photos from today's session logs, keyed by sessionId.
-   * Mirrors how `mealsEaten[].photos` is embedded in GetTodayLogResponse for nutrition.
-   * Added in #405 (GenerateSessionPhotoUploadUrl + SaveSessionPhotos endpoints).
-   * Returns an empty object when no session has any diary photos today.
-   */
-  photosBySession?: Record<string, SessionPhotoDto[]>;
-  /**
-   * Persisted session-level note for today's session log, keyed by sessionId.
-   * Only present for sessions that have a non-empty note — mirrors how
-   * nutrition's today read path returns each meal's note.
-   * Added in #405 review fix: seeds the note textarea so REPLACE semantics
-   * do not wipe previously saved notes on re-open.
-   */
-  notesBySession?: Record<string, string>;
-  /**
-   * Per-session, per-exercise logged sets with actual values, snapshot-planned
-   * values, and backend-computed isModified flag.
-   * Outer key = sessionId (string UUID), inner key = exerciseExternalId (string UUID).
-   * Hand-declared until regen-api surfaces LoggedSetsBySessionExercise natively (#440).
-   */
-  loggedSetsBySessionExercise?: Record<string, Record<string, LoggedSetDto[]>>;
-  /**
-   * Per-session roll-up modification flag: true when the session has at least one
-   * exercise with at least one isModified set.
-   * Hand-declared until regen-api surfaces HasModificationsBySession natively (#440).
-   */
-  hasModificationsBySession?: Record<string, boolean>;
-};
+export type TodayTrainingResponse = GetTodaySessionResponse;
 
 /**
  * @deprecated Use `GetFullTrainingPlanResponse` from generated. Kept as alias for backward compatibility.
@@ -188,61 +88,20 @@ export type FullPlanWeek = WeekDto;
 export type FullPlanSession = SessionDto;
 
 /**
- * Augmented ExerciseDto — adds hasModifications from #440, and widens
- * `sets` from `SetDto[]` to `FullPlanSet[]` (a superset with actual values,
- * snapshot-planned values, and the isModified flag).
- *
- * Uses `Omit` to replace the generated `sets` property so TypeScript resolves
- * the narrower `FullPlanSet[]` type unambiguously (plain intersection would
- * produce `SetDto[] & FullPlanSet[]`, which TypeScript cannot narrow at call sites).
- *
- * Hand-declared until regen-api produces these fields natively.
+ * `FullPlanExercise` is now a direct alias for the generated `ExerciseDto`.
+ * After the #440 regen `ExerciseDto` carries `hasModifications` and
+ * `sets?: SetDto[]` (where `SetDto` has all actual + planned + isModified fields).
+ * Kept as alias for backward compatibility with `SetGrid` and `LiveFinishedSummary`.
  */
-export type FullPlanExercise = Omit<ExerciseDto, 'sets'> & {
-  /**
-   * True when at least one set under this exercise has isModified == true.
-   * Always false when no workout log exists for this exercise.
-   */
-  hasModifications?: boolean;
-  /** Augmented sets with actual + planned values and isModified (#440). */
-  sets?: FullPlanSet[];
-};
+export type FullPlanExercise = ExerciseDto;
 
 /**
- * Augmented SetDto — adds actual values, snapshot-planned values, and
- * the backend-computed isModified flag introduced in #440.
- * Hand-declared until regen-api produces these fields natively in generated.ts.
- * Drop augmentation once generated.ts emits the full shape.
+ * `FullPlanSet` is now a direct alias for the generated `SetDto`.
+ * After the #440 regen `SetDto` carries all actual values, snapshot-planned
+ * values, and the backend-computed `isModified` flag.
+ * Kept as alias for backward compatibility with `SetGrid` and `LiveFinishedSummary`.
  */
-export type FullPlanSet = SetDto & {
-  // ── Actual logged values ────────────────────────────────────────────────────
-  /** Actual reps completed. Null when set has not been performed. */
-  actualReps?: number | null;
-  /** Actual weight (kg) logged. Null when not performed. */
-  actualWeightKg?: number | null;
-  /** Actual RPE logged. Null when not performed. */
-  actualRpe?: number | null;
-  /** Actual duration (seconds) logged. Null when not performed. */
-  actualDurationSeconds?: number | null;
-  /** Actual distance (meters) logged. Null when not performed. */
-  actualDistanceMeters?: number | null;
-  // ── Snapshot-planned values ─────────────────────────────────────────────────
-  /** Snapshot-planned repetitions at log time. Null for legacy logs. */
-  plannedReps?: number | null;
-  /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
-  plannedWeightKg?: number | null;
-  /** Snapshot-planned RPE at log time. Null for legacy logs. */
-  plannedRpe?: number | null;
-  /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
-  plannedDurationSeconds?: number | null;
-  /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
-  plannedDistanceMeters?: number | null;
-  /**
-   * Backend-computed: true when any actual field differs from its snapshot-planned
-   * counterpart. Always false for legacy sets (no snapshot).
-   */
-  isModified?: boolean;
-};
+export type FullPlanSet = SetDto;
 
 // --- API calls ---
 
@@ -258,11 +117,8 @@ export async function getFullTrainingPlan(planId: string): Promise<GetFullTraini
 
 // ─── Session photo upload API (#405) ─────────────────────────────────────────
 // Mirrors the nutrition meal-photo API pattern exactly.
-
-export interface GenerateSessionPhotoUploadUrlResponse {
-  uploadUrl: string;
-  blobUrl: string;
-}
+// GenerateSessionPhotoUploadUrlResponse and SessionPhotoDto are now natively
+// in generated.ts — consumed via the re-exports above.
 
 /**
  * Request a signed upload URL for a training-session diary photo.

--- a/mobile/src/api/wod-types.ts
+++ b/mobile/src/api/wod-types.ts
@@ -7,61 +7,26 @@
  *   - WodConfig     — configuration parameters per format
  *   - WodResult     — outcome-only capture (no per-rep mid-round data)
  *
- * IMPORTANT: generated.ts does not yet include these shapes (regen-api requires
- * a running backend which is outside mobile-expo's allowlist). Once the backend
- * is running and regen-api is executed, these declarations should be replaced with
- * re-exports from generated.ts and this file removed.
+ * After the #440 regen, `WodResult`, `WodConfig`, `WorkoutFormat`, `MovementType`,
+ * `LoggedSetDto`, and `UpdateWorkoutSetRequest` (with planned fields) are all
+ * emitted natively by generated.ts.  This file re-exports the canonical shapes
+ * and retains only the genuinely-additive hand-maintained types.
  */
 
-/**
- * Workout format / scoring methodology for a session or per-exercise override.
- * Mirrors backend WorkoutFormat enum.
- */
-export type WorkoutFormat = 'Standard' | 'ForTime' | 'AMRAP' | 'EMOM' | 'Tabata';
-
-/**
- * How performance in an exercise is measured.
- * Mirrors backend MovementType enum.
- */
-export type MovementType = 'Reps' | 'Time' | 'Distance' | 'RepsForTime';
-
-/**
- * Configuration parameters for a WOD format.
- * Only fields relevant to the chosen format are expected to be set.
- *
- * - EMOM:    intervalSeconds + totalRounds
- * - AMRAP:   timeCapSeconds
- * - ForTime: timeCapSeconds
- * - Tabata:  workSeconds + restSeconds + totalRounds
- */
-export interface WodConfig {
-  timeCapSeconds?: number | null;
-  intervalSeconds?: number | null;
-  totalRounds?: number | null;
-  workSeconds?: number | null;
-  restSeconds?: number | null;
-}
-
-/**
- * Outcome-only capture for a WOD format session or per-exercise result.
- * Submitted at log root (session WOD) or per exercise (per-exercise format).
- *
- * - AMRAP:   roundsCompleted + extraReps
- * - EMOM:    roundsCompleted + failedRounds
- * - Tabata:  roundsCompleted + repsByRound (total reps per round, optional)
- * - ForTime: totalTimeSeconds
- */
-export interface WodResult {
-  roundsCompleted?: number | null;
-  extraReps?: number | null;
-  totalTimeSeconds?: number | null;
-  failedRounds?: number[] | null;
-  repsByRound?: number[] | null;
-}
+// ── Re-exports from generated.ts ────────────────────────────────────────────
+// These were hand-declared here before #440 regen; generated.ts is now the
+// single source of truth.
+import type { WodResult, WodConfig, LoggedSetDto, UpdateWorkoutSetRequest } from './generated';
+import { WorkoutFormat, MovementType } from './generated';
+export type { WodResult, WodConfig, LoggedSetDto, UpdateWorkoutSetRequest };
+export { WorkoutFormat, MovementType };
 
 /**
  * Extended SessionExercise shape that includes WOD fields from #205.
  * Extends the generated SessionExercise with the new backend fields.
+ *
+ * Still hand-maintained: this is the *plan prescription* shape for the live
+ * session screen, which uses SessionExercise (not ExerciseDto / SetDto).
  */
 export interface WodSessionExercise {
   exerciseExternalId?: string;
@@ -86,46 +51,13 @@ export interface WodSessionExercise {
 }
 
 /**
- * Per-set request payload with snapshot-planned fields (#441 / backend #440).
- *
- * Hand-declared until regen-api is run against the backend that includes
- * these fields on UpdateWorkoutSetRequest.  Drop the augmentation once
- * generated.ts emits the planned fields natively.
- */
-export interface UpdateWorkoutSetWithPlannedRequest {
-  setNumber?: number;
-  /** Actual reps completed. */
-  reps?: number | null;
-  /** Actual weight in kg. */
-  weightKg?: number | null;
-  /** Rate of Perceived Exertion (1-10). */
-  rpe?: number | null;
-  /** Duration in seconds. */
-  durationSeconds?: number | null;
-  /** Distance in meters. */
-  distanceMeters?: number | null;
-  /** When this set was completed. */
-  completedAt?: string | null;
-  // ── Snapshot-planned fields — frozen from plan prescription at log time ──────
-  /** Prescribed repetitions from the plan (snapshot). */
-  plannedReps?: number | null;
-  /** Prescribed weight (kg) from the plan (snapshot). */
-  plannedWeightKg?: number | null;
-  /** Prescribed RPE from the plan (snapshot). */
-  plannedRpe?: number | null;
-  /** Prescribed duration in seconds from the plan (snapshot). */
-  plannedDurationSeconds?: number | null;
-  /** Prescribed distance in meters from the plan (snapshot). */
-  plannedDistanceMeters?: number | null;
-}
-
-/**
- * Extended UpdateWorkoutExerciseRequest that includes WodResult and planned-field sets.
+ * Extended UpdateWorkoutExerciseRequest that includes WodResult and the
+ * generated UpdateWorkoutSetRequest (which now carries planned fields natively).
  */
 export interface UpdateWodExerciseRequest {
   exerciseExternalId?: string;
   exerciseName?: string;
-  sets?: UpdateWorkoutSetWithPlannedRequest[];
+  sets?: UpdateWorkoutSetRequest[];
   /** WOD outcome for this exercise (when exercise has a format override). */
   wodResult?: WodResult | null;
 }
@@ -139,33 +71,4 @@ export interface UpdateWorkoutWodRequest {
   exercises?: UpdateWodExerciseRequest[];
   /** WOD outcome for the whole session (when session has a non-Standard format). */
   wodResult?: WodResult | null;
-}
-
-/**
- * Per-set read DTO with actual values, snapshot-planned values, and the
- * backend-computed isModified flag (#441 / backend #440).
- *
- * Hand-declared until regen-api is run.  Used by GetTodaySession
- * (loggedSetsBySessionExercise) and GetFullTrainingPlan.
- */
-export interface LoggedSetDto {
-  /** 1-based set number within the exercise. */
-  setNumber: number;
-  // ── Actual logged values ───────────────────────────────────────────────────
-  actualReps?: number | null;
-  actualWeightKg?: number | null;
-  actualRpe?: number | null;
-  actualDurationSeconds?: number | null;
-  actualDistanceMeters?: number | null;
-  // ── Snapshot-planned values ────────────────────────────────────────────────
-  plannedReps?: number | null;
-  plannedWeightKg?: number | null;
-  plannedRpe?: number | null;
-  plannedDurationSeconds?: number | null;
-  plannedDistanceMeters?: number | null;
-  /**
-   * Backend-computed: true when any actual field differs from its
-   * snapshot-planned counterpart.  Always false for legacy sets (no snapshot).
-   */
-  isModified: boolean;
 }

--- a/mobile/src/api/wod-types.ts
+++ b/mobile/src/api/wod-types.ts
@@ -86,19 +86,46 @@ export interface WodSessionExercise {
 }
 
 /**
- * Extended UpdateWorkoutExerciseRequest that includes WodResult.
+ * Per-set request payload with snapshot-planned fields (#441 / backend #440).
+ *
+ * Hand-declared until regen-api is run against the backend that includes
+ * these fields on UpdateWorkoutSetRequest.  Drop the augmentation once
+ * generated.ts emits the planned fields natively.
+ */
+export interface UpdateWorkoutSetWithPlannedRequest {
+  setNumber?: number;
+  /** Actual reps completed. */
+  reps?: number | null;
+  /** Actual weight in kg. */
+  weightKg?: number | null;
+  /** Rate of Perceived Exertion (1-10). */
+  rpe?: number | null;
+  /** Duration in seconds. */
+  durationSeconds?: number | null;
+  /** Distance in meters. */
+  distanceMeters?: number | null;
+  /** When this set was completed. */
+  completedAt?: string | null;
+  // ── Snapshot-planned fields — frozen from plan prescription at log time ──────
+  /** Prescribed repetitions from the plan (snapshot). */
+  plannedReps?: number | null;
+  /** Prescribed weight (kg) from the plan (snapshot). */
+  plannedWeightKg?: number | null;
+  /** Prescribed RPE from the plan (snapshot). */
+  plannedRpe?: number | null;
+  /** Prescribed duration in seconds from the plan (snapshot). */
+  plannedDurationSeconds?: number | null;
+  /** Prescribed distance in meters from the plan (snapshot). */
+  plannedDistanceMeters?: number | null;
+}
+
+/**
+ * Extended UpdateWorkoutExerciseRequest that includes WodResult and planned-field sets.
  */
 export interface UpdateWodExerciseRequest {
   exerciseExternalId?: string;
   exerciseName?: string;
-  sets?: Array<{
-    setNumber?: number;
-    reps?: number | null;
-    weightKg?: number | null;
-    durationSeconds?: number | null;
-    distanceMeters?: number | null;
-    completedAt?: string | null;
-  }>;
+  sets?: UpdateWorkoutSetWithPlannedRequest[];
   /** WOD outcome for this exercise (when exercise has a format override). */
   wodResult?: WodResult | null;
 }
@@ -112,4 +139,33 @@ export interface UpdateWorkoutWodRequest {
   exercises?: UpdateWodExerciseRequest[];
   /** WOD outcome for the whole session (when session has a non-Standard format). */
   wodResult?: WodResult | null;
+}
+
+/**
+ * Per-set read DTO with actual values, snapshot-planned values, and the
+ * backend-computed isModified flag (#441 / backend #440).
+ *
+ * Hand-declared until regen-api is run.  Used by GetTodaySession
+ * (loggedSetsBySessionExercise) and GetFullTrainingPlan.
+ */
+export interface LoggedSetDto {
+  /** 1-based set number within the exercise. */
+  setNumber: number;
+  // ── Actual logged values ───────────────────────────────────────────────────
+  actualReps?: number | null;
+  actualWeightKg?: number | null;
+  actualRpe?: number | null;
+  actualDurationSeconds?: number | null;
+  actualDistanceMeters?: number | null;
+  // ── Snapshot-planned values ────────────────────────────────────────────────
+  plannedReps?: number | null;
+  plannedWeightKg?: number | null;
+  plannedRpe?: number | null;
+  plannedDurationSeconds?: number | null;
+  plannedDistanceMeters?: number | null;
+  /**
+   * Backend-computed: true when any actual field differs from its
+   * snapshot-planned counterpart.  Always false for legacy sets (no snapshot).
+   */
+  isModified: boolean;
 }

--- a/mobile/src/api/workouts.ts
+++ b/mobile/src/api/workouts.ts
@@ -8,12 +8,12 @@ import type {
   StartWorkoutResponse,
   UpdateWorkoutExerciseRequest,
   UpdateWorkoutRequest,
+  UpdateWorkoutSetRequest,
   GetExerciseProgressResponse,
   ExerciseProgressPoint,
   GoLiveResponse,
   AbandonWorkoutResponse,
 } from './generated';
-import type { UpdateWorkoutSetWithPlannedRequest } from './wod-types';
 
 // Re-export generated types so consumer imports (`from '@/api/workouts'`) still work.
 export type {
@@ -28,8 +28,14 @@ export type {
   ExerciseProgressPoint,
   GoLiveResponse,
   AbandonWorkoutResponse,
-  UpdateWorkoutSetWithPlannedRequest,
 };
+
+/**
+ * `UpdateWorkoutSetWithPlannedRequest` is now identical to the generated
+ * `UpdateWorkoutSetRequest` (which carries planned fields natively after the #440 regen).
+ * Kept as an alias so callers that still reference the old name compile without changes.
+ */
+export type { UpdateWorkoutSetRequest, UpdateWorkoutSetRequest as UpdateWorkoutSetWithPlannedRequest };
 
 /**
  * @deprecated Use `GetExerciseProgressResponse` from generated. Kept as alias for backward compatibility.

--- a/mobile/src/api/workouts.ts
+++ b/mobile/src/api/workouts.ts
@@ -13,6 +13,7 @@ import type {
   GoLiveResponse,
   AbandonWorkoutResponse,
 } from './generated';
+import type { UpdateWorkoutSetWithPlannedRequest } from './wod-types';
 
 // Re-export generated types so consumer imports (`from '@/api/workouts'`) still work.
 export type {
@@ -27,6 +28,7 @@ export type {
   ExerciseProgressPoint,
   GoLiveResponse,
   AbandonWorkoutResponse,
+  UpdateWorkoutSetWithPlannedRequest,
 };
 
 /**

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1370,6 +1370,8 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               isMarkAllTrainingLoading={markAllTrainingDoneMutation.isPending}
               onSessionPhotoPress={handleSessionPhotoPress}
               photosBySession={photosBySession}
+              loggedSetsBySessionExercise={trainingQuery.data?.loggedSetsBySessionExercise}
+              hasModificationsBySession={trainingQuery.data?.hasModificationsBySession}
             />
           </View>
         ) : hasActivePlanButNoTrainingToday ? (

--- a/mobile/src/components/training/ExpandableExerciseCard.tsx
+++ b/mobile/src/components/training/ExpandableExerciseCard.tsx
@@ -78,6 +78,12 @@ interface ExpandableExerciseCardProps {
    * section-note line in `SectionHeader`.
    */
   notes?: string | null
+  /**
+   * When true, renders a small "upraveno" badge in the summary line to
+   * signal that at least one set in this exercise was modified vs. the plan.
+   * Designed for the finished Today card and plan detail screens (#441).
+   */
+  hasModifications?: boolean
   children: React.ReactNode
 }
 
@@ -99,6 +105,7 @@ export function ExpandableExerciseCard({
   hideCompletionIndicator = false,
   nonExpandable = false,
   notes,
+  hasModifications = false,
   children,
 }: ExpandableExerciseCardProps) {
   const colors = useTheme()
@@ -151,10 +158,21 @@ export function ExpandableExerciseCard({
           <Text style={[Type.subheadline, { color: colors.label }]} numberOfLines={1}>
             {name}
           </Text>
-          {summaryText.length > 0 && (
-            <Text style={[Type.caption1, { color: colors.label2, marginTop: 1 }]} numberOfLines={1}>
-              {summaryText}
-            </Text>
+          {(summaryText.length > 0 || hasModifications) && (
+            <View style={styles.summaryRow}>
+              {summaryText.length > 0 && (
+                <Text style={[Type.caption1, { color: colors.label2 }]} numberOfLines={1}>
+                  {summaryText}
+                </Text>
+              )}
+              {hasModifications && (
+                <View style={[styles.modifiedBadge, { backgroundColor: colors.goldBg }]}>
+                  <Text style={[styles.modifiedBadgeText, { color: colors.gold }]}>
+                    {t('training.upraveno')}
+                  </Text>
+                </View>
+              )}
+            </View>
           )}
           {bodyParts && bodyParts.length > 0 && (
             <View style={styles.badgeRow}>
@@ -285,6 +303,25 @@ const styles = StyleSheet.create({
   nameWrap: {
     flex: 1,
     minWidth: 0,
+  },
+  /** Row wrapping summary text + optional "upraveno" badge. */
+  summaryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 1,
+  },
+  /** Small pill badge shown when hasModifications is true. */
+  modifiedBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 4,
+  },
+  modifiedBadgeText: {
+    fontFamily: interFamily('600'),
+    fontSize: 10,
+    fontWeight: '600',
   },
   badgeRow: {
     flexDirection: 'row',

--- a/mobile/src/components/training/ExpandableSessionCard.tsx
+++ b/mobile/src/components/training/ExpandableSessionCard.tsx
@@ -163,7 +163,7 @@ export function ExpandableSessionCard({
   const [lightboxVisible, setLightboxVisible] = useState(false)
   const photoList = photos ?? []
   const hasPhotos = photoList.length > 0
-  const photoUrls = photoList.map((p) => p.blobUrl).filter(Boolean)
+  const photoUrls = photoList.map((p) => p.blobUrl).filter((u): u is string => typeof u === 'string' && u.length > 0)
   const photoNotes = photoList.map((p) => p.note ?? null)
 
   const handleBadgePress = useCallback(() => {

--- a/mobile/src/components/training/ExpandableSessionCard.tsx
+++ b/mobile/src/components/training/ExpandableSessionCard.tsx
@@ -126,6 +126,13 @@ interface ExpandableSessionCardProps {
    * only — mirrors MealRow's `hasPhotos`/`photos` pattern exactly.
    */
   photos?: SessionPhotoDto[]
+  /**
+   * When true, renders an "upraveno" pill badge in the session header row,
+   * mirroring the exercise-level badge from ExpandableExerciseCard.
+   * Sourced from `hasModificationsBySession[sessionId]` (Today card) or
+   * `session.hasModifications` (full-plan / plan-detail screen).
+   */
+  hasModifications?: boolean
   children: React.ReactNode
 }
 
@@ -152,6 +159,7 @@ export function ExpandableSessionCard({
   bodyFooter,
   onPhotoPress,
   photos,
+  hasModifications = false,
 }: ExpandableSessionCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -227,9 +235,26 @@ export function ExpandableSessionCard({
           >
             {name}
           </Text>
-          <Text style={[Type.caption1, { color: colors.label2, marginTop: 2 }]} numberOfLines={1}>
-            {summaryText}
-          </Text>
+          {/* Summary row: summary text + optional session-level "upraveno" badge.
+              Mirrors ExpandableExerciseCard's summaryRow — same flexDirection,
+              gap, and pill style so session and exercise badges are visually
+              identical. */}
+          {(summaryText.length > 0 || hasModifications) && (
+            <View style={styles.summaryRow}>
+              {summaryText.length > 0 && (
+                <Text style={[Type.caption1, { color: colors.label2 }]} numberOfLines={1}>
+                  {summaryText}
+                </Text>
+              )}
+              {hasModifications && (
+                <View style={[styles.modifiedBadge, { backgroundColor: colors.goldBg }]}>
+                  <Text style={[styles.modifiedBadgeText, { color: colors.gold }]}>
+                    {t('training.upraveno')}
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
         </View>
 
         {/* Photo indicator badge — tappable, shown only when this session has
@@ -364,6 +389,27 @@ const styles = StyleSheet.create({
   nameWrap: {
     flex: 1,
     minWidth: 0,
+  },
+  /** Row wrapping summary text + optional "upraveno" badge — mirrors
+   *  ExpandableExerciseCard.summaryRow for visual consistency. */
+  summaryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 2,
+  },
+  /** Small gold pill shown when hasModifications is true — mirrors
+   *  ExpandableExerciseCard.modifiedBadge exactly (same padding, radius, font). */
+  modifiedBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 4,
+  },
+  modifiedBadgeText: {
+    fontFamily: interFamily('600'),
+    fontSize: 10,
+    fontWeight: '600',
   },
   /**
    * Gold-tinted circular camera button — mirrors MealRow's cameraBtn style.

--- a/mobile/src/components/training/LiveFinishedSummary.tsx
+++ b/mobile/src/components/training/LiveFinishedSummary.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@/hooks/useTheme'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { useTranslation } from 'react-i18next'
-import type { WorkoutFormat } from '@/api/wod-types'
+import type { WorkoutFormat, LoggedSetDto } from '@/api/wod-types'
 import type { FullPlanSet } from '@/api/training'
 import { SetGrid } from '@/components/training/SetGrid'
 
@@ -20,6 +20,12 @@ export interface FinishedExerciseSetData {
   completedSetNumbers: number[]
   /** 1-based set numbers that the user skipped (↷). */
   skippedSetNumbers: number[]
+  /**
+   * Actual vs. snapshot-planned set data from the finished workout log.
+   * When present, SetGrid renders treatment B: actual headline, planned
+   * caption, and a gold change-indicator dot for modified sets (#441).
+   */
+  loggedSets?: LoggedSetDto[]
 }
 
 export interface FinishedWorkoutCardData {
@@ -183,6 +189,7 @@ export function LiveFinishedSummary({
                       sets={ex.sets}
                       completedSetNumbers={ex.completedSetNumbers}
                       skippedSetNumbers={ex.skippedSetNumbers}
+                      loggedSets={ex.loggedSets}
                     />
                   </View>
                 ))}

--- a/mobile/src/components/training/SetGrid.tsx
+++ b/mobile/src/components/training/SetGrid.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { interFamily } from '@/constants/typography'
 import type { FullPlanSet } from '@/api/training'
+import type { LoggedSetDto } from '@/api/wod-types'
 
 interface SetGridProps {
   sets: FullPlanSet[]
@@ -17,20 +18,72 @@ interface SetGridProps {
    * should not appear in both arrays.
    */
   skippedSetNumbers?: number[]
+  /**
+   * Per-set actual vs. planned data from the backend (#440).
+   * When provided, SetGrid renders treatment B:
+   *   - actual value as the headline (gold when the set has been completed)
+   *   - snapshot-planned value as a quiet "plán…" caption below
+   *   - gold change-indicator dot next to the status column when isModified
+   *
+   * Indexed by 1-based set number matching `sets[i].setNumber`.
+   * Sets without a matching entry in this map fall back to the planned-only display.
+   *
+   * For the Today card the per-exercise sets don't carry individual actual data
+   * (that lives in loggedSetsBySessionExercise) — callers should convert to this
+   * map before passing in.
+   */
+  loggedSets?: LoggedSetDto[]
 }
 
 /**
  * 5-column grid: Set / Reps / Weight / Rest / Status
  * Matches the tp-ex-set-grid layout in the prototype.
+ *
+ * Treatment B (when loggedSets is provided):
+ *   - Actual value is the headline per cell (displayed in gold when completed).
+ *   - Snapshot-planned value is a quiet "plán…" caption below the headline.
+ *   - A small gold change-indicator dot appears in the status column when the
+ *     set's isModified flag is true.
+ *   - Extra sets beyond the plan count (setNumber > sets.length) show the actual
+ *     in gold with a "navíc" caption and no planned value.
+ *   - Skipped sets show the planned caption and the skip marker; actual is blank.
  */
-export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = [] }: SetGridProps) {
+export function SetGrid({
+  sets,
+  completedSetNumbers = [],
+  skippedSetNumbers = [],
+  loggedSets,
+}: SetGridProps) {
   const colors = useTheme()
   const { t } = useTranslation()
 
+  // Build a lookup map: 1-based setNumber → LoggedSetDto
+  const loggedBySetNumber = React.useMemo<Map<number, LoggedSetDto>>(() => {
+    const map = new Map<number, LoggedSetDto>()
+    if (loggedSets) {
+      for (const ls of loggedSets) {
+        map.set(ls.setNumber, ls)
+      }
+    }
+    return map
+  }, [loggedSets])
+
+  // Determine the full set of row numbers to render.
+  // When loggedSets has entries beyond the planned count (extra sets), include them.
+  const plannedSetNumbers = sets.map((s) => s.setNumber ?? -1).filter((n) => n > 0)
+  const extraSetNumbers: number[] = []
+  if (loggedSets) {
+    for (const ls of loggedSets) {
+      if (!plannedSetNumbers.includes(ls.setNumber) && ls.setNumber > 0) {
+        extraSetNumbers.push(ls.setNumber)
+      }
+    }
+    extraSetNumbers.sort((a, b) => a - b)
+  }
+
   return (
     <View>
-      {/* Header row — title-case, semi-bold, label2, centered.
-          Set# and Status columns are fixed-width; middle three share equal flex. */}
+      {/* Header row */}
       <View style={[styles.grid, { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }]}>
         <Text style={[styles.hdrSet, { color: colors.label2 }]}>{t('training.set')}</Text>
         <Text style={[styles.hdr, { color: colors.label2 }]}>{t('training.reps')}</Text>
@@ -39,28 +92,112 @@ export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = []
         <Text style={[styles.hdrStatus, { color: colors.label2 }]}>{t('training.status')}</Text>
       </View>
 
-      {/* Data rows — every row gets a bottom hairline so the table reads as
-          a clean grid (matches prototype .tp-set-cell { border-bottom }). */}
+      {/* Planned set rows */}
       {sets.map((s) => {
         const setNum = s.setNumber ?? -1
         const isCompleted = completedSetNumbers.includes(setNum)
         const isSkipped = !isCompleted && skippedSetNumbers.includes(setNum)
+        const logged = loggedBySetNumber.get(setNum)
         const cellBorder = { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }
+
+        // Treatment B: when we have logged data for this set
+        if (logged && loggedSets) {
+          const { isModified } = logged
+          const hasActualReps = logged.actualReps != null
+          const hasActualWeight = logged.actualWeightKg != null
+          const isExtra = false // planned row — not extra
+
+          // Value cells — show actual + planned caption, or planned only when skipped
+          const repsCell = isSkipped
+            ? { headline: null, caption: logged.plannedReps != null ? `${logged.plannedReps}` : (s.reps != null ? `${s.reps}` : null) }
+            : hasActualReps
+              ? { headline: `${logged.actualReps}`, caption: logged.plannedReps != null ? `${logged.plannedReps}` : null }
+              : { headline: s.reps != null ? `${s.reps}` : null, caption: null }
+
+          const weightCell = isSkipped
+            ? { headline: null, caption: formatWeight(logged.plannedWeightKg ?? s.weightKg) }
+            : logged.actualWeightKg != null
+              ? { headline: formatWeight(logged.actualWeightKg), caption: logged.plannedWeightKg != null ? formatWeight(logged.plannedWeightKg) : null }
+              : { headline: formatWeight(s.weightKg), caption: null }
+
+          const actualColor = isCompleted ? colors.gold : colors.label
+
+          return (
+            <View key={setNum} style={[styles.grid, cellBorder]}>
+              <Text style={[styles.cellSet, { color: colors.label }]}>{s.setNumber}</Text>
+
+              {/* Reps cell — actual headline + planned caption */}
+              <View style={[styles.cellStack, styles.cellFlex]}>
+                {repsCell.headline != null ? (
+                  <Text style={[styles.cell, { color: actualColor }]}>{repsCell.headline}</Text>
+                ) : (
+                  <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+                )}
+                {repsCell.caption != null && (
+                  <Text style={[styles.planCaption, { color: colors.label3 }]}>
+                    {t('training.plan')}{repsCell.caption}
+                  </Text>
+                )}
+              </View>
+
+              {/* Weight cell */}
+              <View style={[styles.cellStack, styles.cellFlex]}>
+                {weightCell.headline != null ? (
+                  <Text style={[styles.cell, { color: actualColor }]}>{weightCell.headline}</Text>
+                ) : (
+                  <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+                )}
+                {weightCell.caption != null && (
+                  <Text style={[styles.planCaption, { color: colors.label3 }]}>
+                    {t('training.plan')}{weightCell.caption}
+                  </Text>
+                )}
+              </View>
+
+              {/* Rest cell — always from plan */}
+              <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
+                {s.restSeconds != null ? `${s.restSeconds} s` : '—'}
+              </Text>
+
+              {/* Status cell — tick, skip, dash + gold dot when isModified */}
+              <View style={[styles.cellStatus, styles.statusWrap]}>
+                <Text
+                  style={[
+                    styles.statusText,
+                    isCompleted
+                      ? { color: colors.green, fontFamily: interFamily('600'), fontWeight: '600' }
+                      : isSkipped
+                        ? { color: colors.label3, fontFamily: interFamily('600'), fontWeight: '600' }
+                        : { color: colors.label3 },
+                  ]}
+                >
+                  {isCompleted ? '✓' : isSkipped ? '↷' : '—'}
+                </Text>
+                {isModified && !isSkipped && (
+                  <View style={[styles.modifiedDot, { backgroundColor: colors.gold }]} />
+                )}
+              </View>
+            </View>
+          )
+        }
+
+        // Plain display (no logged data / pre-log)
         return (
-          <View key={s.setNumber} style={[styles.grid, cellBorder]}>
+          <View key={setNum} style={[styles.grid, cellBorder]}>
             <Text style={[styles.cellSet, { color: colors.label }]}>{s.setNumber}</Text>
-            <Text style={[styles.cell, { color: colors.label }]}>
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
               {s.reps != null ? String(s.reps) : '—'}
             </Text>
-            <Text style={[styles.cell, { color: colors.label }]}>
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
               {s.weightKg != null ? `${s.weightKg} kg` : '—'}
             </Text>
-            <Text style={[styles.cell, { color: colors.label }]}>
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
               {s.restSeconds != null ? `${s.restSeconds} s` : '—'}
             </Text>
             <Text
               style={[
                 styles.cellStatus,
+                styles.statusText,
                 isCompleted
                   ? { color: colors.green, fontFamily: interFamily('600'), fontWeight: '600' }
                   : isSkipped
@@ -73,13 +210,62 @@ export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = []
           </View>
         )
       })}
+
+      {/* Extra set rows (beyond plan count) — actual in gold, "navíc" caption */}
+      {extraSetNumbers.map((setNum) => {
+        const logged = loggedBySetNumber.get(setNum)
+        if (!logged) return null
+        const cellBorder = { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }
+
+        return (
+          <View key={`extra-${setNum}`} style={[styles.grid, cellBorder]}>
+            <Text style={[styles.cellSet, { color: colors.gold }]}>{setNum}</Text>
+
+            <View style={[styles.cellStack, styles.cellFlex]}>
+              {logged.actualReps != null ? (
+                <Text style={[styles.cell, { color: colors.gold }]}>{logged.actualReps}</Text>
+              ) : (
+                <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+              )}
+              <Text style={[styles.planCaption, { color: colors.gold }]}>
+                {t('training.navic')}
+              </Text>
+            </View>
+
+            <View style={[styles.cellStack, styles.cellFlex]}>
+              {logged.actualWeightKg != null ? (
+                <Text style={[styles.cell, { color: colors.gold }]}>{formatWeight(logged.actualWeightKg)}</Text>
+              ) : (
+                <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+              )}
+            </View>
+
+            {/* Rest — not applicable for extra sets */}
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label3 }]}>—</Text>
+
+            <View style={[styles.cellStatus, styles.statusWrap]}>
+              <Text style={[styles.statusText, { color: colors.gold, fontFamily: interFamily('600'), fontWeight: '600' }]}>
+                ✓
+              </Text>
+            </View>
+          </View>
+        )
+      })}
     </View>
   )
+}
+
+/** Format a weight value as "X kg" or "BW" when null / zero. */
+function formatWeight(kg: number | null | undefined): string | null {
+  if (kg == null) return null
+  if (kg === 0) return 'BW'
+  return `${kg} kg`
 }
 
 const styles = StyleSheet.create({
   grid: {
     flexDirection: 'row',
+    alignItems: 'flex-start',
     paddingHorizontal: 8,
     paddingVertical: 6,
   },
@@ -116,15 +302,43 @@ const styles = StyleSheet.create({
   cellStatus: {
     width: 40,
     flexShrink: 0,
+  },
+  cell: {
     fontFamily: interFamily('400'),
     fontSize: 12,
     textAlign: 'center',
   },
-  cell: {
+  cellFlex: {
     flex: 1,
+  },
+  /** Stack for cells that show an actual headline + planned caption below. */
+  cellStack: {
+    alignItems: 'center',
+  },
+  /** Quiet "plán X" caption below the actual value. */
+  planCaption: {
+    fontFamily: interFamily('400'),
+    fontSize: 10,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+  /** Status column inner wrapper — horizontally centres the tick/skip
+   *  glyph and optionally the gold modification dot. */
+  statusWrap: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  statusText: {
     fontFamily: interFamily('400'),
     fontSize: 12,
     textAlign: 'center',
+  },
+  /** Small gold dot rendered below the status glyph when isModified. */
+  modifiedDot: {
+    width: 5,
+    height: 5,
+    borderRadius: 3,
+    marginTop: 2,
   },
 })
 

--- a/mobile/src/components/training/SetGrid.tsx
+++ b/mobile/src/components/training/SetGrid.tsx
@@ -138,7 +138,7 @@ export function SetGrid({
                 )}
                 {repsCell.caption != null && (
                   <Text style={[styles.planCaption, { color: colors.label3 }]}>
-                    {t('training.plan')}{repsCell.caption}
+                    {t('training.plan')} {repsCell.caption}
                   </Text>
                 )}
               </View>
@@ -152,7 +152,7 @@ export function SetGrid({
                 )}
                 {weightCell.caption != null && (
                   <Text style={[styles.planCaption, { color: colors.label3 }]}>
-                    {t('training.plan')}{weightCell.caption}
+                    {t('training.plan')} {weightCell.caption}
                   </Text>
                 )}
               </View>

--- a/mobile/src/components/training/SetGrid.tsx
+++ b/mobile/src/components/training/SetGrid.tsx
@@ -62,7 +62,9 @@ export function SetGrid({
     const map = new Map<number, LoggedSetDto>()
     if (loggedSets) {
       for (const ls of loggedSets) {
-        map.set(ls.setNumber, ls)
+        if (ls.setNumber != null) {
+          map.set(ls.setNumber, ls)
+        }
       }
     }
     return map
@@ -74,8 +76,9 @@ export function SetGrid({
   const extraSetNumbers: number[] = []
   if (loggedSets) {
     for (const ls of loggedSets) {
-      if (!plannedSetNumbers.includes(ls.setNumber) && ls.setNumber > 0) {
-        extraSetNumbers.push(ls.setNumber)
+      const sn = ls.setNumber
+      if (sn != null && !plannedSetNumbers.includes(sn) && sn > 0) {
+        extraSetNumbers.push(sn)
       }
     }
     extraSetNumbers.sort((a, b) => a - b)

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -171,7 +171,7 @@ interface TrainingCardProps {
    * Per-session roll-up modification flag, keyed by sessionId.
    * Sourced from `hasModificationsBySession` in TodayTrainingResponse (#440).
    * When true for a session, the session-level "upraveno" badge is shown in the
-   * session header (passed to SectionHeader via the "upraveno" concept).
+   * ExpandableSessionCard header for that session.
    */
   hasModificationsBySession?: Record<string, boolean>
 }
@@ -609,7 +609,7 @@ interface SessionSectionListProps {
   /**
    * Whether this session has any modifications overall.
    * Sourced from `hasModificationsBySession[sessionId]`.
-   * Currently unused but available for a future session-level "upraveno" badge.
+   * Passed to ExpandableSessionCard to render the session-level "upraveno" badge.
    */
   sessionHasModifications?: boolean
   t: (key: string, opts?: Record<string, unknown>) => string
@@ -642,6 +642,7 @@ function SessionSectionList({
   onSessionPhotoPress,
   sessionPhotos,
   loggedSetsForSession,
+  sessionHasModifications,
   t,
 }: SessionSectionListProps) {
   const colors = useTheme()
@@ -669,6 +670,7 @@ function SessionSectionList({
               headerRight={sessionCheckbox}
               onPhotoPress={onSessionPhotoPress}
               photos={sessionPhotos}
+              hasModifications={sessionHasModifications ?? false}
             >
               {/* Section-grouped exercise cards */}
               {sections.map((section, sectionIdx) => {

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -19,7 +19,9 @@ import { SectionHeader } from '@/components/training/SectionHeader'
 import { SetGrid } from '@/components/training/SetGrid'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
 import type { TrainingSession, TrainingSection, MuscleGroup, SessionPhotoDto } from '@/api/training'
+import type { LoggedSetDto } from '@/api/wod-types'
 import type { SessionCtaState } from './trainingCardHelpers'
+import { deriveExerciseHasModifications } from './trainingCardHelpers'
 import { SessionEditingBanner } from '@/components/today/SessionEditingBanner'
 
 // ─── Section fallback ──────────────────────────────────────────────────────────
@@ -158,6 +160,20 @@ interface TrainingCardProps {
    * Sourced from `photosBySession` in TodayTrainingResponse (#405).
    */
   photosBySession?: Record<string, SessionPhotoDto[]>
+  /**
+   * Per-session, per-exercise logged sets with actual values, snapshot-planned
+   * values, and isModified flag. Outer key = sessionId, inner key = exerciseExternalId.
+   * Sourced from `loggedSetsBySessionExercise` in TodayTrainingResponse (#440).
+   * When present, SetGrid renders treatment B (actual headline + planned caption + dot).
+   */
+  loggedSetsBySessionExercise?: Record<string, Record<string, LoggedSetDto[]>>
+  /**
+   * Per-session roll-up modification flag, keyed by sessionId.
+   * Sourced from `hasModificationsBySession` in TodayTrainingResponse (#440).
+   * When true for a session, the session-level "upraveno" badge is shown in the
+   * session header (passed to SectionHeader via the "upraveno" concept).
+   */
+  hasModificationsBySession?: Record<string, boolean>
 }
 
 // ─── formatSets ───────────────────────────────────────────────────────────────
@@ -282,6 +298,8 @@ export function TrainingCard({
   lockStateBySession = {},
   onSessionPhotoPress,
   photosBySession = {},
+  loggedSetsBySessionExercise,
+  hasModificationsBySession,
 }: TrainingCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -486,6 +504,16 @@ export function TrainingCard({
                   ? (photosBySession[session.sessionId] ?? [])
                   : []
               }
+              loggedSetsForSession={
+                session.sessionId != null
+                  ? loggedSetsBySessionExercise?.[session.sessionId]
+                  : undefined
+              }
+              sessionHasModifications={
+                session.sessionId != null
+                  ? (hasModificationsBySession?.[session.sessionId] ?? false)
+                  : false
+              }
               t={t}
             />
           )
@@ -572,6 +600,18 @@ interface SessionSectionListProps {
    * Passed to ExpandableSessionCard so the per-session badge + lightbox work.
    */
   sessionPhotos?: SessionPhotoDto[]
+  /**
+   * Per-exercise logged sets for this specific session (inner key = exerciseExternalId).
+   * Already sliced from `loggedSetsBySessionExercise[sessionId]` by the parent.
+   * Passed down to SetGrid for treatment B rendering (#440).
+   */
+  loggedSetsForSession?: Record<string, LoggedSetDto[]>
+  /**
+   * Whether this session has any modifications overall.
+   * Sourced from `hasModificationsBySession[sessionId]`.
+   * Currently unused but available for a future session-level "upraveno" badge.
+   */
+  sessionHasModifications?: boolean
   t: (key: string, opts?: Record<string, unknown>) => string
 }
 
@@ -601,6 +641,7 @@ function SessionSectionList({
   onSessionCta,
   onSessionPhotoPress,
   sessionPhotos,
+  loggedSetsForSession,
   t,
 }: SessionSectionListProps) {
   const colors = useTheme()
@@ -809,6 +850,14 @@ function SessionSectionList({
                             ? getMuscleGroupColor(primaryMg, colors)
                             : colors.gold
 
+                          // Derive per-exercise modification flag from per-set
+                          // isModified flags (#441 — plan endpoint has no per-exercise
+                          // field; GetTodaySession has loggedSetsBySessionExercise).
+                          const exHasModifications =
+                            exId != null
+                              ? deriveExerciseHasModifications(exId, loggedSetsForSession)
+                              : false
+
                           return (
                             <ExpandableExerciseCard
                               key={exId ?? exIdx}
@@ -830,8 +879,17 @@ function SessionSectionList({
                                   : undefined
                               }
                               notes={exercise.notes}
+                              hasModifications={exHasModifications}
                             >
-                              <SetGrid sets={sets} completedSetNumbers={completedSetNumbers} />
+                              <SetGrid
+                                sets={sets}
+                                completedSetNumbers={completedSetNumbers}
+                                loggedSets={
+                                  exId != null
+                                    ? (loggedSetsForSession?.[exId] ?? undefined)
+                                    : undefined
+                                }
+                              />
                             </ExpandableExerciseCard>
                           )
                         })}

--- a/mobile/src/components/training/trainingCardHelpers.ts
+++ b/mobile/src/components/training/trainingCardHelpers.ts
@@ -12,6 +12,7 @@
  */
 
 import type { TrainingSession } from '@/api/training'
+import type { LoggedSetDto } from '@/api/wod-types'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -135,6 +136,34 @@ export function deriveSessionCtaState(
   if (hasActiveLiveSession) return 'in-progress'
 
   return 'not-started'
+}
+
+// ─── deriveExerciseHasModifications ─────────────────────────────────────────
+
+/**
+ * Derives whether a specific exercise has any modified sets, given the
+ * per-exercise logged-sets map from GetTodaySession.
+ *
+ * The plan/today endpoint does NOT expose a per-exercise hasModifications field
+ * (it only has hasModificationsBySession at session level).  This helper derives
+ * the per-exercise flag from the per-set isModified flags in
+ * loggedSetsBySessionExercise so the Today card can show the "upraveno" badge on
+ * individual exercise headers (#441 design handoff finding #3).
+ *
+ * @param exerciseExternalId   The exercise's external id.
+ * @param loggedSetsForSession The inner map for this session:
+ *                             exerciseExternalId → LoggedSetDto[].
+ *                             May be undefined if no log exists yet.
+ * @returns true when any set under this exercise has isModified === true.
+ */
+export function deriveExerciseHasModifications(
+  exerciseExternalId: string,
+  loggedSetsForSession: Readonly<Record<string, LoggedSetDto[]>> | undefined,
+): boolean {
+  if (!loggedSetsForSession) return false
+  const sets = loggedSetsForSession[exerciseExternalId]
+  if (!sets || sets.length === 0) return false
+  return sets.some((s) => s.isModified)
 }
 
 // ─── computeLockedSessionIds ──────────────────────────────────────────────────

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -1056,6 +1056,9 @@
     "workoutUntimedCount_few": "{{count}} neměřené",
     "workoutUntimedCount_many": "{{count}} neměřených",
     "workoutUntimedCount_other": "{{count}} neměřených",
+    "upraveno": "upraveno",
+    "plan": "plán",
+    "navic": "navíc",
     "section": {
       "label": "Sekce",
       "defaultName": "Hlavní",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -998,6 +998,9 @@
     "exerciseCount_other": "{{count}} Übungen",
     "workoutUntimedCount_one": "{{count}} ohne Zeit",
     "workoutUntimedCount_other": "{{count}} ohne Zeit",
+    "upraveno": "geändert",
+    "plan": "Plan",
+    "navic": "extra",
     "section": {
       "label": "Abschnitt",
       "defaultName": "Haupt",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -773,6 +773,9 @@
     "exerciseCount_other": "{{count}} exercises",
     "workoutUntimedCount_one": "{{count}} untimed",
     "workoutUntimedCount_other": "{{count}} untimed",
+    "upraveno": "modified",
+    "plan": "plan",
+    "navic": "extra",
     "section": {
       "label": "Section",
       "defaultName": "Main",


### PR DESCRIPTION
## Summary
- Sends snapshot-planned set values (PlannedReps/WeightKg/Rpe/DurationSeconds/DistanceMeters) in the `PUT /client/training/logs/{logId}` payload, sourced from the live-session plan data.
- Consumes the #440 backend contract to render Treatment B in `SetGrid` — actual headline, quiet `plán…` caption, gold change-indicator dot on `isModified` (all via `useTheme()` tokens).
- Wires per-exercise `upraveno` badges across live-finished summary, the finished Today card, and plan detail; WOD per-movement sets use the same treatment. Edge cases handled: skipped (planned caption + skip marker), extra (`navíc`, gold), swapped/ad-hoc.
- Reconciles the previously hand-declared augmentation types in `training.ts` / `wod-types.ts` down to the canonical NSwag-generated client after the full #440 regen.

## Related issue
Fixes #441

## Parent epic (sub-issue PR)
Part of epic #439 — base branch: `feature/439-planned-vs-actual-training`.

## Scope
mobile

## QA verdict (from qa-tester)
Static gates green: `npx tsc --noEmit` clean, `npx expo-doctor` 19/19. Interactive simulator QA was **environmentally blocked** (CocoaPods 1.16.2 / Ruby 4.0.2 `ASCII-8BIT` encoding bug breaks the dev-client build) — mobile rides on static gates + code review for this PR. Known QA-tooling limitation, not a product defect.

## Test plan
- [ ] Send snapshot-planned values per set in the PUT payload from prefillForm/plannedSet.
- [ ] regen-api run against the updated backend; `generated.ts` not hand-edited.
- [ ] Treatment B in SetGrid and all set-rendering paths (actual headline / plan caption / gold dot on isModified).
- [ ] Surfaces: live-session finished summary, finished Today card, mobile plan detail.
- [ ] `upraveno` roll-up badge at session-header AND exercise-header level when hasModifications is true.
- [ ] WOD per-movement sets use the same treatment; WodResult row unchanged.
- [ ] Edge cases: skipped / extra / swapped sets.
- [ ] New i18n keys (upraveno/plan/navic) in cs/en/de.
- [ ] No hardcoded colors/spacing; no `any`.
- [ ] `npx tsc --noEmit` and `npx expo-doctor` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)