### PR TITLE
chore: QA seed — prescribed sets + four-case planned-vs-actual WorkoutLog (#457)

### DIFF
--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -83,6 +83,23 @@ public static class QaSeedRunner
     public static readonly Guid QaPastCompletedWorkoutLogId = new("11111111-1111-1111-2222-000000000005");
     public static readonly Guid QaPastSkippedWorkoutLogId   = new("11111111-1111-1111-2222-000000000006");
 
+    // -------------------------------------------------------------------------
+    // #457 — Main plan (dddd...) WorkoutLog with four-case planned-vs-actual sets.
+    // A distinct GUID so the WorkoutLogs==0 minimal-kind assertion is not affected
+    // (gated to Rich seed path only, same as the past-plan logs above).
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Completed WorkoutLog for the main QA training plan (dddddddd-...), Standard section.
+    /// Exercises four per-set cases needed by the planned-vs-actual UI surface:
+    ///   Exercise 1 (QA Squat) — Set 1: modified (actual != planned), Set 2: as-prescribed.
+    ///   Exercise 2 (QA Deadlift) — Set 1: skipped (planned present, actual null), Set 2: extra (no planned snapshot).
+    /// </summary>
+    public static readonly Guid QaMainPlanCompletedWorkoutLogId = new("11111111-1111-1111-4455-000000000001");
+
+    // Section ID within the main-plan completed WorkoutLog (mirrors StandardSectionId).
+    public static readonly Guid MainPlanCompletedSectionId = new("11111111-1111-1111-4455-000000000002");
+
     // Section IDs within the three past sessions.
     public static readonly Guid PastCompletedSectionId = new("11111111-1111-1111-3333-000000000001");
     public static readonly Guid PastSkippedSectionId   = new("11111111-1111-1111-3333-000000000002");
@@ -211,6 +228,9 @@ public static class QaSeedRunner
         {
             // Training plan — ForTime + 0-exercise fixture for #258 non-regression.
             await EnsureTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
+
+            // Main-plan completed WorkoutLog — exercises four planned-vs-actual set cases (#457).
+            await EnsureMainPlanWorkoutLogAsync(mongo, logger);
 
             // Past-dated training plan — three sessions in distinct completion states for #326.
             await EnsurePastTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
@@ -484,7 +504,9 @@ public static class QaSeedRunner
                                         },
                                     ],
                                 },
-                                // Section 3 — Standard (null format) + 2 synthetic exercises (non-regression)
+                                // Section 3 — Standard (null format) + 2 synthetic exercises with prescribed sets.
+                                // Sets are populated so the planned-vs-actual WorkoutLog (#457) can exercise
+                                // all four UI cases: modified, as-prescribed, skipped, extra.
                                 new TrainingSection
                                 {
                                     SectionId    = StandardSectionId,
@@ -500,6 +522,12 @@ public static class QaSeedRunner
                                             ExerciseName       = "QA Squat",
                                             Order              = 1,
                                             MovementType       = MovementType.Reps,
+                                            // Prescribed: 2 sets × 10 reps @ 80 kg.
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 10, WeightKg = 80m },
+                                                new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 10, WeightKg = 80m },
+                                            ],
                                         },
                                         new SessionExercise
                                         {
@@ -507,6 +535,12 @@ public static class QaSeedRunner
                                             ExerciseName       = "QA Deadlift",
                                             Order              = 2,
                                             MovementType       = MovementType.Reps,
+                                            // Prescribed: 2 sets × 5 reps @ 100 kg.
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 5, WeightKg = 100m },
+                                                new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 5, WeightKg = 100m },
+                                            ],
                                         },
                                     ],
                                 },
@@ -546,6 +580,132 @@ public static class QaSeedRunner
         logger.LogInformation(
             "QA TrainingPlan created: externalId={ExternalId} clientId={ClientId}",
             QaTrainingPlanExternalId, clientProfilePublicId);
+    }
+
+    /// <summary>
+    /// Seeds a completed WorkoutLog against the main QA training plan (dddddddd-...)
+    /// Standard section, exercising all four planned-vs-actual set cases in one session:
+    ///
+    ///   Exercise 1 (QA Squat):
+    ///     Set 1 — MODIFIED    PlannedReps=10, PlannedWeightKg=80, actual Reps=8,  WeightKg=85  → IsModified=true.
+    ///     Set 2 — AS-PRESCRIBED PlannedReps=10, PlannedWeightKg=80, actual Reps=10, WeightKg=80 → IsModified=false.
+    ///
+    ///   Exercise 2 (QA Deadlift):
+    ///     Set 1 — SKIPPED     PlannedReps=5, PlannedWeightKg=100, Reps=null, WeightKg=null     → planned set, no actual.
+    ///     Set 2 — EXTRA       PlannedReps=null (no snapshot), actual Reps=6, WeightKg=90       → no planned snapshot.
+    ///
+    /// ClientId = ClientUserId (ApplicationUser.Id) — WorkoutLog ownership mirrors
+    /// CompleteWorkoutEndpoint's filter on AppClaims.UserId.
+    /// Gated to the Rich seed path only; never created for the Minimal kind.
+    /// </summary>
+    private static async Task EnsureMainPlanWorkoutLogAsync(
+        IMongoContext mongo,
+        ILogger logger)
+    {
+        var existing = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaMainPlanCompletedWorkoutLogId)
+            .FirstOrDefaultAsync();
+
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "QA MainPlan WorkoutLog already present: externalId={ExternalId}", QaMainPlanCompletedWorkoutLogId);
+            return;
+        }
+
+        var completedAt = DateTime.UtcNow.Date.AddDays(-3).AddHours(11); // 11:00 UTC, 3 days ago.
+        var log = new WorkoutLog
+        {
+            ExternalId  = QaMainPlanCompletedWorkoutLogId,
+            // ClientId = ApplicationUser.Id — CompleteWorkoutEndpoint scopes WorkoutLogs by
+            // Guid.Parse(AppClaims.UserId) which is ApplicationUser.Id, NOT ClientProfile.PublicId.
+            ClientId      = ClientUserId,
+            PlanId        = QaTrainingPlanExternalId,
+            SessionId     = QaSessionId,
+            StartedAt     = completedAt.AddMinutes(-60),
+            CompletedAt   = completedAt,
+            CompletedDate = WorkoutLog.ToCompletionDateUtc(completedAt),
+            IsCompleted   = true,
+            DateCreated   = completedAt.AddMinutes(-60),
+            DateUpdated   = completedAt,
+            Sections =
+            [
+                new WorkoutSection
+                {
+                    SectionId = MainPlanCompletedSectionId,
+                    Order     = 2,    // mirrors Standard section Order=2 in the plan
+                    Name      = "Standard test",
+                    Format    = null,
+                    Exercises =
+                    [
+                        // Exercise 1: QA Squat — Set 1 modified, Set 2 as-prescribed.
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = StandardExercise1Id,
+                            ExerciseName       = "QA Squat",
+                            Sets =
+                            [
+                                // MODIFIED — actual differs from planned.
+                                new WorkoutSet
+                                {
+                                    SetNumber       = 1,
+                                    Reps            = 8,          // actual: fewer reps
+                                    WeightKg        = 85m,         // actual: heavier weight
+                                    PlannedReps     = 10,          // snapshot from plan prescription
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt     = completedAt.AddMinutes(-50),
+                                },
+                                // AS-PRESCRIBED — actual matches planned exactly.
+                                new WorkoutSet
+                                {
+                                    SetNumber       = 2,
+                                    Reps            = 10,
+                                    WeightKg        = 80m,
+                                    PlannedReps     = 10,
+                                    PlannedWeightKg = 80m,
+                                    CompletedAt     = completedAt.AddMinutes(-40),
+                                },
+                            ],
+                        },
+                        // Exercise 2: QA Deadlift — Set 1 skipped (planned present, no actual),
+                        //                           Set 2 extra (actual present, no planned snapshot).
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = StandardExercise2Id,
+                            ExerciseName       = "QA Deadlift",
+                            Sets =
+                            [
+                                // SKIPPED — planned prescription captured, client did not perform the set.
+                                // Reps/WeightKg are null; PlannedReps/PlannedWeightKg are set.
+                                new WorkoutSet
+                                {
+                                    SetNumber       = 1,
+                                    Reps            = null,
+                                    WeightKg        = null,
+                                    PlannedReps     = 5,
+                                    PlannedWeightKg = 100m,
+                                    CompletedAt     = null,
+                                },
+                                // EXTRA — client logged an additional set beyond what was prescribed.
+                                // No planned snapshot (PlannedReps/PlannedWeightKg remain null).
+                                new WorkoutSet
+                                {
+                                    SetNumber   = 2,
+                                    Reps        = 6,
+                                    WeightKg    = 90m,
+                                    CompletedAt = completedAt.AddMinutes(-20),
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        await mongo.WorkoutLogs.InsertOneAsync(log);
+        logger.LogInformation(
+            "QA MainPlan WorkoutLog created: externalId={ExternalId} planId={PlanId} sessionId={SessionId}",
+            QaMainPlanCompletedWorkoutLogId, QaTrainingPlanExternalId, QaSessionId);
     }
 
     /// <summary>

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -548,4 +548,142 @@ public class QaSeedRunnerTests : IAsyncLifetime
         day.DayOfWeek.Should().Be(1, "Monday is day 1");
         day.Meals.Should().HaveCount(3, "Breakfast, Lunch, Dinner");
     }
+
+    /// <summary>
+    /// The main QA training plan (dddddddd-...) Standard section must have prescribed sets
+    /// on both exercises so the planned-vs-actual WorkoutLog has concrete prescription values
+    /// to compare against.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_MainPlan_StandardSectionHasPrescribedSets()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        var plan = await mongo.TrainingPlans
+            .Find(p => p.ExternalId == QaSeedRunner.QaTrainingPlanExternalId)
+            .FirstOrDefaultAsync(ct);
+
+        plan.Should().NotBeNull("main training plan must be seeded");
+
+        var session = plan!.Weeks[0].Sessions.Single(s => s.SessionId == QaSeedRunner.QaSessionId);
+        var standardSection = session.Sections.Single(s => s.SectionId == QaSeedRunner.StandardSectionId);
+
+        standardSection.Exercises.Should().HaveCount(2, "Standard section has two exercises");
+
+        var squat = standardSection.Exercises.Single(e => e.ExerciseExternalId == QaSeedRunner.StandardExercise1Id);
+        squat.Sets.Should().HaveCount(2, "QA Squat has 2 prescribed sets");
+        squat.Sets.Should().AllSatisfy(s =>
+        {
+            s.Reps.Should().Be(10, "prescribed 10 reps");
+            s.WeightKg.Should().Be(80m, "prescribed 80 kg");
+        });
+
+        var deadlift = standardSection.Exercises.Single(e => e.ExerciseExternalId == QaSeedRunner.StandardExercise2Id);
+        deadlift.Sets.Should().HaveCount(2, "QA Deadlift has 2 prescribed sets");
+        deadlift.Sets.Should().AllSatisfy(s =>
+        {
+            s.Reps.Should().Be(5, "prescribed 5 reps");
+            s.WeightKg.Should().Be(100m, "prescribed 100 kg");
+        });
+    }
+
+    /// <summary>
+    /// The completed WorkoutLog seeded for the main QA plan must exercise all four
+    /// planned-vs-actual set cases in a single session:
+    ///
+    ///   QA Squat  Set 1 — MODIFIED      actual != planned  (IsModified=true)
+    ///   QA Squat  Set 2 — AS-PRESCRIBED actual == planned  (IsModified=false)
+    ///   QA Deadlift Set 1 — SKIPPED     planned present, actual null
+    ///   QA Deadlift Set 2 — EXTRA       no planned snapshot, actual present
+    ///
+    /// ClientId must be ApplicationUser.Id so the log is visible to CompleteWorkoutEndpoint
+    /// and the coach-view planned-vs-actual query.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_MainPlanWorkoutLog_ExercisesFourPlannedVsActualCases()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        var log = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaSeedRunner.QaMainPlanCompletedWorkoutLogId)
+            .FirstOrDefaultAsync(ct);
+
+        log.Should().NotBeNull("main-plan completed WorkoutLog must be seeded");
+        log!.IsCompleted.Should().BeTrue("log is marked complete");
+        log.PlanId.Should().Be(QaSeedRunner.QaTrainingPlanExternalId);
+        log.SessionId.Should().Be(QaSeedRunner.QaSessionId);
+        log.ClientId.Should().Be(QaSeedRunner.ClientUserId,
+            "WorkoutLog.ClientId must be ApplicationUser.Id (11111111-...) — same contract as past-plan logs");
+        log.CompletedDate.Should().NotBeNull("CompletedDate is required for the partial unique index");
+
+        log.Sections.Should().HaveCount(1, "one section mirrors the Standard section");
+        var section = log.Sections[0];
+        section.Exercises.Should().HaveCount(2);
+
+        // ── Exercise 1: QA Squat ───────────────────────────────────────────────
+        var squat = section.Exercises.Single(e => e.ExerciseExternalId == QaSeedRunner.StandardExercise1Id);
+        squat.Sets.Should().HaveCount(2);
+
+        var squatSet1 = squat.Sets.Single(s => s.SetNumber == 1);
+        squatSet1.Reps.Should().Be(8, "actual reps differ from planned");
+        squatSet1.WeightKg.Should().Be(85m, "actual weight differs from planned");
+        squatSet1.PlannedReps.Should().Be(10, "snapshot from plan prescription");
+        squatSet1.PlannedWeightKg.Should().Be(80m);
+        squatSet1.IsModified.Should().BeTrue("actual != planned → MODIFIED");
+
+        var squatSet2 = squat.Sets.Single(s => s.SetNumber == 2);
+        squatSet2.Reps.Should().Be(10);
+        squatSet2.WeightKg.Should().Be(80m);
+        squatSet2.PlannedReps.Should().Be(10);
+        squatSet2.PlannedWeightKg.Should().Be(80m);
+        squatSet2.IsModified.Should().BeFalse("actual == planned → AS-PRESCRIBED");
+
+        // ── Exercise 2: QA Deadlift ────────────────────────────────────────────
+        var deadlift = section.Exercises.Single(e => e.ExerciseExternalId == QaSeedRunner.StandardExercise2Id);
+        deadlift.Sets.Should().HaveCount(2);
+
+        var deadliftSet1 = deadlift.Sets.Single(s => s.SetNumber == 1);
+        deadliftSet1.PlannedReps.Should().Be(5, "prescription captured");
+        deadliftSet1.PlannedWeightKg.Should().Be(100m);
+        deadliftSet1.Reps.Should().BeNull("client did not perform the set → SKIPPED");
+        deadliftSet1.WeightKg.Should().BeNull();
+        deadliftSet1.CompletedAt.Should().BeNull("skipped set has no completion timestamp");
+
+        var deadliftSet2 = deadlift.Sets.Single(s => s.SetNumber == 2);
+        deadliftSet2.Reps.Should().Be(6, "client logged an extra set");
+        deadliftSet2.WeightKg.Should().Be(90m);
+        deadliftSet2.PlannedReps.Should().BeNull("no planned snapshot → EXTRA set");
+        deadliftSet2.PlannedWeightKg.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Seeding twice must not create a duplicate main-plan WorkoutLog.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_MainPlanWorkoutLog_IsIdempotent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        var count = await mongo.WorkoutLogs.CountDocumentsAsync(
+            Builders<WorkoutLog>.Filter.Eq(l => l.ExternalId, QaSeedRunner.QaMainPlanCompletedWorkoutLogId),
+            cancellationToken: ct);
+
+        count.Should().Be(1, "main-plan WorkoutLog must not be duplicated on re-seed");
+    }
 }


### PR DESCRIPTION
## Summary
- Adds prescribed `Sets` (reps + weightKg) to the two Standard-section exercises (QA Squat 2×10@80kg, QA Deadlift 2×5@100kg) on the main QA training plan `dddddddd-...`, so the plan carries a prescription before any client WorkoutLog exists.
- Seeds one completed `WorkoutLog` (`EnsureMainPlanWorkoutLogAsync`) against that plan that exercises all four planned-vs-actual set cases in a single session: **modified** (Squat S1: 8/85 vs 10/80), **as-prescribed** (Squat S2: 10/80==planned), **skipped** (Deadlift S1: planned 5/100, actuals null), **extra** (Deadlift S2: 6/90, no planned snapshot).
- `ClientId = ClientUserId` (ApplicationUser.Id) to match `CompleteWorkoutEndpoint`'s ownership filter; gated to the Rich seed path only (distinct GUID so the WorkoutLogs==0 minimal-kind assertion is untouched); idempotent on re-seed.
- Adds three Testcontainers-backed tests covering prescribed-set shape, the four-case WorkoutLog, and idempotency.

## Related issue
Fixes #457

## Scope
backend (`backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs`, `backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs`)

Standalone follow-up from already-shipped epic #439 (planned-vs-actual training values) — branched off and based on `develop`, not a live epic branch.

## QA verdict (from qa-tester)
OVERALL: ⚠️ INTERACTIVE-REQUIRED — data-level ACs PASS (10/10 Testcontainers).
- AC1 (plan has prescribed sets before any WorkoutLog) — ✅ PASS.
- AC2 (completed WorkoutLog exercises all four planned-vs-actual cases) — ✅ PASS (`IsModified` is a real computed member; idempotency verified).
- AC3 (coach-web + mobile render the full treatment) — deferred. This AC is **enabled-by-construction**: this seed is precisely what makes the render QA-able; it is circular to verify the render before the seed lands. The interactive render check runs after `npm run e2e:up` re-seeds the harness with this branch's backend.

## Test plan
- [x] The QA seed creates a training plan whose Standard-section exercises have prescribed sets (reps + weightKg) before any client WorkoutLog is created.
- [x] The seed creates a completed WorkoutLog for the QA client against that plan, with per-set planned snapshots exercising all four cases (modified, as-prescribed, skipped, extra) in one session.
- [ ] With this seed, coach web plan-detail and mobile planned-vs-actual surfaces render the full treatment (plán caption + gold dot + upraveno badge) without manual API data-manufacturing. *(Deferred / enabled-by-construction — verify post-merge once the harness re-seeds.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)