### PR TITLE
chore: fix iOS dev-client build — UTF-8 locale for pod install (Ruby 4.0.2 ASCII-8BIT crash)

### DIFF
--- a/mobile/scripts/qa-build-dev-client.sh
+++ b/mobile/scripts/qa-build-dev-client.sh
@@ -82,7 +82,12 @@ pods_manifest="$mobile_dir/ios/Pods/Manifest.lock"
 podfile_lock="$mobile_dir/ios/Podfile.lock"
 if [[ ! -f "$pods_manifest" ]] || ! diff -q "$pods_manifest" "$podfile_lock" > /dev/null 2>&1; then
   echo "[qa-build] Pods/Manifest.lock missing or diverged — running pod install" >&2
-  (cd "$mobile_dir/ios" && pod install) >&2
+  # Force UTF-8 locale for this step only. CocoaPods 1.16.2 under Ruby 4.0.2
+  # raises Encoding::CompatibilityError ("Unicode Normalization not appropriate
+  # for ASCII-8BIT") when the process locale is not UTF-8. Exporting LANG/LC_ALL
+  # here scopes the fix to the pod install subshell without touching the global
+  # system Ruby or CocoaPods installation.
+  (cd "$mobile_dir/ios" && export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8 && pod install) >&2
 fi
 
 workspace="$(find "$mobile_dir/ios" -maxdepth 1 -name "*.xcworkspace" -print -quit)"


### PR DESCRIPTION
## Summary
- Forces a **script-local** UTF-8 locale (`LANG`/`LC_ALL=en_US.UTF-8`) for the `pod install` subshell in `mobile/scripts/qa-build-dev-client.sh`.
- Resolves `Encoding::CompatibilityError: Unicode Normalization not appropriate for ASCII-8BIT` raised by CocoaPods 1.16.2 under Ruby 4.0.2, which blocked the entire XcodeBuildMCP iOS-simulator QA path.
- Fix is scoped to the `pod install` subshell only — no global system Ruby / CocoaPods mutation, no `.ruby-version` / Bundler pin.

## Root cause
CocoaPods 1.16.2 running on Ruby 4.0.2 performs Unicode normalization on path/spec strings. When the process locale is not UTF-8 (default on the QA host), those strings arrive as `ASCII-8BIT` and Ruby 4.0.2 refuses to normalize them, raising `Encoding::CompatibilityError`. Exporting a UTF-8 locale for the subshell makes the strings UTF-8-tagged, so normalization succeeds.

## The fix (one line)
```sh
(cd "$mobile_dir/ios" && export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8 && pod install) >&2
```
(previously: `(cd "$mobile_dir/ios" && pod install) >&2`)

## Related issue
Fixes #458

(Standalone follow-up from epic #439 — not a sub-issue, base = `develop`.)

## Scope
mobile (script only — `mobile/scripts/qa-build-dev-client.sh`). `mobile/ios/` is gitignored and untouched.

## Verification note
- Dev verified `pod install` runs **clean** on the host with the locale exported — no ASCII-8BIT crash. This is the direct proof for the fix.
- ⚠️ **Caveat — full build not exercised end-to-end.** The complete 5–8 min Expo prebuild + Metro bundle + `xcodebuild` archive (AC #2 iOS-sim install/launch, AC #3 no-regression of the later steps) was **not** re-run end-to-end due to host/time constraints. The remaining steps were unchanged by this diff; the verified surface is the `pod install` step that was the actual failure point.
- No `qa-tester` was dispatched — this is a pure host-script fix whose verification surface is the `pod install` proof above.

## Test plan
- [ ] `mobile/scripts/qa-build-dev-client.sh` completes a clean dev-client `.app` build on the dev host (pod step verified; full archive caveated above).
- [ ] iOS-simulator interactive QA path (install dev-client `.app` via XcodeBuildMCP + launch + interact) works end-to-end (not yet exercised — see caveat).
- [ ] No other `qa-build-dev-client.sh` steps regress (Expo prebuild, Metro bundle, Xcode archive) (unchanged by diff; not re-run end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)