### PR TITLE
fix: qa-fetch-refresh-token.sh fails on macOS (head -n -1 unsupported)

### DIFF
--- a/mobile/scripts/qa-fetch-refresh-token.sh
+++ b/mobile/scripts/qa-fetch-refresh-token.sh
@@ -95,23 +95,27 @@ if [[ -z "$harness_url" ]]; then
 fi
 
 # ── POST to /auth/login on the compose harness ─────────────────────────────
-# Capture body + HTTP status code in one curl call.
-# The status code is appended after a newline separator.
-response="$(
+# Capture body and HTTP status code separately to avoid BSD head(1) incompatibility.
+# BSD head on macOS rejects negative line counts (head -n -1 → "illegal line count").
+# Using -o to write the body to a temp file and -w to capture only the status code
+# on stdout avoids any line-trimming and keeps stderr clean from response data.
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+status_code="$(
   curl -k -sS \
-    -w '\n%{http_code}' \
+    -o "$body_file" \
+    -w '%{http_code}' \
     -X POST "$harness_url/auth/login" \
     -H 'Content-Type: application/json' \
-    -d "{\"email\":\"$email\",\"password\":\"$QA_SEED_PASSWORD\"}" \
-  2>&1
+    -d "{\"email\":\"$email\",\"password\":\"$QA_SEED_PASSWORD\"}"
 )" || {
+  rm -f "$body_file"
   echo "error: harness unreachable at $harness_url — run \`scripts/test-env up\`" >&2
   exit 1
 }
 
-# Split body and status code (last line).
-status_code="$(printf '%s' "$response" | tail -1)"
-body="$(printf '%s' "$response" | head -n -1)"
+body="$(cat "$body_file")"
 
 # ── Handle HTTP error codes ────────────────────────────────────────────────
 case "$status_code" in


### PR DESCRIPTION
## Summary
- `mobile/scripts/qa-fetch-refresh-token.sh` exited 1 for every role on macOS because the body/status split used `head -n -1`, which BSD `head` rejects (`illegal line count -- -1`).
- Restructures the curl call to write the response body to a `mktemp` file (`-o`) and capture only the HTTP status code on stdout (`-w '%{http_code}'`), eliminating any line-trimming. Portable across BSD and GNU.
- Adds a `trap 'rm -f "$body_file"' EXIT` (plus an explicit `rm` on the curl-failure branch) so the temp file is always cleaned up.
- The `--encode` / `--deeplink` base64-URL path is unchanged — body/status split is independent of the encoding step.

## Related issue
Fixes #460

## Scope
mobile (script only — no app code)

## Root cause
BSD `head` on macOS does not accept negative line counts, so `head -n -1` (used to drop the appended status-code line from the combined curl output) aborted with `head: illegal line count -- -1`, causing the script to exit 1 and print nothing.

## Fix
Separate-capture pattern: `curl -o "$body_file" -w '%{http_code}'`. Status code comes back on stdout; body is read from the temp file via `cat`. No `head`/`tail`/`sed` line surgery, so no userland-portability dependency. Temp file cleaned via `trap ... EXIT` and on the curl-failure path.

## QA verdict (from qa-tester)
No qa-tester dispatch — pure shell-script fix with no acceptance-criteria UI surface. Dev verified `bash -n` (syntax) clean.

## Verification note
- `bash -n` syntax check: clean (dev agent).
- ⚠️ Live harness smoke (running the script end-to-end against a booted compose stack and confirming a token prints on macOS) was **not** run by the dev agent — the agent's bash allowlist does not permit booting the harness. Recommend a manual `bash mobile/scripts/qa-fetch-refresh-token.sh client` against a live stack before relying on it in QA.

## Test plan
- [ ] `bash mobile/scripts/qa-fetch-refresh-token.sh [client|trainer|nutritionist] [--encode|--deeplink]` prints the seeded user's refresh token (resolved against the current branch's compose harness).
- [ ] Works on macOS (BSD userland) as well as Linux (GNU userland).

🤖 Generated with [Claude Code](https://claude.com/claude-code)