### PR TITLE
fix: classify extra/navíc sets by snapshot nullness, not plan-array membership

### DIFF
--- a/web/src/components/training/SectionCard.tsx
+++ b/web/src/components/training/SectionCard.tsx
@@ -484,33 +484,52 @@ export function SectionCard({
                                 loggedSet={loggedSetsMap?.[s.setNumber]}
                               />
                             ))}
-                            {/* Extra sets — sets logged beyond the plan count.
-                                These have set numbers > ex.sets.length. */}
+                            {/* Extra sets — logged sets with NO planned snapshot at all
+                                (client performed sets that were never prescribed, or
+                                the plan had no snapshot at log time).
+                                NOTE: a logged set whose setNumber is absent from ex.sets
+                                because the coach deleted that prescribed set post-log will
+                                still carry non-null planned* snapshot fields. Those sets
+                                must NOT be classified as navíc — they render with
+                                actual headline + "plán …" caption just like any other
+                                logged-with-snapshot set. isExtraSet is keyed on snapshot
+                                nullness, not on plan-array membership. */}
                             {loggedSetsMap &&
                               Object.values(loggedSetsMap)
                                 .filter((ls) => !ex.sets.some((s) => s.setNumber === ls.setNumber))
                                 .sort((a, b) => a.setNumber - b.setNumber)
-                                .map((ls) => (
-                                  <SetRow
-                                    key={`extra-${ls.setNumber}`}
-                                    set={{
-                                      setNumber: ls.setNumber,
-                                      type: 'Normal',
-                                      reps: null,
-                                      weightKg: null,
-                                      durationSeconds: null,
-                                      rpe: null,
-                                      distanceMeters: null,
-                                      restSeconds: null,
-                                    }}
-                                    movementType="Reps"
-                                    onUpdate={() => {/* extra sets are read-only */}}
-                                    onRemove={() => {/* extra sets are read-only */}}
-                                    completionState="completed"
-                                    loggedSet={ls}
-                                    isExtraSet
-                                  />
-                                ))}
+                                .map((ls) => {
+                                  // A set is genuinely "extra" (navíc) only when every
+                                  // planned snapshot field is null — meaning there was no
+                                  // plan prescription at the time of logging.
+                                  const hasSnapshot =
+                                    ls.plannedReps != null ||
+                                    ls.plannedWeightKg != null ||
+                                    ls.plannedRpe != null ||
+                                    ls.plannedDurationSeconds != null ||
+                                    ls.plannedDistanceMeters != null;
+                                  return (
+                                    <SetRow
+                                      key={`extra-${ls.setNumber}`}
+                                      set={{
+                                        setNumber: ls.setNumber,
+                                        type: 'Normal',
+                                        reps: null,
+                                        weightKg: null,
+                                        durationSeconds: null,
+                                        rpe: null,
+                                        distanceMeters: null,
+                                        restSeconds: null,
+                                      }}
+                                      movementType="Reps"
+                                      onUpdate={() => {/* extra/orphaned sets are read-only */}}
+                                      onRemove={() => {/* extra/orphaned sets are read-only */}}
+                                      completionState="completed"
+                                      loggedSet={ls}
+                                      isExtraSet={!hasSnapshot}
+                                    />
+                                  );
+                                })}
 
                             {/* Add set — hidden when the section is locked
                                 (also covers session-locked + day-in-past per


### PR DESCRIPTION
## Summary
- Coach plan-detail was mislabeling a logged set as "navíc" (extra) whenever its prescribed set had been deleted from the plan after the client logged against it.
- `SectionCard.tsx` now derives `isExtraSet` from whether **all** `planned*` snapshot fields are null on the logged set, instead of plan-array (`setNumber`) membership.
- A logged set carrying a non-null planned snapshot now renders actual headline + "plán <snapshot>" caption + gold dot when actual differs — even if no matching plan-prescribed set currently exists.
- "navíc" classification now applies only to logged sets with no planned snapshot at all (sets the client added beyond the plan).

## Related issue
Fixes #459

## Root cause
Deleting a prescribed set renumbers the remaining sets, so a previously-logged set's `setNumber` falls out of the plan's `ex.sets` array. The old `isExtraSet` heuristic keyed on that array membership, so an orphaned-but-snapshotted logged set was misclassified as extra — suppressing its "plán" caption and gold modified-dot and losing the actual-vs-planned context. The snapshot fields on the log record are the canonical record of what was prescribed at log time.

## Fix
In `web/src/components/training/SectionCard.tsx`, the orphaned-set branch computes `hasSnapshot = plannedReps|plannedWeightKg|plannedRpe|plannedDurationSeconds|plannedDistanceMeters != null` and passes `isExtraSet={!hasSnapshot}`. This aligns the web classification with the backend's source-of-truth (the per-set snapshot on `LoggedSetDto`).

## Scope
web

## QA verdict (from qa-tester)
OVERALL ⚠️ INTERACTIVE-REQUIRED — code-verified PASS on both ACs (web build clean, render path confirmed in SectionCard.tsx + SetRow.tsx). Live deleted-prescribed-set repro deferred: needs the compose harness + the #457 seed (not yet merged) to render the orphaned-snapshot scenario.

### Deferred interactive note
Once #457 lands, drive the live repro at :5173 (coach deletes a prescribed set post-log, open plan-detail) and capture `.qa-artifacts/459/orchestrator-web-deleted-prescribed-set.png` (orphaned-snapshot shows actual + "plán" + dot, not navíc) and `.qa-artifacts/459/orchestrator-web-true-extra-set.png` (client-added null-snapshot set shows navíc).

## Test plan
- [ ] A logged set with a non-null planned snapshot shows actual headline + "plán <snapshot>" caption + gold dot when actual differs — regardless of current plan-array membership (covers the deleted-prescribed-set repro).
- [ ] "navíc"/extra applies only to logged sets with no planned snapshot at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)