### PR TITLE
fix: surface reminder toggle on Today expanded meal/session cards

### DIFF
--- a/mobile/src/components/nutrition/MealRow.tsx
+++ b/mobile/src/components/nutrition/MealRow.tsx
@@ -14,6 +14,7 @@ import { Radius } from '@/constants/radius'
 import { getMealKindConfig } from '@/constants/mealKinds'
 import { totalMealItems } from '@/lib/nutrition-plan-helpers'
 import { FoodItemRow, RecipeItemRow } from '@/components/nutrition/MealCard'
+import { MealReminderRow } from '@/components/nutrition/MealReminderRow'
 import { NoteBanner } from '@/components/ui/NoteBanner'
 import { ImageLightbox } from '@/components/ui/ImageLightbox'
 import type { PlanMeal } from '@/api/nutrition'
@@ -65,6 +66,20 @@ interface MealRowProps {
    * the lightbox when photos are opened.
    */
   mealNote?: string | null
+  /**
+   * Plan id used to namespace the MMKV reminder key — `meal-<planId>-<mealId>`.
+   * When provided in accordion mode, a `MealReminderRow` is mounted in the
+   * expanded body so the Today screen surfaces the same reminder toggle as the
+   * plan-detail screen. Omit for read-only (plans-page) usage where reminders
+   * are managed on the plan-detail screen directly.
+   */
+  planId?: string
+  /**
+   * Localized day label (e.g. "Pondělí") passed through to MealReminderRow
+   * for the push-notification body. Pass empty string to omit the day part.
+   * Defaults to '' when omitted.
+   */
+  dayLabel?: string
 }
 
 /**
@@ -92,6 +107,8 @@ export const MealRow = React.memo(function MealRow({
   hasPhotos,
   photos,
   mealNote,
+  planId,
+  dayLabel = '',
 }: MealRowProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -343,6 +360,15 @@ export const MealRow = React.memo(function MealRow({
                   mealName={title}
                 />
               ))}
+              {/* Reminder toggle — mounted inside the measured body so its
+                  height is counted toward the accordion expand measurement.
+                  Only rendered in accordion mode when a planId is provided
+                  (Today screen). Reuses the exact same MMKV key as
+                  plan-detail (meal-<planId>-<mealId>) for cross-surface
+                  parity. */}
+              {isExpandable && planId != null ? (
+                <MealReminderRow meal={meal} planId={planId} dayLabel={dayLabel} />
+              ) : null}
             </View>
           </Animated.View>
         </>

--- a/mobile/src/components/nutrition/NutritionCard.tsx
+++ b/mobile/src/components/nutrition/NutritionCard.tsx
@@ -58,6 +58,13 @@ interface NutritionCardProps {
    * overlay caption when the user opens photos for that meal.
    */
   mealNoteByMealId?: Record<string, string | null>
+  /**
+   * Plan id passed through to each MealRow so the reminder toggle in the
+   * expanded accordion body uses the correct MMKV namespace
+   * (`meal-<planId>-<mealId>`). When omitted, the reminder toggle is not
+   * rendered (read-only / plan-overview contexts).
+   */
+  planId?: string
 }
 
 /**
@@ -83,6 +90,7 @@ export function NutritionCard({
   isMarkAllLoading,
   mealPhotosByMealId,
   mealNoteByMealId,
+  planId,
 }: NutritionCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -144,6 +152,7 @@ export function NutritionCard({
             hasPhotos={meal.mealId ? (eatenMealIdsWithPhotos?.has(meal.mealId) ?? false) : false}
             photos={meal.mealId ? (mealPhotosByMealId?.[meal.mealId] ?? []) : []}
             mealNote={meal.mealId ? (mealNoteByMealId?.[meal.mealId] ?? null) : null}
+            planId={planId}
           />
         ))}
       </View>

--- a/mobile/src/components/today/HasTrainerState.tsx
+++ b/mobile/src/components/today/HasTrainerState.tsx
@@ -1372,6 +1372,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               photosBySession={photosBySession}
               loggedSetsBySessionExercise={trainingQuery.data?.loggedSetsBySessionExercise}
               hasModificationsBySession={trainingQuery.data?.hasModificationsBySession}
+              planId={training?.planId ?? undefined}
             />
           </View>
         ) : hasActivePlanButNoTrainingToday ? (
@@ -1453,6 +1454,7 @@ export function HasTrainerState({ topBanner }: HasTrainerStateProps = {}) {
               onPhotoPress={handlePhotoPress}
               onMarkAllEaten={handleMarkAllEaten}
               isMarkAllLoading={markAllEatenMutation.isPending}
+              planId={plan!.planId ?? undefined}
             />
           </View>
         ) : hasActivePlanButNoDayToday ? (

--- a/mobile/src/components/training/TrainingCard.tsx
+++ b/mobile/src/components/training/TrainingCard.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/lib/training-plan-format'
 import { SectionHeader } from '@/components/training/SectionHeader'
 import { SetGrid } from '@/components/training/SetGrid'
+import { SessionReminderRow } from '@/components/training/SessionReminderRow'
 import { getMuscleGroupColor } from '@/constants/muscleGroups'
 import type { TrainingSession, TrainingSection, MuscleGroup, SessionPhotoDto } from '@/api/training'
 import type { LoggedSetDto } from '@/api/wod-types'
@@ -174,6 +175,13 @@ interface TrainingCardProps {
    * ExpandableSessionCard header for that session.
    */
   hasModificationsBySession?: Record<string, boolean>
+  /**
+   * Training plan id passed through to each session card's `bodyFooter` slot
+   * so the `SessionReminderRow` uses the correct MMKV namespace
+   * (`session-<planId>-<sessionId>`). When omitted, the reminder toggle is not
+   * rendered in the expanded session body.
+   */
+  planId?: string
 }
 
 // ─── formatSets ───────────────────────────────────────────────────────────────
@@ -300,6 +308,7 @@ export function TrainingCard({
   photosBySession = {},
   loggedSetsBySessionExercise,
   hasModificationsBySession,
+  planId,
 }: TrainingCardProps) {
   const colors = useTheme()
   const { t } = useTranslation()
@@ -514,6 +523,7 @@ export function TrainingCard({
                   ? (hasModificationsBySession?.[session.sessionId] ?? false)
                   : false
               }
+              planId={planId}
               t={t}
             />
           )
@@ -612,6 +622,12 @@ interface SessionSectionListProps {
    * Passed to ExpandableSessionCard to render the session-level "upraveno" badge.
    */
   sessionHasModifications?: boolean
+  /**
+   * Training plan id forwarded to ExpandableSessionCard's `bodyFooter` so the
+   * SessionReminderRow can namespace its MMKV key correctly. When omitted, no
+   * reminder toggle is rendered in the expanded session body.
+   */
+  planId?: string
   t: (key: string, opts?: Record<string, unknown>) => string
 }
 
@@ -643,6 +659,7 @@ function SessionSectionList({
   sessionPhotos,
   loggedSetsForSession,
   sessionHasModifications,
+  planId,
   t,
 }: SessionSectionListProps) {
   const colors = useTheme()
@@ -671,6 +688,11 @@ function SessionSectionList({
               onPhotoPress={onSessionPhotoPress}
               photos={sessionPhotos}
               hasModifications={sessionHasModifications ?? false}
+              bodyFooter={
+                planId != null
+                  ? <SessionReminderRow session={session} planId={planId} />
+                  : undefined
+              }
             >
               {/* Section-grouped exercise cards */}
               {sections.map((section, sectionIdx) => {


### PR DESCRIPTION
## Summary
- The Today (home) screen's expanded meal/session cards now surface the same reminder toggle as the plan-detail screen, so clients can set reminders without navigating away from their primary daily surface.
- `MealReminderRow` is mounted inside `MealRow`'s measured accordion body (gated on `planId`); `SessionReminderRow` is passed via `ExpandableSessionCard`'s existing `bodyFooter` slot from `TrainingCard`.
- Real `planId` is threaded `HasTrainerState` → `NutritionCard`/`TrainingCard` → the reminder rows.
- Reminder state stays local (MMKV + expo-notifications) under the same namespaced keys as plan-detail (`meal-<planId>-<mealId>` / `session-<planId>-<sessionId>`), so cross-surface parity is guaranteed by shared key. No new i18n — reuses existing reminder keys.

## Related issue
Fixes #466

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS (relayed by orchestrator).

## Test plan
- [ ] On the Today (home) screen, expanding a meal card shows a reminder toggle matching plan-detail.
- [ ] On the Today (home) screen, expanding a training session card shows a reminder toggle matching plan-detail.
- [ ] Toggling a reminder from the Today expanded view has the same effect as toggling it from plan detail (shared MMKV key → same scheduled notification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)