### PR TITLE
chore(#474): seed multi-section / shared-exercise workout fixture for planned-vs-actual QA

### DIFF
--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -97,6 +97,41 @@ public static class QaSeedRunner
     /// </summary>
     public static readonly Guid QaMainPlanCompletedWorkoutLogId = new("11111111-1111-1111-4455-000000000001");
 
+    // -------------------------------------------------------------------------
+    // #474 — Multi-section fixture: second client/trainer pair with a session
+    // where the SAME exercise appears in both a Standard section AND an AMRAP
+    // section. Demonstrates section-keyed planned-vs-actual read path (coach-detail).
+    // -------------------------------------------------------------------------
+
+    // Second QA client/trainer pair — separate from the #457/#326 pair so the
+    // two planned-vs-actual scenarios are independently exercisable.
+    public static readonly Guid Client2UserId    = new("55555555-5555-5555-5555-555555555555");
+    public static readonly Guid Trainer2UserId   = new("66666666-6666-6666-6666-666666666666");
+    public static readonly Guid Client2ProfilePublicId  = new("55555555-5555-5555-aaaa-000000000001");
+    public static readonly Guid Trainer2ProfilePublicId = new("66666666-6666-6666-bbbb-000000000001");
+
+    public const string Client2Email  = "qa.client2@fitnessplatform.test";
+    public const string Trainer2Email = "qa.trainer2@fitnessplatform.test";
+
+    // Training plan for the multi-section fixture.
+    public static readonly Guid QaMultiSectionPlanExternalId = new("55555555-5555-5555-dddd-000000000001");
+
+    // Session in the multi-section plan.
+    public static readonly Guid QaMultiSectionSessionId = new("55555555-5555-5555-bbbb-000000000001");
+
+    // Standard section — edited reps/weights logged here.
+    public static readonly Guid MultiSectionStandardSectionId = new("55555555-5555-5555-aaaa-000000000001");
+
+    // AMRAP section — left at planned values (no edits).
+    public static readonly Guid MultiSectionAmrapSectionId = new("55555555-5555-5555-aaaa-000000000002");
+
+    // The SAME exercise appears in BOTH sections to prove section-keyed lookup
+    // returns independent values per section.
+    public static readonly Guid SharedExerciseId = new("55555555-5555-5555-cccc-000000000001");
+
+    // WorkoutLog for the completed multi-section session.
+    public static readonly Guid QaMultiSectionWorkoutLogId = new("55555555-5555-5555-4455-000000000001");
+
     // Section ID within the main-plan completed WorkoutLog (mirrors StandardSectionId).
     public static readonly Guid MainPlanCompletedSectionId = new("11111111-1111-1111-4455-000000000002");
 
@@ -149,6 +184,7 @@ public static class QaSeedRunner
     public const string ClientEmail   = "qa.client@fitnessplatform.test";
     public const string TrainerEmail  = "qa.trainer@fitnessplatform.test";
     public const string NutriEmail    = "qa.nutri@fitnessplatform.test";
+    // #474 second pair — separate accounts so multi-section fixture is independently exercisable.
 
     // Sourced from QA_SEED_PASSWORD via .env.test (gitignored). The harness
     // refuses to seed without it so a missing env file fails fast instead of
@@ -212,6 +248,10 @@ public static class QaSeedRunner
         await EnsureUserAsync(userManager, TrainerUserId, TrainerEmail, "QA",  "Trainer",  UserRole.Trainer,      logger);
         await EnsureUserAsync(userManager, NutriUserId,   NutriEmail,   "QA",  "Nutri",    UserRole.Nutritionist, logger);
 
+        // #474 — second pair for the multi-section fixture.
+        await EnsureUserAsync(userManager, Client2UserId,  Client2Email,  "QA",  "Client2",  UserRole.Client,  logger);
+        await EnsureUserAsync(userManager, Trainer2UserId, Trainer2Email, "QA",  "Trainer2", UserRole.Trainer, logger);
+
         // Profiles — each user requires a role-matching profile row so that
         // trainer endpoints (which look up ProfessionalProfile by UserId) and
         // client endpoints (which look up ClientProfile by UserId) work without
@@ -220,9 +260,17 @@ public static class QaSeedRunner
         var trainerProfile = await EnsureProfessionalProfileAsync(db, TrainerUserId, TrainerProfilePublicId, logger);
         var nutriProfile   = await EnsureProfessionalProfileAsync(db, NutriUserId,   NutriProfilePublicId,   logger);
 
+        // #474 — profiles for the second pair.
+        var client2Profile  = await EnsureClientProfileAsync(db, Client2UserId,  Client2ProfilePublicId,  logger);
+        var trainer2Profile = await EnsureProfessionalProfileAsync(db, Trainer2UserId, Trainer2ProfilePublicId, logger);
+
         // Trainer↔client link — without this the trainer dashboard returns an
         // empty client list and Playwright's getByText('QA Client') never resolves.
         await EnsureTrainerClientLinkAsync(db, trainerProfile, clientProfile, logger);
+
+        // #474 — trainer↔client link for the second pair (done regardless of kind
+        // so minimal mode also has two clean pairs with working auth).
+        await EnsureTrainerClientLinkAsync(db, trainer2Profile, client2Profile, logger);
 
         if (kind == SeedKind.Rich)
         {
@@ -234,6 +282,10 @@ public static class QaSeedRunner
 
             // Past-dated training plan — three sessions in distinct completion states for #326.
             await EnsurePastTrainingPlanAsync(mongo, clientProfile.PublicId, trainerProfile.PublicId, logger);
+
+            // #474 — Multi-section plan + completed WorkoutLog for section-keying coach-detail fixture.
+            await EnsureMultiSectionTrainingPlanAsync(mongo, client2Profile.PublicId, Trainer2UserId, logger);
+            await EnsureMultiSectionWorkoutLogAsync(mongo, logger);
 
             // Foods + Recipes + NutritionPlan.
             // NutriUserId (not nutriProfile.PublicId) — ownership guards in UploadFoodImageUrlEndpoint
@@ -253,8 +305,9 @@ public static class QaSeedRunner
             logger.LogInformation("QA seed kind=minimal — skipping training plan, foods, recipes, nutrition plan, and blobs.");
         }
 
-        logger.LogInformation("QA seed complete (kind={Kind}) — client={Client} trainer={Trainer} nutri={Nutri}",
-            kind, ClientEmail, TrainerEmail, NutriEmail);
+        logger.LogInformation(
+            "QA seed complete (kind={Kind}) — client={Client} trainer={Trainer} nutri={Nutri} client2={Client2} trainer2={Trainer2}",
+            kind, ClientEmail, TrainerEmail, NutriEmail, Client2Email, Trainer2Email);
     }
 
     private static async Task EnsureUserAsync(
@@ -1062,6 +1115,266 @@ public static class QaSeedRunner
             "completed={CompletedId} skipped={SkippedId} untouched={UntouchedId}",
             QaPastTrainingPlanExternalId, startDate,
             QaPastSessionCompletedId, QaPastSessionSkippedId, QaPastSessionUntouchedId);
+    }
+
+    /// <summary>
+    /// Seeds a training plan for the second QA client/trainer pair (#474).
+    ///
+    /// The plan has one Published week with one session.  That session contains
+    /// two sections that BOTH reference the same shared exercise
+    /// (<see cref="SharedExerciseId"/> = "QA Kettlebell Swing"):
+    ///
+    ///   Section 1 — Standard (null format) + 1 prescribed set for QA Kettlebell Swing.
+    ///   Section 2 — AMRAP 10 min + 1 prescribed set for QA Kettlebell Swing.
+    ///
+    /// This shape lets the coach-detail "planned-vs-actual" read path verify that
+    /// it correctly keys actual values by (SectionId, ExerciseExternalId) rather
+    /// than by ExerciseExternalId alone — a different section should return different
+    /// values even when the exercise is the same object.
+    ///
+    /// TrainerId = Trainer2UserId (ApplicationUser.Id) — same rule as all other plans.
+    /// ClientId  = client2ProfilePublicId (ClientProfile.PublicId) — same rule as all other plans.
+    /// </summary>
+    private static async Task EnsureMultiSectionTrainingPlanAsync(
+        IMongoContext mongo,
+        Guid client2ProfilePublicId,
+        Guid trainer2UserId,
+        ILogger logger)
+    {
+        var existing = await mongo.TrainingPlans
+            .Find(p => p.ExternalId == QaMultiSectionPlanExternalId)
+            .FirstOrDefaultAsync();
+
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "QA MultiSection TrainingPlan already present: externalId={ExternalId}", QaMultiSectionPlanExternalId);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+
+        var plan = new TrainingPlan
+        {
+            ExternalId    = QaMultiSectionPlanExternalId,
+            ClientId      = client2ProfilePublicId,
+            TrainerId     = trainer2UserId,
+            Name          = "QA Multi-Section Plan — shared-exercise section-keying fixture",
+            Status        = TrainingPlanStatus.Active,
+            DateCreated   = now,
+            DatePublished = now,
+            Version       = 1,
+            Weeks =
+            [
+                new TrainingWeek
+                {
+                    WeekNumber    = 1,
+                    Status        = WeekStatus.Published,
+                    DatePublished = now,
+                    Sessions =
+                    [
+                        new TrainingSession
+                        {
+                            SessionId = QaMultiSectionSessionId,
+                            DayOfWeek = 2, // Tuesday
+                            Name      = "QA Multi-Section Session",
+                            Order     = 1,
+                            Sections  =
+                            [
+                                // Section 1 — Standard: prescribed set for QA Kettlebell Swing.
+                                new TrainingSection
+                                {
+                                    SectionId    = MultiSectionStandardSectionId,
+                                    Order        = 0,
+                                    Name         = "Standard work",
+                                    Format       = null,
+                                    FormatConfig = null,
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = SharedExerciseId,
+                                            ExerciseName       = "QA Kettlebell Swing",
+                                            Order              = 1,
+                                            MovementType       = MovementType.Reps,
+                                            // Prescribed: 3 sets × 15 reps @ 24 kg.
+                                            Sets =
+                                            [
+                                                new ExerciseSet { SetNumber = 1, Type = SetType.Normal, Reps = 15, WeightKg = 24m },
+                                                new ExerciseSet { SetNumber = 2, Type = SetType.Normal, Reps = 15, WeightKg = 24m },
+                                                new ExerciseSet { SetNumber = 3, Type = SetType.Normal, Reps = 15, WeightKg = 24m },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                // Section 2 — AMRAP 10 min: same exercise but AMRAP context.
+                                // No prescribed sets (AMRAP format — reps accumulate per round).
+                                new TrainingSection
+                                {
+                                    SectionId    = MultiSectionAmrapSectionId,
+                                    Order        = 1,
+                                    Name         = "AMRAP 10 min",
+                                    Format       = WorkoutFormat.AMRAP,
+                                    FormatConfig = new WodConfig { TimeCapSeconds = 600 },
+                                    Exercises =
+                                    [
+                                        new SessionExercise
+                                        {
+                                            ExerciseExternalId = SharedExerciseId,
+                                            ExerciseName       = "QA Kettlebell Swing",
+                                            Order              = 1,
+                                            MovementType       = MovementType.Reps,
+                                            // AMRAP: no prescribed sets — client accumulates rounds.
+                                            Sets = [],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        await mongo.TrainingPlans.InsertOneAsync(plan);
+
+        logger.LogInformation(
+            "QA MultiSection TrainingPlan created: externalId={ExternalId} clientId={ClientId}",
+            QaMultiSectionPlanExternalId, client2ProfilePublicId);
+    }
+
+    /// <summary>
+    /// Seeds a completed WorkoutLog for the multi-section session (#474).
+    ///
+    /// Standard section — QA Kettlebell Swing with EDITED values (actual != planned):
+    ///   Set 1: actual Reps=12, WeightKg=28, planned Reps=15, WeightKg=24  → IsModified=true ("upraveno").
+    ///   Set 2: actual Reps=15, WeightKg=24, planned Reps=15, WeightKg=24  → IsModified=false (as-prescribed).
+    ///   Set 3: actual Reps=10, WeightKg=28, planned Reps=15, WeightKg=24  → IsModified=true ("upraveno").
+    ///
+    /// AMRAP section — QA Kettlebell Swing logged at planned values only (no modifications):
+    ///   Set 1: actual Reps=15, WeightKg=24, no planned snapshot           → no "upraveno".
+    ///
+    /// This data lets the coach-detail demonstrate:
+    ///   - Standard section: Set 1 and Set 3 show "upraveno"; Set 2 shows plain actual.
+    ///   - AMRAP section: shows only the AMRAP count with no "upraveno" badge.
+    ///
+    /// SectionId is set on each logged section so the section-keying read path works (#472).
+    /// </summary>
+    private static async Task EnsureMultiSectionWorkoutLogAsync(
+        IMongoContext mongo,
+        ILogger logger)
+    {
+        var existing = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaMultiSectionWorkoutLogId)
+            .FirstOrDefaultAsync();
+
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "QA MultiSection WorkoutLog already present: externalId={ExternalId}", QaMultiSectionWorkoutLogId);
+            return;
+        }
+
+        var completedAt = DateTime.UtcNow.Date.AddDays(-1).AddHours(14); // 14:00 UTC, yesterday.
+        var log = new WorkoutLog
+        {
+            ExternalId    = QaMultiSectionWorkoutLogId,
+            // ClientId = ApplicationUser.Id — same contract as all other WorkoutLogs.
+            ClientId      = Client2UserId,
+            PlanId        = QaMultiSectionPlanExternalId,
+            SessionId     = QaMultiSectionSessionId,
+            StartedAt     = completedAt.AddMinutes(-40),
+            CompletedAt   = completedAt,
+            CompletedDate = WorkoutLog.ToCompletionDateUtc(completedAt),
+            IsCompleted   = true,
+            DateCreated   = completedAt.AddMinutes(-40),
+            DateUpdated   = completedAt,
+            Sections =
+            [
+                // Standard section — edited reps/weights on Set 1 + Set 3; Set 2 as-prescribed.
+                new WorkoutSection
+                {
+                    SectionId = MultiSectionStandardSectionId,
+                    Order     = 0, // mirrors Standard section Order=0 in the plan
+                    Name      = "Standard work",
+                    Format    = null,
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = SharedExerciseId,
+                            ExerciseName       = "QA Kettlebell Swing",
+                            Sets =
+                            [
+                                // MODIFIED — client used heavier KB for fewer reps.
+                                new WorkoutSet
+                                {
+                                    SetNumber       = 1,
+                                    Reps            = 12,
+                                    WeightKg        = 28m,
+                                    PlannedReps     = 15,
+                                    PlannedWeightKg = 24m,
+                                    CompletedAt     = completedAt.AddMinutes(-30),
+                                },
+                                // AS-PRESCRIBED — exactly as planned.
+                                new WorkoutSet
+                                {
+                                    SetNumber       = 2,
+                                    Reps            = 15,
+                                    WeightKg        = 24m,
+                                    PlannedReps     = 15,
+                                    PlannedWeightKg = 24m,
+                                    CompletedAt     = completedAt.AddMinutes(-20),
+                                },
+                                // MODIFIED — client again used heavier KB for fewer reps.
+                                new WorkoutSet
+                                {
+                                    SetNumber       = 3,
+                                    Reps            = 10,
+                                    WeightKg        = 28m,
+                                    PlannedReps     = 15,
+                                    PlannedWeightKg = 24m,
+                                    CompletedAt     = completedAt.AddMinutes(-10),
+                                },
+                            ],
+                        },
+                    ],
+                },
+                // AMRAP section — same exercise, logged at face value (no edits).
+                // No planned snapshot because AMRAP sections don't carry prescribed sets.
+                new WorkoutSection
+                {
+                    SectionId = MultiSectionAmrapSectionId,
+                    Order     = 1, // mirrors AMRAP section Order=1 in the plan
+                    Name      = "AMRAP 10 min",
+                    Format    = WorkoutFormat.AMRAP,
+                    Exercises =
+                    [
+                        new WorkoutExercise
+                        {
+                            ExerciseExternalId = SharedExerciseId,
+                            ExerciseName       = "QA Kettlebell Swing",
+                            Sets =
+                            [
+                                // No planned snapshot — AMRAP accumulates rounds, not prescribed sets.
+                                new WorkoutSet
+                                {
+                                    SetNumber   = 1,
+                                    Reps        = 15,
+                                    WeightKg    = 24m,
+                                    CompletedAt = completedAt.AddMinutes(-5),
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        await mongo.WorkoutLogs.InsertOneAsync(log);
+        logger.LogInformation(
+            "QA MultiSection WorkoutLog created: externalId={ExternalId} planId={PlanId} sessionId={SessionId}",
+            QaMultiSectionWorkoutLogId, QaMultiSectionPlanExternalId, QaMultiSectionSessionId);
     }
 
     private static async Task EnsureFoodsAsync(

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -296,8 +296,11 @@ public class QaSeedRunnerTests : IAsyncLifetime
             .Should().Be(1);
         (await db.Users.CountAsync(u => u.Email == QaSeedRunner.NutriEmail, ct))
             .Should().Be(1);
+        // Both trainer↔client links are seeded outside the Rich guard (so both
+        // pairs are available for auth in any seed mode). Minimal mode creates
+        // both links but no plans/foods/blobs.
         (await db.ClientProfessionalLinks.CountAsync(ct))
-            .Should().Be(1, "trainer↔client link is part of the minimal fixture");
+            .Should().Be(2, "both trainer↔client links are part of the minimal fixture (#474 adds a second pair)");
 
         // Rich fixtures must be absent.
         (await mongo.TrainingPlans.CountDocumentsAsync(
@@ -308,6 +311,10 @@ public class QaSeedRunnerTests : IAsyncLifetime
             Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaPastTrainingPlanExternalId),
             cancellationToken: ct))
             .Should().Be(0, "minimal seed skips the past training plan (#326)");
+        (await mongo.TrainingPlans.CountDocumentsAsync(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaMultiSectionPlanExternalId),
+            cancellationToken: ct))
+            .Should().Be(0, "minimal seed skips the multi-section training plan (#474)");
         (await mongo.WorkoutLogs.CountDocumentsAsync(
             Builders<WorkoutLog>.Filter.Empty,
             cancellationToken: ct))
@@ -685,5 +692,136 @@ public class QaSeedRunnerTests : IAsyncLifetime
             cancellationToken: ct);
 
         count.Should().Be(1, "main-plan WorkoutLog must not be duplicated on re-seed");
+    }
+
+    /// <summary>
+    /// The multi-section fixture (#474) must seed:
+    ///  - A TrainingPlan for the second QA client/trainer pair with one session
+    ///    whose two sections BOTH reference the same shared exercise (SharedExerciseId).
+    ///  - A completed WorkoutLog with SectionId set on both sections so the
+    ///    section-keying read path works. The Standard section contains edited
+    ///    values (Set 1 and Set 3: IsModified=true). The AMRAP section contains
+    ///    a plain logged set with no planned snapshot (IsModified=false).
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_MultiSectionFixture_HasSharedExerciseInBothSectionsWithCorrectValues()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        // Plan must exist and be owned by the second pair.
+        var plan = await mongo.TrainingPlans
+            .Find(p => p.ExternalId == QaSeedRunner.QaMultiSectionPlanExternalId)
+            .FirstOrDefaultAsync(ct);
+
+        plan.Should().NotBeNull("multi-section training plan must be seeded");
+        plan!.TrainerId.Should().Be(QaSeedRunner.Trainer2UserId,
+            "TrainingPlan.TrainerId must be Trainer2UserId (ApplicationUser.Id)");
+        plan.ClientId.Should().Be(QaSeedRunner.Client2ProfilePublicId,
+            "TrainingPlan.ClientId must be Client2ProfilePublicId (ClientProfile.PublicId)");
+
+        var session = plan.Weeks[0].Sessions.Single(s => s.SessionId == QaSeedRunner.QaMultiSectionSessionId);
+        session.Sections.Should().HaveCount(2, "session has Standard + AMRAP sections");
+
+        var standardSection = session.Sections.Single(s => s.SectionId == QaSeedRunner.MultiSectionStandardSectionId);
+        standardSection.Format.Should().BeNull("Standard section has null format");
+        standardSection.Exercises.Should().HaveCount(1);
+        standardSection.Exercises[0].ExerciseExternalId.Should().Be(QaSeedRunner.SharedExerciseId);
+        standardSection.Exercises[0].Sets.Should().HaveCount(3, "Standard section has 3 prescribed sets");
+
+        var amrapSection = session.Sections.Single(s => s.SectionId == QaSeedRunner.MultiSectionAmrapSectionId);
+        amrapSection.Format.Should().Be(FitnessPlatform.Application.Domain.Enums.WorkoutFormat.AMRAP);
+        amrapSection.Exercises.Should().HaveCount(1);
+        amrapSection.Exercises[0].ExerciseExternalId.Should().Be(QaSeedRunner.SharedExerciseId,
+            "AMRAP section references the SAME exercise as the Standard section");
+        amrapSection.Exercises[0].Sets.Should().BeEmpty("AMRAP section carries no prescribed sets");
+
+        // WorkoutLog must exist with SectionId populated on both sections.
+        var log = await mongo.WorkoutLogs
+            .Find(l => l.ExternalId == QaSeedRunner.QaMultiSectionWorkoutLogId)
+            .FirstOrDefaultAsync(ct);
+
+        log.Should().NotBeNull("multi-section WorkoutLog must be seeded");
+        log!.IsCompleted.Should().BeTrue("log is marked complete");
+        log.PlanId.Should().Be(QaSeedRunner.QaMultiSectionPlanExternalId);
+        log.SessionId.Should().Be(QaSeedRunner.QaMultiSectionSessionId);
+        log.ClientId.Should().Be(QaSeedRunner.Client2UserId,
+            "WorkoutLog.ClientId must be ApplicationUser.Id (Client2UserId)");
+        log.CompletedDate.Should().NotBeNull("CompletedDate is required for the partial unique index");
+        log.Sections.Should().HaveCount(2, "log captures both Standard and AMRAP sections");
+
+        // Standard section in the log — SectionId must match the plan section.
+        var logStandard = log.Sections.Single(s => s.SectionId == QaSeedRunner.MultiSectionStandardSectionId);
+        logStandard.Exercises.Should().HaveCount(1);
+        var logStandardExercise = logStandard.Exercises[0];
+        logStandardExercise.ExerciseExternalId.Should().Be(QaSeedRunner.SharedExerciseId);
+        logStandardExercise.Sets.Should().HaveCount(3);
+
+        // Set 1: MODIFIED (actual Reps=12 != planned 15, actual WeightKg=28 != planned 24).
+        var set1 = logStandardExercise.Sets.Single(s => s.SetNumber == 1);
+        set1.Reps.Should().Be(12);
+        set1.WeightKg.Should().Be(28m);
+        set1.PlannedReps.Should().Be(15);
+        set1.PlannedWeightKg.Should().Be(24m);
+        set1.IsModified.Should().BeTrue("Set 1 actual != planned → MODIFIED (shows 'upraveno' on coach-detail)");
+
+        // Set 2: AS-PRESCRIBED (actual matches planned).
+        var set2 = logStandardExercise.Sets.Single(s => s.SetNumber == 2);
+        set2.Reps.Should().Be(15);
+        set2.WeightKg.Should().Be(24m);
+        set2.PlannedReps.Should().Be(15);
+        set2.PlannedWeightKg.Should().Be(24m);
+        set2.IsModified.Should().BeFalse("Set 2 actual == planned → AS-PRESCRIBED (no 'upraveno' badge)");
+
+        // Set 3: MODIFIED.
+        var set3 = logStandardExercise.Sets.Single(s => s.SetNumber == 3);
+        set3.Reps.Should().Be(10);
+        set3.WeightKg.Should().Be(28m);
+        set3.IsModified.Should().BeTrue("Set 3 actual != planned → MODIFIED");
+
+        // AMRAP section in the log — SectionId must match the plan AMRAP section.
+        var logAmrap = log.Sections.Single(s => s.SectionId == QaSeedRunner.MultiSectionAmrapSectionId);
+        logAmrap.Format.Should().Be(FitnessPlatform.Application.Domain.Enums.WorkoutFormat.AMRAP);
+        logAmrap.Exercises.Should().HaveCount(1);
+        var logAmrapExercise = logAmrap.Exercises[0];
+        logAmrapExercise.ExerciseExternalId.Should().Be(QaSeedRunner.SharedExerciseId,
+            "AMRAP section references the SAME exercise but is keyed by a different SectionId");
+        logAmrapExercise.Sets.Should().HaveCount(1);
+
+        var amrapSet = logAmrapExercise.Sets[0];
+        amrapSet.Reps.Should().Be(15);
+        amrapSet.WeightKg.Should().Be(24m);
+        amrapSet.PlannedReps.Should().BeNull("AMRAP set has no planned snapshot");
+        amrapSet.PlannedWeightKg.Should().BeNull("AMRAP set has no planned snapshot");
+        amrapSet.IsModified.Should().BeFalse("AMRAP set without planned snapshot → IsModified=false (no 'upraveno')");
+    }
+
+    /// <summary>
+    /// Seeding twice must not create duplicate multi-section plan or WorkoutLog documents.
+    /// </summary>
+    [Fact]
+    public async Task SeedAsync_MultiSectionFixture_IsIdempotent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await QaSeedRunner.SeedAsync(_factory.Services);
+        await QaSeedRunner.SeedAsync(_factory.Services);
+
+        using var scope = _factory.Services.CreateScope();
+        var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+
+        var planCount = await mongo.TrainingPlans.CountDocumentsAsync(
+            Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, QaSeedRunner.QaMultiSectionPlanExternalId),
+            cancellationToken: ct);
+        planCount.Should().Be(1, "multi-section plan must not be duplicated on re-seed");
+
+        var logCount = await mongo.WorkoutLogs.CountDocumentsAsync(
+            Builders<WorkoutLog>.Filter.Eq(l => l.ExternalId, QaSeedRunner.QaMultiSectionWorkoutLogId),
+            cancellationToken: ct);
+        logCount.Should().Be(1, "multi-section WorkoutLog must not be duplicated on re-seed");
     }
 }

--- a/docs/testing/e2e-fixtures.md
+++ b/docs/testing/e2e-fixtures.md
@@ -52,6 +52,10 @@ docker ps --format '{{.Names}}'
 | Client       | `qa.client@fitnessplatform.test` | `11111111-1111-1111-1111-111111111111`    |
 | Trainer      | `qa.trainer@fitnessplatform.test`| `22222222-2222-2222-2222-222222222222`    |
 | Nutritionist | `qa.nutri@fitnessplatform.test`  | `33333333-3333-3333-3333-333333333333`    |
+| Client 2     | `qa.client2@fitnessplatform.test`| `55555555-5555-5555-5555-555555555555`    |
+| Trainer 2    | `qa.trainer2@fitnessplatform.test`| `66666666-6666-6666-6666-666666666666`   |
+
+The second pair (`Client 2` / `Trainer 2`) is dedicated to the multi-section shared-exercise fixture (#474). They share the same password as the other accounts (`QA_SEED_PASSWORD` from `.env.test`).
 
 All three accounts share the password held in `QA_SEED_PASSWORD` in your local `.env.test` (gitignored). Copy `.env.test.example` to `.env.test` and fill `JWT_SECRET` (≥32 chars) and `QA_SEED_PASSWORD` before the first `npm run e2e:up`. The seed runner refuses to start if `QA_SEED_PASSWORD` is unset, so a missing env file fails fast instead of creating users with a default password.
 
@@ -251,6 +255,86 @@ NutritionPlan (ExternalId = dddddddd-eeee-ffff-0000-111111111111)
 | `QaFoodImageBlobKey`  | `foods/qa-food-1.png`                | 1×1 pixel PNG    |
 
 Both blobs are loaded from embedded resources (`Seed/Assets/qa-avatar.png` and `qa-food.png`) and uploaded to MinIO via `IBlobStorageService.UploadAsync` during seed. Upload is idempotent: `ObjectExistsAsync` is checked first; existing blobs are left in place.
+
+## Seeded multi-section fixture — shared exercise across Standard + AMRAP (#474)
+
+A third training plan is seeded for the **second** QA client/trainer pair. Its purpose is to let the web coach-detail screen demonstrate section-keyed planned-vs-actual values for a session where the same exercise appears in two different section types.
+
+### Ownership
+
+- Client: `qa.client2@fitnessplatform.test` (`Client2UserId = 55555555-5555-5555-5555-555555555555`)
+- Trainer: `qa.trainer2@fitnessplatform.test` (`Trainer2UserId = 66666666-6666-6666-6666-666666666666`)
+- `TrainingPlan.TrainerId` = `Trainer2UserId` (ApplicationUser.Id — same rule as all other plans)
+- `TrainingPlan.ClientId` = `Client2ProfilePublicId = 55555555-5555-5555-aaaa-000000000001` (ClientProfile.PublicId — same rule as all other plans)
+
+### Stable GUIDs
+
+| Constant | Value | What it maps to |
+|---|---|---|
+| `QaMultiSectionPlanExternalId` | `55555555-5555-5555-dddd-000000000001` | Plan `ExternalId` |
+| `QaMultiSectionSessionId` | `55555555-5555-5555-bbbb-000000000001` | Session in Week 1, DayOfWeek=2 (Tuesday) |
+| `MultiSectionStandardSectionId` | `55555555-5555-5555-aaaa-000000000001` | Standard section SectionId |
+| `MultiSectionAmrapSectionId` | `55555555-5555-5555-aaaa-000000000002` | AMRAP section SectionId |
+| `SharedExerciseId` | `55555555-5555-5555-cccc-000000000001` | "QA Kettlebell Swing" (appears in BOTH sections) |
+| `QaMultiSectionWorkoutLogId` | `55555555-5555-5555-4455-000000000001` | Completed WorkoutLog for this session |
+
+### Plan shape
+
+```
+TrainingPlan (ExternalId = 55555555-5555-5555-dddd-000000000001)
+  Status: Active
+  Weeks:
+    Week 1 (Status = Published)
+      Session "QA Multi-Section Session" (DayOfWeek = 2 = Tuesday)
+        Section 1 "Standard work" (Standard, SectionId = 55555555-5555-5555-aaaa-000000000001)
+          [QA Kettlebell Swing — 3 prescribed sets × 15 reps @ 24 kg]
+        Section 2 "AMRAP 10 min" (AMRAP 600s, SectionId = 55555555-5555-5555-aaaa-000000000002)
+          [QA Kettlebell Swing — no prescribed sets (AMRAP accumulates rounds)]
+```
+
+### WorkoutLog shape
+
+```
+WorkoutLog (ExternalId = 55555555-5555-5555-4455-000000000001)
+  IsCompleted: true
+  ClientId: 55555555-5555-5555-5555-555555555555  (Client2UserId — ApplicationUser.Id)
+
+  Section "Standard work" (SectionId = 55555555-5555-5555-aaaa-000000000001)
+    QA Kettlebell Swing:
+      Set 1 — MODIFIED:      actual Reps=12 WeightKg=28 | planned Reps=15 WeightKg=24 → IsModified=true  → shows "upraveno"
+      Set 2 — AS-PRESCRIBED: actual Reps=15 WeightKg=24 | planned Reps=15 WeightKg=24 → IsModified=false → no badge
+      Set 3 — MODIFIED:      actual Reps=10 WeightKg=28 | planned Reps=15 WeightKg=24 → IsModified=true  → shows "upraveno"
+
+  Section "AMRAP 10 min" (SectionId = 55555555-5555-5555-aaaa-000000000002)
+    QA Kettlebell Swing:
+      Set 1 — no planned snapshot: actual Reps=15 WeightKg=24 | planned=null → IsModified=false → no "upraveno"
+```
+
+### What to verify on the coach-detail screen
+
+Log in as `qa.trainer2@fitnessplatform.test` and navigate to the client's workout log for this session. On the coach-detail planned-vs-actual view:
+
+- **Standard section**: Set 1 and Set 3 for "QA Kettlebell Swing" must show the "upraveno" indicator and display the actual values (`12 reps / 28 kg` and `10 reps / 28 kg`). Set 2 shows `15 reps / 24 kg` without an "upraveno" indicator.
+- **AMRAP section**: "QA Kettlebell Swing" shows `15 reps / 24 kg` with no "upraveno" indicator, even though the same exercise ID was edited in the Standard section — because section keying means each section is independent.
+
+### Curl recipe — fetch as Trainer 2
+
+```bash
+# Resolve the api URL for the current branch's stack
+API_URL=$(scripts/test-env ports | jq -r '.api_url')
+
+# Log in as qa.trainer2 and capture the access token
+ACCESS=$(curl -sk -X POST "$API_URL/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"qa.trainer2@fitnessplatform.test","password":"<QA_SEED_PASSWORD>"}' \
+  | jq -r '.accessToken')
+
+# Fetch the multi-section plan
+curl -sk -H "Authorization: Bearer $ACCESS" \
+  "$API_URL/training/plans/55555555-5555-5555-dddd-000000000001" | jq '.'
+```
+
+---
 
 ## CI
 


### PR DESCRIPTION
Closes #474

## What
Extends `QaSeedRunner` with a deterministic fixture that exercises the `(SectionId, ExerciseExternalId)` section-keying logic landed in #472 — the missing data the interactive coach-detail QA for #469/#470 was blocked on.

## Fixture (separate client/trainer pair, isolated from the #457/#326 pair)
- **Client 2** `qa.client2@fitnessplatform.test`, **Trainer 2** `qa.trainer2@fitnessplatform.test` (shared `QA_SEED_PASSWORD`).
- New plan + Tuesday session with the **same exercise** (QA Kettlebell Swing) in **two sections**: a Standard section (3 prescribed sets) and an AMRAP section (no prescribed sets).
- Completed multi-section `WorkoutLog`, `SectionId` set per logged section:
  - Standard: sets 1 & 3 edited (12 reps / 28 kg vs planned 15 / 24) → `IsModified=true` → "upraveno" on those sets; set 2 as-prescribed.
  - AMRAP: planned-only, no snapshot → `IsModified=false` → **no** "upraveno" even though the shared exercise was edited in the Standard section. This is the cross-section isolation #470 fixed.

## Verification
- `dotnet build` clean. `QaSeedRunnerTests` **12/12** (10 pre-existing + 2 new; minimal-kind assertion updated for the 2nd client/trainer link + the new plan's absence in minimal mode).
- `docs/testing/e2e-fixtures.md` updated to document the new pair, session date, and what to look for on the coach-detail screen.

## Notes
- Depends on #472 (merged — section-keying logic must be in the harness image), per the issue.
- `QaSeedRunner` uses idempotent guarded `InsertOneAsync` — additive deterministic seed, not a Mongo data-mutation script (not on the merge-exclusion list, per design review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)