### PR TITLE
feat: persist & surface planned-vs-actual training values (live-session adjustments)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Documents/WorkoutSet.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/WorkoutSet.cs
@@ -4,6 +4,8 @@ namespace FitnessPlatform.Application.Domain.Documents;
 
 /// <summary>
 /// A single set actually performed during a workout with recorded values.
+/// Snapshot-planned fields capture the prescribed values at the time the set was first logged;
+/// they are immutable after initial persistence so later plan edits do not affect them.
 /// </summary>
 public class WorkoutSet
 {
@@ -60,4 +62,56 @@ public class WorkoutSet
     /// </summary>
     [BsonElement("isPR")]
     public bool IsPR { get; set; }
+
+    // ── Snapshot-planned fields ─────────────────────────────────────────────────
+    // Frozen at log time from the plan prescription. Null on legacy documents
+    // (pre-snapshot) — treated as planned == actual / isModified == false.
+
+    /// <summary>
+    /// Prescribed repetitions at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedReps")]
+    [BsonIgnoreIfNull]
+    public int? PlannedReps { get; set; }
+
+    /// <summary>
+    /// Prescribed weight (kg) at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedWeightKg")]
+    [BsonIgnoreIfNull]
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>
+    /// Prescribed RPE at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedRpe")]
+    [BsonIgnoreIfNull]
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>
+    /// Prescribed duration (seconds) at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedDurationSeconds")]
+    [BsonIgnoreIfNull]
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>
+    /// Prescribed distance (meters) at the time this set was first logged.
+    /// </summary>
+    [BsonElement("plannedDistanceMeters")]
+    [BsonIgnoreIfNull]
+    public decimal? PlannedDistanceMeters { get; set; }
+
+    /// <summary>
+    /// Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+    /// Always false for legacy sets whose planned fields are all null (backward-compatible default).
+    /// Never stored — derived on read.
+    /// </summary>
+    [BsonIgnore]
+    public bool IsModified =>
+        PlannedReps.HasValue && Reps != PlannedReps ||
+        PlannedWeightKg.HasValue && WeightKg != PlannedWeightKg ||
+        PlannedRpe.HasValue && Rpe != PlannedRpe ||
+        PlannedDurationSeconds.HasValue && DurationSeconds != PlannedDurationSeconds ||
+        PlannedDistanceMeters.HasValue && DistanceMeters != PlannedDistanceMeters;
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanEndpoint.cs
@@ -132,6 +132,38 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
         // per set so accidental duplicate logs don't wipe completion state.
         var completedSets = new Dictionary<(Guid sessionId, Guid exerciseId, int setNumber), DateTime>();
 
+        // Extended lookup: (sessionId, exerciseId, setNumber) → WorkoutSet for actual+planned values.
+        // We prefer the most-recently-updated log per session (mirrors the dedup logic used elsewhere).
+        // If two logs for the same session have the set, the one from the "best" log wins.
+        var loggedSets = new Dictionary<(Guid sessionId, Guid exerciseId, int setNumber), WorkoutSet>();
+
+        // Deduplicate logs per sessionId: prefer most-recently-updated FINALISED, else most-recent.
+        var bestLogBySession = workoutLogs
+            .Where(l => l.SessionId.HasValue)
+            .GroupBy(l => l.SessionId!.Value)
+            .Select(g =>
+            {
+                var finalised = g
+                    .Where(l => l.IsCompleted)
+                    .OrderByDescending(l => l.DateUpdated ?? l.DateCreated)
+                    .FirstOrDefault();
+                return finalised ?? g.OrderByDescending(l => l.DateUpdated ?? l.DateCreated).First();
+            })
+            .ToList();
+
+        foreach (var log in bestLogBySession)
+        {
+            var sessionId = log.SessionId!.Value;
+            foreach (var ex in log.Exercises)
+            {
+                foreach (var set in ex.Sets)
+                {
+                    var key = (sessionId, ex.ExerciseExternalId, set.SetNumber);
+                    loggedSets[key] = set;
+                }
+            }
+        }
+
         foreach (var log in workoutLogs)
         {
             if (log.SessionId is null) continue;
@@ -293,6 +325,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                         {
                             var key = (session.SessionId, ex.ExerciseExternalId, set.SetNumber);
                             completedSets.TryGetValue(key, out var completedAt);
+                            loggedSets.TryGetValue(key, out var loggedSet);
 
                             return new SetDto
                             {
@@ -303,12 +336,26 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                                 DurationSeconds = set.DurationSeconds,
                                 DistanceMeters = set.DistanceMeters,
                                 RestSeconds = set.RestSeconds,
-                                CompletedAt = completedAt == default ? null : completedAt
+                                CompletedAt = completedAt == default ? null : completedAt,
+                                // Actual values from the workout log (null when not yet logged).
+                                ActualReps = loggedSet?.Reps,
+                                ActualWeightKg = loggedSet?.WeightKg,
+                                ActualRpe = loggedSet?.Rpe,
+                                ActualDurationSeconds = loggedSet?.DurationSeconds,
+                                ActualDistanceMeters = loggedSet?.DistanceMeters,
+                                // Snapshot-planned values (null on legacy logs → isModified stays false).
+                                PlannedReps = loggedSet?.PlannedReps,
+                                PlannedWeightKg = loggedSet?.PlannedWeightKg,
+                                PlannedRpe = loggedSet?.PlannedRpe,
+                                PlannedDurationSeconds = loggedSet?.PlannedDurationSeconds,
+                                PlannedDistanceMeters = loggedSet?.PlannedDistanceMeters,
+                                IsModified = loggedSet?.IsModified ?? false
                             };
                         }).ToList();
 
                         // An exercise is complete only when every planned set has a log entry.
                         var isCompleted = setDtos.Count > 0 && setDtos.All(s => s.CompletedAt is not null);
+                        var hasModifications = setDtos.Any(s => s.IsModified);
 
                         return new ExerciseDto
                         {
@@ -323,6 +370,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                             MovementType = ex.MovementType.ToString(),
                             MuscleGroups = muscleGroups,
                             IsCompleted = isCompleted,
+                            HasModifications = hasModifications,
                             Sets = setDtos
                         };
                     }).ToList();
@@ -350,6 +398,7 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                 var exerciseDtos = sectionDtos.SelectMany(s => s.Exercises).ToList();
 
                 var completedExerciseCount = exerciseDtos.Count(e => e.IsCompleted);
+                var sessionHasModifications = exerciseDtos.Any(e => e.HasModifications);
 
                 // Resolve lock state for this session (Stable if no active lock doc).
                 var sessionLockState = "Stable";
@@ -373,7 +422,8 @@ public class GetFullTrainingPlanEndpoint(IMongoContext mongo, IApplicationDbCont
                     Sections = sectionDtos,
                     Exercises = exerciseDtos,
                     LockState = sessionLockState,
-                    LockHolder = sessionLockHolder
+                    LockHolder = sessionLockHolder,
+                    HasModifications = sessionHasModifications
                 };
             }).ToList();
 

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetFullPlan/GetFullTrainingPlanResponse.cs
@@ -131,6 +131,12 @@ public class SessionDto
     /// Possible values: "Coach", "Client", or null when the session is Stable.
     /// </summary>
     public string? LockHolder { get; set; }
+
+    /// <summary>
+    /// True when at least one exercise in this session has HasModifications == true.
+    /// Always false when no workout log exists for this session.
+    /// </summary>
+    public bool HasModifications { get; set; }
 }
 
 /// <summary>
@@ -216,12 +222,18 @@ public class ExerciseDto
     /// <summary>True when every planned set has a completed workout log entry.</summary>
     public bool IsCompleted { get; set; }
 
-    /// <summary>Planned sets with per-set completion timestamps.</summary>
+    /// <summary>
+    /// True when at least one set under this exercise has IsModified == true.
+    /// Always false when no workout log exists for this exercise.
+    /// </summary>
+    public bool HasModifications { get; set; }
+
+    /// <summary>Planned sets with per-set completion timestamps and actual-vs-planned delta.</summary>
     public List<SetDto> Sets { get; set; } = [];
 }
 
 /// <summary>
-/// A planned set with its completion state derived from workout logs.
+/// A planned set with its completion state and actual-vs-planned delta derived from workout logs.
 /// </summary>
 public class SetDto
 {
@@ -231,16 +243,16 @@ public class SetDto
     /// <summary>Set type (Normal, Warmup, Dropset, Superset).</summary>
     public string Type { get; set; } = "";
 
-    /// <summary>Target number of repetitions.</summary>
+    /// <summary>Target number of repetitions (from the plan prescription).</summary>
     public int? Reps { get; set; }
 
-    /// <summary>Target weight in kilograms.</summary>
+    /// <summary>Target weight in kilograms (from the plan prescription).</summary>
     public decimal? WeightKg { get; set; }
 
-    /// <summary>Target duration in seconds (for timed exercises).</summary>
+    /// <summary>Target duration in seconds (from the plan prescription).</summary>
     public int? DurationSeconds { get; set; }
 
-    /// <summary>Target distance in meters (for distance-based exercises).</summary>
+    /// <summary>Target distance in meters (from the plan prescription).</summary>
     public decimal? DistanceMeters { get; set; }
 
     /// <summary>Rest time after this set in seconds.</summary>
@@ -248,4 +260,46 @@ public class SetDto
 
     /// <summary>When this set was completed, or null if not yet done.</summary>
     public DateTime? CompletedAt { get; set; }
+
+    // ── Actual logged values (from WorkoutLog) ──────────────────────────────────
+    // Null when no log exists for this set (i.e. set not yet performed).
+
+    /// <summary>Actual repetitions logged. Null when not yet performed.</summary>
+    public int? ActualReps { get; set; }
+
+    /// <summary>Actual weight (kg) logged. Null when not yet performed.</summary>
+    public decimal? ActualWeightKg { get; set; }
+
+    /// <summary>Actual RPE logged. Null when not yet performed.</summary>
+    public decimal? ActualRpe { get; set; }
+
+    /// <summary>Actual duration (seconds) logged. Null when not yet performed.</summary>
+    public int? ActualDurationSeconds { get; set; }
+
+    /// <summary>Actual distance (meters) logged. Null when not yet performed.</summary>
+    public decimal? ActualDistanceMeters { get; set; }
+
+    // ── Snapshot-planned values (frozen on WorkoutLog at log time) ──────────────
+    // Null on legacy logs that pre-date snapshot storage — treat as planned == actual.
+
+    /// <summary>Snapshot-planned repetitions at log time. Null for legacy logs.</summary>
+    public int? PlannedReps { get; set; }
+
+    /// <summary>Snapshot-planned weight (kg) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>Snapshot-planned RPE at log time. Null for legacy logs.</summary>
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>Snapshot-planned duration (seconds) at log time. Null for legacy logs.</summary>
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>Snapshot-planned distance (meters) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedDistanceMeters { get; set; }
+
+    /// <summary>
+    /// Backend-computed flag: true when any actual field differs from its snapshot-planned
+    /// counterpart. Always false for legacy sets (no snapshot → treated as planned == actual).
+    /// </summary>
+    public bool IsModified { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionEndpoint.cs
@@ -5,6 +5,7 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -268,6 +269,9 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
                     completedBySession[log.SessionId.Value] = set = [];
 
                 var setsForExerciseInSession = new Dictionary<Guid, List<int>>();
+                var loggedSetsForExercise = new Dictionary<Guid, List<LoggedSetDto>>();
+                var sessionHasModifications = false;
+
                 foreach (var ex in log.Exercises)
                 {
                     if (ex.Sets.Count == 0) continue;
@@ -280,9 +284,35 @@ public class GetTodaySessionEndpoint(IMongoContext mongo, IApplicationDbContext 
                         .ToList();
                     if (completedSetNumbers.Count > 0)
                         setsForExerciseInSession[ex.ExerciseExternalId] = completedSetNumbers;
+
+                    // Build value-bearing LoggedSetDto list for every set in this exercise.
+                    var loggedSetDtos = ex.Sets.Select(s => new LoggedSetDto
+                    {
+                        SetNumber = s.SetNumber,
+                        ActualReps = s.Reps,
+                        ActualWeightKg = s.WeightKg,
+                        ActualRpe = s.Rpe,
+                        ActualDurationSeconds = s.DurationSeconds,
+                        ActualDistanceMeters = s.DistanceMeters,
+                        PlannedReps = s.PlannedReps,
+                        PlannedWeightKg = s.PlannedWeightKg,
+                        PlannedRpe = s.PlannedRpe,
+                        PlannedDurationSeconds = s.PlannedDurationSeconds,
+                        PlannedDistanceMeters = s.PlannedDistanceMeters,
+                        IsModified = s.IsModified
+                    }).ToList();
+
+                    loggedSetsForExercise[ex.ExerciseExternalId] = loggedSetDtos;
+
+                    if (loggedSetDtos.Any(s => s.IsModified))
+                        sessionHasModifications = true;
                 }
                 if (setsForExerciseInSession.Count > 0)
                     response.CompletedSetsBySessionExercise[log.SessionId.Value] = setsForExerciseInSession;
+                if (loggedSetsForExercise.Count > 0)
+                    response.LoggedSetsBySessionExercise[log.SessionId.Value] = loggedSetsForExercise;
+                if (sessionHasModifications)
+                    response.HasModificationsBySession[log.SessionId.Value] = true;
             }
 
             foreach (var (sessionId, set) in completedBySession)

--- a/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientTraining/GetTodaySession/GetTodaySessionResponse.cs
@@ -1,5 +1,6 @@
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 
 namespace FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
 
@@ -139,6 +140,23 @@ public class GetTodaySessionResponse
     /// Empty dictionary when no session has a note today (or when no active plan exists).
     /// </summary>
     public Dictionary<Guid, string> NotesBySession { get; set; } = new();
+
+    /// <summary>
+    /// Per-session, per-exercise logged set values for today.
+    /// Keyed by SessionId → ExerciseExternalId → list of <see cref="LoggedSetDto"/> (one per set).
+    /// Carries actual logged values, snapshot-planned values, and the backend-computed isModified flag.
+    /// Replaces the set-number-only <see cref="CompletedSetsBySessionExercise"/> for callers that
+    /// need actual vs planned comparison.
+    /// Empty when no live-training progress has been logged for today.
+    /// </summary>
+    public Dictionary<Guid, Dictionary<Guid, List<LoggedSetDto>>> LoggedSetsBySessionExercise { get; set; } = new();
+
+    /// <summary>
+    /// Per-session hasModifications flag for today, keyed by SessionId.
+    /// True when any set under any exercise in the session has IsModified == true in the latest log.
+    /// Missing entries are treated as false (no modifications / no log).
+    /// </summary>
+    public Dictionary<Guid, bool> HasModificationsBySession { get; set; } = new();
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/FinishSession/FinishSessionEndpoint.cs
@@ -185,7 +185,15 @@ public class FinishSessionEndpoint(
                                 // Stamp all sets as completed at the supplied instant.
                                 // IsPR is left false — the completion service will set it via PR detection.
                                 CompletedAt = completedAt,
-                                IsPR = false
+                                IsPR = false,
+                                // Snapshot: done-as-prescribed → planned == actual.
+                                // When the trainer finishes a session retroactively the actual
+                                // values ARE the prescription, so isModified stays false for every set.
+                                PlannedReps = es.Reps,
+                                PlannedWeightKg = es.WeightKg,
+                                PlannedRpe = es.Rpe,
+                                PlannedDurationSeconds = es.DurationSeconds,
+                                PlannedDistanceMeters = es.DistanceMeters
                             })
                             .ToList()
                     })

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanEndpoint.cs
@@ -5,6 +5,7 @@ using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Extensions;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.ClientTraining;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using MongoDB.Driver;
 
@@ -150,6 +151,8 @@ public class GetTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lo
                     // Build the per-exercise map of completed set numbers.
                     // A set is "completed" iff its WorkoutSet.CompletedAt is non-null.
                     var completedSetsByExercise = new Dictionary<Guid, List<int>>();
+                    var loggedSetsByExercise = new Dictionary<Guid, List<LoggedSetDto>>();
+                    var sessionHasModifications = false;
 
                     foreach (var ex in log.Exercises)
                     {
@@ -161,13 +164,38 @@ public class GetTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService lo
 
                         if (completedSetNumbers.Count > 0)
                             completedSetsByExercise[ex.ExerciseExternalId] = completedSetNumbers;
+
+                        // Build value-bearing LoggedSetDto list for every set in this exercise.
+                        var loggedSetDtos = ex.Sets.Select(s => new LoggedSetDto
+                        {
+                            SetNumber = s.SetNumber,
+                            ActualReps = s.Reps,
+                            ActualWeightKg = s.WeightKg,
+                            ActualRpe = s.Rpe,
+                            ActualDurationSeconds = s.DurationSeconds,
+                            ActualDistanceMeters = s.DistanceMeters,
+                            PlannedReps = s.PlannedReps,
+                            PlannedWeightKg = s.PlannedWeightKg,
+                            PlannedRpe = s.PlannedRpe,
+                            PlannedDurationSeconds = s.PlannedDurationSeconds,
+                            PlannedDistanceMeters = s.PlannedDistanceMeters,
+                            IsModified = s.IsModified
+                        }).ToList();
+
+                        if (loggedSetDtos.Count > 0)
+                            loggedSetsByExercise[ex.ExerciseExternalId] = loggedSetDtos;
+
+                        if (loggedSetDtos.Any(s => s.IsModified))
+                            sessionHasModifications = true;
                     }
 
                     return new SessionExecutionDto
                     {
                         SessionId = log.SessionId!.Value,
                         IsSessionFinished = log.IsCompleted,
-                        CompletedSetsByExercise = completedSetsByExercise
+                        CompletedSetsByExercise = completedSetsByExercise,
+                        LoggedSetsByExercise = loggedSetsByExercise,
+                        HasModifications = sessionHasModifications
                     };
                 })
                 .ToList();

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/GetTrainingPlan/GetTrainingPlanResponse.cs
@@ -1,4 +1,5 @@
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Features.WorkoutLogs.Shared;
 
 namespace FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
 
@@ -69,6 +70,22 @@ public class SessionExecutionDto
     /// An empty list should not occur but is treated identically to an absent key.
     /// </summary>
     public Dictionary<Guid, List<int>> CompletedSetsByExercise { get; set; } = new();
+
+    /// <summary>
+    /// Per-exercise map of per-set actual values, snapshot-planned values, and isModified flags.
+    /// Key = ExerciseExternalId; value = list of <see cref="LoggedSetDto"/> (one per logged set).
+    /// An absent key means no sets for that exercise were logged.
+    /// The web layer uses this together with <see cref="CompletedSetsByExercise"/> to render
+    /// the actual-vs-planned comparison and the upraveno (modified) indicator per set.
+    /// </summary>
+    public Dictionary<Guid, List<LoggedSetDto>> LoggedSetsByExercise { get; set; } = new();
+
+    /// <summary>
+    /// True when at least one set in any exercise under this session has IsModified == true.
+    /// The web layer uses this to show the upraveno badge at the session-header level.
+    /// Always false when the session has no WorkoutLog (or all logs are legacy without snapshots).
+    /// </summary>
+    public bool HasModifications { get; set; }
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/Shared/LoggedSetDto.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/Shared/LoggedSetDto.cs
@@ -1,0 +1,55 @@
+namespace FitnessPlatform.Application.Features.WorkoutLogs.Shared;
+
+/// <summary>
+/// Per-set actual values + snapshot-planned values + backend-computed isModified flag,
+/// sourced from a <see cref="FitnessPlatform.Application.Domain.Documents.WorkoutSet"/>.
+/// Used by training-read endpoints that need to surface actual-vs-planned comparison
+/// (GetTodaySession, GetFullTrainingPlan, and the trainer GetTrainingPlan).
+/// </summary>
+public class LoggedSetDto
+{
+    /// <summary>1-based set number within the exercise.</summary>
+    public int SetNumber { get; set; }
+
+    // ── Actual logged values ────────────────────────────────────────────────────
+
+    /// <summary>Actual repetitions logged. Null when the set has not been performed.</summary>
+    public int? ActualReps { get; set; }
+
+    /// <summary>Actual weight (kg) logged. Null when not performed.</summary>
+    public decimal? ActualWeightKg { get; set; }
+
+    /// <summary>Actual RPE logged. Null when not performed.</summary>
+    public decimal? ActualRpe { get; set; }
+
+    /// <summary>Actual duration (seconds) logged. Null when not performed.</summary>
+    public int? ActualDurationSeconds { get; set; }
+
+    /// <summary>Actual distance (meters) logged. Null when not performed.</summary>
+    public decimal? ActualDistanceMeters { get; set; }
+
+    // ── Snapshot-planned values ─────────────────────────────────────────────────
+    // Frozen at log time from the plan prescription.
+    // Null on legacy documents that pre-date snapshot storage — treat as planned == actual.
+
+    /// <summary>Snapshot-planned repetitions at log time. Null for legacy logs.</summary>
+    public int? PlannedReps { get; set; }
+
+    /// <summary>Snapshot-planned weight (kg) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>Snapshot-planned RPE at log time. Null for legacy logs.</summary>
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>Snapshot-planned duration (seconds) at log time. Null for legacy logs.</summary>
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>Snapshot-planned distance (meters) at log time. Null for legacy logs.</summary>
+    public decimal? PlannedDistanceMeters { get; set; }
+
+    /// <summary>
+    /// Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+    /// Always false for legacy sets (no snapshot → treated as planned == actual).
+    /// </summary>
+    public bool IsModified { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutEndpoint.cs
@@ -77,6 +77,15 @@ public class UpdateWorkoutEndpoint(
                 .Select(s => (e.ExerciseExternalId, s.SetNumber)))
             .ToHashSet();
 
+        // ── Build snapshot lookup from the existing stored sets ──────────────────
+        // Key: (ExerciseExternalId, SetNumber) → stored WorkoutSet.
+        // Used below to freeze Planned* fields on re-PUT: once a Planned* field has
+        // a non-null value in the database it is immutable; later requests cannot
+        // overwrite it even if they supply different planned values.
+        var storedSetLookup = log.Exercises
+            .SelectMany(e => e.Sets.Select(s => (e.ExerciseExternalId, s)))
+            .ToDictionary(x => (x.ExerciseExternalId, x.s.SetNumber), x => x.s);
+
         // ── Build new exercise list from request ──────────────────────────────────
         // The UpdateWorkout API accepts a flat exercise list (offline-first protocol).
         // Exercises are stored inside a single default section named "Hlavní".
@@ -88,15 +97,27 @@ public class UpdateWorkoutEndpoint(
             ExerciseExternalId = re.ExerciseExternalId,
             ExerciseName = re.ExerciseName,
             WodResult = re.WodResult,
-            Sets = re.Sets.Select(rs => new WorkoutSet
+            Sets = re.Sets.Select(rs =>
             {
-                SetNumber = rs.SetNumber,
-                Reps = rs.Reps,
-                WeightKg = rs.WeightKg,
-                Rpe = rs.Rpe,
-                DurationSeconds = rs.DurationSeconds,
-                DistanceMeters = rs.DistanceMeters,
-                CompletedAt = rs.CompletedAt
+                // Per-field snapshot freeze: use stored value when it is already non-null,
+                // otherwise take the incoming request value (first-log or extra-set case).
+                storedSetLookup.TryGetValue((re.ExerciseExternalId, rs.SetNumber), out var stored);
+
+                return new WorkoutSet
+                {
+                    SetNumber = rs.SetNumber,
+                    Reps = rs.Reps,
+                    WeightKg = rs.WeightKg,
+                    Rpe = rs.Rpe,
+                    DurationSeconds = rs.DurationSeconds,
+                    DistanceMeters = rs.DistanceMeters,
+                    CompletedAt = rs.CompletedAt,
+                    PlannedReps = stored?.PlannedReps ?? rs.PlannedReps,
+                    PlannedWeightKg = stored?.PlannedWeightKg ?? rs.PlannedWeightKg,
+                    PlannedRpe = stored?.PlannedRpe ?? rs.PlannedRpe,
+                    PlannedDurationSeconds = stored?.PlannedDurationSeconds ?? rs.PlannedDurationSeconds,
+                    PlannedDistanceMeters = stored?.PlannedDistanceMeters ?? rs.PlannedDistanceMeters
+                };
             }).ToList()
         }).ToList();
         // Preserve existing section structure when available; otherwise use a single default section.

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutRequest.cs
@@ -104,4 +104,34 @@ public class UpdateWorkoutSetRequest
     /// When this set was completed.
     /// </summary>
     public DateTime? CompletedAt { get; set; }
+
+    // ── Snapshot-planned fields ─────────────────────────────────────────────────
+    // Clients send these once from the plan prescription when first logging a set;
+    // they are frozen as a snapshot onto WorkoutSet and must not change on subsequent calls.
+    // All are nullable for backward compatibility with clients that do not yet send them.
+
+    /// <summary>
+    /// Prescribed repetitions from the plan prescription.
+    /// </summary>
+    public int? PlannedReps { get; set; }
+
+    /// <summary>
+    /// Prescribed weight (kg) from the plan prescription.
+    /// </summary>
+    public decimal? PlannedWeightKg { get; set; }
+
+    /// <summary>
+    /// Prescribed RPE from the plan prescription.
+    /// </summary>
+    public decimal? PlannedRpe { get; set; }
+
+    /// <summary>
+    /// Prescribed duration (seconds) from the plan prescription.
+    /// </summary>
+    public int? PlannedDurationSeconds { get; set; }
+
+    /// <summary>
+    /// Prescribed distance (meters) from the plan prescription.
+    /// </summary>
+    public decimal? PlannedDistanceMeters { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/UpdateWorkout/UpdateWorkoutValidator.cs
@@ -45,6 +45,19 @@ public class UpdateWorkoutValidator : Validator<UpdateWorkoutRequest>
                 set.RuleFor(s => s.Rpe)
                     .InclusiveBetween(1, 10)
                     .When(s => s.Rpe.HasValue);
+
+                // ── Snapshot-planned bounds — mirror actual-value rules ─────────
+                set.RuleFor(s => s.PlannedReps)
+                    .InclusiveBetween(1, 1000)
+                    .When(s => s.PlannedReps.HasValue);
+
+                set.RuleFor(s => s.PlannedWeightKg)
+                    .GreaterThanOrEqualTo(0)
+                    .When(s => s.PlannedWeightKg.HasValue);
+
+                set.RuleFor(s => s.PlannedRpe)
+                    .InclusiveBetween(1, 10)
+                    .When(s => s.PlannedRpe.HasValue);
             });
         });
     }

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionLoggedSetsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientTraining/GetTodaySessionLoggedSetsTests.cs
@@ -1,0 +1,497 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.ClientTraining.GetTodaySession;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientTraining;
+
+/// <summary>
+/// Tests for <see cref="GetTodaySessionEndpoint"/> — verifies that
+/// <c>LoggedSetsBySessionExercise</c> and <c>HasModificationsBySession</c>
+/// are correctly populated from WorkoutLog data.
+/// </summary>
+public class GetTodaySessionLoggedSetsTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _userIdGuid = Guid.NewGuid(); // ApplicationUser.Id (used in WorkoutLog.ClientId)
+
+    private IApplicationDbContext CreateMockDb() =>
+        new MockDbBuilder()
+            .With(new ClientProfile { UserId = _userIdGuid, PublicId = _clientId })
+            .Build();
+
+    private static int TodayDow()
+    {
+        var dow = (int)DateTime.UtcNow.DayOfWeek;
+        return dow == 0 ? 7 : dow;
+    }
+
+    private static DateTime StartOfCurrentWeek()
+    {
+        var today = DateTime.UtcNow.Date;
+        return today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
+    }
+
+    private IMongoContext CreateMongoWithPlanAndLog(
+        TrainingPlan plan,
+        List<WorkoutLog>? workoutLogs = null)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        // Plans collection
+        var plans = new List<TrainingPlan> { plan };
+        var planCollection = Substitute.For<IMongoCollection<TrainingPlan>>();
+        planCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingPlan>>(),
+                Arg.Any<FindOptions<TrainingPlan, TrainingPlan>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingPlan>>();
+                var moved = false;
+                cursor.Current.Returns(plans);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return true; });
+                return cursor;
+            });
+        mongo.TrainingPlans.Returns(planCollection);
+
+        // Exercises collection (empty — muscle groups not needed for these tests)
+        var exerciseCollection = Substitute.For<IMongoCollection<Exercise>>();
+        exerciseCollection.FindAsync(
+                Arg.Any<FilterDefinition<Exercise>>(),
+                Arg.Any<FindOptions<Exercise, Exercise>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<Exercise>>();
+                var moved = false;
+                cursor.Current.Returns(new List<Exercise>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => false);
+                return cursor;
+            });
+        mongo.Exercises.Returns(exerciseCollection);
+
+        // TrainingCompletions collection (empty for these tests)
+        var completionCollection = Substitute.For<IMongoCollection<TrainingCompletion>>();
+        completionCollection.FindAsync(
+                Arg.Any<FilterDefinition<TrainingCompletion>>(),
+                Arg.Any<FindOptions<TrainingCompletion, TrainingCompletion>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<TrainingCompletion>>();
+                var moved = false;
+                cursor.Current.Returns(new List<TrainingCompletion>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => false);
+                return cursor;
+            });
+        mongo.TrainingCompletions.Returns(completionCollection);
+
+        // WorkoutLogs collection
+        var logDocs = workoutLogs ?? [];
+        var logCollection = Substitute.For<IMongoCollection<WorkoutLog>>();
+        logCollection.FindAsync(
+                Arg.Any<FilterDefinition<WorkoutLog>>(),
+                Arg.Any<FindOptions<WorkoutLog, WorkoutLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<WorkoutLog>>();
+                var moved = false;
+                cursor.Current.Returns(logDocs);
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return logDocs.Count > 0; });
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => { if (moved) return false; moved = true; return logDocs.Count > 0; });
+                return cursor;
+            });
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        // SessionLogs collection (empty)
+        var sessionLogCollection = Substitute.For<IMongoCollection<SessionLog>>();
+        sessionLogCollection.FindAsync(
+                Arg.Any<FilterDefinition<SessionLog>>(),
+                Arg.Any<FindOptions<SessionLog, SessionLog>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                var cursor = Substitute.For<IAsyncCursor<SessionLog>>();
+                var moved = false;
+                cursor.Current.Returns(new List<SessionLog>());
+                cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ => false);
+                cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ => false);
+                return cursor;
+            });
+        mongo.SessionLogs.Returns(sessionLogCollection);
+
+        return mongo;
+    }
+
+    private GetTodaySessionEndpoint CreateEndpoint(IMongoContext mongo, IApplicationDbContext db)
+    {
+        var lockService = Substitute.For<ISessionLockService>();
+        lockService.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SessionLock>() as IReadOnlyList<SessionLock>);
+
+        return Factory.Create<GetTodaySessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_userIdGuid, AppRoles.Client))),
+            mongo, db, lockService);
+    }
+
+    private TrainingPlan BuildPlanWithSession(Guid sessionId, Guid exerciseId, int dow)
+    {
+        var startOfWeek = StartOfCurrentWeek();
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = startOfWeek,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    DatePublished = startOfWeek,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = dow,
+                            Name = "Test Session",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = Guid.NewGuid(),
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Squat",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 80m },
+                                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 80m }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = startOfWeek
+        };
+    }
+
+    // ── LoggedSetsBySessionExercise populated from WorkoutLog ──────────────────
+
+    [Fact]
+    public async Task HandleAsync_WithWorkoutLog_PopulatesLoggedSetsBySessionExercise()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 10,
+                                    WeightKg = 80m,
+                                    PlannedReps = 10,
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                },
+                                new WorkoutSet
+                                {
+                                    SetNumber = 2,
+                                    Reps = 8,            // actual differs from plan
+                                    WeightKg = 80m,
+                                    PlannedReps = 10,    // planned was 10
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var response = ep.Response;
+
+        response.LoggedSetsBySessionExercise.Should().ContainKey(sessionId);
+        var exerciseSets = response.LoggedSetsBySessionExercise[sessionId];
+        exerciseSets.Should().ContainKey(exerciseId);
+
+        var sets = exerciseSets[exerciseId];
+        sets.Should().HaveCount(2);
+
+        // Set 1: actual == planned → IsModified = false
+        var set1 = sets.Single(s => s.SetNumber == 1);
+        set1.ActualReps.Should().Be(10);
+        set1.PlannedReps.Should().Be(10);
+        set1.IsModified.Should().BeFalse();
+
+        // Set 2: actual (8) != planned (10) → IsModified = true
+        var set2 = sets.Single(s => s.SetNumber == 2);
+        set2.ActualReps.Should().Be(8);
+        set2.PlannedReps.Should().Be(10);
+        set2.IsModified.Should().BeTrue();
+    }
+
+    // ── HasModificationsBySession set when any set is modified ─────────────────
+
+    [Fact]
+    public async Task HandleAsync_WithModifiedSet_SetsHasModificationsBySession()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 7,         // actual differs
+                                    WeightKg = 80m,
+                                    PlannedReps = 10, // planned
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.HasModificationsBySession.Should().ContainKey(sessionId);
+        ep.Response.HasModificationsBySession[sessionId].Should().BeTrue();
+    }
+
+    // ── HasModificationsBySession absent when all sets are as-planned ──────────
+
+    [Fact]
+    public async Task HandleAsync_WithNoModifiedSets_HasModificationsAbsentOrFalse()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 10,
+                                    WeightKg = 80m,
+                                    PlannedReps = 10,     // matches actual
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        // Should NOT have a true entry for this session
+        if (ep.Response.HasModificationsBySession.TryGetValue(sessionId, out var val))
+            val.Should().BeFalse();
+        // else: absent key is treated as false — pass
+    }
+
+    // ── Backward compatible: legacy sets without planned fields → IsModified false ─
+
+    [Fact]
+    public async Task HandleAsync_WithLegacySetNoPlannedFields_IsModifiedFalse()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var workoutLog = new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = _userIdGuid,
+            SessionId = sessionId,
+            StartedAt = DateTime.UtcNow,
+            IsCompleted = false,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Hlavní",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = exerciseId,
+                            ExerciseName = "Squat",
+                            Sets =
+                            [
+                                new WorkoutSet
+                                {
+                                    SetNumber = 1,
+                                    Reps = 10,
+                                    WeightKg = 80m,
+                                    // No planned fields — simulates legacy document
+                                    CompletedAt = DateTime.UtcNow
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            DateCreated = DateTime.UtcNow
+        };
+
+        var mongo = CreateMongoWithPlanAndLog(plan, [workoutLog]);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.LoggedSetsBySessionExercise.Should().ContainKey(sessionId);
+        var sets = ep.Response.LoggedSetsBySessionExercise[sessionId][exerciseId];
+        sets[0].IsModified.Should().BeFalse();
+        sets[0].PlannedReps.Should().BeNull();
+    }
+
+    // ── No log → empty LoggedSetsBySessionExercise ─────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_WithNoWorkoutLog_LoggedSetsIsEmpty()
+    {
+        var sessionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var todayDow = TodayDow();
+        var plan = BuildPlanWithSession(sessionId, exerciseId, todayDow);
+        var db = CreateMockDb();
+
+        var mongo = CreateMongoWithPlanAndLog(plan, []);
+        var ep = CreateEndpoint(mongo, db);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.Response.LoggedSetsBySessionExercise.Should().BeEmpty();
+        ep.Response.HasModificationsBySession.Should().BeEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionPlannedSnapshotTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/FinishSessionPlannedSnapshotTests.cs
@@ -1,0 +1,188 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.FinishSession;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the snapshot-planned-equals-actual behaviour in
+/// <see cref="FinishSessionEndpoint"/>.MaterializeFromTemplate.
+/// When a trainer retroactively finishes a session the log is built from
+/// the prescription: each set's planned values must equal its actual values
+/// so that IsModified == false (done-as-prescribed).
+/// </summary>
+public class FinishSessionPlannedSnapshotTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    private IWorkoutCompletionService StubCompletionService()
+    {
+        var svc = Substitute.For<IWorkoutCompletionService>();
+        svc.CompleteAsync(Arg.Any<WorkoutLog>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new List<string>());
+        return svc;
+    }
+
+    private static TrainingPlan CreatePlanWithPrescribedSets(Guid trainerId, Guid sessionId)
+    {
+        var sectionId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        return new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            StartDate = DateTime.UtcNow.Date.AddDays(-30),
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = sessionId,
+                            DayOfWeek = 1,
+                            Name = "Push Day",
+                            Order = 1,
+                            Sections =
+                            [
+                                new TrainingSection
+                                {
+                                    SectionId = sectionId,
+                                    Order = 0,
+                                    Name = "Hlavní",
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = exerciseId,
+                                            ExerciseName = "Bench Press",
+                                            Order = 1,
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 100m, Rpe = 7m },
+                                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 100m, Rpe = 8m },
+                                                new ExerciseSet { SetNumber = 3, Reps = 8,  WeightKg = 100m }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            Version = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-30)
+        };
+    }
+
+    private static (IMongoContext Mongo, IMongoCollection<WorkoutLog> LogCollection) CreateMockMongoWithInsert(
+        TrainingPlan plan,
+        IReadOnlyList<WorkoutLog> existingLogs)
+    {
+        var mongo = Substitute.For<IMongoContext>();
+
+        var planCollection = TrainingPlanTestHelpers.CreateMockCollection([plan]);
+        mongo.TrainingPlans.Returns(planCollection);
+
+        var logCollection = TrainingPlanTestHelpers.CreateMockWorkoutLogCollection(existingLogs.ToList());
+        mongo.WorkoutLogs.Returns(logCollection);
+
+        return (mongo, logCollection);
+    }
+
+    // ── MaterializeFromTemplate: planned == actual for every set ──────────────
+
+    [Fact]
+    public async Task MaterializeFromTemplate_InsertedLog_HasPlannedEqualsActualOnEachSet()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPrescribedSets(_trainerId, sessionId);
+        var (mongo, logCollection) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        WorkoutLog? insertedLog = null;
+        await logCollection.InsertOneAsync(
+            Arg.Do<WorkoutLog>(l => insertedLog = l),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Re-fetch the log that was inserted (NSubstitute captured it above).
+        // Because NSubstitute Arg.Do fires when the method is called but we set
+        // up the capture after .Returns(), we verify via the completion-service call.
+        await completionService.Received(1).CompleteAsync(
+            Arg.Is<WorkoutLog>(l =>
+                // Every set must have planned == actual and IsModified == false.
+                l.Exercises.All(ex =>
+                    ex.Sets.All(s =>
+                        s.PlannedReps == s.Reps &&
+                        s.PlannedWeightKg == s.WeightKg &&
+                        s.PlannedRpe == s.Rpe &&
+                        s.PlannedDurationSeconds == s.DurationSeconds &&
+                        s.PlannedDistanceMeters == s.DistanceMeters &&
+                        !s.IsModified))),
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Specific values snapshot correctly ────────────────────────────────────
+
+    [Fact]
+    public async Task MaterializeFromTemplate_SetsSnapshotFromPrescribedValues()
+    {
+        var sessionId = Guid.NewGuid();
+        var plan = CreatePlanWithPrescribedSets(_trainerId, sessionId);
+        var (mongo, _) = CreateMockMongoWithInsert(plan, []);
+        var completionService = StubCompletionService();
+
+        var ep = Factory.Create<FinishSessionEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, completionService);
+
+        await ep.HandleAsync(
+            new FinishSessionRequest { PlanId = plan.ExternalId, SessionId = sessionId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Verify the first set of the materialized log has Rpe snapshot set.
+        // (PlannedRpe = 7m for set 1 as prescribed; set 3 has no Rpe → PlannedRpe null)
+        await completionService.Received(1).CompleteAsync(
+            Arg.Is<WorkoutLog>(l =>
+                l.Exercises[0].Sets[0].PlannedRpe == 7m &&
+                l.Exercises[0].Sets[0].PlannedReps == 10 &&
+                l.Exercises[0].Sets[0].PlannedWeightKg == 100m &&
+                l.Exercises[0].Sets[2].PlannedRpe == null),  // set 3 has no Rpe in prescription
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLoggedSetsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/GetTrainingPlanLoggedSetsTests.cs
@@ -1,0 +1,288 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.TrainingPlans.GetTrainingPlan;
+using FitnessPlatform.Tests.Endpoints;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests for the <see cref="GetTrainingPlanEndpoint"/> <c>SessionExecutionDto</c>
+/// planned-vs-actual extension (issue #440):
+/// — <c>LoggedSetsByExercise</c> carries actual + snapshot-planned + isModified per set.
+/// — <c>HasModifications</c> is true when any set in the session is modified.
+/// — Backward compatibility: legacy sets without planned fields → isModified=false.
+/// </summary>
+public class GetTrainingPlanLoggedSetsTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _planId = Guid.NewGuid();
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _exerciseId = Guid.NewGuid();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    private TrainingPlan BuildPlan()
+    {
+        var session = new TrainingSession
+        {
+            SessionId = _sessionId,
+            Name = "Session 1",
+            DayOfWeek = 1,
+            Sections =
+            [
+                new TrainingSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Name = "Main",
+                    Order = 0,
+                    Exercises =
+                    [
+                        new SessionExercise
+                        {
+                            ExerciseExternalId = _exerciseId,
+                            ExerciseName = "Squat",
+                            Order = 0,
+                            Sets =
+                            [
+                                new ExerciseSet { SetNumber = 1, Reps = 10, WeightKg = 80m },
+                                new ExerciseSet { SetNumber = 2, Reps = 10, WeightKg = 80m }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        return new TrainingPlan
+        {
+            ExternalId = _planId,
+            ClientId = _clientId,
+            TrainerId = _trainerId,
+            Name = "Test Plan",
+            Status = TrainingPlanStatus.Active,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber = 1,
+                    Status = WeekStatus.Published,
+                    Sessions = [session]
+                }
+            ],
+            Version = 1,
+            DateCreated = _now
+        };
+    }
+
+    private WorkoutLog BuildLog(List<WorkoutSet> sets)
+    {
+        return new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            PlanId = _planId,
+            SessionId = _sessionId,
+            StartedAt = _now.AddMinutes(-30),
+            IsCompleted = true,
+            CompletedAt = _now,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = Guid.NewGuid(),
+                    Order = 0,
+                    Name = "Main",
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = _exerciseId,
+                            ExerciseName = "Squat",
+                            Sets = sets
+                        }
+                    ]
+                }
+            ],
+            DateCreated = _now
+        };
+    }
+
+    private async Task<GetTrainingPlanResponse?> ExecuteAsync(
+        TrainingPlan plan,
+        WorkoutLog[] logs)
+    {
+        var mongo = TrainingPlanTestHelpers.CreateMockMongoWithLogs(
+            plans: [plan],
+            workoutLogs: logs);
+
+        var ep = Factory.Create<GetTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo,
+            TrainingPlanTestHelpers.CreateNoOpLockService());
+
+        await ep.HandleAsync(
+            new GetTrainingPlanRequest { PlanId = _planId },
+            TestContext.Current.CancellationToken);
+
+        if (ep.HttpContext.Response.StatusCode != 200)
+            return null;
+
+        return ep.Response;
+    }
+
+    // ── LoggedSetsByExercise populated correctly ────────────────────────────────
+
+    [Fact]
+    public async Task SessionExecution_WithPlannedSnapshot_LoggedSetsByExerciseContainsActualAndPlanned()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 10,
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-20)
+            },
+            new WorkoutSet
+            {
+                SetNumber = 2,
+                Reps = 8,           // fewer than planned
+                WeightKg = 80m,
+                PlannedReps = 10,   // planned was 10
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-15)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().HaveCount(1);
+
+        var exec = response.SessionExecutions.Single();
+        exec.LoggedSetsByExercise.Should().ContainKey(_exerciseId);
+
+        var sets = exec.LoggedSetsByExercise[_exerciseId];
+        sets.Should().HaveCount(2);
+
+        var set1 = sets.Single(s => s.SetNumber == 1);
+        set1.ActualReps.Should().Be(10);
+        set1.PlannedReps.Should().Be(10);
+        set1.IsModified.Should().BeFalse();
+
+        var set2 = sets.Single(s => s.SetNumber == 2);
+        set2.ActualReps.Should().Be(8);
+        set2.PlannedReps.Should().Be(10);
+        set2.IsModified.Should().BeTrue();
+    }
+
+    // ── HasModifications set when any set is modified ──────────────────────────
+
+    [Fact]
+    public async Task SessionExecution_WithModifiedSet_HasModificationsTrue()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 6,           // diverges from plan
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-25)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        var exec = response!.SessionExecutions.Single();
+        exec.HasModifications.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SessionExecution_AllSetsAsPlanned_HasModificationsFalse()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 10,
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-25)
+            },
+            new WorkoutSet
+            {
+                SetNumber = 2,
+                Reps = 10,
+                WeightKg = 80m,
+                PlannedReps = 10,
+                PlannedWeightKg = 80m,
+                CompletedAt = _now.AddMinutes(-20)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        var exec = response!.SessionExecutions.Single();
+        exec.HasModifications.Should().BeFalse();
+    }
+
+    // ── Backward compatibility: legacy log without planned fields ──────────────
+
+    [Fact]
+    public async Task SessionExecution_LegacySetWithoutPlannedFields_IsModifiedFalseAndPlannedNull()
+    {
+        var plan = BuildPlan();
+        var log = BuildLog(
+        [
+            new WorkoutSet
+            {
+                SetNumber = 1,
+                Reps = 10,
+                WeightKg = 80m,
+                // No planned fields — legacy document
+                CompletedAt = _now.AddMinutes(-25)
+            }
+        ]);
+
+        var response = await ExecuteAsync(plan, [log]);
+
+        response.Should().NotBeNull();
+        var exec = response!.SessionExecutions.Single();
+        exec.HasModifications.Should().BeFalse();
+
+        exec.LoggedSetsByExercise.Should().ContainKey(_exerciseId);
+        var set = exec.LoggedSetsByExercise[_exerciseId].Single();
+        set.IsModified.Should().BeFalse();
+        set.PlannedReps.Should().BeNull();
+    }
+
+    // ── No log → SessionExecution absent → LoggedSetsByExercise empty ──────────
+
+    [Fact]
+    public async Task SessionExecution_NoLog_LoggedSetsByExerciseIsEmpty()
+    {
+        var plan = BuildPlan();
+        var response = await ExecuteAsync(plan, []);
+
+        response.Should().NotBeNull();
+        response!.SessionExecutions.Should().BeEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/UpdateWorkoutPlannedSnapshotTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/UpdateWorkoutPlannedSnapshotTests.cs
@@ -1,0 +1,523 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.WorkoutLogs.UpdateWorkout;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Endpoints;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Tests for snapshot-planned field persistence in <see cref="UpdateWorkoutEndpoint"/>.
+/// Covers:
+/// — planned fields are forwarded from request onto WorkoutSet (happy path)
+/// — IsModified computed property reflects actual-vs-planned differences
+/// — backward-compatible: omitting planned fields does not break existing behaviour
+/// </summary>
+public class UpdateWorkoutPlannedSnapshotTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private UpdateWorkoutEndpoint CreateEndpoint(IMongoContext mongo)
+    {
+        var db = Substitute.For<IApplicationDbContext>();
+        var notifier = Substitute.For<IRealtimeNotifier>();
+        var logger = Substitute.For<ILogger<UpdateWorkoutEndpoint>>();
+
+        return Factory.Create<UpdateWorkoutEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            mongo, db, notifier, logger);
+    }
+
+    // ── Happy path: planned values are persisted alongside actuals ─────────────
+
+    [Fact]
+    public async Task HandleAsync_WithPlannedFields_PersistsSnapshotOnWorkoutSet()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var ep = CreateEndpoint(mongo);
+
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Squat",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 8,                 // actual: slightly fewer than prescribed
+                            WeightKg = 100m,
+                            Rpe = 8m,
+                            PlannedReps = 10,         // snapshot-planned
+                            PlannedWeightKg = 100m,
+                            PlannedRpe = 7m
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Verify planned fields are written to the document.
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedReps == 10 &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == 100m &&
+                w.Exercises[0].Sets[0].PlannedRpe == 7m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithAllFivePlannedFields_PersistsAll()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var ep = CreateEndpoint(mongo);
+
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Run",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            DurationSeconds = 120,
+                            DistanceMeters = 500m,
+                            PlannedReps = null,
+                            PlannedWeightKg = null,
+                            PlannedRpe = null,
+                            PlannedDurationSeconds = 120,
+                            PlannedDistanceMeters = 500m
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedDurationSeconds == 120 &&
+                w.Exercises[0].Sets[0].PlannedDistanceMeters == 500m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Backward compatibility: no planned fields → existing behaviour unchanged ─
+
+    [Fact]
+    public async Task HandleAsync_WithoutPlannedFields_SetsAreNullAndIsModifiedFalse()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+        var log = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [log]);
+        var ep = CreateEndpoint(mongo);
+
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Deadlift",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest { SetNumber = 1, Reps = 5, WeightKg = 150m }
+                        // No planned fields
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedReps == null &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == null &&
+                // IsModified must be false when no snapshot exists
+                !w.Exercises[0].Sets[0].IsModified),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── IsModified computed property ────────────────────────────────────────────
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenRepsDiffer()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 8,
+            PlannedReps = 10
+        };
+
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_FalseWhenActualEqualsPlanned()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 10,
+            WeightKg = 100m,
+            PlannedReps = 10,
+            PlannedWeightKg = 100m
+        };
+
+        set.IsModified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_FalseWhenNoPlannedFieldsSet()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 10,
+            WeightKg = 100m
+            // No planned fields — legacy document
+        };
+
+        set.IsModified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenWeightDiffers()
+    {
+        var set = new WorkoutSet
+        {
+            SetNumber = 1,
+            Reps = 10,
+            WeightKg = 90m,
+            PlannedReps = 10,
+            PlannedWeightKg = 100m
+        };
+
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenRpeDiffers()
+    {
+        var set = new WorkoutSet { SetNumber = 1, Rpe = 9m, PlannedRpe = 7m };
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenDurationDiffers()
+    {
+        var set = new WorkoutSet { SetNumber = 1, DurationSeconds = 90, PlannedDurationSeconds = 60 };
+        set.IsModified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void WorkoutSet_IsModified_TrueWhenDistanceDiffers()
+    {
+        var set = new WorkoutSet { SetNumber = 1, DistanceMeters = 450m, PlannedDistanceMeters = 500m };
+        set.IsModified.Should().BeTrue();
+    }
+
+    // ── Snapshot immutability: re-PUT must not overwrite an existing snapshot ───
+
+    /// <summary>
+    /// A second PUT that supplies different Planned* values must not overwrite
+    /// the snapshot recorded on the first PUT. The stored non-null values win.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RePut_WithDifferentPlannedValues_PreservesOriginalSnapshot()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        // Simulate the document as it exists AFTER the first PUT:
+        // the snapshot fields are already populated.
+        var storedLog = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        storedLog.Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new WorkoutExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Squat",
+                        Sets =
+                        [
+                            new WorkoutSet
+                            {
+                                SetNumber = 1,
+                                Reps = 8,
+                                WeightKg = 100m,
+                                PlannedReps = 10,       // original snapshot
+                                PlannedWeightKg = 105m  // original snapshot
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [storedLog]);
+        var ep = CreateEndpoint(mongo);
+
+        // Second PUT: coach edited the plan — client sends new Planned* values that differ.
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Squat",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 9,                    // actual updated
+                            WeightKg = 102.5m,           // actual updated
+                            PlannedReps = 12,            // attacker/stale value — must be ignored
+                            PlannedWeightKg = 110m       // attacker/stale value — must be ignored
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // Snapshot fields must remain at the ORIGINAL values (10, 105m), not the request values (12, 110m).
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                w.Exercises[0].Sets[0].PlannedReps == 10 &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == 105m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A second PUT must still update actual (Reps, WeightKg, Rpe, etc.) values —
+    /// only the Planned* snapshot fields are frozen, not the whole set.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RePut_UpdatesActualValuesWhilePreservingSnapshot()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        // Stored state: snapshot already set, actuals from first PUT.
+        var storedLog = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        storedLog.Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new WorkoutExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Bench Press",
+                        Sets =
+                        [
+                            new WorkoutSet
+                            {
+                                SetNumber = 1,
+                                Reps = 5,
+                                WeightKg = 80m,
+                                PlannedReps = 8,
+                                PlannedWeightKg = 80m
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [storedLog]);
+        var ep = CreateEndpoint(mongo);
+
+        // Second PUT: client corrects their actual reps/weight.
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Bench Press",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 7,              // corrected actual
+                            WeightKg = 82.5m,      // corrected actual
+                            PlannedReps = 99,      // should be ignored — stored is 8
+                            PlannedWeightKg = 99m  // should be ignored — stored is 80m
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                // Actuals are updated to the new values.
+                w.Exercises[0].Sets[0].Reps == 7 &&
+                w.Exercises[0].Sets[0].WeightKg == 82.5m &&
+                // Snapshot stays frozen at original values.
+                w.Exercises[0].Sets[0].PlannedReps == 8 &&
+                w.Exercises[0].Sets[0].PlannedWeightKg == 80m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// An extra set added on a re-PUT (index beyond stored count) has no prior snapshot.
+    /// The request's Planned* values flow through without error.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_RePut_ExtraSetBeyondStoredCount_TakesRequestPlannedValues()
+    {
+        var logId = Guid.NewGuid();
+        var exerciseId = Guid.NewGuid();
+
+        // Stored state: only set 1 exists.
+        var storedLog = WorkoutLogTestHelpers.CreateLog(externalId: logId, clientId: _clientId);
+        storedLog.Sections =
+        [
+            new WorkoutSection
+            {
+                SectionId = Guid.NewGuid(),
+                Order = 0,
+                Name = "Hlavní",
+                Exercises =
+                [
+                    new WorkoutExercise
+                    {
+                        ExerciseExternalId = exerciseId,
+                        ExerciseName = "Pull-up",
+                        Sets =
+                        [
+                            new WorkoutSet
+                            {
+                                SetNumber = 1,
+                                Reps = 10,
+                                PlannedReps = 10
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo(logs: [storedLog]);
+        var ep = CreateEndpoint(mongo);
+
+        // Second PUT: client adds an extra set 2 (no stored snapshot for it).
+        var request = new UpdateWorkoutRequest
+        {
+            LogId = logId,
+            Exercises =
+            [
+                new UpdateWorkoutExerciseRequest
+                {
+                    ExerciseExternalId = exerciseId,
+                    ExerciseName = "Pull-up",
+                    Sets =
+                    [
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 1,
+                            Reps = 10,
+                            PlannedReps = 99 // ignored — stored is 10
+                        },
+                        new UpdateWorkoutSetRequest
+                        {
+                            SetNumber = 2,         // extra set — no stored snapshot
+                            Reps = 8,
+                            PlannedReps = 8        // should flow through (no stored value)
+                        }
+                    ]
+                }
+            ]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.WorkoutLogs.Received().ReplaceOneAsync(
+            Arg.Any<FilterDefinition<WorkoutLog>>(),
+            Arg.Is<WorkoutLog>(w =>
+                // Set 1: snapshot frozen at original 10.
+                w.Exercises[0].Sets[0].PlannedReps == 10 &&
+                // Set 2 (extra): request planned value flows through.
+                w.Exercises[0].Sets[1].PlannedReps == 8),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/mobile/app/(client)/(tabs)/plans/[planId].tsx
+++ b/mobile/app/(client)/(tabs)/plans/[planId].tsx
@@ -42,6 +42,7 @@ import {
   type SectionDto,
   type WorkoutFormat,
   type MuscleGroup,
+  type LoggedSetDto,
 } from '@/api/training'
 import {
   getSubmittedQuestionnairesByCoach,
@@ -1436,6 +1437,7 @@ function TrainingPlanDetail({
                       standalone
                       headerRight={sessionCheckIndicator}
                       bodyFooter={<SessionReminderRow session={session} planId={planId} />}
+                      hasModifications={session.hasModifications ?? false}
                     >
                       {/* Section-grouped exercise cards (read-only) */}
                       {sections.map((section, sectionIdx) => {
@@ -1529,6 +1531,28 @@ function TrainingPlanDetail({
                                     ? getMuscleGroupColor(primaryMg, colors)
                                     : colors.gold
 
+                                // Build LoggedSetDto array from FullPlanSet (#441).
+                                // FullPlanSet carries actual + planned + isModified after
+                                // backend #440. Sets without actual data (never performed)
+                                // have all actual* === null and isModified === false.
+                                const planLoggedSets: LoggedSetDto[] | undefined =
+                                  sets.some((s) => s.isModified != null)
+                                    ? sets.map((s, si) => ({
+                                        setNumber: s.setNumber ?? si + 1,
+                                        actualReps: s.actualReps ?? undefined,
+                                        actualWeightKg: s.actualWeightKg ?? undefined,
+                                        actualRpe: s.actualRpe ?? undefined,
+                                        actualDurationSeconds: s.actualDurationSeconds ?? undefined,
+                                        actualDistanceMeters: s.actualDistanceMeters ?? undefined,
+                                        plannedReps: s.plannedReps ?? undefined,
+                                        plannedWeightKg: s.plannedWeightKg ?? undefined,
+                                        plannedRpe: s.plannedRpe ?? undefined,
+                                        plannedDurationSeconds: s.plannedDurationSeconds ?? undefined,
+                                        plannedDistanceMeters: s.plannedDistanceMeters ?? undefined,
+                                        isModified: s.isModified ?? false,
+                                      }))
+                                    : undefined
+
                                 return (
                                   <ExpandableExerciseCard
                                     key={exId ?? exIdx}
@@ -1542,6 +1566,7 @@ function TrainingPlanDetail({
                                     nonExpandable={isWodFormat}
                                     hideCompletionIndicator={isWodFormat}
                                     notes={exercise.notes}
+                                    hasModifications={exercise.hasModifications ?? false}
                                   >
                                     <SetGrid
                                       sets={sets}
@@ -1549,6 +1574,7 @@ function TrainingPlanDetail({
                                         .filter((s) => s.completedAt != null)
                                         .map((s) => s.setNumber ?? 0)
                                         .filter((n) => n > 0)}
+                                      loggedSets={planLoggedSets}
                                     />
                                   </ExpandableExerciseCard>
                                 )

--- a/mobile/app/(client)/plan-photos.tsx
+++ b/mobile/app/(client)/plan-photos.tsx
@@ -61,8 +61,13 @@ import { ImageLightbox } from '@/components/ui/ImageLightbox'
 type UiCategory = 'Food' | 'Progress' | 'Free'
 type FilterCategory = 'All' | UiCategory
 
-/** Map from PlanPhotoCategory wire value back to UI category for display. */
-const WIRE_TO_UI: Record<PlanPhotoCategory, UiCategory> = {
+/**
+ * Map from PlanPhotoCategory wire value back to UI category for display.
+ * Partial by design: wire categories without a dedicated chip (e.g. Training,
+ * which is surfaced on session-scoped screens, not this plan-photos filter)
+ * fall back to 'Free' at the call site via `?? 'Free'`.
+ */
+const WIRE_TO_UI: Partial<Record<PlanPhotoCategory, UiCategory>> = {
   [PlanPhotoCategory.Food]: 'Food',
   [PlanPhotoCategory.Body]: 'Progress',
   [PlanPhotoCategory.FreeForm]: 'Free',

--- a/mobile/app/(client)/session-log-photo.tsx
+++ b/mobile/app/(client)/session-log-photo.tsx
@@ -72,7 +72,9 @@ export default function SessionLogPhotoScreen() {
     const cache = queryClient.getQueryData<TodayTrainingResponse>(['today-training'])
     const photos = (cache?.photosBySession ?? {})[sessionId] ?? []
     return photos
-      .filter((p) => typeof p.blobUrl === 'string' && p.blobUrl.length > 0)
+      .filter((p): p is typeof p & { blobUrl: string } =>
+        typeof p.blobUrl === 'string' && p.blobUrl.length > 0,
+      )
       .map((p) => ({ blobUrl: p.blobUrl, note: p.note ?? null }))
   }, [queryClient, sessionId])
 
@@ -93,7 +95,9 @@ export default function SessionLogPhotoScreen() {
       source: 'library',
       allowsMultipleSelection: true,
       requestUploadUrl: async ({ contentType, sizeBytes }) => {
-        return generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        const res = await generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        // Generated type marks these optional; the API always returns them.
+        return { uploadUrl: res.uploadUrl ?? '', blobUrl: res.blobUrl ?? '' }
       },
     },
     undefined,
@@ -110,7 +114,9 @@ export default function SessionLogPhotoScreen() {
     {
       source: 'camera',
       requestUploadUrl: async ({ contentType, sizeBytes }) => {
-        return generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        const res = await generateSessionPhotoUploadUrl(sessionId, contentType, sizeBytes)
+        // Generated type marks these optional; the API always returns them.
+        return { uploadUrl: res.uploadUrl ?? '', blobUrl: res.blobUrl ?? '' }
       },
     },
     (blobUrl) => {

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -58,6 +58,7 @@ import type {
   WodResult,
   UpdateWorkoutWodRequest,
   UpdateWodExerciseRequest,
+  LoggedSetDto,
 } from '@/api/wod-types'
 import { SectionHeader } from '@/components/training/SectionHeader'
 import { ExpandableExerciseCard } from '@/components/training/ExpandableExerciseCard'
@@ -2406,15 +2407,25 @@ export default function WorkoutLogScreen() {
           reps: isDone ? (override?.reps ?? planned.reps) : undefined,
           weightKg: isDone ? (override?.weightKg ?? planned.weightKg) : undefined,
           // Time-movement actuals: durationSeconds replaces the reps slot.
-          durationSeconds: isDone ? (override?.durationSeconds ?? null) : undefined,
+          // Use undefined (not null) to match UpdateWorkoutSetRequest's field type.
+          durationSeconds: isDone ? (override?.durationSeconds ?? undefined) : undefined,
           // Distance-movement actuals: distanceMeters replaces the weightKg slot.
-          distanceMeters: isDone ? (override?.distanceMeters ?? null) : undefined,
+          distanceMeters: isDone ? (override?.distanceMeters ?? undefined) : undefined,
           // Only truly completed sets carry completedAt. Skipped sets must NOT
           // receive a completedAt timestamp — the backend (GetTodaySession)
           // uses CompletedAt != null to populate completedSetsBySessionExercise,
           // so sending completedAt for skipped sets caused them to show as '✓'
           // on the Today-screen TrainingCard SetGrid (bug #322).
           completedAt: isDone ? new Date().toISOString() : undefined,
+          // Snapshot-planned values (#441): the backend stores these on the
+          // WorkoutLog so the isModified flag can be computed on read. Send
+          // the original plan values from the exercise's planned sets.
+          // Use undefined (not null) to match UpdateWorkoutSetRequest's field type.
+          plannedReps: planned.reps ?? undefined,
+          plannedWeightKg: planned.weightKg ?? undefined,
+          plannedRpe: planned.rpe ?? undefined,
+          plannedDurationSeconds: planned.durationSeconds ?? undefined,
+          plannedDistanceMeters: planned.distanceMeters ?? undefined,
         }
       })
       // Per-exercise WOD result (only present when the exercise has a format override).
@@ -2893,11 +2904,53 @@ export default function WorkoutLogScreen() {
           (si) => plannedSets[si]?.setNumber ?? si + 1,
         )
         if (plannedSets.length > 0) {
+          // Build client-side LoggedSetDto from the live session store (#441).
+          // The backend computes isModified server-side (stored in WorkoutLog),
+          // but for the local finished summary we derive it from the plan vs
+          // the user's actual inputs (formOverrides). This gives immediate
+          // visual feedback in the LiveFinishedSummary before the PUT/GET cycle.
+          const loggedSets: LoggedSetDto[] = plannedSets.map((planned, si) => {
+            const override = formOverrides[exId]?.[si]
+            const isDone = doneIndices.includes(si)
+            const actualReps = isDone ? (override?.reps ?? planned.reps ?? null) : null
+            const actualWeightKg = isDone ? (override?.weightKg ?? planned.weightKg ?? null) : null
+            const actualDurationSeconds = isDone ? (override?.durationSeconds ?? null) : null
+            const actualDistanceMeters = isDone ? (override?.distanceMeters ?? null) : null
+            // isModified: true when the user changed reps or weight vs. plan.
+            const repsModified =
+              isDone &&
+              actualReps != null &&
+              planned.reps != null &&
+              actualReps !== planned.reps
+            const weightModified =
+              isDone &&
+              actualWeightKg != null &&
+              planned.weightKg != null &&
+              actualWeightKg !== planned.weightKg
+            const durationModified =
+              isDone &&
+              actualDurationSeconds != null &&
+              planned.durationSeconds != null &&
+              actualDurationSeconds !== planned.durationSeconds
+            return {
+              setNumber: planned.setNumber ?? si + 1,
+              actualReps: actualReps ?? undefined,
+              actualWeightKg: actualWeightKg ?? undefined,
+              actualDurationSeconds: actualDurationSeconds ?? undefined,
+              actualDistanceMeters: actualDistanceMeters ?? undefined,
+              plannedReps: planned.reps ?? undefined,
+              plannedWeightKg: planned.weightKg ?? undefined,
+              plannedDurationSeconds: planned.durationSeconds ?? undefined,
+              plannedDistanceMeters: planned.distanceMeters ?? undefined,
+              isModified: repsModified || weightModified || durationModified,
+            }
+          })
           exerciseSets.push({
             exerciseName: ex.exerciseName ?? '',
             sets: plannedSets,
             completedSetNumbers: completedSetNums,
             skippedSetNumbers: skippedSetNums,
+            loggedSets,
           })
         }
       }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web",
     "test": "jest",
     "typecheck": "tsc --noEmit",
+    "expo-doctor": "npx expo-doctor",
     "generate-api": "cd ../backend && curl -sk https://localhost:5001/swagger/v1/swagger.json -o swagger.json && dotnet nswag run nswag.mobile.json && sed -i '' 's|/\\* eslint-disable \\*/|/* eslint-disable */\\n// @ts-nocheck|' ../mobile/src/api/generated.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"

--- a/mobile/src/api/generated.ts
+++ b/mobile/src/api/generated.ts
@@ -8750,6 +8750,78 @@ export class ApiClient {
     }
 
     /**
+     * Save photos / note for a training session diary entry
+     * @param sessionId The unique identifier of the training session whose photos/note are being saved.
+    Sourced from the route segment {SessionId}.
+     * @return No Content
+     */
+    saveSessionPhotosEndpoint(sessionId: string, saveSessionPhotosRequest: SaveSessionPhotosRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/client/training/log/sessions/{sessionId}/photos";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(saveSessionPhotosRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSaveSessionPhotosEndpoint(_response);
+        });
+    }
+
+    protected processSaveSessionPhotosEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Mark all training sessions for a day complete
      * @return Success
      */
@@ -9407,6 +9479,82 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetFullTrainingPlanResponse>(null as any);
+    }
+
+    /**
+     * Generate training session photo upload URL
+     * @param sessionId The unique identifier of the session the photo will be attached to.
+    Sourced from the route segment {SessionId}.
+     * @return Success
+     */
+    generateSessionPhotoUploadUrlEndpoint(sessionId: string, generateSessionPhotoUploadUrlRequest: GenerateSessionPhotoUploadUrlRequest, signal?: AbortSignal): Promise<GenerateSessionPhotoUploadUrlResponse> {
+        let url_ = this.baseUrl + "/client/training/log/sessions/{sessionId}/photo-upload-url";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateSessionPhotoUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateSessionPhotoUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateSessionPhotoUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateSessionPhotoUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateSessionPhotoUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateSessionPhotoUploadUrlResponse>(null as any);
     }
 
     /**
@@ -12790,7 +12938,7 @@ export interface WodResult {
     repsByRound?: number[] | undefined;
 }
 
-/** A single set actually performed during a workout with recorded values. */
+/** A single set actually performed during a workout with recorded values. Snapshot-planned fields capture the prescribed values at the time the set was first logged; they are immutable after initial persistence so later plan edits do not affect them. */
 export interface WorkoutSet {
     /** Set number within the exercise (1-based). */
     setNumber?: number;
@@ -12808,6 +12956,20 @@ export interface WorkoutSet {
     completedAt?: string | undefined;
     /** Whether this set is a personal record for this exercise. */
     isPR?: boolean;
+    /** Prescribed repetitions at the time this set was first logged. */
+    plannedReps?: number | undefined;
+    /** Prescribed weight (kg) at the time this set was first logged. */
+    plannedWeightKg?: number | undefined;
+    /** Prescribed RPE at the time this set was first logged. */
+    plannedRpe?: number | undefined;
+    /** Prescribed duration (seconds) at the time this set was first logged. */
+    plannedDurationSeconds?: number | undefined;
+    /** Prescribed distance (meters) at the time this set was first logged. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+Always false for legacy sets whose planned fields are all null (backward-compatible default).
+Never stored — derived on read. */
+    isModified?: boolean;
 }
 
 /** Request to progressively update a workout log with exercise data. Designed for offline-first: client sends all exercises/sets accumulated so far. */
@@ -12852,29 +13014,32 @@ export interface UpdateWorkoutSetRequest {
     distanceMeters?: number | undefined;
     /** When this set was completed. */
     completedAt?: string | undefined;
+    /** Prescribed repetitions from the plan prescription. */
+    plannedReps?: number | undefined;
+    /** Prescribed weight (kg) from the plan prescription. */
+    plannedWeightKg?: number | undefined;
+    /** Prescribed RPE from the plan prescription. */
+    plannedRpe?: number | undefined;
+    /** Prescribed duration (seconds) from the plan prescription. */
+    plannedDurationSeconds?: number | undefined;
+    /** Prescribed distance (meters) from the plan prescription. */
+    plannedDistanceMeters?: number | undefined;
 }
 
-/** RFC7807 compatible problem details/ error response class. this can be used by configuring startup like so: app.UseFastEndpoints(c => c.Errors.UseProblemDetails()) */
 export interface ProblemDetails {
     type?: string;
     title?: string;
     status?: number;
     instance?: string;
     traceId?: string;
-    /** the details of the error */
     detail?: string | undefined;
     errors?: ProblemDetails_Error[];
 }
 
-/** the error details object */
 export interface ProblemDetails_Error {
-    /** the name of the error or property of the dto that caused the error */
     name?: string;
-    /** the reason for the error */
     reason?: string;
-    /** the code of the error */
     code?: string | undefined;
-    /** the severity of the error */
     severity?: string | undefined;
 }
 
@@ -13026,7 +13191,7 @@ export interface PutSettingsResponse {
     profession?: string;
     /** Day of the week (0 = Sunday … 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned time of day. */
+    /** Time of day for the reminder. Between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
@@ -13043,7 +13208,7 @@ Accepted values: "Training", "Nutrition". */
     profession: string;
     /** Day of the week on which the reminder fires (0 = Sunday … 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned local time of day for the reminder. Minutes, Seconds, and Milliseconds must all be zero. */
+    /** Local time of day for the reminder. Must be between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
@@ -13079,7 +13244,7 @@ export interface PutOverrideResponse {
 export interface PutOverrideRequest {
     /** Override day of week (0 = Sunday … 6 = Saturday). Null = inherit. */
     dayOfWeek?: number | undefined;
-    /** Override time of day (hour-aligned). Null = inherit. Minutes/Seconds/Milliseconds must be zero if set. */
+    /** Override time of day. Null = inherit. Must be between 00:00:00 and 23:59:59 if set. */
     timeOfDay?: string | undefined;
     /** Override enabled flag. Null = inherit. */
     enabled?: boolean | undefined;
@@ -13156,7 +13321,7 @@ export interface CheckInSettingDto {
     profession?: string;
     /** Day of the week (0 = Sunday, 1 = Monday, …, 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned time of day in "HH:mm:ss" format. */
+    /** Time of day for the reminder in "HH:mm:ss" format. Between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
@@ -13616,6 +13781,45 @@ of 1-based set numbers that were stamped as complete in the WorkoutLog.
 An absent key means no sets for that exercise were logged.
 An empty list should not occur but is treated identically to an absent key. */
     completedSetsByExercise?: { [key: string]: number[]; };
+    /** Per-exercise map of per-set actual values, snapshot-planned values, and isModified flags.
+Key = ExerciseExternalId; value = list of LoggedSetDto (one per logged set).
+An absent key means no sets for that exercise were logged.
+The web layer uses this together with CompletedSetsByExercise to render
+the actual-vs-planned comparison and the upraveno (modified) indicator per set. */
+    loggedSetsByExercise?: { [key: string]: LoggedSetDto[]; };
+    /** True when at least one set in any exercise under this session has IsModified == true.
+The web layer uses this to show the upraveno badge at the session-header level.
+Always false when the session has no WorkoutLog (or all logs are legacy without snapshots). */
+    hasModifications?: boolean;
+}
+
+/** Per-set actual values + snapshot-planned values + backend-computed isModified flag, sourced from a WorkoutSet. Used by training-read endpoints that need to surface actual-vs-planned comparison (GetTodaySession, GetFullTrainingPlan, and the trainer GetTrainingPlan). */
+export interface LoggedSetDto {
+    /** 1-based set number within the exercise. */
+    setNumber?: number;
+    /** Actual repetitions logged. Null when the set has not been performed. */
+    actualReps?: number | undefined;
+    /** Actual weight (kg) logged. Null when not performed. */
+    actualWeightKg?: number | undefined;
+    /** Actual RPE logged. Null when not performed. */
+    actualRpe?: number | undefined;
+    /** Actual duration (seconds) logged. Null when not performed. */
+    actualDurationSeconds?: number | undefined;
+    /** Actual distance (meters) logged. Null when not performed. */
+    actualDistanceMeters?: number | undefined;
+    /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+    plannedReps?: number | undefined;
+    /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+    plannedWeightKg?: number | undefined;
+    /** Snapshot-planned RPE at log time. Null for legacy logs. */
+    plannedRpe?: number | undefined;
+    /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+    plannedDurationSeconds?: number | undefined;
+    /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+Always false for legacy sets (no snapshot → treated as planned == actual). */
+    isModified?: boolean;
 }
 
 /** Per-session edit-lock state projected into the trainer read model. A session with no active lock document reports Stable with a null holder. */
@@ -16003,6 +16207,28 @@ export interface CreateExerciseRequest {
     techniqueNotes?: string | undefined;
 }
 
+/** Request model for saving the complete photo and note state of a training session diary entry. The Photos list and Note are replaced with exactly what the client sends. */
+export interface SaveSessionPhotosRequest {
+    /** The complete list of photos to persist on the session log.
+Replaces the existing Photos list entirely — pass an empty list to remove all photos.
+Each item carries the blob URL and an optional per-photo caption.
+Existing URLs that are re-submitted keep their original UploadedAt
+timestamp; new URLs receive the current UTC time. */
+    photos?: SessionPhotoInput[];
+    /** Optional free-text note to persist on the session log entry (max 500 chars).
+When non-null, the stored note is replaced with the trimmed value
+(whitespace-only strings are treated as null). When null, the existing note is cleared. */
+    note?: string | undefined;
+}
+
+/** A single photo input in a SaveSessionPhotosRequest. */
+export interface SessionPhotoInput {
+    /** The MinIO blob URL for this photo, as returned by the signed-URL upload helper. */
+    blobUrl?: string;
+    /** Optional per-photo caption (max 500 chars). */
+    note?: string | undefined;
+}
+
 /** Response for marking all training sessions on a day complete. */
 export interface MarkWholeDayCompleteResponse {
     /** The date that was marked complete. */
@@ -16264,6 +16490,38 @@ Populated via a single batch GetStateAsync call on the session lock service. */
 Possible values: "Coach" (trainer/nutritionist holds the lock) or "Client".
 Null / missing when the session is in the Stable state. */
     lockHolderBySession?: { [key: string]: string; };
+    /** Per-session photo list for today, keyed by SessionId.
+Each value is an ordered list of photos that were saved to the session log for today's date.
+Sourced from the SessionLog MongoDB document for today.
+Empty dictionary when no photos have been saved for any session today (or when no active plan exists). */
+    photosBySession?: { [key: string]: SessionPhotoDto[]; };
+    /** Per-session diary note for today, keyed by SessionId.
+Only populated for sessions whose SessionLog has a non-null, non-empty Note.
+Allows the mobile client to pre-load the existing note into its textarea so a subsequent
+Save does not overwrite it with null (data-loss prevention).
+Empty dictionary when no session has a note today (or when no active plan exists). */
+    notesBySession?: { [key: string]: string; };
+    /** Per-session, per-exercise logged set values for today.
+Keyed by SessionId → ExerciseExternalId → list of LoggedSetDto (one per set).
+Carries actual logged values, snapshot-planned values, and the backend-computed isModified flag.
+Replaces the set-number-only CompletedSetsBySessionExercise for callers that
+need actual vs planned comparison.
+Empty when no live-training progress has been logged for today. */
+    loggedSetsBySessionExercise?: { [key: string]: { [key: string]: LoggedSetDto[]; }; };
+    /** Per-session hasModifications flag for today, keyed by SessionId.
+True when any set under any exercise in the session has IsModified == true in the latest log.
+Missing entries are treated as false (no modifications / no log). */
+    hasModificationsBySession?: { [key: string]: boolean; };
+}
+
+/** A photo attached to a session diary entry, as returned in PhotosBySession. */
+export interface SessionPhotoDto {
+    /** The MinIO blob URL for this photo. */
+    blobUrl?: string;
+    /** UTC timestamp when the photo was uploaded/persisted. */
+    uploadedAt?: string;
+    /** Optional per-photo caption (max 500 chars). Null when none was provided. */
+    note?: string | undefined;
 }
 
 /** Full training plan response for the client mobile view. Contains all published weeks enriched with completion state and muscle group data. */
@@ -16344,6 +16602,9 @@ Populated via a batch GetStateAsync call on the session lock service. */
     /** Who currently holds the lock, if any.
 Possible values: "Coach", "Client", or null when the session is Stable. */
     lockHolder?: string | undefined;
+    /** True when at least one exercise in this session has HasModifications == true.
+Always false when no workout log exists for this session. */
+    hasModifications?: boolean;
 }
 
 /** An ordered section within a session (e.g. "Hlavní", "Warm-up", "Cool-down"). */
@@ -16398,28 +16659,71 @@ Empty list when the exercise no longer exists in the database. */
     muscleGroups?: MuscleGroup[];
     /** True when every planned set has a completed workout log entry. */
     isCompleted?: boolean;
-    /** Planned sets with per-set completion timestamps. */
+    /** True when at least one set under this exercise has IsModified == true.
+Always false when no workout log exists for this exercise. */
+    hasModifications?: boolean;
+    /** Planned sets with per-set completion timestamps and actual-vs-planned delta. */
     sets?: SetDto[];
 }
 
-/** A planned set with its completion state derived from workout logs. */
+/** A planned set with its completion state and actual-vs-planned delta derived from workout logs. */
 export interface SetDto {
     /** 1-based set number within the exercise. */
     setNumber?: number;
     /** Set type (Normal, Warmup, Dropset, Superset). */
     type?: string;
-    /** Target number of repetitions. */
+    /** Target number of repetitions (from the plan prescription). */
     reps?: number | undefined;
-    /** Target weight in kilograms. */
+    /** Target weight in kilograms (from the plan prescription). */
     weightKg?: number | undefined;
-    /** Target duration in seconds (for timed exercises). */
+    /** Target duration in seconds (from the plan prescription). */
     durationSeconds?: number | undefined;
-    /** Target distance in meters (for distance-based exercises). */
+    /** Target distance in meters (from the plan prescription). */
     distanceMeters?: number | undefined;
     /** Rest time after this set in seconds. */
     restSeconds?: number | undefined;
     /** When this set was completed, or null if not yet done. */
     completedAt?: string | undefined;
+    /** Actual repetitions logged. Null when not yet performed. */
+    actualReps?: number | undefined;
+    /** Actual weight (kg) logged. Null when not yet performed. */
+    actualWeightKg?: number | undefined;
+    /** Actual RPE logged. Null when not yet performed. */
+    actualRpe?: number | undefined;
+    /** Actual duration (seconds) logged. Null when not yet performed. */
+    actualDurationSeconds?: number | undefined;
+    /** Actual distance (meters) logged. Null when not yet performed. */
+    actualDistanceMeters?: number | undefined;
+    /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+    plannedReps?: number | undefined;
+    /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+    plannedWeightKg?: number | undefined;
+    /** Snapshot-planned RPE at log time. Null for legacy logs. */
+    plannedRpe?: number | undefined;
+    /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+    plannedDurationSeconds?: number | undefined;
+    /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned
+counterpart. Always false for legacy sets (no snapshot → treated as planned == actual). */
+    isModified?: boolean;
+}
+
+/** Response for the session photo upload URL generation endpoint. */
+export interface GenerateSessionPhotoUploadUrlResponse {
+    /** Time-limited pre-signed URL the client uses to PUT the image directly to blob storage. */
+    uploadUrl?: string;
+    /** The permanent blob URL to pass to POST /client/training/log/sessions/{sessionId}/photos
+after the upload completes. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed training session photo upload URL. */
+export interface GenerateSessionPhotoUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 10 MiB. */
+    sizeBytes?: number;
 }
 
 /** Response model returned after sending a client request. */
@@ -16493,6 +16797,7 @@ export enum PlanPhotoCategory {
     Food = "Food",
     Body = "Body",
     FreeForm = "FreeForm",
+    Training = "Training",
 }
 
 /** Identifies whether a PlanPhoto is associated with a nutrition plan or a training plan. */

--- a/mobile/src/api/training.ts
+++ b/mobile/src/api/training.ts
@@ -11,13 +11,15 @@ import type {
   TrainingSection as GeneratedTrainingSection,
   TrainingSession,
   GetTodaySessionResponse,
-  GetFullTrainingPlanResponse as GeneratedFullTrainingPlanResponse,
-  WeekDto as GeneratedWeekDto,
-  SessionDto as GeneratedSessionDto,
-  SectionDto as GeneratedSectionDto,
+  GetFullTrainingPlanResponse,
+  WeekDto,
+  SessionDto,
+  SectionDto,
   ExerciseDto,
   SetDto,
   WodConfig,
+  SessionPhotoDto,
+  GenerateSessionPhotoUploadUrlResponse,
 } from './generated';
 
 // Re-export generated types and enums so consumer imports (`from '@/api/training'`) still work.
@@ -27,59 +29,15 @@ export type {
   SessionExercise,
   TrainingSession,
   GetTodaySessionResponse,
+  GetFullTrainingPlanResponse,
+  WeekDto,
+  SessionDto,
+  SectionDto,
   ExerciseDto,
   SetDto,
   WodConfig,
-};
-
-/**
- * Augmented SectionDto — adds `formatConfig`, `notes`, and `isCompleted` that
- * the backend now emits but NSwag hasn't been re-run for yet.
- * Drop the augmentation fields once the generated client is regenerated
- * and the fields appear on GeneratedSectionDto directly.
- */
-export type SectionDto = Omit<GeneratedSectionDto, 'exercises'> & {
-  formatConfig?: WodConfig | null;
-  notes?: string | null;
-  /** True when the backend considers this section fully complete.
-   * For sections with exercises: every exercise has IsCompleted=true.
-   * For sections without exercises: the section id is in
-   * TrainingCompletion.CompletedSectionIds (#260 fix). */
-  isCompleted?: boolean;
-  exercises?: GeneratedSectionDto['exercises'];
-};
-
-/**
- * Augmented SessionDto — propagates SectionDto augmentation so
- * `response.weeks[i].sessions[j].sections[k].formatConfig` is typed correctly
- * without per-call casts.
- * Also adds `lockState` which the backend (#382) now includes in GetFullTrainingPlan
- * responses. Drop once regen produces this field natively.
- */
-export type SessionDto = Omit<GeneratedSessionDto, 'sections'> & {
-  sections?: SectionDto[];
-  /**
-   * Session edit-lock state from the backend.
-   * "Stable"  — no active lock; normal operation.
-   * "Editing" — a trainer currently holds the edit lock; banner should be shown.
-   * "Live"    — the client's own live session is in progress; no banner.
-   * Defaults to "Stable" when the field is absent (pre-#382 response shape).
-   */
-  lockState?: string;
-};
-
-/**
- * Augmented WeekDto — propagates SessionDto augmentation up the chain.
- */
-export type WeekDto = Omit<GeneratedWeekDto, 'sessions'> & {
-  sessions?: SessionDto[];
-};
-
-/**
- * Augmented GetFullTrainingPlanResponse — propagates WeekDto augmentation up the chain.
- */
-export type GetFullTrainingPlanResponse = Omit<GeneratedFullTrainingPlanResponse, 'weeks'> & {
-  weeks?: WeekDto[];
+  SessionPhotoDto,
+  GenerateSessionPhotoUploadUrlResponse,
 };
 
 /**
@@ -94,52 +52,25 @@ export type TrainingSection = Omit<GeneratedTrainingSection, 'notes'> & {
   notes?: string | null;
 }
 
-// Re-export WodResult from wod-types (hand-declared until fully superseded by generated).
+// Re-export WOD types from wod-types (UpdateWodExerciseRequest and UpdateWorkoutWodRequest
+// are still hand-maintained; WodResult, WodConfig, LoggedSetDto are re-exported
+// from generated via wod-types).
 export type {
   WodResult,
   WodSessionExercise,
+  LoggedSetDto,
+  UpdateWodExerciseRequest,
+  UpdateWorkoutWodRequest,
 } from './wod-types';
 
 /**
- * A single training-session diary photo from the session log.
- * Mirrors `MealPhotoDto` from nutrition (blobUrl, uploadedAt, note?).
- *
- * Hand-declared until regen-api is run against the backend (#405).
- * Drop this type once generated.ts emits `SessionPhotoDto` natively.
+ * `TodayTrainingResponse` is now a direct alias for `GetTodaySessionResponse`.
+ * After the #440 regen all previously-augmented fields
+ * (`lockStateBySession`, `photosBySession`, `notesBySession`,
+ * `loggedSetsBySessionExercise`, `hasModificationsBySession`)
+ * are emitted natively by generated.ts.
  */
-export interface SessionPhotoDto {
-  blobUrl: string;
-  uploadedAt?: string;
-  note?: string | null;
-}
-
-/**
- * Augmented GetTodaySessionResponse — adds:
- *   - `lockStateBySession` (#382): session edit-lock state.
- *   - `photosBySession` (#405): per-session diary photos from the session log.
- *   - `notesBySession` (#405): persisted session-level notes keyed by sessionId.
- *
- * All fields hand-declared until regen-api runs against the updated backend.
- * Drop the augmentation for each field once the generated client emits it natively.
- */
-export type TodayTrainingResponse = GetTodaySessionResponse & {
-  lockStateBySession?: Record<string, string>;
-  /**
-   * Per-session diary photos from today's session logs, keyed by sessionId.
-   * Mirrors how `mealsEaten[].photos` is embedded in GetTodayLogResponse for nutrition.
-   * Added in #405 (GenerateSessionPhotoUploadUrl + SaveSessionPhotos endpoints).
-   * Returns an empty object when no session has any diary photos today.
-   */
-  photosBySession?: Record<string, SessionPhotoDto[]>;
-  /**
-   * Persisted session-level note for today's session log, keyed by sessionId.
-   * Only present for sessions that have a non-empty note — mirrors how
-   * nutrition's today read path returns each meal's note.
-   * Added in #405 review fix: seeds the note textarea so REPLACE semantics
-   * do not wipe previously saved notes on re-open.
-   */
-  notesBySession?: Record<string, string>;
-};
+export type TodayTrainingResponse = GetTodaySessionResponse;
 
 /**
  * @deprecated Use `GetFullTrainingPlanResponse` from generated. Kept as alias for backward compatibility.
@@ -157,12 +88,18 @@ export type FullPlanWeek = WeekDto;
 export type FullPlanSession = SessionDto;
 
 /**
- * @deprecated Use `ExerciseDto` from generated. Kept as alias for backward compatibility.
+ * `FullPlanExercise` is now a direct alias for the generated `ExerciseDto`.
+ * After the #440 regen `ExerciseDto` carries `hasModifications` and
+ * `sets?: SetDto[]` (where `SetDto` has all actual + planned + isModified fields).
+ * Kept as alias for backward compatibility with `SetGrid` and `LiveFinishedSummary`.
  */
 export type FullPlanExercise = ExerciseDto;
 
 /**
- * @deprecated Use `SetDto` from generated. Kept as alias for backward compatibility.
+ * `FullPlanSet` is now a direct alias for the generated `SetDto`.
+ * After the #440 regen `SetDto` carries all actual values, snapshot-planned
+ * values, and the backend-computed `isModified` flag.
+ * Kept as alias for backward compatibility with `SetGrid` and `LiveFinishedSummary`.
  */
 export type FullPlanSet = SetDto;
 
@@ -180,11 +117,8 @@ export async function getFullTrainingPlan(planId: string): Promise<GetFullTraini
 
 // ─── Session photo upload API (#405) ─────────────────────────────────────────
 // Mirrors the nutrition meal-photo API pattern exactly.
-
-export interface GenerateSessionPhotoUploadUrlResponse {
-  uploadUrl: string;
-  blobUrl: string;
-}
+// GenerateSessionPhotoUploadUrlResponse and SessionPhotoDto are now natively
+// in generated.ts — consumed via the re-exports above.
 
 /**
  * Request a signed upload URL for a training-session diary photo.

--- a/mobile/src/api/wod-types.ts
+++ b/mobile/src/api/wod-types.ts
@@ -7,61 +7,26 @@
  *   - WodConfig     — configuration parameters per format
  *   - WodResult     — outcome-only capture (no per-rep mid-round data)
  *
- * IMPORTANT: generated.ts does not yet include these shapes (regen-api requires
- * a running backend which is outside mobile-expo's allowlist). Once the backend
- * is running and regen-api is executed, these declarations should be replaced with
- * re-exports from generated.ts and this file removed.
+ * After the #440 regen, `WodResult`, `WodConfig`, `WorkoutFormat`, `MovementType`,
+ * `LoggedSetDto`, and `UpdateWorkoutSetRequest` (with planned fields) are all
+ * emitted natively by generated.ts.  This file re-exports the canonical shapes
+ * and retains only the genuinely-additive hand-maintained types.
  */
 
-/**
- * Workout format / scoring methodology for a session or per-exercise override.
- * Mirrors backend WorkoutFormat enum.
- */
-export type WorkoutFormat = 'Standard' | 'ForTime' | 'AMRAP' | 'EMOM' | 'Tabata';
-
-/**
- * How performance in an exercise is measured.
- * Mirrors backend MovementType enum.
- */
-export type MovementType = 'Reps' | 'Time' | 'Distance' | 'RepsForTime';
-
-/**
- * Configuration parameters for a WOD format.
- * Only fields relevant to the chosen format are expected to be set.
- *
- * - EMOM:    intervalSeconds + totalRounds
- * - AMRAP:   timeCapSeconds
- * - ForTime: timeCapSeconds
- * - Tabata:  workSeconds + restSeconds + totalRounds
- */
-export interface WodConfig {
-  timeCapSeconds?: number | null;
-  intervalSeconds?: number | null;
-  totalRounds?: number | null;
-  workSeconds?: number | null;
-  restSeconds?: number | null;
-}
-
-/**
- * Outcome-only capture for a WOD format session or per-exercise result.
- * Submitted at log root (session WOD) or per exercise (per-exercise format).
- *
- * - AMRAP:   roundsCompleted + extraReps
- * - EMOM:    roundsCompleted + failedRounds
- * - Tabata:  roundsCompleted + repsByRound (total reps per round, optional)
- * - ForTime: totalTimeSeconds
- */
-export interface WodResult {
-  roundsCompleted?: number | null;
-  extraReps?: number | null;
-  totalTimeSeconds?: number | null;
-  failedRounds?: number[] | null;
-  repsByRound?: number[] | null;
-}
+// ── Re-exports from generated.ts ────────────────────────────────────────────
+// These were hand-declared here before #440 regen; generated.ts is now the
+// single source of truth.
+import type { WodResult, WodConfig, LoggedSetDto, UpdateWorkoutSetRequest } from './generated';
+import { WorkoutFormat, MovementType } from './generated';
+export type { WodResult, WodConfig, LoggedSetDto, UpdateWorkoutSetRequest };
+export { WorkoutFormat, MovementType };
 
 /**
  * Extended SessionExercise shape that includes WOD fields from #205.
  * Extends the generated SessionExercise with the new backend fields.
+ *
+ * Still hand-maintained: this is the *plan prescription* shape for the live
+ * session screen, which uses SessionExercise (not ExerciseDto / SetDto).
  */
 export interface WodSessionExercise {
   exerciseExternalId?: string;
@@ -86,19 +51,13 @@ export interface WodSessionExercise {
 }
 
 /**
- * Extended UpdateWorkoutExerciseRequest that includes WodResult.
+ * Extended UpdateWorkoutExerciseRequest that includes WodResult and the
+ * generated UpdateWorkoutSetRequest (which now carries planned fields natively).
  */
 export interface UpdateWodExerciseRequest {
   exerciseExternalId?: string;
   exerciseName?: string;
-  sets?: Array<{
-    setNumber?: number;
-    reps?: number | null;
-    weightKg?: number | null;
-    durationSeconds?: number | null;
-    distanceMeters?: number | null;
-    completedAt?: string | null;
-  }>;
+  sets?: UpdateWorkoutSetRequest[];
   /** WOD outcome for this exercise (when exercise has a format override). */
   wodResult?: WodResult | null;
 }

--- a/mobile/src/api/workouts.ts
+++ b/mobile/src/api/workouts.ts
@@ -8,6 +8,7 @@ import type {
   StartWorkoutResponse,
   UpdateWorkoutExerciseRequest,
   UpdateWorkoutRequest,
+  UpdateWorkoutSetRequest,
   GetExerciseProgressResponse,
   ExerciseProgressPoint,
   GoLiveResponse,
@@ -28,6 +29,13 @@ export type {
   GoLiveResponse,
   AbandonWorkoutResponse,
 };
+
+/**
+ * `UpdateWorkoutSetWithPlannedRequest` is now identical to the generated
+ * `UpdateWorkoutSetRequest` (which carries planned fields natively after the #440 regen).
+ * Kept as an alias so callers that still reference the old name compile without changes.
+ */
+export type { UpdateWorkoutSetRequest, UpdateWorkoutSetRequest as UpdateWorkoutSetWithPlannedRequest };
 
 /**
  * @deprecated Use `GetExerciseProgressResponse` from generated. Kept as alias for backward compatibility.

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1370,6 +1370,8 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               isMarkAllTrainingLoading={markAllTrainingDoneMutation.isPending}
               onSessionPhotoPress={handleSessionPhotoPress}
               photosBySession={photosBySession}
+              loggedSetsBySessionExercise={trainingQuery.data?.loggedSetsBySessionExercise}
+              hasModificationsBySession={trainingQuery.data?.hasModificationsBySession}
             />
           </View>
         ) : hasActivePlanButNoTrainingToday ? (

--- a/mobile/src/components/training/ExpandableExerciseCard.tsx
+++ b/mobile/src/components/training/ExpandableExerciseCard.tsx
@@ -78,6 +78,12 @@ interface ExpandableExerciseCardProps {
    * section-note line in `SectionHeader`.
    */
   notes?: string | null
+  /**
+   * When true, renders a small "upraveno" badge in the summary line to
+   * signal that at least one set in this exercise was modified vs. the plan.
+   * Designed for the finished Today card and plan detail screens (#441).
+   */
+  hasModifications?: boolean
   children: React.ReactNode
 }
 
@@ -99,6 +105,7 @@ export function ExpandableExerciseCard({
   hideCompletionIndicator = false,
   nonExpandable = false,
   notes,
+  hasModifications = false,
   children,
 }: ExpandableExerciseCardProps) {
   const colors = useTheme()
@@ -151,10 +158,21 @@ export function ExpandableExerciseCard({
           <Text style={[Type.subheadline, { color: colors.label }]} numberOfLines={1}>
             {name}
           </Text>
-          {summaryText.length > 0 && (
-            <Text style={[Type.caption1, { color: colors.label2, marginTop: 1 }]} numberOfLines={1}>
-              {summaryText}
-            </Text>
+          {(summaryText.length > 0 || hasModifications) && (
+            <View style={styles.summaryRow}>
+              {summaryText.length > 0 && (
+                <Text style={[Type.caption1, { color: colors.label2 }]} numberOfLines={1}>
+                  {summaryText}
+                </Text>
+              )}
+              {hasModifications && (
+                <View style={[styles.modifiedBadge, { backgroundColor: colors.goldBg }]}>
+                  <Text style={[styles.modifiedBadgeText, { color: colors.gold }]}>
+                    {t('training.upraveno')}
+                  </Text>
+                </View>
+              )}
+            </View>
           )}
           {bodyParts && bodyParts.length > 0 && (
             <View style={styles.badgeRow}>
@@ -285,6 +303,25 @@ const styles = StyleSheet.create({
   nameWrap: {
     flex: 1,
     minWidth: 0,
+  },
+  /** Row wrapping summary text + optional "upraveno" badge. */
+  summaryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 1,
+  },
+  /** Small pill badge shown when hasModifications is true. */
+  modifiedBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 4,
+  },
+  modifiedBadgeText: {
+    fontFamily: interFamily('600'),
+    fontSize: 10,
+    fontWeight: '600',
   },
   badgeRow: {
     flexDirection: 'row',

--- a/mobile/src/components/training/ExpandableSessionCard.tsx
+++ b/mobile/src/components/training/ExpandableSessionCard.tsx
@@ -126,6 +126,13 @@ interface ExpandableSessionCardProps {
    * only — mirrors MealRow's `hasPhotos`/`photos` pattern exactly.
    */
   photos?: SessionPhotoDto[]
+  /**
+   * When true, renders an "upraveno" pill badge in the session header row,
+   * mirroring the exercise-level badge from ExpandableExerciseCard.
+   * Sourced from `hasModificationsBySession[sessionId]` (Today card) or
+   * `session.hasModifications` (full-plan / plan-detail screen).
+   */
+  hasModifications?: boolean
   children: React.ReactNode
 }
 
@@ -152,6 +159,7 @@ export function ExpandableSessionCard({
   bodyFooter,
   onPhotoPress,
   photos,
+  hasModifications = false,
 }: ExpandableSessionCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -163,7 +171,7 @@ export function ExpandableSessionCard({
   const [lightboxVisible, setLightboxVisible] = useState(false)
   const photoList = photos ?? []
   const hasPhotos = photoList.length > 0
-  const photoUrls = photoList.map((p) => p.blobUrl).filter(Boolean)
+  const photoUrls = photoList.map((p) => p.blobUrl).filter((u): u is string => typeof u === 'string' && u.length > 0)
   const photoNotes = photoList.map((p) => p.note ?? null)
 
   const handleBadgePress = useCallback(() => {
@@ -227,9 +235,26 @@ export function ExpandableSessionCard({
           >
             {name}
           </Text>
-          <Text style={[Type.caption1, { color: colors.label2, marginTop: 2 }]} numberOfLines={1}>
-            {summaryText}
-          </Text>
+          {/* Summary row: summary text + optional session-level "upraveno" badge.
+              Mirrors ExpandableExerciseCard's summaryRow — same flexDirection,
+              gap, and pill style so session and exercise badges are visually
+              identical. */}
+          {(summaryText.length > 0 || hasModifications) && (
+            <View style={styles.summaryRow}>
+              {summaryText.length > 0 && (
+                <Text style={[Type.caption1, { color: colors.label2 }]} numberOfLines={1}>
+                  {summaryText}
+                </Text>
+              )}
+              {hasModifications && (
+                <View style={[styles.modifiedBadge, { backgroundColor: colors.goldBg }]}>
+                  <Text style={[styles.modifiedBadgeText, { color: colors.gold }]}>
+                    {t('training.upraveno')}
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
         </View>
 
         {/* Photo indicator badge — tappable, shown only when this session has
@@ -364,6 +389,27 @@ const styles = StyleSheet.create({
   nameWrap: {
     flex: 1,
     minWidth: 0,
+  },
+  /** Row wrapping summary text + optional "upraveno" badge — mirrors
+   *  ExpandableExerciseCard.summaryRow for visual consistency. */
+  summaryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 2,
+  },
+  /** Small gold pill shown when hasModifications is true — mirrors
+   *  ExpandableExerciseCard.modifiedBadge exactly (same padding, radius, font). */
+  modifiedBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 4,
+  },
+  modifiedBadgeText: {
+    fontFamily: interFamily('600'),
+    fontSize: 10,
+    fontWeight: '600',
   },
   /**
    * Gold-tinted circular camera button — mirrors MealRow's cameraBtn style.

--- a/mobile/src/components/training/LiveFinishedSummary.tsx
+++ b/mobile/src/components/training/LiveFinishedSummary.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@/hooks/useTheme'
 import { Type } from '@/constants/typography'
 import { Radius } from '@/constants/radius'
 import { useTranslation } from 'react-i18next'
-import type { WorkoutFormat } from '@/api/wod-types'
+import type { WorkoutFormat, LoggedSetDto } from '@/api/wod-types'
 import type { FullPlanSet } from '@/api/training'
 import { SetGrid } from '@/components/training/SetGrid'
 
@@ -20,6 +20,12 @@ export interface FinishedExerciseSetData {
   completedSetNumbers: number[]
   /** 1-based set numbers that the user skipped (↷). */
   skippedSetNumbers: number[]
+  /**
+   * Actual vs. snapshot-planned set data from the finished workout log.
+   * When present, SetGrid renders treatment B: actual headline, planned
+   * caption, and a gold change-indicator dot for modified sets (#441).
+   */
+  loggedSets?: LoggedSetDto[]
 }
 
 export interface FinishedWorkoutCardData {
@@ -183,6 +189,7 @@ export function LiveFinishedSummary({
                       sets={ex.sets}
                       completedSetNumbers={ex.completedSetNumbers}
                       skippedSetNumbers={ex.skippedSetNumbers}
+                      loggedSets={ex.loggedSets}
                     />
                   </View>
                 ))}

--- a/mobile/src/components/training/SetGrid.tsx
+++ b/mobile/src/components/training/SetGrid.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/hooks/useTheme'
 import { interFamily } from '@/constants/typography'
 import type { FullPlanSet } from '@/api/training'
+import type { LoggedSetDto } from '@/api/wod-types'
 
 interface SetGridProps {
   sets: FullPlanSet[]
@@ -17,20 +18,75 @@ interface SetGridProps {
    * should not appear in both arrays.
    */
   skippedSetNumbers?: number[]
+  /**
+   * Per-set actual vs. planned data from the backend (#440).
+   * When provided, SetGrid renders treatment B:
+   *   - actual value as the headline (gold when the set has been completed)
+   *   - snapshot-planned value as a quiet "plán…" caption below
+   *   - gold change-indicator dot next to the status column when isModified
+   *
+   * Indexed by 1-based set number matching `sets[i].setNumber`.
+   * Sets without a matching entry in this map fall back to the planned-only display.
+   *
+   * For the Today card the per-exercise sets don't carry individual actual data
+   * (that lives in loggedSetsBySessionExercise) — callers should convert to this
+   * map before passing in.
+   */
+  loggedSets?: LoggedSetDto[]
 }
 
 /**
  * 5-column grid: Set / Reps / Weight / Rest / Status
  * Matches the tp-ex-set-grid layout in the prototype.
+ *
+ * Treatment B (when loggedSets is provided):
+ *   - Actual value is the headline per cell (displayed in gold when completed).
+ *   - Snapshot-planned value is a quiet "plán…" caption below the headline.
+ *   - A small gold change-indicator dot appears in the status column when the
+ *     set's isModified flag is true.
+ *   - Extra sets beyond the plan count (setNumber > sets.length) show the actual
+ *     in gold with a "navíc" caption and no planned value.
+ *   - Skipped sets show the planned caption and the skip marker; actual is blank.
  */
-export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = [] }: SetGridProps) {
+export function SetGrid({
+  sets,
+  completedSetNumbers = [],
+  skippedSetNumbers = [],
+  loggedSets,
+}: SetGridProps) {
   const colors = useTheme()
   const { t } = useTranslation()
 
+  // Build a lookup map: 1-based setNumber → LoggedSetDto
+  const loggedBySetNumber = React.useMemo<Map<number, LoggedSetDto>>(() => {
+    const map = new Map<number, LoggedSetDto>()
+    if (loggedSets) {
+      for (const ls of loggedSets) {
+        if (ls.setNumber != null) {
+          map.set(ls.setNumber, ls)
+        }
+      }
+    }
+    return map
+  }, [loggedSets])
+
+  // Determine the full set of row numbers to render.
+  // When loggedSets has entries beyond the planned count (extra sets), include them.
+  const plannedSetNumbers = sets.map((s) => s.setNumber ?? -1).filter((n) => n > 0)
+  const extraSetNumbers: number[] = []
+  if (loggedSets) {
+    for (const ls of loggedSets) {
+      const sn = ls.setNumber
+      if (sn != null && !plannedSetNumbers.includes(sn) && sn > 0) {
+        extraSetNumbers.push(sn)
+      }
+    }
+    extraSetNumbers.sort((a, b) => a - b)
+  }
+
   return (
     <View>
-      {/* Header row — title-case, semi-bold, label2, centered.
-          Set# and Status columns are fixed-width; middle three share equal flex. */}
+      {/* Header row */}
       <View style={[styles.grid, { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }]}>
         <Text style={[styles.hdrSet, { color: colors.label2 }]}>{t('training.set')}</Text>
         <Text style={[styles.hdr, { color: colors.label2 }]}>{t('training.reps')}</Text>
@@ -39,28 +95,112 @@ export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = []
         <Text style={[styles.hdrStatus, { color: colors.label2 }]}>{t('training.status')}</Text>
       </View>
 
-      {/* Data rows — every row gets a bottom hairline so the table reads as
-          a clean grid (matches prototype .tp-set-cell { border-bottom }). */}
+      {/* Planned set rows */}
       {sets.map((s) => {
         const setNum = s.setNumber ?? -1
         const isCompleted = completedSetNumbers.includes(setNum)
         const isSkipped = !isCompleted && skippedSetNumbers.includes(setNum)
+        const logged = loggedBySetNumber.get(setNum)
         const cellBorder = { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }
+
+        // Treatment B: when we have logged data for this set
+        if (logged && loggedSets) {
+          const { isModified } = logged
+          const hasActualReps = logged.actualReps != null
+          const hasActualWeight = logged.actualWeightKg != null
+          const isExtra = false // planned row — not extra
+
+          // Value cells — show actual + planned caption, or planned only when skipped
+          const repsCell = isSkipped
+            ? { headline: null, caption: logged.plannedReps != null ? `${logged.plannedReps}` : (s.reps != null ? `${s.reps}` : null) }
+            : hasActualReps
+              ? { headline: `${logged.actualReps}`, caption: logged.plannedReps != null ? `${logged.plannedReps}` : null }
+              : { headline: s.reps != null ? `${s.reps}` : null, caption: null }
+
+          const weightCell = isSkipped
+            ? { headline: null, caption: formatWeight(logged.plannedWeightKg ?? s.weightKg) }
+            : logged.actualWeightKg != null
+              ? { headline: formatWeight(logged.actualWeightKg), caption: logged.plannedWeightKg != null ? formatWeight(logged.plannedWeightKg) : null }
+              : { headline: formatWeight(s.weightKg), caption: null }
+
+          const actualColor = isCompleted ? colors.gold : colors.label
+
+          return (
+            <View key={setNum} style={[styles.grid, cellBorder]}>
+              <Text style={[styles.cellSet, { color: colors.label }]}>{s.setNumber}</Text>
+
+              {/* Reps cell — actual headline + planned caption */}
+              <View style={[styles.cellStack, styles.cellFlex]}>
+                {repsCell.headline != null ? (
+                  <Text style={[styles.cell, { color: actualColor }]}>{repsCell.headline}</Text>
+                ) : (
+                  <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+                )}
+                {repsCell.caption != null && (
+                  <Text style={[styles.planCaption, { color: colors.label3 }]}>
+                    {t('training.plan')} {repsCell.caption}
+                  </Text>
+                )}
+              </View>
+
+              {/* Weight cell */}
+              <View style={[styles.cellStack, styles.cellFlex]}>
+                {weightCell.headline != null ? (
+                  <Text style={[styles.cell, { color: actualColor }]}>{weightCell.headline}</Text>
+                ) : (
+                  <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+                )}
+                {weightCell.caption != null && (
+                  <Text style={[styles.planCaption, { color: colors.label3 }]}>
+                    {t('training.plan')} {weightCell.caption}
+                  </Text>
+                )}
+              </View>
+
+              {/* Rest cell — always from plan */}
+              <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
+                {s.restSeconds != null ? `${s.restSeconds} s` : '—'}
+              </Text>
+
+              {/* Status cell — tick, skip, dash + gold dot when isModified */}
+              <View style={[styles.cellStatus, styles.statusWrap]}>
+                <Text
+                  style={[
+                    styles.statusText,
+                    isCompleted
+                      ? { color: colors.green, fontFamily: interFamily('600'), fontWeight: '600' }
+                      : isSkipped
+                        ? { color: colors.label3, fontFamily: interFamily('600'), fontWeight: '600' }
+                        : { color: colors.label3 },
+                  ]}
+                >
+                  {isCompleted ? '✓' : isSkipped ? '↷' : '—'}
+                </Text>
+                {isModified && !isSkipped && (
+                  <View style={[styles.modifiedDot, { backgroundColor: colors.gold }]} />
+                )}
+              </View>
+            </View>
+          )
+        }
+
+        // Plain display (no logged data / pre-log)
         return (
-          <View key={s.setNumber} style={[styles.grid, cellBorder]}>
+          <View key={setNum} style={[styles.grid, cellBorder]}>
             <Text style={[styles.cellSet, { color: colors.label }]}>{s.setNumber}</Text>
-            <Text style={[styles.cell, { color: colors.label }]}>
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
               {s.reps != null ? String(s.reps) : '—'}
             </Text>
-            <Text style={[styles.cell, { color: colors.label }]}>
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
               {s.weightKg != null ? `${s.weightKg} kg` : '—'}
             </Text>
-            <Text style={[styles.cell, { color: colors.label }]}>
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label }]}>
               {s.restSeconds != null ? `${s.restSeconds} s` : '—'}
             </Text>
             <Text
               style={[
                 styles.cellStatus,
+                styles.statusText,
                 isCompleted
                   ? { color: colors.green, fontFamily: interFamily('600'), fontWeight: '600' }
                   : isSkipped
@@ -73,13 +213,62 @@ export function SetGrid({ sets, completedSetNumbers = [], skippedSetNumbers = []
           </View>
         )
       })}
+
+      {/* Extra set rows (beyond plan count) — actual in gold, "navíc" caption */}
+      {extraSetNumbers.map((setNum) => {
+        const logged = loggedBySetNumber.get(setNum)
+        if (!logged) return null
+        const cellBorder = { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.sep2 }
+
+        return (
+          <View key={`extra-${setNum}`} style={[styles.grid, cellBorder]}>
+            <Text style={[styles.cellSet, { color: colors.gold }]}>{setNum}</Text>
+
+            <View style={[styles.cellStack, styles.cellFlex]}>
+              {logged.actualReps != null ? (
+                <Text style={[styles.cell, { color: colors.gold }]}>{logged.actualReps}</Text>
+              ) : (
+                <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+              )}
+              <Text style={[styles.planCaption, { color: colors.gold }]}>
+                {t('training.navic')}
+              </Text>
+            </View>
+
+            <View style={[styles.cellStack, styles.cellFlex]}>
+              {logged.actualWeightKg != null ? (
+                <Text style={[styles.cell, { color: colors.gold }]}>{formatWeight(logged.actualWeightKg)}</Text>
+              ) : (
+                <Text style={[styles.cell, { color: colors.label3 }]}>—</Text>
+              )}
+            </View>
+
+            {/* Rest — not applicable for extra sets */}
+            <Text style={[styles.cell, styles.cellFlex, { color: colors.label3 }]}>—</Text>
+
+            <View style={[styles.cellStatus, styles.statusWrap]}>
+              <Text style={[styles.statusText, { color: colors.gold, fontFamily: interFamily('600'), fontWeight: '600' }]}>
+                ✓
+              </Text>
+            </View>
+          </View>
+        )
+      })}
     </View>
   )
+}
+
+/** Format a weight value as "X kg" or "BW" when null / zero. */
+function formatWeight(kg: number | null | undefined): string | null {
+  if (kg == null) return null
+  if (kg === 0) return 'BW'
+  return `${kg} kg`
 }
 
 const styles = StyleSheet.create({
   grid: {
     flexDirection: 'row',
+    alignItems: 'flex-start',
     paddingHorizontal: 8,
     paddingVertical: 6,
   },
@@ -116,15 +305,43 @@ const styles = StyleSheet.create({
   cellStatus: {
     width: 40,
     flexShrink: 0,
+  },
+  cell: {
     fontFamily: interFamily('400'),
     fontSize: 12,
     textAlign: 'center',
   },
-  cell: {
+  cellFlex: {
     flex: 1,
+  },
+  /** Stack for cells that show an actual headline + planned caption below. */
+  cellStack: {
+    alignItems: 'center',
+  },
+  /** Quiet "plán X" caption below the actual value. */
+  planCaption: {
+    fontFamily: interFamily('400'),
+    fontSize: 10,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+  /** Status column inner wrapper — horizontally centres the tick/skip
+   *  glyph and optionally the gold modification dot. */
+  statusWrap: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  statusText: {
     fontFamily: interFamily('400'),
     fontSize: 12,
     textAlign: 'center',
+  },
+  /** Small gold dot rendered below the status glyph when isModified. */
+  modifiedDot: {
+    width: 5,
+    height: 5,
+    borderRadius: 3,
+    marginTop: 2,
   },
 })
 

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -19,7 +19,9 @@ import { SectionHeader } from '@/components/training/SectionHeader'
 import { SetGrid } from '@/components/training/SetGrid'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
 import type { TrainingSession, TrainingSection, MuscleGroup, SessionPhotoDto } from '@/api/training'
+import type { LoggedSetDto } from '@/api/wod-types'
 import type { SessionCtaState } from './trainingCardHelpers'
+import { deriveExerciseHasModifications } from './trainingCardHelpers'
 import { SessionEditingBanner } from '@/components/today/SessionEditingBanner'
 
 // ─── Section fallback ──────────────────────────────────────────────────────────
@@ -158,6 +160,20 @@ interface TrainingCardProps {
    * Sourced from `photosBySession` in TodayTrainingResponse (#405).
    */
   photosBySession?: Record<string, SessionPhotoDto[]>
+  /**
+   * Per-session, per-exercise logged sets with actual values, snapshot-planned
+   * values, and isModified flag. Outer key = sessionId, inner key = exerciseExternalId.
+   * Sourced from `loggedSetsBySessionExercise` in TodayTrainingResponse (#440).
+   * When present, SetGrid renders treatment B (actual headline + planned caption + dot).
+   */
+  loggedSetsBySessionExercise?: Record<string, Record<string, LoggedSetDto[]>>
+  /**
+   * Per-session roll-up modification flag, keyed by sessionId.
+   * Sourced from `hasModificationsBySession` in TodayTrainingResponse (#440).
+   * When true for a session, the session-level "upraveno" badge is shown in the
+   * ExpandableSessionCard header for that session.
+   */
+  hasModificationsBySession?: Record<string, boolean>
 }
 
 // ─── formatSets ───────────────────────────────────────────────────────────────
@@ -282,6 +298,8 @@ export function TrainingCard({
   lockStateBySession = {},
   onSessionPhotoPress,
   photosBySession = {},
+  loggedSetsBySessionExercise,
+  hasModificationsBySession,
 }: TrainingCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -486,6 +504,16 @@ export function TrainingCard({
                   ? (photosBySession[session.sessionId] ?? [])
                   : []
               }
+              loggedSetsForSession={
+                session.sessionId != null
+                  ? loggedSetsBySessionExercise?.[session.sessionId]
+                  : undefined
+              }
+              sessionHasModifications={
+                session.sessionId != null
+                  ? (hasModificationsBySession?.[session.sessionId] ?? false)
+                  : false
+              }
               t={t}
             />
           )
@@ -572,6 +600,18 @@ interface SessionSectionListProps {
    * Passed to ExpandableSessionCard so the per-session badge + lightbox work.
    */
   sessionPhotos?: SessionPhotoDto[]
+  /**
+   * Per-exercise logged sets for this specific session (inner key = exerciseExternalId).
+   * Already sliced from `loggedSetsBySessionExercise[sessionId]` by the parent.
+   * Passed down to SetGrid for treatment B rendering (#440).
+   */
+  loggedSetsForSession?: Record<string, LoggedSetDto[]>
+  /**
+   * Whether this session has any modifications overall.
+   * Sourced from `hasModificationsBySession[sessionId]`.
+   * Passed to ExpandableSessionCard to render the session-level "upraveno" badge.
+   */
+  sessionHasModifications?: boolean
   t: (key: string, opts?: Record<string, unknown>) => string
 }
 
@@ -601,6 +641,8 @@ function SessionSectionList({
   onSessionCta,
   onSessionPhotoPress,
   sessionPhotos,
+  loggedSetsForSession,
+  sessionHasModifications,
   t,
 }: SessionSectionListProps) {
   const colors = useTheme()
@@ -628,6 +670,7 @@ function SessionSectionList({
               headerRight={sessionCheckbox}
               onPhotoPress={onSessionPhotoPress}
               photos={sessionPhotos}
+              hasModifications={sessionHasModifications ?? false}
             >
               {/* Section-grouped exercise cards */}
               {sections.map((section, sectionIdx) => {
@@ -809,6 +852,14 @@ function SessionSectionList({
                             ? getMuscleGroupColor(primaryMg, colors)
                             : colors.gold
 
+                          // Derive per-exercise modification flag from per-set
+                          // isModified flags (#441 — plan endpoint has no per-exercise
+                          // field; GetTodaySession has loggedSetsBySessionExercise).
+                          const exHasModifications =
+                            exId != null
+                              ? deriveExerciseHasModifications(exId, loggedSetsForSession)
+                              : false
+
                           return (
                             <ExpandableExerciseCard
                               key={exId ?? exIdx}
@@ -830,8 +881,17 @@ function SessionSectionList({
                                   : undefined
                               }
                               notes={exercise.notes}
+                              hasModifications={exHasModifications}
                             >
-                              <SetGrid sets={sets} completedSetNumbers={completedSetNumbers} />
+                              <SetGrid
+                                sets={sets}
+                                completedSetNumbers={completedSetNumbers}
+                                loggedSets={
+                                  exId != null
+                                    ? (loggedSetsForSession?.[exId] ?? undefined)
+                                    : undefined
+                                }
+                              />
                             </ExpandableExerciseCard>
                           )
                         })}

--- a/mobile/src/components/training/trainingCardHelpers.ts
+++ b/mobile/src/components/training/trainingCardHelpers.ts
@@ -12,6 +12,7 @@
  */
 
 import type { TrainingSession } from '@/api/training'
+import type { LoggedSetDto } from '@/api/wod-types'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -135,6 +136,34 @@ export function deriveSessionCtaState(
   if (hasActiveLiveSession) return 'in-progress'
 
   return 'not-started'
+}
+
+// ─── deriveExerciseHasModifications ─────────────────────────────────────────
+
+/**
+ * Derives whether a specific exercise has any modified sets, given the
+ * per-exercise logged-sets map from GetTodaySession.
+ *
+ * The plan/today endpoint does NOT expose a per-exercise hasModifications field
+ * (it only has hasModificationsBySession at session level).  This helper derives
+ * the per-exercise flag from the per-set isModified flags in
+ * loggedSetsBySessionExercise so the Today card can show the "upraveno" badge on
+ * individual exercise headers (#441 design handoff finding #3).
+ *
+ * @param exerciseExternalId   The exercise's external id.
+ * @param loggedSetsForSession The inner map for this session:
+ *                             exerciseExternalId → LoggedSetDto[].
+ *                             May be undefined if no log exists yet.
+ * @returns true when any set under this exercise has isModified === true.
+ */
+export function deriveExerciseHasModifications(
+  exerciseExternalId: string,
+  loggedSetsForSession: Readonly<Record<string, LoggedSetDto[]>> | undefined,
+): boolean {
+  if (!loggedSetsForSession) return false
+  const sets = loggedSetsForSession[exerciseExternalId]
+  if (!sets || sets.length === 0) return false
+  return sets.some((s) => s.isModified)
 }
 
 // ─── computeLockedSessionIds ──────────────────────────────────────────────────

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -1056,6 +1056,9 @@
     "workoutUntimedCount_few": "{{count}} neměřené",
     "workoutUntimedCount_many": "{{count}} neměřených",
     "workoutUntimedCount_other": "{{count}} neměřených",
+    "upraveno": "upraveno",
+    "plan": "plán",
+    "navic": "navíc",
     "section": {
       "label": "Sekce",
       "defaultName": "Hlavní",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -998,6 +998,9 @@
     "exerciseCount_other": "{{count}} Übungen",
     "workoutUntimedCount_one": "{{count}} ohne Zeit",
     "workoutUntimedCount_other": "{{count}} ohne Zeit",
+    "upraveno": "geändert",
+    "plan": "Plan",
+    "navic": "extra",
     "section": {
       "label": "Abschnitt",
       "defaultName": "Haupt",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -773,6 +773,9 @@
     "exerciseCount_other": "{{count}} exercises",
     "workoutUntimedCount_one": "{{count}} untimed",
     "workoutUntimedCount_other": "{{count}} untimed",
+    "upraveno": "modified",
+    "plan": "plan",
+    "navic": "extra",
     "section": {
       "label": "Section",
       "defaultName": "Main",

--- a/web/src/api/training-plan-types.ts
+++ b/web/src/api/training-plan-types.ts
@@ -150,6 +150,51 @@ export interface TrainingPlanCompletion {
 }
 
 /**
+ * Per-set actual + snapshot-planned values and the backend-computed isModified flag.
+ * Sourced from a WorkoutSet document. Key fields are null for legacy sets without
+ * snapshot storage — treat as planned == actual / isModified == false.
+ *
+ * Hand-written (not from generated.ts) — the plan response is consumed via the
+ * hand-written TrainingPlanDetail type, not the NSwag-generated client.
+ */
+export interface LoggedSetDto {
+  /** 1-based set number within the exercise. */
+  setNumber: number;
+
+  // ── Actual logged values ─────────────────────────────────────────────────────
+  /** Actual repetitions logged. Null when the set has not been performed. */
+  actualReps: number | null;
+  /** Actual weight (kg) logged. Null when not performed. */
+  actualWeightKg: number | null;
+  /** Actual RPE logged. Null when not performed. */
+  actualRpe: number | null;
+  /** Actual duration (seconds) logged. Null when not performed. */
+  actualDurationSeconds: number | null;
+  /** Actual distance (meters) logged. Null when not performed. */
+  actualDistanceMeters: number | null;
+
+  // ── Snapshot-planned values ──────────────────────────────────────────────────
+  // Frozen at log time from the plan prescription.
+  // Null on legacy documents that pre-date snapshot storage.
+  /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+  plannedReps: number | null;
+  /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+  plannedWeightKg: number | null;
+  /** Snapshot-planned RPE at log time. Null for legacy logs. */
+  plannedRpe: number | null;
+  /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+  plannedDurationSeconds: number | null;
+  /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+  plannedDistanceMeters: number | null;
+
+  /**
+   * Backend-computed flag: true when any actual field differs from its snapshot-planned
+   * counterpart. Always false for legacy sets (no snapshot → treated as planned == actual).
+   */
+  isModified: boolean;
+}
+
+/**
  * Per-session workout-log execution data returned by the trainer endpoint.
  * Used to derive completed / skipped / not-yet-reached states per set.
  *
@@ -169,6 +214,19 @@ export interface SessionExecutionDto {
    * An absent key means no sets for that exercise were logged.
    */
   completedSetsByExercise: Record<string, number[]>;
+  /**
+   * Key = exerciseExternalId (matches SessionExercise.exerciseExternalId).
+   * Value = list of LoggedSetDto (one per logged set), carrying actual values,
+   * snapshot-planned values, and the isModified flag.
+   * An absent key means no sets for that exercise were logged.
+   */
+  loggedSetsByExercise: Record<string, LoggedSetDto[]>;
+  /**
+   * True when at least one set in any exercise under this session has isModified === true.
+   * The web layer uses this to show the "upraveno" badge at the session-header level.
+   * Always false when the session has no WorkoutLog (or all logs are legacy without snapshots).
+   */
+  hasModifications: boolean;
 }
 
 /**

--- a/web/src/components/common/CompletionBadge.tsx
+++ b/web/src/components/common/CompletionBadge.tsx
@@ -147,12 +147,26 @@ type DayBadgeProps = {
   counts?: DayCompletionCounts;
 };
 
+/**
+ * Training: "upraveno" (modified) roll-up badge.
+ * Shown at exercise-header and session-header level when any set under the
+ * exercise / session has isModified === true.
+ * false → nothing rendered (returns null).
+ * true  → accent pill with a small pencil-edit icon + t('training.completionState.modified') label.
+ */
+type ModifiedBadgeProps = {
+  kind: 'modified';
+  state: boolean;
+  counts?: undefined;
+};
+
 export type CompletionBadgeProps =
   | SetBadgeProps
   | ExerciseBadgeProps
   | SessionBadgeProps
   | MealBadgeProps
-  | DayBadgeProps;
+  | DayBadgeProps
+  | ModifiedBadgeProps;
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -184,6 +198,9 @@ export function CompletionBadge(props: CompletionBadgeProps) {
   }
   if (props.kind === 'day') {
     return <DayBadge state={props.state} counts={props.counts} t={t} />;
+  }
+  if (props.kind === 'modified') {
+    return <ModifiedBadge state={props.state} t={t} />;
   }
   return <SessionBadge state={props.state} counts={props.counts} t={t} />;
 }
@@ -322,6 +339,44 @@ function DayBadge({
       title={label}
     >
       <IconCheckCircle2 size={12} />
+      {label}
+    </span>
+  );
+}
+
+// ── Modified (upraveno) badge ────────────────────────────────────────────────
+
+function ModifiedBadge({
+  state,
+  t,
+}: {
+  state: boolean;
+  t: ReturnType<typeof useTranslation>['t'];
+}) {
+  if (!state) return null;
+  const label = t('training.completionState.modified');
+  return (
+    <span
+      className={accentPill}
+      aria-label={label}
+      title={label}
+    >
+      {/* Inline pencil-edit SVG — same pattern as other micro-icons above */}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={10}
+        height={10}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+      </svg>
       {label}
     </span>
   );

--- a/web/src/components/training/ExerciseCardHeader.tsx
+++ b/web/src/components/training/ExerciseCardHeader.tsx
@@ -37,6 +37,11 @@ interface ExerciseCardHeaderProps {
   exerciseCompletionState?: ExerciseCompletionState;
   /** Counts for the aggregate badge (required when exerciseCompletionState is set). */
   exerciseCounts?: ExerciseCounts;
+  /**
+   * True when any set under this exercise has isModified === true (derived client-side).
+   * Shows the "upraveno" roll-up badge next to the completion badge.
+   */
+  hasModifications?: boolean;
 }
 
 export function ExerciseCardHeader({
@@ -56,6 +61,7 @@ export function ExerciseCardHeader({
   disabled,
   exerciseCompletionState,
   exerciseCounts,
+  hasModifications,
 }: ExerciseCardHeaderProps) {
   const { t } = useTranslation();
 
@@ -114,6 +120,12 @@ export function ExerciseCardHeader({
               kind="exercise"
               state={exerciseCompletionState}
               counts={exerciseCounts}
+            />
+          )}
+          {hasModifications && (
+            <CompletionBadge
+              kind="modified"
+              state={hasModifications}
             />
           )}
         </div>

--- a/web/src/components/training/SectionCard.tsx
+++ b/web/src/components/training/SectionCard.tsx
@@ -15,6 +15,7 @@ import type { ExerciseSet } from '@/api/training-plan-types';
 import {
   deriveSetCompletionState,
   deriveExerciseCompletionState,
+  deriveExerciseModificationState,
 } from '@/lib/completionState';
 
 /**
@@ -328,6 +329,21 @@ export function SectionCard({
                   ex.sets.length,
                 );
 
+              // Derive modification state: true when any logged set under this
+              // exercise has isModified === true. Backend has no per-exercise flag —
+              // we derive client-side mirroring deriveExerciseCompletionState.
+              const exHasModifications = deriveExerciseModificationState(
+                sessionExecution,
+                ex.exerciseExternalId,
+              );
+
+              // Logged sets for this exercise, keyed by 1-based setNumber.
+              const loggedSetsMap = sessionExecution?.loggedSetsByExercise[ex.exerciseExternalId]
+                ? Object.fromEntries(
+                    sessionExecution.loggedSetsByExercise[ex.exerciseExternalId].map((ls) => [ls.setNumber, ls])
+                  )
+                : undefined;
+
               return (
                 <div
                   key={exKey}
@@ -374,6 +390,9 @@ export function SectionCard({
                     // Completion state (additive, display-only).
                     exerciseCompletionState={exCompletionState}
                     exerciseCounts={exCounts}
+                    // Modification roll-up: true when any set under this exercise
+                    // has isModified === true (derived client-side).
+                    hasModifications={exHasModifications || undefined}
                   />
 
                   <div className="collapse-grid" data-open={isExOpen}>
@@ -411,6 +430,7 @@ export function SectionCard({
                                 movementType={ex.movementType}
                                 sectionFormat={section.format}
                                 onUpdate={(updates) => onUpdateSet(exIdx, 0, updates)}
+                                loggedSet={loggedSetsMap?.[ex.sets[0].setNumber]}
                               />
                             </div>
                           )
@@ -441,7 +461,7 @@ export function SectionCard({
                               <span />
                             </div>
 
-                            {/* Set rows */}
+                            {/* Set rows (planned sets) */}
                             {ex.sets.map((s, sIdx) => (
                               <SetRow
                                 key={sIdx}
@@ -460,8 +480,37 @@ export function SectionCard({
                                       )
                                     : undefined
                                 }
+                                // Logged-set actual/planned overlay when available
+                                loggedSet={loggedSetsMap?.[s.setNumber]}
                               />
                             ))}
+                            {/* Extra sets — sets logged beyond the plan count.
+                                These have set numbers > ex.sets.length. */}
+                            {loggedSetsMap &&
+                              Object.values(loggedSetsMap)
+                                .filter((ls) => !ex.sets.some((s) => s.setNumber === ls.setNumber))
+                                .sort((a, b) => a.setNumber - b.setNumber)
+                                .map((ls) => (
+                                  <SetRow
+                                    key={`extra-${ls.setNumber}`}
+                                    set={{
+                                      setNumber: ls.setNumber,
+                                      type: 'Normal',
+                                      reps: null,
+                                      weightKg: null,
+                                      durationSeconds: null,
+                                      rpe: null,
+                                      distanceMeters: null,
+                                      restSeconds: null,
+                                    }}
+                                    movementType="Reps"
+                                    onUpdate={() => {/* extra sets are read-only */}}
+                                    onRemove={() => {/* extra sets are read-only */}}
+                                    completionState="completed"
+                                    loggedSet={ls}
+                                    isExtraSet
+                                  />
+                                ))}
 
                             {/* Add set — hidden when the section is locked
                                 (also covers session-locked + day-in-past per

--- a/web/src/components/training/SetRow.tsx
+++ b/web/src/components/training/SetRow.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import type { ExerciseSet, MovementType } from '@/api/training-plan-types';
+import type { ExerciseSet, MovementType, LoggedSetDto } from '@/api/training-plan-types';
 import type { SetCompletionState } from '@/lib/completionState';
 import { CompletionBadge } from '@/components/common/CompletionBadge';
 
@@ -11,6 +11,20 @@ interface SetRowProps {
   onRemove: () => void;
   /** Completion state for this set (additive display-only; omit to render nothing). */
   completionState?: SetCompletionState;
+  /**
+   * Logged-set actual + snapshot-planned values from the client's workout log.
+   * When present, the set is rendered in read-view (Treatment B):
+   *   - Actual value as the headline number
+   *   - Snapshot-planned as a quiet "plán…" caption below
+   *   - Gold accent change-indicator dot when isModified === true
+   * When absent (no workout log for this set), the editable plan inputs render as normal.
+   */
+  loggedSet?: LoggedSetDto;
+  /**
+   * When true, the set is an extra set performed beyond the plan count
+   * (actual only, no planned value). Shown in gold + "navíc" caption.
+   */
+  isExtraSet?: boolean;
 }
 
 /**
@@ -21,7 +35,7 @@ interface SetRowProps {
  *   Distance    → distance + duration + rest
  *   RepsForTime → reps + rest
  */
-export function SetRow({ set, movementType, onUpdate, onDuplicate, onRemove, completionState }: SetRowProps) {
+export function SetRow({ set, movementType, onUpdate, onDuplicate, onRemove, completionState, loggedSet, isExtraSet }: SetRowProps) {
   const { t } = useTranslation();
 
   // Shared input styling. Values are centered in their columns so that the
@@ -69,9 +83,96 @@ export function SetRow({ set, movementType, onUpdate, onDuplicate, onRemove, com
     />
   );
 
+  /**
+   * Renders a single value cell in "logged view" (Treatment B):
+   *   - actual value as headline (gold if isExtraSet, else default text color)
+   *   - snapshot-planned as a quiet "plán X" caption below (hidden for extra sets)
+   *   - gold dot change indicator when isModified === true
+   *
+   * Returns null when both actual and planned are null (set not performed).
+   */
+  const loggedCell = (
+    actual: number | null | undefined,
+    planned: number | null | undefined,
+    isModifiedField: boolean,
+  ) => {
+    const actualDisplay = actual != null ? String(actual) : '–';
+    const plannedDisplay = planned != null ? String(planned) : null;
+    return (
+      <div className="flex flex-col items-center gap-0" style={{ minWidth: 0 }}>
+        {/* Actual headline */}
+        <span
+          className={
+            isExtraSet
+              ? 'text-[12px] font-semibold text-accent tabular-nums'
+              : 'text-[12px] font-semibold text-text tabular-nums'
+          }
+        >
+          {actualDisplay}
+          {isModifiedField && !isExtraSet && (
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full bg-accent ml-[2px] align-middle"
+              aria-label={t('training.completionState.modified')}
+            />
+          )}
+        </span>
+        {/* Snapshot-planned caption */}
+        {!isExtraSet && plannedDisplay != null && (
+          <span className="text-[9px] text-text4 tabular-nums leading-none">
+            {t('training.completionState.plan')} {plannedDisplay}
+          </span>
+        )}
+        {/* Extra-set "navíc" caption */}
+        {isExtraSet && (
+          <span className="text-[9px] text-accent tabular-nums leading-none">
+            {t('training.completionState.navic')}
+          </span>
+        )}
+      </div>
+    );
+  };
+
   // Determine grid template based on movementType.
   // Columns: # | type-specific fields | rest | remove
   const renderColumns = () => {
+    // When loggedSet is present, render actual/planned overlay instead of editable inputs
+    if (loggedSet) {
+      switch (movementType) {
+        case 'Time':
+          return (
+            <>
+              {loggedCell(loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified)}
+              {/* Rest is plan-only — no logged "actual rest" in the contract */}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+        case 'Distance':
+          return (
+            <>
+              {loggedCell(loggedSet.actualDistanceMeters, loggedSet.plannedDistanceMeters, loggedSet.isModified)}
+              {loggedCell(loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified)}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+        case 'RepsForTime':
+          return (
+            <>
+              {loggedCell(loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+        // Reps (default)
+        default:
+          return (
+            <>
+              {loggedCell(loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified)}
+              {loggedCell(loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+              {numInput(set.restSeconds, (v) => onUpdate({ restSeconds: v }), '--', t('training.restSecondsLabel'))}
+            </>
+          );
+      }
+    }
+
     switch (movementType) {
       case 'Time':
         return (

--- a/web/src/components/training/WodExerciseRow.tsx
+++ b/web/src/components/training/WodExerciseRow.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import type { ExerciseSet, MovementType, WorkoutFormat } from '@/api/training-plan-types';
+import type { ExerciseSet, MovementType, WorkoutFormat, LoggedSetDto } from '@/api/training-plan-types';
 
 interface WodExerciseRowProps {
   /** The single set holding the WOD round prescription. */
@@ -13,6 +13,11 @@ interface WodExerciseRowProps {
   sectionFormat: WorkoutFormat;
   /** Patches the single set in the store. */
   onUpdate: (updates: Partial<ExerciseSet>) => void;
+  /**
+   * Logged-set actual + snapshot-planned values from the client's workout log.
+   * When present, renders actual as headline + snapshot-planned as caption + change dot.
+   */
+  loggedSet?: LoggedSetDto;
 }
 
 /**
@@ -29,12 +34,47 @@ interface WodExerciseRowProps {
  *   Distance    → distance (m) + duration (s)
  *   RepsForTime → reps
  */
-export function WodExerciseRow({ set, movementType, sectionFormat, onUpdate }: WodExerciseRowProps) {
+export function WodExerciseRow({ set, movementType, sectionFormat, onUpdate, loggedSet }: WodExerciseRowProps) {
   const { t } = useTranslation();
   // Tabata sets work duration at the section level (`formatConfig.workSeconds`),
   // so per-exercise reps don't make sense — the trainer prescribes load and
   // movement; the rep count is whatever the client achieves in the work window.
   const hideReps = sectionFormat === 'Tabata';
+
+  /**
+   * Renders a single WOD field in "logged view" (Treatment B):
+   *   - actual value as headline
+   *   - snapshot-planned as quiet "plán X" caption
+   *   - gold dot change indicator when isModifiedField is true
+   */
+  const loggedWodField = (
+    label: string,
+    actual: number | null | undefined,
+    planned: number | null | undefined,
+    isModifiedField: boolean,
+    unit?: string,
+  ) => (
+    <span className="inline-flex items-start gap-1.5">
+      <span className="text-[11px] font-medium text-text3 uppercase">{label}</span>
+      <span className="inline-flex flex-col items-end">
+        <span className="text-[12px] font-semibold text-text tabular-nums">
+          {actual != null ? String(actual) : '–'}
+          {isModifiedField && (
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full bg-accent ml-[2px] align-middle"
+              aria-label={t('training.completionState.modified')}
+            />
+          )}
+        </span>
+        {planned != null && (
+          <span className="text-[9px] text-text4 tabular-nums leading-none">
+            {t('training.completionState.plan')} {planned}
+          </span>
+        )}
+      </span>
+      {unit && <span className="text-[11px] text-text4">{unit}</span>}
+    </span>
+  );
 
   const inputStyle: React.CSSProperties = {
     border: 'none',
@@ -93,6 +133,42 @@ export function WodExerciseRow({ set, movementType, sectionFormat, onUpdate }: W
     numInput(set.weightKg, (v) => onUpdate({ weightKg: v })),
     'kg',
   );
+
+  // When a logged set is present, render actual/planned overlay instead of editable inputs
+  if (loggedSet) {
+    switch (movementType) {
+      case 'Time':
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {loggedWodField(t('training.wod.durationLabel'), loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified, 's')}
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+          </div>
+        );
+      case 'Distance':
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {loggedWodField(t('training.wod.distanceLabel'), loggedSet.actualDistanceMeters, loggedSet.plannedDistanceMeters, loggedSet.isModified, 'm')}
+            {loggedWodField(t('training.wod.durationLabel'), loggedSet.actualDurationSeconds, loggedSet.plannedDurationSeconds, loggedSet.isModified, 's')}
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+          </div>
+        );
+      case 'RepsForTime':
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {!hideReps && loggedWodField(t('training.repsLabel'), loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+          </div>
+        );
+      // Reps (default)
+      default:
+        return (
+          <div className="flex items-center gap-3 flex-wrap">
+            {loggedWodField(t('training.weightLabel'), loggedSet.actualWeightKg, loggedSet.plannedWeightKg, loggedSet.isModified, 'kg')}
+            {!hideReps && loggedWodField(t('training.repsLabel'), loggedSet.actualReps, loggedSet.plannedReps, loggedSet.isModified)}
+          </div>
+        );
+    }
+  }
 
   switch (movementType) {
     case 'Time':

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1215,7 +1215,10 @@
       "exerciseCompleted": "{{done}}/{{total}} dokončeno",
       "exerciseSkippedSuffix": "{{count}} vynecháno",
       "sessionAllComplete": "Vše dokončeno",
-      "sessionMixed": "{{completed}} dokončeno · {{skipped}} vynecháno"
+      "sessionMixed": "{{completed}} dokončeno · {{skipped}} vynecháno",
+      "modified": "upraveno",
+      "plan": "plán",
+      "navic": "navíc"
     },
     "retroactiveFinish": {
       "buttonLabel": "Označit jako dokončeno",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1199,7 +1199,10 @@
       "exerciseCompleted": "{{done}}/{{total}} abgeschlossen",
       "exerciseSkippedSuffix": "{{count}} übersprungen",
       "sessionAllComplete": "Alles erledigt",
-      "sessionMixed": "{{completed}} abgeschlossen · {{skipped}} übersprungen"
+      "sessionMixed": "{{completed}} abgeschlossen · {{skipped}} übersprungen",
+      "modified": "geändert",
+      "plan": "Plan",
+      "navic": "extra"
     },
     "retroactiveFinish": {
       "buttonLabel": "Als abgeschlossen markieren",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1200,7 +1200,10 @@
       "exerciseCompleted": "{{done}}/{{total}} completed",
       "exerciseSkippedSuffix": "{{count}} skipped",
       "sessionAllComplete": "All complete",
-      "sessionMixed": "{{completed}} completed · {{skipped}} skipped"
+      "sessionMixed": "{{completed}} completed · {{skipped}} skipped",
+      "modified": "modified",
+      "plan": "plan",
+      "navic": "extra"
     },
     "retroactiveFinish": {
       "buttonLabel": "Mark finished",

--- a/web/src/lib/completionState.ts
+++ b/web/src/lib/completionState.ts
@@ -22,6 +22,29 @@
 import type { SessionExecutionDto } from '@/api/training-plan-types';
 import type { MealLogDto } from '@/api/plan-types';
 
+// ── Per-exercise modification state ─────────────────────────────────────────
+
+/**
+ * Derive whether an exercise has any set-level modifications.
+ *
+ * The backend only surfaces session-level hasModifications and per-set isModified
+ * flags. There is no per-exercise hasModifications on the DTO — we derive it
+ * client-side by checking whether any LoggedSetDto under the exercise has
+ * isModified === true.
+ *
+ * @param sessionExecution  The execution record for the session (may be undefined)
+ * @param exerciseExternalId The exercise to check
+ */
+export function deriveExerciseModificationState(
+  sessionExecution: SessionExecutionDto | undefined,
+  exerciseExternalId: string,
+): boolean {
+  if (!sessionExecution) return false;
+  const loggedSets = sessionExecution.loggedSetsByExercise[exerciseExternalId];
+  if (!loggedSets || loggedSets.length === 0) return false;
+  return loggedSets.some((s) => s.isModified);
+}
+
 // ── Per-set state ────────────────────────────────────────────────────────────
 
 export type SetCompletionState = 'completed' | 'skipped' | 'not-reached';

--- a/web/src/pages/TrainingPlanPage.tsx
+++ b/web/src/pages/TrainingPlanPage.tsx
@@ -1132,6 +1132,15 @@ export default function TrainingPlanPage() {
                           />
                         );
                       })()}
+                      {/* Session-level "upraveno" badge — shown when the client
+                          performed at least one set that differs from the plan.
+                          hasModifications is backend-computed on the SessionExecutionDto. */}
+                      {sessionExec?.hasModifications && (
+                        <CompletionBadge
+                          kind="modified"
+                          state={sessionExec.hasModifications}
+                        />
+                      )}
                     </span>
                     {/* ── Edit-lock affordances (published sessions only) ─────────
                         Live   → in-progress badge + disabled affordance with tooltip


### PR DESCRIPTION
## Summary

Epic #439 — surface client-adjusted (actual) set values against the original
prescription (snapshot-planned) across every training read surface, so coaches
can tell at a glance whether a session was performed as prescribed. Three
sub-issues, each individually QA'd, two-pass-reviewed, and merged into this
epic branch:

- **Backend (#440):** 5 nullable `Planned*` snapshot fields on the embedded
  Mongo `WorkoutSet` doc; `PUT /client/training/logs/{logId}` persists them
  with server-side per-field snapshot immutability on re-PUT (a frozen
  `Planned*` value can never be overwritten); `FinishSession` stamps
  `planned == actual` (done-as-prescribed → never modified); backend-computed
  `isModified` per set + `hasModifications` per exercise/session; extended the
  three read endpoints (today session, full plan, trainer `SessionExecutionDto.
  loggedSetsByExercise`). No EF migration — `WorkoutSet` is an embedded
  document. 275 backend tests green.
- **Web (#442):** coach plan-detail Treatment B (actual headline + "plán"
  caption + gold change dot via brand token), `upraveno` badges at session +
  exercise headers, WOD per-movement rows, skipped/extra-set edge cases. New
  DTO fields hand-added to `web/src/api/training-plan-types.ts` (web does not
  consume `generated.ts` for `SessionExecutionDto`); `generated.ts` untouched.
- **Mobile (#441):** same Treatment B across Today card / plan detail / live
  summary; `upraveno` badges at session + exercise headers; regenerated
  `mobile/src/api/generated.ts` via NSwag (baseUrl default restored to
  `https://localhost:5001`); reconciled previously hand-declared types onto the
  regenerated client; skipped/extra-set edge cases.

## Related issues

Fixes #439
Fixes #440
Fixes #441
Fixes #442

## Scope

cross-cut (backend + web + mobile)

## QA verdict (from qa-tester, per sub-issue)

- **Backend #440:** ✅ PASS — 275 tests green (snapshot persistence,
  immutability-on-re-PUT, FinishSession planned==actual, backward-compat
  null-snapshot → not-modified).
- **Web #442:** ✅ PASS — coach view interactively verified live on
  manufactured #440 data: `upraveno` badges, skipped marker, and extra-set
  (`navíc` + gold) paths confirmed. The plán-caption + gold-dot path was
  code-verified (not interactively) because the available seed fixture had no
  prescribed sets and a completed-session lock blocked manufacturing one.
- **Mobile #441:** ✅ PASS on static gates — `tsc --noEmit` + `expo-doctor`
  clean, plus two-pass review. Interactive iOS-Simulator QA was
  environmentally blocked by a CocoaPods/Ruby toolchain bug; mobile rode on
  static gates + two-pass review for this epic.

## Known follow-ups (non-blocking)

- **Web** `SectionCard` extra-set detection keys on plan-set membership vs.
  null snapshot — a logged set whose prescribed counterpart is later deleted
  by the coach would render as `navíc`/gold rather than modified. Rare
  post-log-plan-edit edge case; display-only.
- **Mobile** live-summary local optimistic `isModified` omits distance and is
  keyed on `completedSetNumbers`. Transient — the backend-computed flag is
  authoritative on the next read and overwrites the local value.

## Test plan (union of sub-issue ACs, deduplicated)

- [ ] A set whose actual differs from snapshot-planned shows actual as headline
      + planned as "plán" caption + gold change indicator on every surface
      (live summary, Today card, mobile plan detail, web plan detail).
- [ ] A session/exercise with any modified set shows an `upraveno` badge in the
      completion-badge slot on the coach view.
- [ ] WOD per-movement sets get the same treatment; `WodResult` rows unchanged.
- [ ] Skipped sets show the planned caption + existing skip marker; actual blank.
- [ ] Extra sets beyond the plan show the actual in gold with a `navíc` caption
      and no planned value.
- [ ] Pre-snapshot legacy logs show no false `upraveno` badges (backward compat).
- [ ] New strings (`upraveno`/`modified`, `plán`, `navíc`) present in cs/en/de
      across both web and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)