### PR TITLE
fix: standard-workout summary card shows actual edited values

### DIFF
--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -1485,47 +1485,6 @@ interface SectionFinishedExerciseRow {
   loggedSets: LoggedSetDto[]
 }
 
-/**
- * Collapse an exercise's logged sets into a single one-line summary:
- *
- *   "3 × 10 · 50 kg"             — all sets identical
- *   "3 × 8-10 · 50 kg"           — varied reps, same weight
- *   "3 × 10 · 40-50 kg"          — same reps, varied weight (pyramid)
- *   "3 × 8-10 · 40-50 kg"        — both vary
- *   "3 × 10 · BW"                — bodyweight only
- *
- * Returns null when there are no sets with any rep data (purely skipped
- * exercise) so the meta line can be omitted entirely.
- */
-function summarizeExerciseSets(
-  sets: SectionFinishedExerciseRow['sets'],
-  t: (key: string) => string,
-): string | null {
-  // Consider only sets the user actually finished. An exercise with zero
-  // completed sets returns null so the meta line is hidden entirely.
-  const doneSets = sets.filter((s) => s.done)
-  if (doneSets.length === 0) return null
-  const reps = doneSets.map((s) => s.reps).filter((r): r is number => r != null && r > 0)
-  if (reps.length === 0) return null
-  const weights = doneSets.map((s) => s.weightKg ?? 0)
-
-  const setCount = doneSets.length
-  const minR = Math.min(...reps)
-  const maxR = Math.max(...reps)
-  const repsPart =
-    minR === maxR ? `${setCount}×${minR}` : `${setCount}×${minR}-${maxR}`
-
-  const allBW = weights.every((w) => w === 0)
-  if (allBW) return `${repsPart} · ${t('training.live.bw')}`
-
-  // Only consider non-zero weights for the range so a mixed BW/loaded
-  // exercise still reports the loaded range cleanly.
-  const loaded = weights.filter((w) => w > 0)
-  const minW = Math.min(...loaded)
-  const maxW = Math.max(...loaded)
-  const weightPart = minW === maxW ? `${minW} kg` : `${minW}-${maxW} kg`
-  return `${repsPart} · ${weightPart}`
-}
 
 interface SectionFinishedNextWorkout {
   /** Display name of the upcoming workout (section). */
@@ -1762,13 +1721,17 @@ function SectionFinishedScreen({
                 {/* Treatment B: actual headline + "plán X" caption + gold dot
                     when the user edited a value, matching LiveFinishedSummary
                     (#468). SetGrid renders one row per planned set so skipped
-                    sets show '↷' and completed sets show the actual value. */}
-                <SetGrid
-                  sets={ex.plannedSets}
-                  completedSetNumbers={ex.completedSetNumbers}
-                  skippedSetNumbers={ex.skippedSetNumbers}
-                  loggedSets={ex.loggedSets}
-                />
+                    sets show '↷' and completed sets show the actual value.
+                    Guard mirrors finishedWorkoutCards memo: skip the grid
+                    entirely when an exercise has no planned sets. */}
+                {ex.plannedSets.length > 0 && (
+                  <SetGrid
+                    sets={ex.plannedSets}
+                    completedSetNumbers={ex.completedSetNumbers}
+                    skippedSetNumbers={ex.skippedSetNumbers}
+                    loggedSets={ex.loggedSets}
+                  />
+                )}
               </View>
             ))}
           </ScrollView>
@@ -1960,13 +1923,6 @@ const sectionFinishedStyles = StyleSheet.create({
   },
   summaryExerciseName: {
     ...Type.headline,
-  },
-  // One-line "N×reps · weight" meta below the exercise name. Tabular-num so
-  // the row stays vertically aligned across exercises.
-  summaryExerciseMeta: {
-    ...Type.subheadline,
-    fontVariant: ['tabular-nums'],
-    marginTop: 2,
   },
   // Next-workout preview card — rendered in the pinned bottom slot
   // (`pinnedNextCardWrap` in the page-level styles handles the spacing

--- a/mobile/app/(client)/training-session/[id].tsx
+++ b/mobile/app/(client)/training-session/[id].tsx
@@ -1457,9 +1457,9 @@ interface SectionFinishedExerciseRow {
   /**
    * One entry per planned set, carrying its set number, the actual (or
    * planned-fallback) reps + weight, and a `done` flag identifying whether
-   * the user actually completed it. The stats card + per-exercise meta line
-   * only count sets with `done === true` — skipping the workout before
-   * completing anything must report 0/0/0, not the prescribed plan.
+   * the user actually completed it. The stats card only counts sets with
+   * `done === true` — skipping the workout before completing anything must
+   * report 0/0/0, not the prescribed plan.
    */
   sets: {
     setNumber: number
@@ -1467,6 +1467,22 @@ interface SectionFinishedExerciseRow {
     weightKg: number | null
     done: boolean
   }[]
+  /**
+   * Planned sets from the session's exercise prescription.
+   * Passed directly to SetGrid as the `sets` prop so it can render set
+   * numbers, rest times, and the planned-value captions for treatment B.
+   */
+  plannedSets: ExerciseSet[]
+  /** 1-based set numbers that the user actually completed. */
+  completedSetNumbers: number[]
+  /** 1-based set numbers that the user skipped (↷). */
+  skippedSetNumbers: number[]
+  /**
+   * Actual vs. snapshot-planned set data built client-side from formOverrides
+   * (#441/#468). Passed to SetGrid to enable treatment B: actual headline +
+   * "plán X" caption + gold change-dot when the user edited a value.
+   */
+  loggedSets: LoggedSetDto[]
 }
 
 /**
@@ -1726,38 +1742,35 @@ function SectionFinishedScreen({
             contentContainerStyle={sectionFinishedStyles.summaryListContent}
             showsVerticalScrollIndicator
           >
-            {exerciseSummaries.map((ex, exIdx) => {
-              const summary = summarizeExerciseSets(ex.sets, t)
-              return (
-                <View
-                  key={`${exIdx}-${ex.name}`}
-                  style={[
-                    sectionFinishedStyles.summaryExerciseBlock,
-                    exIdx < exerciseSummaries.length - 1 && {
-                      borderBottomWidth: StyleSheet.hairlineWidth,
-                      borderBottomColor: colors.sep2,
-                    },
-                  ]}
+            {exerciseSummaries.map((ex, exIdx) => (
+              <View
+                key={`${exIdx}-${ex.name}`}
+                style={[
+                  sectionFinishedStyles.summaryExerciseBlock,
+                  exIdx < exerciseSummaries.length - 1 && {
+                    borderBottomWidth: StyleSheet.hairlineWidth,
+                    borderBottomColor: colors.sep2,
+                  },
+                ]}
+              >
+                <Text
+                  style={[sectionFinishedStyles.summaryExerciseName, { color: colors.label }]}
+                  numberOfLines={1}
                 >
-                  <Text
-                    style={[sectionFinishedStyles.summaryExerciseName, { color: colors.label }]}
-                    numberOfLines={1}
-                  >
-                    {ex.name}
-                  </Text>
-                  {summary != null && (
-                    <Text
-                      style={[
-                        sectionFinishedStyles.summaryExerciseMeta,
-                        { color: colors.label3 },
-                      ]}
-                    >
-                      {summary}
-                    </Text>
-                  )}
-                </View>
-              )
-            })}
+                  {ex.name}
+                </Text>
+                {/* Treatment B: actual headline + "plán X" caption + gold dot
+                    when the user edited a value, matching LiveFinishedSummary
+                    (#468). SetGrid renders one row per planned set so skipped
+                    sets show '↷' and completed sets show the actual value. */}
+                <SetGrid
+                  sets={ex.plannedSets}
+                  completedSetNumbers={ex.completedSetNumbers}
+                  skippedSetNumbers={ex.skippedSetNumbers}
+                  loggedSets={ex.loggedSets}
+                />
+              </View>
+            ))}
           </ScrollView>
         </View>
       )}
@@ -3783,7 +3796,8 @@ export default function WorkoutLogScreen() {
                       const exId = ex.exerciseExternalId ?? ''
                       const overrides = formOverrides[exId] ?? {}
                       const doneSetIdxs = new Set(completedSets[exId] ?? [])
-                      const sets = (ex.sets ?? []).map((planned, sIdx) => {
+                      const plannedSets = ex.sets ?? []
+                      const sets = plannedSets.map((planned, sIdx) => {
                         const ovr = overrides[sIdx]
                         return {
                           setNumber: planned.setNumber ?? sIdx + 1,
@@ -3796,7 +3810,79 @@ export default function WorkoutLogScreen() {
                           done: doneSetIdxs.has(sIdx),
                         }
                       })
-                      return { name: ex.exerciseName ?? '', sets }
+                      // Build treatment-B fields: actual headline + "plán X"
+                      // caption + gold change-dot when the user edited a value.
+                      // Mirrors the finishedWorkoutCards memo used by
+                      // LiveFinishedSummary (#468).
+                      const doneIndices = completedSets[exId] ?? []
+                      const isExSkipped = skippedExercises.includes(exId)
+                      const skippedIndices = isExSkipped
+                        ? plannedSets.map((_, si) => si)
+                        : (skippedSets[exId] ?? [])
+                      const completedSetNumbers = doneIndices.map(
+                        (si) => plannedSets[si]?.setNumber ?? si + 1,
+                      )
+                      const skippedSetNumbers = skippedIndices.map(
+                        (si) => plannedSets[si]?.setNumber ?? si + 1,
+                      )
+                      const loggedSets: LoggedSetDto[] = plannedSets.map(
+                        (planned, si) => {
+                          const ovr = overrides[si]
+                          const isDone = doneIndices.includes(si)
+                          const actualReps = isDone
+                            ? (ovr?.reps ?? planned.reps ?? null)
+                            : null
+                          const actualWeightKg = isDone
+                            ? (ovr?.weightKg ?? planned.weightKg ?? null)
+                            : null
+                          const actualDurationSeconds = isDone
+                            ? (ovr?.durationSeconds ?? null)
+                            : null
+                          const actualDistanceMeters = isDone
+                            ? (ovr?.distanceMeters ?? null)
+                            : null
+                          const repsModified =
+                            isDone &&
+                            actualReps != null &&
+                            planned.reps != null &&
+                            actualReps !== planned.reps
+                          const weightModified =
+                            isDone &&
+                            actualWeightKg != null &&
+                            planned.weightKg != null &&
+                            actualWeightKg !== planned.weightKg
+                          const durationModified =
+                            isDone &&
+                            actualDurationSeconds != null &&
+                            planned.durationSeconds != null &&
+                            actualDurationSeconds !== planned.durationSeconds
+                          return {
+                            setNumber: planned.setNumber ?? si + 1,
+                            actualReps: actualReps ?? undefined,
+                            actualWeightKg: actualWeightKg ?? undefined,
+                            actualDurationSeconds:
+                              actualDurationSeconds ?? undefined,
+                            actualDistanceMeters:
+                              actualDistanceMeters ?? undefined,
+                            plannedReps: planned.reps ?? undefined,
+                            plannedWeightKg: planned.weightKg ?? undefined,
+                            plannedDurationSeconds:
+                              planned.durationSeconds ?? undefined,
+                            plannedDistanceMeters:
+                              planned.distanceMeters ?? undefined,
+                            isModified:
+                              repsModified || weightModified || durationModified,
+                          }
+                        },
+                      )
+                      return {
+                        name: ex.exerciseName ?? '',
+                        sets,
+                        plannedSets,
+                        completedSetNumbers,
+                        skippedSetNumbers,
+                        loggedSets,
+                      }
                     })
                   })()}
                   sectionFormat={finishedFormat}


### PR DESCRIPTION
## Summary
- The section-finished interstitial card (`SectionFinishedScreen` in `mobile/app/(client)/training-session/[id].tsx`) rendered planned reps/weight via the compact `summarizeExerciseSets` formatter instead of the client's actual edited values.
- Root cause: that interstitial collapsed all sets to one string via `summarizeExerciseSets()` rather than using the `SetGrid` + `loggedSets` treatment-B rendering that `LiveFinishedSummary` already uses.
- Fix: extend `SectionFinishedExerciseRow` with `plannedSets` / `completedSetNumbers` / `skippedSetNumbers` / `loggedSets`; build `loggedSets` from `formOverrides` with the same logic as the `finishedWorkoutCards` memo; replace the `summarizeExerciseSets` line with `<SetGrid .../>`.
- Result: the interstitial now shows actual values + "plán X" captions + gold change-dots, consistent with the session summary. One file changed.

## Related issue
Fixes #468

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS (acceptance criteria verified by qa-tester prior to review).

## Test plan
- [ ] Standard-workout summary card shows the client's actual (edited) weights and reps, consistent with the session summary page.
- [ ] Original planned values appear only as "plán X" reference captions when the client changed them, matching session-summary behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)