### PR TITLE
feat: client on-track verdict endpoint

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ClientDashboardConstants.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ClientDashboardConstants.cs
@@ -32,4 +32,9 @@ public static class ClientDashboardConstants
     /// Weight change (kg) below which movement is considered Stable.
     /// </summary>
     public const decimal WeightStableBandKg = 0.5m;
+
+    /// <summary>
+    /// Number of days in the rolling window used to compute nutrition compliance.
+    /// </summary>
+    public const int ComplianceWindowDays = 30;
 }

--- a/backend/FitnessPlatform.Application/Domain/Constants/ClientDashboardConstants.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ClientDashboardConstants.cs
@@ -1,0 +1,35 @@
+namespace FitnessPlatform.Application.Domain.Constants;
+
+/// <summary>
+/// Named constants for client dashboard / verdict calculations.
+/// Centralised here so thresholds are documented and testable in isolation.
+/// </summary>
+public static class ClientDashboardConstants
+{
+    /// <summary>
+    /// Number of days without any activity (workout log, meal log, or measurement)
+    /// that causes the inactivity signal to fire and the verdict to become OffTrack.
+    /// </summary>
+    public const int InactivityThresholdDays = 14;
+
+    /// <summary>
+    /// Compliance percentage at or above which the nutrition signal is considered "on track".
+    /// </summary>
+    public const decimal ComplianceOnTrackThreshold = 85m;
+
+    /// <summary>
+    /// Compliance percentage above which the signal is "needs attention" (60-84%).
+    /// Below this threshold it becomes OffTrack.
+    /// </summary>
+    public const decimal ComplianceNeedsAttentionThreshold = 60m;
+
+    /// <summary>
+    /// Weight delta (kg) above which the Away direction triggers OffTrack.
+    /// </summary>
+    public const decimal WeightOffTrackDeltaKg = 1m;
+
+    /// <summary>
+    /// Weight change (kg) below which movement is considered Stable.
+    /// </summary>
+    public const decimal WeightStableBandKg = 0.5m;
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/ClientVerdict.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/ClientVerdict.cs
@@ -1,0 +1,23 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Represents the on-track verdict for a client as assessed by the trainer dashboard.
+/// </summary>
+public enum ClientVerdict
+{
+    /// <summary>
+    /// All active signals are within target thresholds.
+    /// </summary>
+    OnTrack,
+
+    /// <summary>
+    /// Exactly one active signal is off target.
+    /// </summary>
+    NeedsAttention,
+
+    /// <summary>
+    /// At least one critical threshold is breached: compliance below 60%,
+    /// inactivity for more than N days, or weight moving Away by more than 1 kg.
+    /// </summary>
+    OffTrack
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/WeightDirection.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/WeightDirection.cs
@@ -1,0 +1,22 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Indicates the direction a client's weight is moving relative to their target.
+/// </summary>
+public enum WeightDirection
+{
+    /// <summary>
+    /// Weight is moving toward the client's target weight.
+    /// </summary>
+    Towards,
+
+    /// <summary>
+    /// Weight is moving away from the client's target weight.
+    /// </summary>
+    Away,
+
+    /// <summary>
+    /// Weight change is negligible (within ±0.5 kg) or no target/measurements available.
+    /// </summary>
+    Stable
+}

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IClientVerdictService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IClientVerdictService.cs
@@ -1,0 +1,84 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Interfaces;
+
+/// <summary>
+/// Computes the on-track verdict and supporting signals for a single client.
+/// </summary>
+public interface IClientVerdictService
+{
+    /// <summary>
+    /// Calculates the verdict and all dashboard signals for the given client.
+    /// </summary>
+    /// <param name="clientUserId">
+    /// The client's <c>ApplicationUser.Id</c> (Guid) — used for MongoDB queries
+    /// (WorkoutLog, MealLog, NutritionPlan, TrainingPlan).
+    /// </param>
+    /// <param name="clientProfileId">
+    /// The client's <c>ClientProfile.Id</c> (long) — used for PostgreSQL queries
+    /// (BodyMeasurement is keyed on ClientProfileId).
+    /// </param>
+    /// <param name="clientPublicId">
+    /// The client's <c>ApplicationUser.PublicId</c> (Guid) — used for
+    /// PersonalRecord queries (PersonalRecord.ClientId == ApplicationUser.PublicId).
+    /// </param>
+    /// <param name="targetWeightKg">
+    /// The client's target weight in kg from onboarding, or null if not set.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="ClientVerdictResult"/> with all computed signals.</returns>
+    Task<ClientVerdictResult> ComputeAsync(
+        Guid clientUserId,
+        long clientProfileId,
+        Guid clientPublicId,
+        decimal? targetWeightKg,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Computed signals and verdict for a single client.
+/// </summary>
+public class ClientVerdictResult
+{
+    /// <summary>Overall on-track verdict.</summary>
+    public ClientVerdict Verdict { get; set; }
+
+    /// <summary>
+    /// Nutrition plan compliance percent (0-100), or null when no active nutrition plan exists.
+    /// Uses NutritionCompliancePercent only — never the combined CompliancePercent which collapses
+    /// to 0 when no plan is active.
+    /// </summary>
+    public decimal? CompliancePercent { get; set; }
+
+    /// <summary>
+    /// Delta between the client's current weight and their target weight, in kg.
+    /// Null when no measurements exist or no target weight is set.
+    /// </summary>
+    public decimal? WeightDeltaToGoal { get; set; }
+
+    /// <summary>Weight direction relative to the target.</summary>
+    public WeightDirection WeightDirection { get; set; } = WeightDirection.Stable;
+
+    /// <summary>
+    /// Number of distinct workout log sessions completed in the current ISO week
+    /// (Monday–Sunday). Null when no active training plan exists.
+    /// </summary>
+    public int? TrainingFrequencyActual { get; set; }
+
+    /// <summary>
+    /// Number of sessions prescribed per week in the active training plan's current
+    /// published week. Null when no active training plan exists.
+    /// </summary>
+    public int? TrainingFrequencyPrescribed { get; set; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent activity (workout log, meal log, or measurement).
+    /// Null when no activity exists.
+    /// </summary>
+    public DateTime? LastActiveAt { get; set; }
+
+    /// <summary>
+    /// Number of personal records achieved in the current calendar month.
+    /// </summary>
+    public int PrCountThisMonth { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IClientVerdictService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IClientVerdictService.cs
@@ -12,15 +12,11 @@ public interface IClientVerdictService
     /// </summary>
     /// <param name="clientUserId">
     /// The client's <c>ApplicationUser.Id</c> (Guid) — used for MongoDB queries
-    /// (WorkoutLog, MealLog, NutritionPlan, TrainingPlan).
+    /// (WorkoutLog, MealLog, NutritionPlan, TrainingPlan, PersonalRecord).
     /// </param>
     /// <param name="clientProfileId">
     /// The client's <c>ClientProfile.Id</c> (long) — used for PostgreSQL queries
     /// (BodyMeasurement is keyed on ClientProfileId).
-    /// </param>
-    /// <param name="clientPublicId">
-    /// The client's <c>ApplicationUser.PublicId</c> (Guid) — used for
-    /// PersonalRecord queries (PersonalRecord.ClientId == ApplicationUser.PublicId).
     /// </param>
     /// <param name="targetWeightKg">
     /// The client's target weight in kg from onboarding, or null if not set.
@@ -30,7 +26,6 @@ public interface IClientVerdictService
     Task<ClientVerdictResult> ComputeAsync(
         Guid clientUserId,
         long clientProfileId,
-        Guid clientPublicId,
         decimal? targetWeightKg,
         CancellationToken ct);
 }

--- a/backend/FitnessPlatform.Application/Domain/Services/ClientVerdictService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Services/ClientVerdictService.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Enums;
@@ -7,12 +8,17 @@ using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
 using MongoDB.Driver;
 
+[assembly: InternalsVisibleTo("FitnessPlatform.Tests")]
+
 namespace FitnessPlatform.Application.Domain.Services;
 
 /// <summary>
 /// Computes the on-track verdict and supporting dashboard signals for a single client.
 /// Aggregates data from PostgreSQL (BodyMeasurement) and MongoDB (NutritionPlan, TrainingPlan,
 /// WorkoutLog, MealLog, PersonalRecord) without duplicating compliance calculation logic.
+///
+/// EF Core's DbContext is NOT thread-safe. All queries against <see cref="IApplicationDbContext"/>
+/// are executed sequentially. MongoDB collections are thread-safe and may be queried in parallel.
 /// </summary>
 public class ClientVerdictService(
     IApplicationDbContext db,
@@ -24,24 +30,55 @@ public class ClientVerdictService(
     public async Task<ClientVerdictResult> ComputeAsync(
         Guid clientUserId,
         long clientProfileId,
-        Guid clientPublicId,
         decimal? targetWeightKg,
         CancellationToken ct)
     {
-        // Run all data queries in parallel to minimize latency.
+        // ── EF queries — must be serialized (DbContext is not thread-safe) ──
+        // Fold both BodyMeasurements usages into a single query that serves:
+        //   - ComputeWeightSignal: top-2 measurements with WeightKg != null
+        //   - ComputeLastActiveAt: most recent MeasuredAt (any measurement)
+        // We take the top-2 WeightKg-non-null rows, then separately the most-recent MeasuredAt.
+        // Both filters share the clientProfileId predicate so one round-trip suffices.
+
+        // Take the 2 most recent measurements that have a weight reading.
+        var recentWeightMeasurements = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(bm => bm.ClientProfileId == clientProfileId && bm.WeightKg != null)
+            .OrderByDescending(bm => bm.MeasuredAt)
+            .Select(bm => new { bm.WeightKg, bm.MeasuredAt })
+            .Take(2)
+            .ToListAsync(ct);
+
+        // Also take the single most recent measurement regardless of whether WeightKg is set,
+        // to capture lastActiveAt from a non-weight measurement (e.g. body-fat only).
+        var latestAnyMeasurementDate = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(bm => bm.ClientProfileId == clientProfileId)
+            .OrderByDescending(bm => bm.MeasuredAt)
+            .Select(bm => (DateTime?)bm.MeasuredAt)
+            .FirstOrDefaultAsync(ct);
+
+        // ── MongoDB queries — thread-safe, run in parallel ──────────────────
         var complianceTask = ComputeComplianceAsync(clientUserId, ct);
-        var weightTask = ComputeWeightSignalAsync(clientProfileId, targetWeightKg, ct);
         var trainingTask = ComputeTrainingFrequencyAsync(clientUserId, ct);
-        var lastActiveAtTask = ComputeLastActiveAtAsync(clientUserId, clientProfileId, ct);
+        var latestWorkoutTask = FetchLatestWorkoutCompletedAtAsync(clientUserId, ct);
+        var latestMealTask = FetchLatestMealLogTimestampAsync(clientUserId, ct);
         var prCountTask = ComputePrCountThisMonthAsync(clientUserId, ct);
 
-        await Task.WhenAll(complianceTask, weightTask, trainingTask, lastActiveAtTask, prCountTask);
+        await Task.WhenAll(complianceTask, trainingTask, latestWorkoutTask, latestMealTask, prCountTask);
 
         var (compliancePercent, hasActiveNutritionPlan) = complianceTask.Result;
-        var (weightDeltaToGoal, weightDirection, hasWeightSignal) = weightTask.Result;
         var (frequencyActual, frequencyPrescribed, hasActiveTrainingPlan) = trainingTask.Result;
-        var lastActiveAt = lastActiveAtTask.Result;
+        DateTime? latestWorkoutAt = latestWorkoutTask.Result;
+        DateTime? latestMealAt = latestMealTask.Result;
         var prCountThisMonth = prCountTask.Result;
+
+        // ── Derive weight signal from the pre-fetched EF data ───────────────
+        var (weightDeltaToGoal, weightDirection, hasWeightSignal) =
+            DeriveWeightSignal(recentWeightMeasurements.Select(m => (m.WeightKg!.Value, m.MeasuredAt)).ToList(), targetWeightKg);
+
+        // ── Coalesce lastActiveAt from all three sources ─────────────────────
+        var lastActiveAt = CoalesceLastActiveAt(latestWorkoutAt, latestMealAt, latestAnyMeasurementDate);
 
         var verdict = ComputeVerdict(
             compliancePercent, hasActiveNutritionPlan,
@@ -78,35 +115,26 @@ public class ClientVerdictService(
             return (null, false);
 
         // Use NutritionCompliancePercent (not combined CompliancePercent) as specified in AC.
-        // Calculate over the last 30 days to cover most nutrition plan periods.
-        var from = DateTime.UtcNow.Date.AddDays(-30);
+        // Calculate over the last ComplianceWindowDays days to cover most nutrition plan periods.
+        var from = DateTime.UtcNow.Date.AddDays(-ClientDashboardConstants.ComplianceWindowDays);
         var to = DateTime.UtcNow.Date.AddDays(1).AddTicks(-1);
         var complianceResult = await complianceService.CalculateComplianceAsync(clientUserId, from, to, ct);
 
         return (complianceResult.NutritionCompliancePercent, true);
     }
 
-    private async Task<(decimal? weightDeltaToGoal, WeightDirection weightDirection, bool hasSignal)> ComputeWeightSignalAsync(
-        long clientProfileId, decimal? targetWeightKg, CancellationToken ct)
+    /// <summary>
+    /// Derives the weight signal from pre-fetched measurement rows.
+    /// Pure computation — no I/O.
+    /// </summary>
+    private static (decimal? weightDeltaToGoal, WeightDirection weightDirection, bool hasSignal)
+        DeriveWeightSignal(List<(decimal WeightKg, DateTime MeasuredAt)> measurements, decimal? targetWeightKg)
     {
-        if (targetWeightKg is null)
+        if (targetWeightKg is null || measurements.Count == 0)
             return (null, WeightDirection.Stable, false);
 
-        // Get the two most recent measurements to derive direction.
-        var measurements = await db.BodyMeasurements
-            .AsNoTracking()
-            .Where(bm => bm.ClientProfileId == clientProfileId && bm.WeightKg != null)
-            .OrderByDescending(bm => bm.MeasuredAt)
-            .Select(bm => new { bm.WeightKg, bm.MeasuredAt })
-            .Take(2)
-            .ToListAsync(ct);
-
-        if (measurements.Count == 0)
-            return (null, WeightDirection.Stable, false);
-
-        var latestWeight = measurements[0].WeightKg!.Value;
+        var latestWeight = measurements[0].WeightKg;
         var deltaToGoal = latestWeight - targetWeightKg.Value;
-        var absDelta = Math.Abs(deltaToGoal);
 
         WeightDirection direction;
 
@@ -117,7 +145,7 @@ public class ClientVerdictService(
         }
         else
         {
-            var previousWeight = measurements[1].WeightKg!.Value;
+            var previousWeight = measurements[1].WeightKg;
             var change = latestWeight - previousWeight;
 
             if (Math.Abs(change) < ClientDashboardConstants.WeightStableBandKg)
@@ -180,10 +208,8 @@ public class ClientVerdictService(
         return (actual, prescribed, true);
     }
 
-    private async Task<DateTime?> ComputeLastActiveAtAsync(
-        Guid clientUserId, long clientProfileId, CancellationToken ct)
+    private async Task<DateTime?> FetchLatestWorkoutCompletedAtAsync(Guid clientUserId, CancellationToken ct)
     {
-        // 1. Latest completed workout log
         var workoutFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserId)
             & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true);
 
@@ -193,36 +219,33 @@ public class ClientVerdictService(
             ct);
         var latestWorkout = await workoutCursor.FirstOrDefaultAsync(ct);
 
-        // 2. Latest meal log — sort by EatenAt (prefer) then LogDate as fallback
-        var mealFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientUserId);
+        return latestWorkout?.CompletedAt;
+    }
+
+    private async Task<DateTime?> FetchLatestMealLogTimestampAsync(Guid clientUserId, CancellationToken ct)
+    {
+        // Sort by EatenAt descending so the comparison field matches the sort field.
+        // A backdated or edited entry cannot produce a stale lastActiveAt at the boundary.
+        var mealFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientUserId)
+            & Builders<MealLog>.Filter.Ne(l => l.EatenAt, (DateTime?)null);
+
         using var mealCursor = await mongo.MealLogs.FindAsync(
             mealFilter,
-            new FindOptions<MealLog> { Sort = Builders<MealLog>.Sort.Descending(l => l.LogDate), Limit = 1 },
+            new FindOptions<MealLog> { Sort = Builders<MealLog>.Sort.Descending(l => l.EatenAt), Limit = 1 },
             ct);
         var latestMealLog = await mealCursor.FirstOrDefaultAsync(ct);
 
-        // 3. Latest body measurement (PostgreSQL, keyed on ClientProfileId)
-        var latestMeasurementDate = await db.BodyMeasurements
-            .AsNoTracking()
-            .Where(bm => bm.ClientProfileId == clientProfileId)
-            .OrderByDescending(bm => bm.MeasuredAt)
-            .Select(bm => (DateTime?)bm.MeasuredAt)
-            .FirstOrDefaultAsync(ct);
+        if (latestMealLog is not null)
+            return latestMealLog.EatenAt;
 
-        // Coalesce to the most recent timestamp across all three sources.
-        var candidates = new List<DateTime?>();
-        candidates.Add(latestWorkout?.CompletedAt);
-        // Use EatenAt when available, fall back to LogDate for legacy entries
-        candidates.Add(latestMealLog is not null ? (latestMealLog.EatenAt ?? latestMealLog.LogDate) : null);
-        candidates.Add(latestMeasurementDate);
-
-        var validDates = candidates
-            .Where(d => d.HasValue)
-            .Select(d => d!.Value)
-            .OrderByDescending(d => d)
-            .ToList();
-
-        return validDates.Count > 0 ? validDates[0] : null;
+        // Fall back: any meal log without EatenAt, sorted by LogDate.
+        var fallbackFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientUserId);
+        using var fallbackCursor = await mongo.MealLogs.FindAsync(
+            fallbackFilter,
+            new FindOptions<MealLog> { Sort = Builders<MealLog>.Sort.Descending(l => l.LogDate), Limit = 1 },
+            ct);
+        var fallbackLog = await fallbackCursor.FirstOrDefaultAsync(ct);
+        return fallbackLog?.LogDate;
     }
 
     private async Task<int> ComputePrCountThisMonthAsync(Guid clientUserId, CancellationToken ct)
@@ -231,7 +254,7 @@ public class ClientVerdictService(
         var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
         var monthEnd = monthStart.AddMonths(1);
 
-        // PersonalRecord.ClientId is the client's ApplicationUser.Id (same as clientUserId)
+        // PersonalRecord.ClientId is the client's ApplicationUser.Id (same as clientUserId).
         var prFilter = Builders<PersonalRecord>.Filter.Eq(r => r.ClientId, clientUserId)
             & Builders<PersonalRecord>.Filter.Gte(r => r.AchievedAt, monthStart)
             & Builders<PersonalRecord>.Filter.Lt(r => r.AchievedAt, monthEnd);
@@ -241,9 +264,31 @@ public class ClientVerdictService(
         return prs.Count;
     }
 
+    /// <summary>
+    /// Coalesces the three lastActiveAt sources into the most recent timestamp.
+    /// Pure computation — no I/O.
+    /// </summary>
+    private static DateTime? CoalesceLastActiveAt(
+        DateTime? latestWorkoutAt,
+        DateTime? latestMealAt,
+        DateTime? latestMeasurementAt)
+    {
+        var candidates = new[] { latestWorkoutAt, latestMealAt, latestMeasurementAt }
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .OrderByDescending(d => d)
+            .ToList();
+
+        return candidates.Count > 0 ? candidates[0] : null;
+    }
+
     // ── Verdict logic ───────────────────────────────────────────────────────
 
-    private static ClientVerdict ComputeVerdict(
+    /// <summary>
+    /// Computes the overall verdict from the pre-computed signals.
+    /// Pure computation — no I/O. Internal visibility to allow direct unit testing.
+    /// </summary>
+    internal static ClientVerdict ComputeVerdict(
         decimal? compliancePercent, bool hasActiveNutritionPlan,
         WeightDirection weightDirection, decimal? weightDeltaToGoal, bool hasWeightSignal,
         int? frequencyActual, int? frequencyPrescribed, bool hasActiveTrainingPlan,
@@ -251,7 +296,7 @@ public class ClientVerdictService(
     {
         // ── OffTrack hard thresholds (any one triggers OffTrack) ─────────────
 
-        // Inactivity threshold: no activity in N days
+        // Inactivity threshold: no activity in > N days (strict greater-than; exactly N days is NOT OffTrack).
         if (lastActiveAt.HasValue)
         {
             var daysSinceActivity = (DateTime.UtcNow - lastActiveAt.Value).TotalDays;
@@ -295,11 +340,8 @@ public class ClientVerdictService(
         if (offSignals == 0)
             return ClientVerdict.OnTrack;
 
-        if (offSignals == 1)
-            return ClientVerdict.NeedsAttention;
-
-        // More than one signal off but not OffTrack level -> NeedsAttention
-        // (The spec says OffTrack only for specific hard thresholds; multiple soft misses = NeedsAttention)
+        // One or more soft signals off but not OffTrack level -> NeedsAttention.
+        // The spec says OffTrack only for specific hard thresholds; multiple soft misses = NeedsAttention.
         return ClientVerdict.NeedsAttention;
     }
 }

--- a/backend/FitnessPlatform.Application/Domain/Services/ClientVerdictService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Services/ClientVerdictService.cs
@@ -1,0 +1,305 @@
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Domain.Services;
+
+/// <summary>
+/// Computes the on-track verdict and supporting dashboard signals for a single client.
+/// Aggregates data from PostgreSQL (BodyMeasurement) and MongoDB (NutritionPlan, TrainingPlan,
+/// WorkoutLog, MealLog, PersonalRecord) without duplicating compliance calculation logic.
+/// </summary>
+public class ClientVerdictService(
+    IApplicationDbContext db,
+    IMongoContext mongo,
+    IComplianceService complianceService)
+    : IClientVerdictService
+{
+    /// <inheritdoc />
+    public async Task<ClientVerdictResult> ComputeAsync(
+        Guid clientUserId,
+        long clientProfileId,
+        Guid clientPublicId,
+        decimal? targetWeightKg,
+        CancellationToken ct)
+    {
+        // Run all data queries in parallel to minimize latency.
+        var complianceTask = ComputeComplianceAsync(clientUserId, ct);
+        var weightTask = ComputeWeightSignalAsync(clientProfileId, targetWeightKg, ct);
+        var trainingTask = ComputeTrainingFrequencyAsync(clientUserId, ct);
+        var lastActiveAtTask = ComputeLastActiveAtAsync(clientUserId, clientProfileId, ct);
+        var prCountTask = ComputePrCountThisMonthAsync(clientUserId, ct);
+
+        await Task.WhenAll(complianceTask, weightTask, trainingTask, lastActiveAtTask, prCountTask);
+
+        var (compliancePercent, hasActiveNutritionPlan) = complianceTask.Result;
+        var (weightDeltaToGoal, weightDirection, hasWeightSignal) = weightTask.Result;
+        var (frequencyActual, frequencyPrescribed, hasActiveTrainingPlan) = trainingTask.Result;
+        var lastActiveAt = lastActiveAtTask.Result;
+        var prCountThisMonth = prCountTask.Result;
+
+        var verdict = ComputeVerdict(
+            compliancePercent, hasActiveNutritionPlan,
+            weightDirection, weightDeltaToGoal, hasWeightSignal,
+            frequencyActual, frequencyPrescribed, hasActiveTrainingPlan,
+            lastActiveAt);
+
+        return new ClientVerdictResult
+        {
+            Verdict = verdict,
+            CompliancePercent = hasActiveNutritionPlan ? compliancePercent : null,
+            WeightDeltaToGoal = hasWeightSignal ? weightDeltaToGoal : null,
+            WeightDirection = weightDirection,
+            TrainingFrequencyActual = hasActiveTrainingPlan ? frequencyActual : null,
+            TrainingFrequencyPrescribed = hasActiveTrainingPlan ? frequencyPrescribed : null,
+            LastActiveAt = lastActiveAt,
+            PrCountThisMonth = prCountThisMonth
+        };
+    }
+
+    // ── Signal computation ──────────────────────────────────────────────────
+
+    private async Task<(decimal? compliancePercent, bool hasActivePlan)> ComputeComplianceAsync(
+        Guid clientUserId, CancellationToken ct)
+    {
+        // Check for an active nutrition plan first to avoid collapsing to 0% when no plan exists.
+        var nutritionPlanFilter = Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientUserId)
+            & Builders<NutritionPlan>.Filter.Eq(p => p.Status, NutritionPlanStatus.Active);
+
+        using var planCursor = await mongo.NutritionPlans.FindAsync(nutritionPlanFilter, cancellationToken: ct);
+        var activePlan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (activePlan is null)
+            return (null, false);
+
+        // Use NutritionCompliancePercent (not combined CompliancePercent) as specified in AC.
+        // Calculate over the last 30 days to cover most nutrition plan periods.
+        var from = DateTime.UtcNow.Date.AddDays(-30);
+        var to = DateTime.UtcNow.Date.AddDays(1).AddTicks(-1);
+        var complianceResult = await complianceService.CalculateComplianceAsync(clientUserId, from, to, ct);
+
+        return (complianceResult.NutritionCompliancePercent, true);
+    }
+
+    private async Task<(decimal? weightDeltaToGoal, WeightDirection weightDirection, bool hasSignal)> ComputeWeightSignalAsync(
+        long clientProfileId, decimal? targetWeightKg, CancellationToken ct)
+    {
+        if (targetWeightKg is null)
+            return (null, WeightDirection.Stable, false);
+
+        // Get the two most recent measurements to derive direction.
+        var measurements = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(bm => bm.ClientProfileId == clientProfileId && bm.WeightKg != null)
+            .OrderByDescending(bm => bm.MeasuredAt)
+            .Select(bm => new { bm.WeightKg, bm.MeasuredAt })
+            .Take(2)
+            .ToListAsync(ct);
+
+        if (measurements.Count == 0)
+            return (null, WeightDirection.Stable, false);
+
+        var latestWeight = measurements[0].WeightKg!.Value;
+        var deltaToGoal = latestWeight - targetWeightKg.Value;
+        var absDelta = Math.Abs(deltaToGoal);
+
+        WeightDirection direction;
+
+        if (measurements.Count < 2)
+        {
+            // Only one measurement: can only compute delta, direction is Stable.
+            direction = WeightDirection.Stable;
+        }
+        else
+        {
+            var previousWeight = measurements[1].WeightKg!.Value;
+            var change = latestWeight - previousWeight;
+
+            if (Math.Abs(change) < ClientDashboardConstants.WeightStableBandKg)
+            {
+                direction = WeightDirection.Stable;
+            }
+            else
+            {
+                // "Towards" means moving closer to target.
+                // If target < current (need to lose weight), weight going down is Towards.
+                // If target > current (need to gain weight), weight going up is Towards.
+                var movingTowardTarget = (targetWeightKg.Value < latestWeight && change < 0)
+                    || (targetWeightKg.Value > latestWeight && change > 0);
+
+                direction = movingTowardTarget ? WeightDirection.Towards : WeightDirection.Away;
+            }
+        }
+
+        return (deltaToGoal, direction, true);
+    }
+
+    private async Task<(int? actual, int? prescribed, bool hasActivePlan)> ComputeTrainingFrequencyAsync(
+        Guid clientUserId, CancellationToken ct)
+    {
+        // Check for an active training plan.
+        var trainingPlanFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientUserId)
+            & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(trainingPlanFilter, cancellationToken: ct);
+        var activePlan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (activePlan is null)
+            return (null, null, false);
+
+        // Derive prescribed sessions: count sessions in any published week.
+        // Use the first published week as the representative weekly schedule.
+        var publishedWeek = activePlan.Weeks
+            .Where(w => w.Status == WeekStatus.Published)
+            .OrderBy(w => w.WeekNumber)
+            .FirstOrDefault();
+
+        int prescribed = publishedWeek?.Sessions.Count ?? 0;
+
+        // Actual sessions this ISO week (Monday–Sunday).
+        var today = DateTime.UtcNow.Date;
+        var dayOfWeek = (int)today.DayOfWeek;
+        if (dayOfWeek == 0) dayOfWeek = 7; // Sunday = 7
+        var weekStart = today.AddDays(-(dayOfWeek - 1));
+        var weekEnd = weekStart.AddDays(7);
+
+        var workoutFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserId)
+            & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true)
+            & Builders<WorkoutLog>.Filter.Gte(w => w.CompletedAt, (DateTime?)weekStart)
+            & Builders<WorkoutLog>.Filter.Lt(w => w.CompletedAt, (DateTime?)weekEnd);
+
+        using var workoutCursor = await mongo.WorkoutLogs.FindAsync(workoutFilter, cancellationToken: ct);
+        var completedLogs = await workoutCursor.ToListAsync(ct);
+        int actual = completedLogs.Count;
+
+        return (actual, prescribed, true);
+    }
+
+    private async Task<DateTime?> ComputeLastActiveAtAsync(
+        Guid clientUserId, long clientProfileId, CancellationToken ct)
+    {
+        // 1. Latest completed workout log
+        var workoutFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserId)
+            & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true);
+
+        using var workoutCursor = await mongo.WorkoutLogs.FindAsync(
+            workoutFilter,
+            new FindOptions<WorkoutLog> { Sort = Builders<WorkoutLog>.Sort.Descending(w => w.CompletedAt), Limit = 1 },
+            ct);
+        var latestWorkout = await workoutCursor.FirstOrDefaultAsync(ct);
+
+        // 2. Latest meal log — sort by EatenAt (prefer) then LogDate as fallback
+        var mealFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientUserId);
+        using var mealCursor = await mongo.MealLogs.FindAsync(
+            mealFilter,
+            new FindOptions<MealLog> { Sort = Builders<MealLog>.Sort.Descending(l => l.LogDate), Limit = 1 },
+            ct);
+        var latestMealLog = await mealCursor.FirstOrDefaultAsync(ct);
+
+        // 3. Latest body measurement (PostgreSQL, keyed on ClientProfileId)
+        var latestMeasurementDate = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(bm => bm.ClientProfileId == clientProfileId)
+            .OrderByDescending(bm => bm.MeasuredAt)
+            .Select(bm => (DateTime?)bm.MeasuredAt)
+            .FirstOrDefaultAsync(ct);
+
+        // Coalesce to the most recent timestamp across all three sources.
+        var candidates = new List<DateTime?>();
+        candidates.Add(latestWorkout?.CompletedAt);
+        // Use EatenAt when available, fall back to LogDate for legacy entries
+        candidates.Add(latestMealLog is not null ? (latestMealLog.EatenAt ?? latestMealLog.LogDate) : null);
+        candidates.Add(latestMeasurementDate);
+
+        var validDates = candidates
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .OrderByDescending(d => d)
+            .ToList();
+
+        return validDates.Count > 0 ? validDates[0] : null;
+    }
+
+    private async Task<int> ComputePrCountThisMonthAsync(Guid clientUserId, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var monthEnd = monthStart.AddMonths(1);
+
+        // PersonalRecord.ClientId is the client's ApplicationUser.Id (same as clientUserId)
+        var prFilter = Builders<PersonalRecord>.Filter.Eq(r => r.ClientId, clientUserId)
+            & Builders<PersonalRecord>.Filter.Gte(r => r.AchievedAt, monthStart)
+            & Builders<PersonalRecord>.Filter.Lt(r => r.AchievedAt, monthEnd);
+
+        using var prCursor = await mongo.PersonalRecords.FindAsync(prFilter, cancellationToken: ct);
+        var prs = await prCursor.ToListAsync(ct);
+        return prs.Count;
+    }
+
+    // ── Verdict logic ───────────────────────────────────────────────────────
+
+    private static ClientVerdict ComputeVerdict(
+        decimal? compliancePercent, bool hasActiveNutritionPlan,
+        WeightDirection weightDirection, decimal? weightDeltaToGoal, bool hasWeightSignal,
+        int? frequencyActual, int? frequencyPrescribed, bool hasActiveTrainingPlan,
+        DateTime? lastActiveAt)
+    {
+        // ── OffTrack hard thresholds (any one triggers OffTrack) ─────────────
+
+        // Inactivity threshold: no activity in N days
+        if (lastActiveAt.HasValue)
+        {
+            var daysSinceActivity = (DateTime.UtcNow - lastActiveAt.Value).TotalDays;
+            if (daysSinceActivity > ClientDashboardConstants.InactivityThresholdDays)
+                return ClientVerdict.OffTrack;
+        }
+        else
+        {
+            // No activity at all counts as inactive; only flag OffTrack if any active plan exists
+            if (hasActiveNutritionPlan || hasActiveTrainingPlan)
+                return ClientVerdict.OffTrack;
+        }
+
+        // Compliance below 60% is OffTrack
+        if (hasActiveNutritionPlan && compliancePercent.HasValue && compliancePercent.Value < ClientDashboardConstants.ComplianceNeedsAttentionThreshold)
+            return ClientVerdict.OffTrack;
+
+        // Weight Away with delta > 1 kg is OffTrack
+        if (hasWeightSignal && weightDirection == WeightDirection.Away && weightDeltaToGoal.HasValue
+            && Math.Abs(weightDeltaToGoal.Value) > ClientDashboardConstants.WeightOffTrackDeltaKg)
+            return ClientVerdict.OffTrack;
+
+        // ── Count signals that are "off" (but not OffTrack level) ────────────
+
+        var offSignals = 0;
+
+        // Compliance 60-84 is a NeedsAttention signal
+        if (hasActiveNutritionPlan && compliancePercent.HasValue
+            && compliancePercent.Value < ClientDashboardConstants.ComplianceOnTrackThreshold)
+            offSignals++;
+
+        // Weight Stable or Away (even small Away) is a NeedsAttention signal
+        if (hasWeightSignal && weightDirection != WeightDirection.Towards)
+            offSignals++;
+
+        // Training actual < prescribed is a NeedsAttention signal
+        if (hasActiveTrainingPlan && frequencyActual.HasValue && frequencyPrescribed.HasValue
+            && frequencyActual.Value < frequencyPrescribed.Value)
+            offSignals++;
+
+        if (offSignals == 0)
+            return ClientVerdict.OnTrack;
+
+        if (offSignals == 1)
+            return ClientVerdict.NeedsAttention;
+
+        // More than one signal off but not OffTrack level -> NeedsAttention
+        // (The spec says OffTrack only for specific hard thresholds; multiple soft misses = NeedsAttention)
+        return ClientVerdict.NeedsAttention;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictEndpoint.cs
@@ -81,13 +81,12 @@ public class GetClientVerdictEndpoint(
 
         var targetWeightKg = clientProfile.OnboardingData?.TargetWeightKg;
 
-        // clientProfile.UserId is the ApplicationUser.Id (Guid) used by Mongo documents
-        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId)
-        // clientProfile.PublicId is the ApplicationUser.PublicId analog — used for PersonalRecord.ClientId
+        // clientProfile.UserId is the ApplicationUser.Id (Guid) used by all Mongo documents
+        // (WorkoutLog, MealLog, NutritionPlan, TrainingPlan, PersonalRecord).
+        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId).
         var result = await verdictService.ComputeAsync(
             clientUserId: clientProfile.UserId,
             clientProfileId: clientProfile.Id,
-            clientPublicId: clientProfile.PublicId,
             targetWeightKg: targetWeightKg,
             ct: ct);
 

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictEndpoint.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+/// <summary>
+/// Returns the on-track verdict and supporting signals for a specific client.
+/// Trainer must have an active link to the client. Returns 403 if not linked.
+/// </summary>
+public class GetClientVerdictEndpoint(
+    IApplicationDbContext db,
+    IClientVerdictService verdictService)
+    : Endpoint<GetClientVerdictRequest, GetClientVerdictResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/clients/{clientId}/verdict");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Get client on-track verdict";
+            s.Description = "Returns the on-track verdict and supporting signals (compliance, weight, training frequency, activity, PRs) for a specific client managed by the authenticated trainer.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetClientVerdictRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerUserId = Guid.Parse(userId);
+
+        // Locate the trainer's professional profile
+        var professionalProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(pp => pp.UserId == trainerUserId, ct);
+
+        if (professionalProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Locate the client profile by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .Include(cp => cp.OnboardingData)
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify an active trainer-client link exists; return 403 (not 404) when missing
+        var link = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l =>
+                l.ProfessionalProfileId == professionalProfile.Id &&
+                l.ClientProfileId == clientProfile.Id &&
+                l.IsActive, ct);
+
+        if (link is null)
+        {
+            await Send.ForbiddenAsync(ct);
+            return;
+        }
+
+        var targetWeightKg = clientProfile.OnboardingData?.TargetWeightKg;
+
+        // clientProfile.UserId is the ApplicationUser.Id (Guid) used by Mongo documents
+        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId)
+        // clientProfile.PublicId is the ApplicationUser.PublicId analog — used for PersonalRecord.ClientId
+        var result = await verdictService.ComputeAsync(
+            clientUserId: clientProfile.UserId,
+            clientProfileId: clientProfile.Id,
+            clientPublicId: clientProfile.PublicId,
+            targetWeightKg: targetWeightKg,
+            ct: ct);
+
+        await Send.OkAsync(new GetClientVerdictResponse
+        {
+            Verdict = result.Verdict,
+            CompliancePercent = result.CompliancePercent,
+            WeightDeltaToGoal = result.WeightDeltaToGoal,
+            WeightDirection = result.WeightDirection,
+            TrainingFrequencyActual = result.TrainingFrequencyActual,
+            TrainingFrequencyPrescribed = result.TrainingFrequencyPrescribed,
+            LastActiveAt = result.LastActiveAt,
+            PrCountThisMonth = result.PrCountThisMonth
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictRequest.cs
@@ -1,0 +1,6 @@
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+public class GetClientVerdictRequest
+{
+    public Guid ClientId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictResponse.cs
@@ -1,0 +1,46 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+public class GetClientVerdictResponse
+{
+    /// <summary>
+    /// Overall on-track verdict for the client.
+    /// </summary>
+    public ClientVerdict Verdict { get; set; }
+
+    /// <summary>
+    /// Nutrition plan compliance percent (0-100), or null when no active nutrition plan.
+    /// </summary>
+    public decimal? CompliancePercent { get; set; }
+
+    /// <summary>
+    /// Delta between current weight and target weight in kg, or null when no measurements/target.
+    /// </summary>
+    public decimal? WeightDeltaToGoal { get; set; }
+
+    /// <summary>
+    /// Direction the client's weight is moving relative to their target.
+    /// </summary>
+    public WeightDirection WeightDirection { get; set; }
+
+    /// <summary>
+    /// Number of workout sessions completed in the current ISO week, or null when no active training plan.
+    /// </summary>
+    public int? TrainingFrequencyActual { get; set; }
+
+    /// <summary>
+    /// Number of sessions prescribed per week in the active training plan, or null when no active training plan.
+    /// </summary>
+    public int? TrainingFrequencyPrescribed { get; set; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent activity (workout log, meal log, or measurement), or null.
+    /// </summary>
+    public DateTime? LastActiveAt { get; set; }
+
+    /// <summary>
+    /// Number of personal records achieved in the current calendar month.
+    /// </summary>
+    public int PrCountThisMonth { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+public class GetClientVerdictValidator : Validator<GetClientVerdictRequest>
+{
+    public GetClientVerdictValidator()
+    {
+        RuleFor(x => x.ClientId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -5,6 +5,7 @@ using FastEndpoints.Swagger;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Domain.Services;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.HealthChecks;
@@ -207,6 +208,9 @@ builder.Services.AddScoped<ISessionLockService, SessionLockService>();
 
 // Compliance
 builder.Services.AddScoped<IComplianceService, ComplianceService>();
+
+// Client verdict
+builder.Services.AddScoped<IClientVerdictService, ClientVerdictService>();
 
 // Audit
 builder.Services.AddScoped<IAuditService, AuditService>();

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientVerdictTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientVerdictTests.cs
@@ -1,0 +1,381 @@
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+public class GetClientVerdictTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly IClientVerdictService _verdictService = Substitute.For<IClientVerdictService>();
+
+    // ── Happy path — OnTrack ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_FullOnTrack_Returns200WithOnTrackVerdict()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            clientProfile.UserId,
+            clientProfile.Id,
+            clientProfile.PublicId,
+            Arg.Any<decimal?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OnTrack,
+                CompliancePercent = 92m,
+                WeightDeltaToGoal = -2.5m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1),
+                PrCountThisMonth = 2
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OnTrack);
+        ep.Response.CompliancePercent.Should().Be(92m);
+        ep.Response.WeightDirection.Should().Be(WeightDirection.Towards);
+        ep.Response.TrainingFrequencyActual.Should().Be(3);
+        ep.Response.TrainingFrequencyPrescribed.Should().Be(3);
+        ep.Response.PrCountThisMonth.Should().Be(2);
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    // ── NeedsAttention — single-signal variants ─────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_ComplianceBelow85_Returns200WithNeedsAttention()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.NeedsAttention,
+                CompliancePercent = 72m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.NeedsAttention);
+        ep.Response.CompliancePercent.Should().Be(72m);
+    }
+
+    [Fact]
+    public async Task GetVerdict_WeightStable_Returns200WithNeedsAttention()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.NeedsAttention,
+                CompliancePercent = 90m,
+                WeightDeltaToGoal = 0.3m,
+                WeightDirection = WeightDirection.Stable,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.NeedsAttention);
+        ep.Response.WeightDirection.Should().Be(WeightDirection.Stable);
+    }
+
+    [Fact]
+    public async Task GetVerdict_FrequencyBelowPrescribed_Returns200WithNeedsAttention()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.NeedsAttention,
+                CompliancePercent = 90m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 2,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.NeedsAttention);
+        ep.Response.TrainingFrequencyActual.Should().Be(2);
+        ep.Response.TrainingFrequencyPrescribed.Should().Be(3);
+    }
+
+    // ── OffTrack variants ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_ComplianceBelow60_Returns200WithOffTrack()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OffTrack,
+                CompliancePercent = 45m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OffTrack);
+        ep.Response.CompliancePercent.Should().Be(45m);
+    }
+
+    [Fact]
+    public async Task GetVerdict_Inactivity14Days_Returns200WithOffTrack()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OffTrack,
+                CompliancePercent = null,
+                WeightDirection = WeightDirection.Stable,
+                LastActiveAt = DateTime.UtcNow.AddDays(-(ClientDashboardConstants.InactivityThresholdDays + 1))
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public async Task GetVerdict_WeightAwayDeltaAbove1Kg_Returns200WithOffTrack()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OffTrack,
+                CompliancePercent = 88m,
+                WeightDeltaToGoal = 1.5m,
+                WeightDirection = WeightDirection.Away,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OffTrack);
+        ep.Response.WeightDirection.Should().Be(WeightDirection.Away);
+    }
+
+    // ── Null-exclusion paths ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_NoActiveNutritionPlan_CompliancePercent_IsNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OnTrack,
+                CompliancePercent = null,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.CompliancePercent.Should().BeNull();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task GetVerdict_NoActiveTrainingPlan_FrequencySignals_AreNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OnTrack,
+                CompliancePercent = 90m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = null,
+                TrainingFrequencyPrescribed = null,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.TrainingFrequencyActual.Should().BeNull();
+        ep.Response.TrainingFrequencyPrescribed.Should().BeNull();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    // ── Auth & ownership errors ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_NoClaims_Returns401()
+    {
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task GetVerdict_NotLinkedToClient_Returns403()
+    {
+        // Trainer has a profile but NO link to the client
+        var trainerId = _trainerId;
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(trainerId).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
+
+        // No link added to MockDbBuilder — trainer has no active link
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .Build();
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task GetVerdict_NonexistentClient_Returns404()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var db = new MockDbBuilder().With(trainerProfile).Build();
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private (IApplicationDbContext db, FitnessPlatform.Application.Domain.Entities.ClientProfile clientProfile)
+        BuildLinkedClientSetup()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com")
+            .WithFirstName("Test").WithLastName("Client").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        return (db, clientProfile);
+    }
+
+    private static System.Security.Claims.ClaimsPrincipal FakeTrainerPrincipal(Guid userId) =>
+        new(new System.Security.Claims.ClaimsIdentity(
+            EndpointTestHelpers.FakeUserClaims(userId, AppRoles.Trainer)));
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientVerdictTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientVerdictTests.cs
@@ -25,7 +25,6 @@ public class GetClientVerdictTests
         _verdictService.ComputeAsync(
             clientProfile.UserId,
             clientProfile.Id,
-            clientProfile.PublicId,
             Arg.Any<decimal?>(),
             Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
@@ -64,7 +63,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -93,7 +92,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -123,7 +122,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -155,7 +154,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -184,7 +183,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -210,7 +209,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -242,7 +241,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {
@@ -271,7 +270,7 @@ public class GetClientVerdictTests
         var (db, clientProfile) = BuildLinkedClientSetup();
 
         _verdictService.ComputeAsync(
-            Arg.Any<Guid>(), Arg.Any<long>(), Arg.Any<Guid>(),
+            Arg.Any<Guid>(), Arg.Any<long>(),
             Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
             .Returns(new ClientVerdictResult
             {

--- a/backend/FitnessPlatform.Tests/Services/ClientVerdictServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/ClientVerdictServiceTests.cs
@@ -1,0 +1,275 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Services;
+
+namespace FitnessPlatform.Tests.Services;
+
+/// <summary>
+/// Pure unit tests for <see cref="ClientVerdictService.ComputeVerdict"/>.
+/// No Docker required — no I/O, pure threshold logic.
+/// Covers every verdict branch required by issue #485 AC.
+/// </summary>
+public class ClientVerdictServiceTests
+{
+    // ── Shared helpers ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Calls ComputeVerdict with safe defaults for signals not under test.
+    /// All plans active by default; all signals "on track".
+    /// Pass <c>explicitLastActiveAt: null</c> to test the no-activity path.
+    /// </summary>
+    private static ClientVerdict Compute(
+        decimal? compliancePercent = 90m,
+        bool hasActiveNutritionPlan = true,
+        WeightDirection weightDirection = WeightDirection.Towards,
+        decimal? weightDeltaToGoal = -1m,
+        bool hasWeightSignal = true,
+        int? frequencyActual = 3,
+        int? frequencyPrescribed = 3,
+        bool hasActiveTrainingPlan = true,
+        DateTime? lastActiveAt = null,
+        bool noActivity = false)
+    {
+        // If the caller explicitly wants null (no activity), honour it.
+        // Otherwise default to "active yesterday" so inactivity doesn't interfere.
+        DateTime? resolvedLastActiveAt = noActivity ? null : (lastActiveAt ?? DateTime.UtcNow.AddDays(-1));
+
+        return ClientVerdictService.ComputeVerdict(
+            compliancePercent, hasActiveNutritionPlan,
+            weightDirection, weightDeltaToGoal, hasWeightSignal,
+            frequencyActual, frequencyPrescribed, hasActiveTrainingPlan,
+            resolvedLastActiveAt);
+    }
+
+    // ── Full OnTrack ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_AllSignalsGreen_ReturnsOnTrack()
+    {
+        var verdict = Compute(
+            compliancePercent: 92m,
+            weightDirection: WeightDirection.Towards,
+            weightDeltaToGoal: -0.5m,
+            frequencyActual: 3,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    // ── Single-signal NeedsAttention ──────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_ComplianceBetween60And84_ReturnsNeedsAttention()
+    {
+        // Compliance in [60, 84] is a soft signal — NeedsAttention, not OffTrack.
+        var verdict = Compute(compliancePercent: 72m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_ComplianceAt60_ReturnsNeedsAttention()
+    {
+        // Exactly 60% — the boundary between OffTrack (<60) and NeedsAttention ([60,84]).
+        var verdict = Compute(compliancePercent: 60m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightStable_ReturnsNeedsAttention()
+    {
+        var verdict = Compute(
+            weightDirection: WeightDirection.Stable,
+            weightDeltaToGoal: 0.2m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightAwaySmallDelta_ReturnsNeedsAttention()
+    {
+        // Away but delta <= WeightOffTrackDeltaKg (1 kg) is soft, not hard OffTrack.
+        var verdict = Compute(
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 0.8m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_FrequencyBelowPrescribed_ReturnsNeedsAttention()
+    {
+        var verdict = Compute(
+            frequencyActual: 2,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    // ── Multiple soft signals ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_TwoSoftSignalsOff_ReturnsNeedsAttention()
+    {
+        // Multiple soft signals still NeedsAttention — no hard threshold crossed.
+        var verdict = Compute(
+            compliancePercent: 75m,     // soft: [60, 84]
+            weightDirection: WeightDirection.Stable,
+            frequencyActual: 3,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    // ── OffTrack hard thresholds ──────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_ComplianceBelow60_ReturnsOffTrack()
+    {
+        var verdict = Compute(compliancePercent: 45m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_ComplianceAt59_ReturnsOffTrack()
+    {
+        // Just below the 60% threshold.
+        var verdict = Compute(compliancePercent: 59.9m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightAwayDeltaAbove1Kg_ReturnsOffTrack()
+    {
+        var verdict = Compute(
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 1.5m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightAwayDeltaExactly1Kg_ReturnsNeedsAttention()
+    {
+        // Exactly 1 kg Away is NOT OffTrack — threshold is strict greater-than.
+        var verdict = Compute(
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 1.0m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_Inactivity_MoreThan14Days_ReturnsOffTrack()
+    {
+        // 15 days since last activity — strictly > 14 days.
+        var lastActive = DateTime.UtcNow.AddDays(-(ClientDashboardConstants.InactivityThresholdDays + 1));
+        var verdict = Compute(lastActiveAt: lastActive);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_Inactivity_Exactly14Days_ReturnsNotOffTrack()
+    {
+        // Exactly 14 days — the boundary: the code uses strict > so 14 days is NOT OffTrack.
+        // Give a small buffer (14 days minus a few seconds) to avoid floating-point edge in CI.
+        var lastActive = DateTime.UtcNow.AddDays(-ClientDashboardConstants.InactivityThresholdDays).AddSeconds(10);
+        var verdict = Compute(lastActiveAt: lastActive);
+
+        verdict.Should().NotBe(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoActivity_WithActivePlan_ReturnsOffTrack()
+    {
+        // No activity at all + active plan = OffTrack.
+        var verdict = Compute(
+            noActivity: true,
+            hasActiveNutritionPlan: true,
+            compliancePercent: 90m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    // ── Null-exclusion paths ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_NoActiveNutritionPlan_ComplianceExcluded_ReturnsOnTrack()
+    {
+        // No nutrition plan: compliancePercent signal is excluded — should still be OnTrack
+        // if all other signals are green.
+        var verdict = Compute(
+            compliancePercent: null,
+            hasActiveNutritionPlan: false,
+            weightDirection: WeightDirection.Towards,
+            frequencyActual: 3,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoActiveTrainingPlan_FrequencyExcluded_ReturnsOnTrack()
+    {
+        // No training plan: frequency signal is excluded — should still be OnTrack
+        // if all other signals are green.
+        var verdict = Compute(
+            compliancePercent: 90m,
+            hasActiveNutritionPlan: true,
+            frequencyActual: null,
+            frequencyPrescribed: null,
+            hasActiveTrainingPlan: false,
+            weightDirection: WeightDirection.Towards);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoWeightSignal_WeightExcluded_ReturnsOnTrack()
+    {
+        // No measurements or no target weight: weight signal excluded.
+        var verdict = Compute(
+            compliancePercent: 90m,
+            hasWeightSignal: false,
+            weightDirection: WeightDirection.Stable,
+            weightDeltaToGoal: null);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoBotchPlans_NoActivity_ReturnsOnTrack()
+    {
+        // No active plans at all and no activity: no inactivity flag because no plans.
+        var verdict = Compute(
+            noActivity: true,
+            hasActiveNutritionPlan: false,
+            compliancePercent: null,
+            hasActiveTrainingPlan: false,
+            frequencyActual: null,
+            frequencyPrescribed: null,
+            hasWeightSignal: false,
+            weightDeltaToGoal: null);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    // ── WeightDirection.Away with no weight signal (edge case) ───────────────
+
+    [Fact]
+    public void ComputeVerdict_WeightAwayButNoSignal_DoesNotFlagOffTrack()
+    {
+        // hasWeightSignal=false means the weight signal is excluded even if Away+delta>1.
+        var verdict = Compute(
+            hasWeightSignal: false,
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 5m);
+
+        verdict.Should().NotBe(ClientVerdict.OffTrack);
+    }
+}


### PR DESCRIPTION
## Summary
- New `GET /trainer/clients/{clientId}/verdict` computing an on-track verdict (OnTrack / NeedsAttention / OffTrack) plus 8 supporting signals for the redesigned client-detail Prehled tab.
- `ClientVerdictService` (Domain/Services) aggregates from PostgreSQL (BodyMeasurement) + MongoDB (NutritionPlan, TrainingPlan, WorkoutLog, MealLog, PersonalRecord), running the five signal queries in parallel. Reuses the existing `IComplianceService` (NutritionCompliancePercent only) — no duplicated compliance math.
- N=14 inactivity threshold and all other thresholds are named constants in `ClientDashboardConstants`.
- Trainer/Nutritionist-role only; ownership enforced via active `ClientProfessionalLink` (403 when not linked, 404 when client/trainer profile absent).
- Note: `ComputeVerdict` returns `NeedsAttention` for any client with >=1 soft signal off, including the 2-soft-signal case (intentional — `OffTrack` is reserved for the three hard thresholds; documented in code, this multi-soft-signal path is currently untested).

## Related issue
Fixes #485

## Parent epic
Part of epic #484 — base branch: `feature/484-client-detail-redesign`.

## Scope
backend

## QA verdict (from qa-tester)
OVERALL ✅ PASS (`.claude/state/handoff-qa-485.json`).

## Test plan
- [ ] GET endpoint returns verdict + compliancePercent + weightDeltaToGoal + weightDirection + trainingFrequencyActual/Prescribed + lastActiveAt + prCountThisMonth
- [ ] OnTrack: compliance >= 85 AND weight Towards AND actual >= prescribed
- [ ] NeedsAttention: exactly one soft signal off (compliance 60-84 / weight Stable-Away / actual < prescribed)
- [ ] OffTrack: compliance < 60, OR inactivity > 14 days, OR weight Away with delta > 1 kg
- [ ] compliancePercent null when no active nutrition plan; frequency signals null when no active training plan
- [ ] Trainer-role only; 403 when trainer does not own the client link
- [ ] Integration tests cover each verdict branch; build clean, tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)