### PR TITLE
fix(#471): wire chat header info icon to open the coach's profile

### DIFF
--- a/mobile/app/(client)/(tabs)/messages/[threadId].tsx
+++ b/mobile/app/(client)/(tabs)/messages/[threadId].tsx
@@ -183,7 +183,11 @@ export default function ChatScreen() {
         <ChatHeader
           participant={participant}
           onBack={() => router.back()}
-          onInfoPress={() => {}}
+          onInfoPress={() => {
+            if (participant?.id) {
+              router.push(href(`/(client)/coach-profile/${participant.id}`))
+            }
+          }}
         />
       </View>
 

--- a/mobile/app/(client)/_layout.tsx
+++ b/mobile/app/(client)/_layout.tsx
@@ -26,6 +26,10 @@ export default function ClientLayout() {
         options={{ animation: 'slide_from_right' }}
       />
       <Stack.Screen
+        name="coach-profile/[coachId]"
+        options={{ animation: 'slide_from_right' }}
+      />
+      <Stack.Screen
         name="meal-log-photo"
         options={{ animation: 'slide_from_bottom', presentation: 'modal' }}
       />

--- a/mobile/app/(client)/coach-profile/[coachId].tsx
+++ b/mobile/app/(client)/coach-profile/[coachId].tsx
@@ -49,7 +49,7 @@ export function CoachProfileScreen() {
             hitSlop={8}
           >
             <Ionicons name="chevron-back" size={22} color={colors.gold} />
-            <Text style={[styles.backLabel, { color: colors.gold }]}>{t('collab.title')}</Text>
+            <Text style={[styles.backLabel, { color: colors.gold }]}>{t('messages.title')}</Text>
           </Pressable>
         </View>
         <View style={[styles.headerBorder, { backgroundColor: colors.sep2 }]} />

--- a/mobile/app/(client)/coach-profile/[coachId].tsx
+++ b/mobile/app/(client)/coach-profile/[coachId].tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+} from 'react-native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { BlurView } from 'expo-blur'
+import { Ionicons } from '@expo/vector-icons'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTheme } from '@/hooks/useTheme'
+import { Type } from '@/constants/typography'
+import { ProProfileView } from '@/components/trainers/ProProfileView'
+import { useAuthStore } from '@/stores/auth'
+import type { ColorScheme } from '@/constants/colors'
+
+export function CoachProfileScreen() {
+  const { coachId } = useLocalSearchParams<{ coachId: string }>()
+  const router = useRouter()
+  const colors = useTheme()
+  const insets = useSafeAreaInsets()
+  const { t } = useTranslation()
+
+  const trainer = useAuthStore((s) => s.trainer)
+  const coach = useAuthStore((s) => s.coach)
+  const hasTrainer = useAuthStore((s) => s.hasTrainer)
+  const hasCoach = useAuthStore((s) => s.hasCoach)
+
+  const isLinkedTrainer = trainer?.id === coachId && hasTrainer
+  const isLinkedCoach = coach?.id === coachId && hasCoach
+  const isLinked = isLinkedTrainer || isLinkedCoach
+
+  // Active collaborator entry — used to get the `since` date for the badge
+  const activeCollaborator = isLinkedTrainer ? trainer : isLinkedCoach ? coach : null
+
+  const styles = makeStyles(colors)
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.bg }]}>
+      {/* Fixed blurred header */}
+      <View style={[styles.fixedHeader, { paddingTop: insets.top }]}>
+        <BlurView intensity={80} tint="light" style={StyleSheet.absoluteFill} />
+        <View style={styles.headerContent}>
+          <Pressable
+            onPress={() => router.back()}
+            style={styles.backBtn}
+            hitSlop={8}
+          >
+            <Ionicons name="chevron-back" size={22} color={colors.gold} />
+            <Text style={[styles.backLabel, { color: colors.gold }]}>{t('collab.title')}</Text>
+          </Pressable>
+        </View>
+        <View style={[styles.headerBorder, { backgroundColor: colors.sep2 }]} />
+      </View>
+
+      {/* Content */}
+      <View style={[styles.content, { paddingTop: insets.top + 52 }]}>
+        {isLinked && activeCollaborator ? (
+          <ProProfileView
+            professionalPublicId={activeCollaborator.id}
+            displayName={activeCollaborator.name}
+            activeSince={activeCollaborator.since}
+            onMessagePress={() => router.back()}
+            onEndCollabPress={() => {}}
+            showActionBar={false}
+          />
+        ) : (
+          <ProProfileView
+            professionalPublicId={coachId ?? ''}
+            displayName=""
+            activeSince=""
+            onMessagePress={() => router.back()}
+            onEndCollabPress={() => {}}
+            showActionBar={false}
+          />
+        )}
+      </View>
+    </View>
+  )
+}
+
+const makeStyles = (colors: ColorScheme) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    fixedHeader: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      zIndex: 10,
+    },
+    headerContent: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+    },
+    headerBorder: {
+      height: StyleSheet.hairlineWidth,
+    },
+    backBtn: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 2,
+    },
+    backLabel: {
+      ...Type.body,
+    },
+    content: {
+      flex: 1,
+    },
+  })
+
+export default CoachProfileScreen


### PR DESCRIPTION
Closes #471

## Problem
The info ("i") icon in the chat header was wired to an empty `onInfoPress={() => {}}` handler — tapping it did nothing.

## Fix (mobile)
- New non-tab route `app/(client)/coach-profile/[coachId].tsx`, registered on the `(client)` root Stack alongside the existing `food-detail` / `recipe-detail` / `training-session` routes. Because it lives on the root Stack (above the tab bar), `router.back()` returns to the originating chat thread by construction — no cross-tab activation, and the discover-tab flow is untouched.
- `onInfoPress` in `messages/[threadId].tsx` now pushes `/(client)/coach-profile/${participant.id}` (guarded on `participant?.id`).
- The screen reuses `ProProfileView` with the shared `['trainer-profile', id]` query cache key; no new i18n copy (reuses `collab.title`).

## Verification
- `npx tsc --noEmit` clean; `expo-doctor` 19/19.
- AC4 (no discover-tab regression) verified by inspection — diff touches only the 3 expected files.
- ACs 1–3 (tap → profile → back-to-chat) are interactive; the iOS dev-client build is now working again, so simulator tap-through verification can be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)