### PR TITLE
feat: client detail tabbed shell + Přehled pane

### DIFF
--- a/web/src/api/client-verdict.ts
+++ b/web/src/api/client-verdict.ts
@@ -1,0 +1,48 @@
+import api from '@/lib/api';
+
+/**
+ * On-track verdict for a client as assessed by the trainer dashboard.
+ * Mirrors backend ClientVerdict enum.
+ */
+export type ClientVerdict = 'OnTrack' | 'NeedsAttention' | 'OffTrack';
+
+/**
+ * Direction a client's weight is moving relative to their target.
+ * Mirrors backend WeightDirection enum.
+ */
+export type WeightDirection = 'Towards' | 'Away' | 'Stable';
+
+/**
+ * Response from GET /trainer/clients/{clientId}/verdict.
+ * NOTE: generated.ts does not yet contain this type — regen-api
+ * must be run once the backend is accessible on :5001 (epic branch).
+ * Until then this hand-authored mirror of GetClientVerdictResponse.cs
+ * is the source of truth for the web client.
+ */
+export interface ClientVerdictResponse {
+  verdict: ClientVerdict;
+  /** Nutrition plan compliance percent (0-100), or null when no active plan. */
+  compliancePercent: number | null;
+  /** Delta between current weight and target weight in kg, positive = above target. */
+  weightDeltaToGoal: number | null;
+  /** Direction the weight is moving relative to the goal. */
+  weightDirection: WeightDirection;
+  /** Sessions completed this ISO week, or null when no active training plan. */
+  trainingFrequencyActual: number | null;
+  /** Sessions prescribed per week in active training plan, or null. */
+  trainingFrequencyPrescribed: number | null;
+  /** UTC timestamp of the most recent activity, or null. */
+  lastActiveAt: string | null;
+  /** Number of personal records achieved in the current calendar month. */
+  prCountThisMonth: number;
+}
+
+/** Fetch the on-track verdict for a client. */
+export async function getClientVerdict(
+  clientId: string,
+): Promise<ClientVerdictResponse> {
+  const { data } = await api.get<ClientVerdictResponse>(
+    `/trainer/clients/${clientId}/verdict`,
+  );
+  return data;
+}

--- a/web/src/components/clients/ActiveNutritionPlanCard.tsx
+++ b/web/src/components/clients/ActiveNutritionPlanCard.tsx
@@ -3,7 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import type { PlanSummary, GlobalNutritionSettings } from '@/api/plan-types';
 
 interface ActiveNutritionPlanCardProps {
-  plan: PlanSummary & { globalSettings?: GlobalNutritionSettings | null };
+  plan: PlanSummary;
+  /** Macro targets from the plan detail. PlanSummary does not carry globalSettings. */
+  globalSettings?: GlobalNutritionSettings | null;
   targetWeightKg?: number | null;
   goalLabel?: string | null;
   compliancePercent?: number | null;
@@ -18,6 +20,7 @@ function formatDate(iso: string | null | undefined): string {
 
 export function ActiveNutritionPlanCard({
   plan,
+  globalSettings,
   targetWeightKg,
   goalLabel,
   compliancePercent,
@@ -26,7 +29,7 @@ export function ActiveNutritionPlanCard({
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const gs = plan.globalSettings;
+  const gs = globalSettings;
   const periodStart = formatDate(plan.startDate);
   const periodEnd = formatDate(plan.dateCompleted);
   const period = periodStart && periodEnd

--- a/web/src/components/clients/ActiveNutritionPlanCard.tsx
+++ b/web/src/components/clients/ActiveNutritionPlanCard.tsx
@@ -1,0 +1,115 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { PlanSummary, GlobalNutritionSettings } from '@/api/plan-types';
+
+interface ActiveNutritionPlanCardProps {
+  plan: PlanSummary & { globalSettings?: GlobalNutritionSettings | null };
+  targetWeightKg?: number | null;
+  goalLabel?: string | null;
+  compliancePercent?: number | null;
+  onHistoryClick: () => void;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('cs-CZ', { day: 'numeric', month: 'numeric', year: 'numeric' });
+}
+
+export function ActiveNutritionPlanCard({
+  plan,
+  targetWeightKg,
+  goalLabel,
+  compliancePercent,
+  onHistoryClick,
+}: ActiveNutritionPlanCardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const gs = plan.globalSettings;
+  const periodStart = formatDate(plan.startDate);
+  const periodEnd = formatDate(plan.dateCompleted);
+  const period = periodStart && periodEnd
+    ? `${periodStart} – ${periodEnd}`
+    : periodStart
+      ? t('clientDetail.prehled.planCard.from', { date: periodStart })
+      : '';
+
+  const complianceColor = compliancePercent != null
+    ? compliancePercent >= 80
+      ? 'text-green bg-green-bg'
+      : compliancePercent >= 60
+        ? 'text-orange bg-orange-bg'
+        : 'text-red bg-red-bg'
+    : 'text-text3 bg-bg3';
+
+  return (
+    <div
+      onClick={() => navigate(`/nutrition/plans/${plan.planId}`)}
+      className="border border-border rounded-[var(--radius-lg)] p-4 cursor-pointer transition-[border-color] hover:border-accent-br"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/nutrition/plans/${plan.planId}`); }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="text-[14px] font-bold text-text">🥗 {plan.name}</div>
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-bg text-green">
+          {t('clientDetail.prehled.planCard.active')}
+        </span>
+      </div>
+
+      {/* Period */}
+      {period && (
+        <div className="text-[11px] text-text3 mb-2.5">{period}</div>
+      )}
+
+      {/* Goal */}
+      {(goalLabel || targetWeightKg != null) && (
+        <div className="text-[13px] text-text2 mb-1.5">
+          {t('clientDetail.prehled.planCard.goal')}:{' '}
+          {goalLabel && <b className="text-text">{goalLabel}</b>}
+          {goalLabel && targetWeightKg != null && ' → '}
+          {targetWeightKg != null && (
+            <b className="text-text">
+              {t('clientDetail.prehled.planCard.targetWeight', { kg: targetWeightKg })}
+            </b>
+          )}
+        </div>
+      )}
+
+      {/* Macros */}
+      {gs?.dailyKcal != null && (
+        <div className="text-[16px] font-bold text-accent tracking-[-0.01em] mb-2.5">
+          {gs.dailyKcal} kcal
+          {gs.proteinGrams != null && ` · ${gs.proteinGrams} P`}
+          {gs.carbsGrams != null && ` / ${gs.carbsGrams} C`}
+          {gs.fatGrams != null && ` / ${gs.fatGrams} F`}
+        </div>
+      )}
+
+      {/* Compliance pills */}
+      {compliancePercent != null && (
+        <div className="flex gap-1.5 mb-3">
+          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${complianceColor}`}>
+            {t('clientDetail.prehled.planCard.compliance', { pct: compliancePercent })}
+          </span>
+        </div>
+      )}
+
+      {/* Footer links */}
+      <div className="flex items-center justify-between mt-auto pt-0.5">
+        <span className="text-[12px] font-semibold text-accent">
+          {t('clientDetail.prehled.planCard.openNutrition')} →
+        </span>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onHistoryClick(); }}
+          className="text-[12px] text-text3 bg-transparent border-none cursor-pointer hover:text-text2 transition-colors"
+        >
+          {t('clientDetail.prehled.planCard.history')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/ActiveTrainingPlanCard.tsx
+++ b/web/src/components/clients/ActiveTrainingPlanCard.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { TrainingPlanSummary } from '@/api/training-plan-types';
+
+interface ActiveTrainingPlanCardProps {
+  plan: TrainingPlanSummary;
+  /** Number of sessions completed this week. */
+  trainingFrequencyActual?: number | null;
+  /** Sessions prescribed per week. */
+  trainingFrequencyPrescribed?: number | null;
+  /** Number of PRs achieved this month. */
+  prCountThisMonth?: number;
+  onHistoryClick: () => void;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('cs-CZ', { day: 'numeric', month: 'numeric', year: 'numeric' });
+}
+
+export function ActiveTrainingPlanCard({
+  plan,
+  trainingFrequencyActual,
+  trainingFrequencyPrescribed,
+  prCountThisMonth,
+  onHistoryClick,
+}: ActiveTrainingPlanCardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const periodStart = formatDate(plan.startDate);
+  const period = periodStart
+    ? t('clientDetail.prehled.planCard.from', { date: periodStart })
+    : '';
+
+  const frequencyLabel = trainingFrequencyPrescribed != null
+    ? t('clientDetail.prehled.trainingCard.weeklyFrequency', { count: trainingFrequencyPrescribed })
+    : null;
+
+  const thisWeekLabel = trainingFrequencyActual != null
+    ? t('clientDetail.prehled.trainingCard.thisWeek', { count: trainingFrequencyActual })
+    : null;
+
+  return (
+    <div
+      onClick={() => navigate(`/training/plans/${plan.planId}`)}
+      className="border border-border rounded-[var(--radius-lg)] p-4 cursor-pointer transition-[border-color] hover:border-accent-br"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/training/plans/${plan.planId}`); }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="text-[14px] font-bold text-text">🏋️ {plan.name}</div>
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-bg text-green">
+          {t('clientDetail.prehled.planCard.active')}
+        </span>
+      </div>
+
+      {/* Period */}
+      {period && (
+        <div className="text-[11px] text-text3 mb-2.5">{period}</div>
+      )}
+
+      {/* Description + frequency */}
+      {(plan.description || frequencyLabel) && (
+        <div className="text-[13px] text-text2 mb-1.5">
+          {frequencyLabel && <b className="text-text">{frequencyLabel}</b>}
+          {plan.description && frequencyLabel && ' · '}
+          {plan.description && <b className="text-text">{plan.description}</b>}
+        </div>
+      )}
+
+      {/* PR count + top PR */}
+      {prCountThisMonth != null && (
+        <div className="text-[16px] font-bold text-accent tracking-[-0.01em] mb-2.5">
+          {t('clientDetail.prehled.trainingCard.prThisMonth', { count: prCountThisMonth })}
+        </div>
+      )}
+
+      {/* Pills */}
+      <div className="flex gap-1.5 mb-3 flex-wrap">
+        {thisWeekLabel && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-bg text-green">
+            {thisWeekLabel}
+          </span>
+        )}
+      </div>
+
+      {/* Footer links */}
+      <div className="flex items-center justify-between mt-auto pt-0.5">
+        <span className="text-[12px] font-semibold text-accent">
+          {t('clientDetail.prehled.trainingCard.openTraining')} →
+        </span>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onHistoryClick(); }}
+          className="text-[12px] text-text3 bg-transparent border-none cursor-pointer hover:text-text2 transition-colors"
+        >
+          {t('clientDetail.prehled.planCard.history')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/ActiveTrainingPlanCard.tsx
+++ b/web/src/components/clients/ActiveTrainingPlanCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import type { TrainingPlanSummary } from '@/api/training-plan-types';
+import type { TopPrRecord } from '@/components/domain/RecentActivity/useRecentActivityAggregates';
 
 interface ActiveTrainingPlanCardProps {
   plan: TrainingPlanSummary;
@@ -10,6 +11,8 @@ interface ActiveTrainingPlanCardProps {
   trainingFrequencyPrescribed?: number | null;
   /** Number of PRs achieved this month. */
   prCountThisMonth?: number;
+  /** Top personal record this month derived from the client timeline. */
+  topPr?: TopPrRecord | null;
   onHistoryClick: () => void;
 }
 
@@ -24,6 +27,7 @@ export function ActiveTrainingPlanCard({
   trainingFrequencyActual,
   trainingFrequencyPrescribed,
   prCountThisMonth,
+  topPr,
   onHistoryClick,
 }: ActiveTrainingPlanCardProps) {
   const { t } = useTranslation();
@@ -74,8 +78,17 @@ export function ActiveTrainingPlanCard({
 
       {/* PR count + top PR */}
       {prCountThisMonth != null && (
-        <div className="text-[16px] font-bold text-accent tracking-[-0.01em] mb-2.5">
+        <div className="text-[16px] font-bold text-accent tracking-[-0.01em] mb-1">
           {t('clientDetail.prehled.trainingCard.prThisMonth', { count: prCountThisMonth })}
+        </div>
+      )}
+      {topPr && (
+        <div className="text-[12px] text-text2 mb-2.5">
+          {t('clientDetail.prehled.trainingCard.topPr', {
+            name: topPr.exerciseName,
+            kg: topPr.weightKg,
+            reps: topPr.reps,
+          })}
         </div>
       )}
 

--- a/web/src/components/clients/ClientTabBar.tsx
+++ b/web/src/components/clients/ClientTabBar.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next';
+
+export type ClientTabId =
+  | 'prehled'
+  | 'mereni'
+  | 'fotky'
+  | 'aktivita'
+  | 'plany'
+  | 'checkiny'
+  | 'dotazniky'
+  | 'poznamky';
+
+interface ClientTabBarProps {
+  activeTab: ClientTabId;
+  onTabChange: (tab: ClientTabId) => void;
+}
+
+interface TabDef {
+  id: ClientTabId;
+  labelKey: string;
+}
+
+const TABS: TabDef[] = [
+  { id: 'prehled',    labelKey: 'clientDetail.tabs.prehled' },
+  { id: 'mereni',     labelKey: 'clientDetail.tabs.mereni' },
+  { id: 'fotky',      labelKey: 'clientDetail.tabs.fotky' },
+  { id: 'aktivita',   labelKey: 'clientDetail.tabs.aktivita' },
+  { id: 'plany',      labelKey: 'clientDetail.tabs.plany' },
+  { id: 'checkiny',   labelKey: 'clientDetail.tabs.checkiny' },
+  { id: 'dotazniky',  labelKey: 'clientDetail.tabs.dotazniky' },
+  { id: 'poznamky',   labelKey: 'clientDetail.tabs.poznamky' },
+];
+
+export function ClientTabBar({ activeTab, onTabChange }: ClientTabBarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="flex items-center gap-1 px-20 py-2 border-b border-border"
+      role="tablist"
+      aria-label={t('clientDetail.tabBarLabel')}
+    >
+      {TABS.map((tab) => {
+        const isActive = tab.id === activeTab;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`cl-pane-${tab.id}`}
+            id={`cl-tab-${tab.id}`}
+            onClick={() => onTabChange(tab.id)}
+            className={
+              isActive
+                ? 'inline-flex items-center px-3 py-1 rounded-full text-[13px] font-medium cursor-pointer bg-accent text-white border-none'
+                : 'inline-flex items-center px-3 py-1 rounded-full text-[13px] font-medium cursor-pointer bg-transparent text-text2 border-none hover:text-text transition-colors'
+            }
+          >
+            {t(tab.labelKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/clients/IdentityStrip.tsx
+++ b/web/src/components/clients/IdentityStrip.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui';
+import type { ClientDashboard } from '@/api/nutrition-goals';
+
+interface IdentityStripProps {
+  client: ClientDashboard;
+  clientId: string;
+  clientInitials: string;
+  clientAge: number | null;
+  onEditProfile: () => void;
+  onPhotoDiary: () => void;
+}
+
+export function IdentityStrip({
+  client,
+  clientId,
+  clientInitials,
+  clientAge,
+  onEditProfile,
+  onPhotoDiary,
+}: IdentityStripProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const ob = client.onboarding;
+  const allergiesRaw = ob?.allergies ?? null;
+  let allergiesDisplay: string | null = null;
+  if (allergiesRaw) {
+    try {
+      const arr = JSON.parse(allergiesRaw) as unknown;
+      if (Array.isArray(arr)) {
+        allergiesDisplay = arr.join(', ');
+      } else {
+        allergiesDisplay = allergiesRaw;
+      }
+    } catch {
+      allergiesDisplay = allergiesRaw;
+    }
+  }
+
+  const clientName = `${client.firstName} ${client.lastName}`;
+  const height = client.heightCm;
+
+  return (
+    <div className="flex items-center gap-3.5 px-20 py-5 pb-3.5 max-w-[1200px]">
+      {/* Avatar with camera badge */}
+      <div className="relative flex-shrink-0">
+        <div
+          className="w-12 h-12 rounded-full bg-bg3 flex items-center justify-content-center font-semibold text-[18px] text-text2 flex items-center justify-center"
+          aria-label={clientInitials}
+        >
+          {clientInitials}
+        </div>
+        <button
+          type="button"
+          onClick={onPhotoDiary}
+          title={t('clientDetail.photoDiary')}
+          className="absolute -right-0.5 -bottom-0.5 w-5 h-5 rounded-full bg-accent border-2 border-bg flex items-center justify-center text-white text-[9px] cursor-pointer"
+        >
+          📷
+        </button>
+      </div>
+
+      {/* Name + meta line */}
+      <div className="min-w-0 flex-1">
+        <h1 className="text-[21px] font-bold tracking-[-0.02em] leading-[1.15] text-text">
+          {clientName}
+        </h1>
+        <div className="flex items-center gap-2 mt-0.5 text-[13px] text-text3">
+          {clientAge != null && (
+            <span>
+              {t('clientDetail.ageYears', { count: clientAge })}
+            </span>
+          )}
+          {clientAge != null && height != null && (
+            <span className="text-text4">·</span>
+          )}
+          {height != null && (
+            <span>{height} cm</span>
+          )}
+          {allergiesDisplay && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-orange-bg text-orange">
+              ⚠ {allergiesDisplay}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="ml-auto flex items-center gap-1.5">
+        <Button onClick={onPhotoDiary}>
+          📸 {t('clientDetail.photoDiary')}
+        </Button>
+        <Button onClick={onEditProfile}>
+          ✏ {t('clients.editProfile')}
+        </Button>
+        <Button
+          variant="primary"
+          onClick={() => navigate(`/messages?clientId=${clientId}`)}
+        >
+          ✉ {t('clientDetail.writeMessage')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/IdentityStrip.tsx
+++ b/web/src/components/clients/IdentityStrip.tsx
@@ -47,7 +47,7 @@ export function IdentityStrip({
       {/* Avatar with camera badge */}
       <div className="relative flex-shrink-0">
         <div
-          className="w-12 h-12 rounded-full bg-bg3 flex items-center justify-content-center font-semibold text-[18px] text-text2 flex items-center justify-center"
+          className="w-12 h-12 rounded-full bg-bg3 flex items-center justify-center font-semibold text-[18px] text-text2"
           aria-label={clientInitials}
         >
           {clientInitials}

--- a/web/src/components/clients/PlanCardPlaceholder.tsx
+++ b/web/src/components/clients/PlanCardPlaceholder.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+
+interface PlanCardPlaceholderProps {
+  type: 'nutrition' | 'training';
+  onCreatePlan?: () => void;
+}
+
+export function PlanCardPlaceholder({ type, onCreatePlan }: PlanCardPlaceholderProps) {
+  const { t } = useTranslation();
+
+  const icon = type === 'nutrition' ? '🥗' : '🏋️';
+  const labelKey = type === 'nutrition'
+    ? 'clientDetail.prehled.noActivePlan.nutrition'
+    : 'clientDetail.prehled.noActivePlan.training';
+  const ctaKey = type === 'nutrition'
+    ? 'clientDetail.prehled.noActivePlan.createNutrition'
+    : 'clientDetail.prehled.noActivePlan.createTraining';
+
+  return (
+    <div className="border border-border border-dashed rounded-[var(--radius-lg)] p-4 flex flex-col items-center justify-center gap-2 text-center min-h-[140px]">
+      <div className="text-[28px] opacity-40">{icon}</div>
+      <div className="text-[13px] text-text3">{t(labelKey)}</div>
+      {onCreatePlan && (
+        <button
+          type="button"
+          onClick={onCreatePlan}
+          className="mt-1 text-[12px] font-medium text-accent hover:underline bg-transparent border-none cursor-pointer"
+        >
+          {t(ctaKey)}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/clients/ProgressSnapshot.tsx
+++ b/web/src/components/clients/ProgressSnapshot.tsx
@@ -1,0 +1,147 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ClientVerdictResponse } from '@/api/client-verdict';
+
+interface WeightBar {
+  pct: number;
+  highlight: boolean;
+}
+
+interface ProgressSnapshotProps {
+  startWeight?: number | null;
+  currentWeight?: number | null;
+  targetWeight?: number | null;
+  verdict?: ClientVerdictResponse | null;
+  onAllMeasurementsClick: () => void;
+}
+
+export function ProgressSnapshot({
+  startWeight,
+  currentWeight,
+  targetWeight,
+  verdict,
+  onAllMeasurementsClick,
+}: ProgressSnapshotProps) {
+  const { t } = useTranslation();
+
+  // Build bar chart data from the weight series (same algorithm as old page)
+  const bars = useMemo((): WeightBar[] => {
+    if (startWeight == null || currentWeight == null) return [];
+
+    const tgt = targetWeight ?? currentWeight;
+    const values = [startWeight, currentWeight, tgt];
+    const maxVal = Math.max(...values);
+    const minVal = Math.min(...values);
+    const floor = Math.max(0, minVal - (maxVal - minVal) * 0.5);
+    const range = maxVal - floor || 1;
+
+    return [
+      { pct: ((startWeight - floor) / range) * 100, highlight: false },
+      { pct: ((currentWeight - floor) / range) * 100, highlight: true },
+      { pct: ((tgt - floor) / range) * 100, highlight: false },
+    ];
+  }, [startWeight, currentWeight, targetWeight]);
+
+  const weightDelta = startWeight != null && currentWeight != null
+    ? Math.round((currentWeight - startWeight) * 10) / 10
+    : null;
+  const remaining = currentWeight != null && targetWeight != null
+    ? Math.round(Math.abs(targetWeight - currentWeight) * 10) / 10
+    : null;
+
+  const prTotal = verdict?.prCountThisMonth ?? 0;
+
+  return (
+    <div className="grid gap-3.5" style={{ gridTemplateColumns: '1.5fr 1fr' }}>
+      {/* Weight progress bar chart */}
+      <div className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5">
+        <div className="flex items-center justify-between mb-2.5">
+          <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium">
+            {t('clientDetail.prehled.progress.weightTitle')}
+          </div>
+          <button
+            type="button"
+            onClick={onAllMeasurementsClick}
+            className="text-[11px] font-semibold text-accent bg-transparent border-none cursor-pointer hover:underline"
+          >
+            {t('clientDetail.prehled.progress.allMeasurements')} →
+          </button>
+        </div>
+
+        {bars.length > 0 ? (
+          <>
+            <div className="flex items-end gap-1.5 h-[72px] py-1">
+              {bars.map((bar, i) => (
+                <div
+                  key={i}
+                  className="flex-1 rounded-t-sm"
+                  style={{
+                    height: `${Math.max(bar.pct, 8)}%`,
+                    backgroundColor: 'var(--accent)',
+                    opacity: bar.highlight ? 0.7 : 0.45,
+                  }}
+                />
+              ))}
+            </div>
+            <div className="flex items-baseline justify-between mt-2">
+              <div className="text-[13px] text-text2">
+                {startWeight} → <b className="text-text">{currentWeight} kg</b>
+                {weightDelta != null && weightDelta !== 0 && (
+                  <span className={`ml-1.5 text-[11px] ${weightDelta < 0 ? 'text-green' : 'text-orange'}`}>
+                    ({weightDelta < 0 ? '' : '+'}{weightDelta} kg)
+                  </span>
+                )}
+              </div>
+              {remaining != null && targetWeight != null && (
+                <div className="text-[12px] text-green">
+                  {t('clientDetail.prehled.progress.remaining', { kg: remaining })}
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="text-[13px] text-text3 py-6 text-center">
+            {t('clientDetail.prehled.progress.noData')}
+          </div>
+        )}
+      </div>
+
+      {/* This month stats tile */}
+      <div className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5">
+        <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium mb-2.5">
+          {t('clientDetail.prehled.progress.thisMonth')}
+        </div>
+        <div className="flex flex-col gap-1.5 text-[13px]">
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              🏆 {t('clientDetail.prehled.progress.stats.prTotal')}
+            </span>
+            <b className="text-[15px]">{prTotal}</b>
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              🏋️ {t('clientDetail.prehled.progress.stats.workouts')}
+            </span>
+            <b className="text-[15px]">
+              {verdict?.trainingFrequencyActual != null ? verdict.trainingFrequencyActual : '—'}
+            </b>
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              📏 {t('clientDetail.prehled.progress.stats.measurements')}
+            </span>
+            <b className="text-[15px]">—</b>
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              🥗 {t('clientDetail.prehled.progress.stats.completedDays')}
+            </span>
+            <b className="text-[15px]">
+              {verdict?.compliancePercent != null ? `${verdict.compliancePercent} %` : '—'}
+            </b>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/VerdictHeroCard.tsx
+++ b/web/src/components/clients/VerdictHeroCard.tsx
@@ -1,0 +1,153 @@
+import { useTranslation } from 'react-i18next';
+import type { ClientVerdictResponse } from '@/api/client-verdict';
+
+interface VerdictHeroCardProps {
+  verdict: ClientVerdictResponse;
+}
+
+export function VerdictHeroCard({ verdict }: VerdictHeroCardProps) {
+  const { t } = useTranslation();
+
+  const isOnTrack = verdict.verdict === 'OnTrack';
+  const isNeedsAttention = verdict.verdict === 'NeedsAttention';
+
+  const borderClass = isOnTrack
+    ? 'border-green-bg'
+    : isNeedsAttention
+      ? 'border-orange-bg'
+      : 'border-red-bg';
+
+  const bgClass = isOnTrack
+    ? 'bg-green-bg'
+    : isNeedsAttention
+      ? 'bg-orange-bg'
+      : 'bg-red-bg';
+
+  const emoji = isOnTrack ? '✅' : isNeedsAttention ? '⚠️' : '🔴';
+
+  const labelKey = isOnTrack
+    ? 'clientDetail.verdict.onTrack.label'
+    : isNeedsAttention
+      ? 'clientDetail.verdict.needsAttention.label'
+      : 'clientDetail.verdict.offTrack.label';
+
+  const subtitleKey = isOnTrack
+    ? 'clientDetail.verdict.onTrack.subtitle'
+    : isNeedsAttention
+      ? 'clientDetail.verdict.needsAttention.subtitle'
+      : 'clientDetail.verdict.offTrack.subtitle';
+
+  const valueColorClass = isOnTrack
+    ? 'text-green'
+    : isNeedsAttention
+      ? 'text-orange'
+      : 'text-red';
+
+  const labelColorClass = isOnTrack
+    ? 'text-green'
+    : isNeedsAttention
+      ? 'text-orange'
+      : 'text-red';
+
+  // Format weight delta signal
+  const weightSignal = verdict.weightDeltaToGoal != null
+    ? `${verdict.weightDeltaToGoal < 0 ? '' : '+'}${verdict.weightDeltaToGoal.toFixed(1)} kg ${verdict.weightDirection === 'Towards' ? '↘' : verdict.weightDirection === 'Away' ? '↗' : '→'}`
+    : '—';
+
+  // Training frequency signal
+  const trainingSignal = verdict.trainingFrequencyActual != null && verdict.trainingFrequencyPrescribed != null
+    ? `${verdict.trainingFrequencyActual} / ${verdict.trainingFrequencyPrescribed}`
+    : '—';
+
+  return (
+    <div
+      className={`flex items-center gap-4 flex-wrap border ${borderClass} ${bgClass} rounded-[var(--radius-lg)] px-5 py-4 mb-4`}
+      style={{ borderColor: `var(--${isOnTrack ? 'green' : isNeedsAttention ? 'orange' : 'red'}-br)` }}
+    >
+      {/* Emoji + label */}
+      <div className="flex items-center gap-2.5">
+        <div className="text-[24px] leading-none">{emoji}</div>
+        <div>
+          <div className={`text-[17px] font-bold tracking-[-0.01em] ${labelColorClass}`}>
+            {t(labelKey)}
+          </div>
+          <div className="text-[12px] text-text3 mt-0.5">
+            {t(subtitleKey)}
+          </div>
+        </div>
+      </div>
+
+      {/* Signal stats */}
+      <div className="flex gap-6 ml-auto flex-wrap">
+        {/* Compliance */}
+        <div className="text-center">
+          <div className={`text-[17px] font-bold leading-none ${verdict.compliancePercent != null ? valueColorClass : 'text-text3'}`}>
+            {verdict.compliancePercent != null ? `${verdict.compliancePercent} %` : '—'}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.compliance')}
+          </div>
+        </div>
+
+        {/* Weight delta */}
+        <div className="text-center">
+          <div className={`text-[17px] font-bold leading-none ${verdict.weightDeltaToGoal != null ? valueColorClass : 'text-text3'}`}>
+            {weightSignal}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.weightDelta')}
+          </div>
+        </div>
+
+        {/* Training frequency */}
+        <div className="text-center">
+          <div className="text-[17px] font-bold leading-none text-text">
+            {trainingSignal}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.trainingsPerWeek')}
+          </div>
+        </div>
+
+        {/* PR this month */}
+        <div className="text-center">
+          <div className="text-[17px] font-bold leading-none text-text">
+            {verdict.prCountThisMonth}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.prThisMonth')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Fallback rendered when the verdict query fails (404/403). */
+export function VerdictHeroCardError() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2.5 border border-border bg-bg2 rounded-[var(--radius-lg)] px-5 py-4 mb-4">
+      <div className="text-[20px] leading-none text-text3">—</div>
+      <div className="text-[13px] text-text3">{t('clientDetail.verdict.unavailable')}</div>
+    </div>
+  );
+}
+
+/** Skeleton loading state for the verdict hero. */
+export function VerdictHeroCardSkeleton() {
+  return (
+    <div className="flex items-center gap-4 border border-border bg-bg2 rounded-[var(--radius-lg)] px-5 py-4 mb-4 animate-pulse">
+      <div className="w-6 h-6 bg-bg3 rounded-full" />
+      <div className="h-4 bg-bg3 rounded w-32" />
+      <div className="ml-auto flex gap-6">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="text-center">
+            <div className="h-5 bg-bg3 rounded w-12 mb-1" />
+            <div className="h-2.5 bg-bg3 rounded w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/tabs/AktivitaTab.tsx
+++ b/web/src/components/clients/tabs/AktivitaTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Aktivita tab — filled in by a wave-3 sub-issue. */
+export function AktivitaTab() {
+  return <div id="cl-pane-aktivita" />;
+}

--- a/web/src/components/clients/tabs/CheckinyTab.tsx
+++ b/web/src/components/clients/tabs/CheckinyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Check-iny tab — filled in by a wave-3 sub-issue. */
+export function CheckinyTab() {
+  return <div id="cl-pane-checkiny" />;
+}

--- a/web/src/components/clients/tabs/DotaznikyTab.tsx
+++ b/web/src/components/clients/tabs/DotaznikyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Dotazníky tab — filled in by a wave-3 sub-issue. */
+export function DotaznikyTab() {
+  return <div id="cl-pane-dotazniky" />;
+}

--- a/web/src/components/clients/tabs/FotkyTab.tsx
+++ b/web/src/components/clients/tabs/FotkyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Fotky tab — filled in by a wave-3 sub-issue. */
+export function FotkyTab() {
+  return <div id="cl-pane-fotky" />;
+}

--- a/web/src/components/clients/tabs/MereniTab.tsx
+++ b/web/src/components/clients/tabs/MereniTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Měření tab — filled in by sub-issue #487 or later wave-3 work. */
+export function MereniTab() {
+  return <div id="cl-pane-mereni" />;
+}

--- a/web/src/components/clients/tabs/PlanyTab.tsx
+++ b/web/src/components/clients/tabs/PlanyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Plány tab — filled in by a wave-3 sub-issue. */
+export function PlanyTab() {
+  return <div id="cl-pane-plany" />;
+}

--- a/web/src/components/clients/tabs/PoznamkyTab.tsx
+++ b/web/src/components/clients/tabs/PoznamkyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Poznámky tab — filled in by a wave-3 sub-issue. */
+export function PoznamkyTab() {
+  return <div id="cl-pane-poznamky" />;
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1656,5 +1656,97 @@
       "inviteCheckboxWarning": "Žádost o foto-deník bude odeslána po úspěšném vytvoření pozvánky.",
       "inviteDiaryFailed": "Pozvánka odeslána, ale žádost o foto-deník se nepodařila. Můžete ji odeslat později z detailu klienta."
     }
+  },
+  "clientDetail": {
+    "photoDiary": "Foto-deník",
+    "writeMessage": "Napsat",
+    "lastName": "Příjmení",
+    "heightCm": "Výška (cm)",
+    "weightKg": "Váha (kg)",
+    "tabBarLabel": "Záložky klienta",
+    "ageYears_one": "{{count}} rok",
+    "ageYears_few": "{{count}} roky",
+    "ageYears_many": "{{count}} let",
+    "ageYears_other": "{{count}} let",
+    "tabs": {
+      "prehled": "Přehled",
+      "mereni": "Měření",
+      "fotky": "Fotky",
+      "aktivita": "Aktivita",
+      "plany": "Plány",
+      "checkiny": "Check-iny",
+      "dotazniky": "Dotazníky",
+      "poznamky": "Poznámky"
+    },
+    "verdict": {
+      "unavailable": "Hodnocení není k dispozici",
+      "onTrack": {
+        "label": "Na dobré cestě",
+        "subtitle": "Plány aktivní a aktuální"
+      },
+      "needsAttention": {
+        "label": "Vyžaduje pozornost",
+        "subtitle": "Jeden ukazatel mimo cíl"
+      },
+      "offTrack": {
+        "label": "Mimo plán",
+        "subtitle": "Kritická odchylka — klient potřebuje pomoc"
+      },
+      "signals": {
+        "compliance": "Compliance",
+        "weightDelta": "K cíli",
+        "trainingsPerWeek": "Tréninky/týd",
+        "prThisMonth": "PR tento měsíc"
+      }
+    },
+    "prehled": {
+      "noActivePlan": {
+        "nutrition": "Žádný aktivní jídelníček",
+        "training": "Žádný aktivní tréninkový plán",
+        "createNutrition": "Vytvořit jídelníček →",
+        "createTraining": "Vytvořit tréninkový plán →"
+      },
+      "planCard": {
+        "active": "Aktivní",
+        "goal": "Cíl",
+        "targetWeight": "cílová váha {{kg}} kg",
+        "compliance": "Compliance {{pct}} %",
+        "openNutrition": "Otevřít jídelníček",
+        "history": "Historie plánů",
+        "from": "od {{date}}"
+      },
+      "trainingCard": {
+        "weeklyFrequency_one": "{{count}} trénink týdně",
+        "weeklyFrequency_few": "{{count}} tréninky týdně",
+        "weeklyFrequency_many": "{{count}} tréninků týdně",
+        "weeklyFrequency_other": "{{count}} tréninků týdně",
+        "thisWeek_one": "{{count}}× tento týden",
+        "thisWeek_few": "{{count}}× tento týden",
+        "thisWeek_many": "{{count}}× tento týden",
+        "thisWeek_other": "{{count}}× tento týden",
+        "prThisMonth_one": "{{count}} PR tento měsíc",
+        "prThisMonth_few": "{{count}} PR tento měsíc",
+        "prThisMonth_many": "{{count}} PR tento měsíc",
+        "prThisMonth_other": "{{count}} PR tento měsíc",
+        "openTraining": "Otevřít tréninkový plán"
+      },
+      "progress": {
+        "weightTitle": "Pokrok váhy k cíli",
+        "allMeasurements": "Všechna měření",
+        "remaining": "zbývá {{kg}} kg k cíli",
+        "noData": "Žádná měření",
+        "thisMonth": "Tento měsíc",
+        "stats": {
+          "prTotal": "PR celkem",
+          "workouts": "Tréninky",
+          "measurements": "Měření",
+          "completedDays": "Splněno dní"
+        }
+      }
+    },
+    "pendingInvite": {
+      "title": "Pozvánka odeslána",
+      "description": "Klient zatím nemá vytvořený účet. Na jeho email byla odeslána pozvánka s odkazem pro registraci. Po registraci si klient vyplní své údaje a jeho profil se zde automaticky doplní."
+    }
   }
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1728,6 +1728,7 @@
         "prThisMonth_few": "{{count}} PR tento měsíc",
         "prThisMonth_many": "{{count}} PR tento měsíc",
         "prThisMonth_other": "{{count}} PR tento měsíc",
+        "topPr": "🏆 Top PR: {{name}} — {{kg}} kg × {{reps}} opak.",
         "openTraining": "Otevřít tréninkový plán"
       },
       "progress": {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1636,5 +1636,89 @@
       "inviteCheckboxWarning": "Die Fototagebuch-Anfrage wird nach erfolgreicher Erstellung der Einladung gesendet.",
       "inviteDiaryFailed": "Einladung gesendet, aber Fototagebuch-Anfrage fehlgeschlagen. Sie können sie später über das Klientendetail senden."
     }
+  },
+  "clientDetail": {
+    "photoDiary": "Fototagebuch",
+    "writeMessage": "Schreiben",
+    "lastName": "Nachname",
+    "heightCm": "Körpergröße (cm)",
+    "weightKg": "Gewicht (kg)",
+    "tabBarLabel": "Klienten-Reiter",
+    "ageYears_one": "{{count}} Jahr",
+    "ageYears_other": "{{count}} Jahre",
+    "tabs": {
+      "prehled": "Übersicht",
+      "mereni": "Messungen",
+      "fotky": "Fotos",
+      "aktivita": "Aktivität",
+      "plany": "Pläne",
+      "checkiny": "Check-ins",
+      "dotazniky": "Fragebögen",
+      "poznamky": "Notizen"
+    },
+    "verdict": {
+      "unavailable": "Bewertung nicht verfügbar",
+      "onTrack": {
+        "label": "Auf Kurs",
+        "subtitle": "Pläne aktiv und aktuell"
+      },
+      "needsAttention": {
+        "label": "Benötigt Aufmerksamkeit",
+        "subtitle": "Ein Indikator außerhalb des Ziels"
+      },
+      "offTrack": {
+        "label": "Außer Plan",
+        "subtitle": "Kritische Abweichung — Klient braucht Unterstützung"
+      },
+      "signals": {
+        "compliance": "Compliance",
+        "weightDelta": "Zum Ziel",
+        "trainingsPerWeek": "Einheiten/Woche",
+        "prThisMonth": "PBs diesen Monat"
+      }
+    },
+    "prehled": {
+      "noActivePlan": {
+        "nutrition": "Kein aktiver Ernährungsplan",
+        "training": "Kein aktiver Trainingsplan",
+        "createNutrition": "Ernährungsplan erstellen →",
+        "createTraining": "Trainingsplan erstellen →"
+      },
+      "planCard": {
+        "active": "Aktiv",
+        "goal": "Ziel",
+        "targetWeight": "Zielgewicht {{kg}} kg",
+        "compliance": "Compliance {{pct}} %",
+        "openNutrition": "Ernährungsplan öffnen",
+        "history": "Planhistorie",
+        "from": "ab {{date}}"
+      },
+      "trainingCard": {
+        "weeklyFrequency_one": "{{count}} Einheit/Woche",
+        "weeklyFrequency_other": "{{count}} Einheiten/Woche",
+        "thisWeek_one": "{{count}}× diese Woche",
+        "thisWeek_other": "{{count}}× diese Woche",
+        "prThisMonth_one": "{{count}} PB diesen Monat",
+        "prThisMonth_other": "{{count}} PBs diesen Monat",
+        "openTraining": "Trainingsplan öffnen"
+      },
+      "progress": {
+        "weightTitle": "Gewichtsfortschritt zum Ziel",
+        "allMeasurements": "Alle Messungen",
+        "remaining": "{{kg}} kg bis zum Ziel",
+        "noData": "Keine Messungen",
+        "thisMonth": "Diesen Monat",
+        "stats": {
+          "prTotal": "PBs gesamt",
+          "workouts": "Trainings",
+          "measurements": "Messungen",
+          "completedDays": "Erfüllte Tage"
+        }
+      }
+    },
+    "pendingInvite": {
+      "title": "Einladung gesendet",
+      "description": "Der Klient hat noch kein Konto erstellt. Eine Einladung mit Registrierungslink wurde an seine E-Mail-Adresse gesendet. Nach der Registrierung füllt der Klient seine Daten aus und sein Profil wird hier automatisch aktualisiert."
+    }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1700,6 +1700,7 @@
         "thisWeek_other": "{{count}}× diese Woche",
         "prThisMonth_one": "{{count}} PB diesen Monat",
         "prThisMonth_other": "{{count}} PBs diesen Monat",
+        "topPr": "🏆 Top PB: {{name}} — {{kg}} kg × {{reps}} Whd.",
         "openTraining": "Trainingsplan öffnen"
       },
       "progress": {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1637,5 +1637,89 @@
       "inviteCheckboxWarning": "Diary request will be sent after the invite is successfully created.",
       "inviteDiaryFailed": "Invite sent, but diary request failed. You can send it later from the client detail."
     }
+  },
+  "clientDetail": {
+    "photoDiary": "Photo diary",
+    "writeMessage": "Message",
+    "lastName": "Last name",
+    "heightCm": "Height (cm)",
+    "weightKg": "Weight (kg)",
+    "tabBarLabel": "Client tabs",
+    "ageYears_one": "{{count}} year",
+    "ageYears_other": "{{count}} years",
+    "tabs": {
+      "prehled": "Overview",
+      "mereni": "Measurements",
+      "fotky": "Photos",
+      "aktivita": "Activity",
+      "plany": "Plans",
+      "checkiny": "Check-ins",
+      "dotazniky": "Questionnaires",
+      "poznamky": "Notes"
+    },
+    "verdict": {
+      "unavailable": "Verdict unavailable",
+      "onTrack": {
+        "label": "On Track",
+        "subtitle": "Plans active and up to date"
+      },
+      "needsAttention": {
+        "label": "Needs Attention",
+        "subtitle": "One indicator off target"
+      },
+      "offTrack": {
+        "label": "Off Plan",
+        "subtitle": "Critical deviation — client needs support"
+      },
+      "signals": {
+        "compliance": "Compliance",
+        "weightDelta": "To goal",
+        "trainingsPerWeek": "Sessions/week",
+        "prThisMonth": "PRs this month"
+      }
+    },
+    "prehled": {
+      "noActivePlan": {
+        "nutrition": "No active nutrition plan",
+        "training": "No active training plan",
+        "createNutrition": "Create nutrition plan →",
+        "createTraining": "Create training plan →"
+      },
+      "planCard": {
+        "active": "Active",
+        "goal": "Goal",
+        "targetWeight": "target weight {{kg}} kg",
+        "compliance": "Compliance {{pct}} %",
+        "openNutrition": "Open nutrition plan",
+        "history": "Plan history",
+        "from": "from {{date}}"
+      },
+      "trainingCard": {
+        "weeklyFrequency_one": "{{count}} session/week",
+        "weeklyFrequency_other": "{{count}} sessions/week",
+        "thisWeek_one": "{{count}}× this week",
+        "thisWeek_other": "{{count}}× this week",
+        "prThisMonth_one": "{{count}} PR this month",
+        "prThisMonth_other": "{{count}} PRs this month",
+        "openTraining": "Open training plan"
+      },
+      "progress": {
+        "weightTitle": "Weight progress to goal",
+        "allMeasurements": "All measurements",
+        "remaining": "{{kg}} kg remaining to goal",
+        "noData": "No measurements",
+        "thisMonth": "This month",
+        "stats": {
+          "prTotal": "Total PRs",
+          "workouts": "Workouts",
+          "measurements": "Measurements",
+          "completedDays": "Completed days"
+        }
+      }
+    },
+    "pendingInvite": {
+      "title": "Invitation sent",
+      "description": "The client hasn't created an account yet. An invitation with a registration link was sent to their email. After registering, the client will fill in their details and their profile will update here automatically."
+    }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1701,6 +1701,7 @@
         "thisWeek_other": "{{count}}× this week",
         "prThisMonth_one": "{{count}} PR this month",
         "prThisMonth_other": "{{count}} PRs this month",
+        "topPr": "🏆 Top PR: {{name}} — {{kg}} kg × {{reps}} reps",
         "openTraining": "Open training plan"
       },
       "progress": {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -46,6 +46,7 @@
   --purple-bg: rgba(105, 64, 165, 0.08);
   --orange:    #ad5700;
   --orange-bg: rgba(173, 87, 0, 0.08);
+  --orange-br: rgba(173, 87, 0, 0.2);
 
   /* Diary request status-chip tokens.
      Active-but-unfinished statuses (Pending / Accepted / InProgress) all use

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -5,8 +5,10 @@ import { useTranslation } from 'react-i18next';
 
 import { getClientDashboard } from '@/api/nutrition-goals';
 import { getClientVerdict } from '@/api/client-verdict';
-import { getPlans } from '@/api/plans';
+import { getPlans, getPlan } from '@/api/plans';
 import { getTrainingPlans } from '@/api/training-plans';
+import { getClientTimeline } from '@/api/timeline';
+import { useRecentActivityAggregates } from '@/components/domain/RecentActivity/useRecentActivityAggregates';
 
 import { Button, Dialog, Input } from '@/components/ui';
 import { IdentityStrip } from '@/components/clients/IdentityStrip';
@@ -92,11 +94,28 @@ export default function ClientDetailPage() {
     return age;
   }, [client?.dateOfBirth]);
 
-  const activeNutritionPlan: (PlanSummary & { globalSettings?: null }) | null =
+  const activeNutritionPlanSummary: PlanSummary | null =
     nutritionPlans?.plans?.[0] ?? null;
 
   const activeTrainingPlan: TrainingPlanSummary | null =
     trainingPlans?.plans?.[0] ?? null;
+
+  // Fetch the active nutrition plan detail to get globalSettings (macros).
+  // PlanSummary does not carry globalSettings — the detail does.
+  const { data: activeNutritionPlanDetail } = useQuery({
+    queryKey: ['plan', activeNutritionPlanSummary?.planId],
+    queryFn: () => getPlan(activeNutritionPlanSummary!.planId),
+    enabled: !!activeNutritionPlanSummary?.planId,
+  });
+
+  // Fetch the client timeline so we can derive the top PR for the training card.
+  const { data: timelineData } = useQuery({
+    queryKey: ['client-timeline', id],
+    queryFn: () => getClientTimeline(id!, 50),
+    enabled: !!id && client?.hasRegistered === true,
+  });
+
+  const { topPr } = useRecentActivityAggregates(timelineData?.items ?? []);
 
   const startWeight = client?.weightKg ?? null;
   const currentWeight = client?.latestMeasurement?.weightKg ?? startWeight;
@@ -186,9 +205,10 @@ export default function ClientDetailPage() {
 
               {/* Active plan cards (nutrition + training side by side) */}
               <div className="grid grid-cols-2 gap-3.5 mb-4">
-                {activeNutritionPlan ? (
+                {activeNutritionPlanSummary ? (
                   <ActiveNutritionPlanCard
-                    plan={activeNutritionPlan}
+                    plan={activeNutritionPlanSummary}
+                    globalSettings={activeNutritionPlanDetail?.globalSettings}
                     targetWeightKg={ob?.targetWeightKg}
                     goalLabel={ob?.derivedNutritionGoal ?? ob?.primaryGoal}
                     compliancePercent={client.compliancePercent}
@@ -207,6 +227,7 @@ export default function ClientDetailPage() {
                     trainingFrequencyActual={verdict?.trainingFrequencyActual}
                     trainingFrequencyPrescribed={verdict?.trainingFrequencyPrescribed}
                     prCountThisMonth={verdict?.prCountThisMonth}
+                    topPr={topPr}
                     onHistoryClick={() => setActiveTab('plany')}
                   />
                 ) : (
@@ -228,10 +249,11 @@ export default function ClientDetailPage() {
             </div>
           )}
 
-          {/* ── PLACEHOLDER PANES ── (wave-3 children fill these) */}
+          {/* ── PLACEHOLDER PANES ── (wave-3 children fill these)
+              NOTE: id="cl-pane-<id>" lives on each placeholder component's root div,
+              not on this wrapper, to avoid duplicate DOM ids. */}
           {activeTab === 'mereni' && (
             <div
-              id="cl-pane-mereni"
               role="tabpanel"
               aria-labelledby="cl-tab-mereni"
               className="tab-content-transition"
@@ -242,7 +264,6 @@ export default function ClientDetailPage() {
 
           {activeTab === 'fotky' && (
             <div
-              id="cl-pane-fotky"
               role="tabpanel"
               aria-labelledby="cl-tab-fotky"
               className="tab-content-transition"
@@ -253,7 +274,6 @@ export default function ClientDetailPage() {
 
           {activeTab === 'aktivita' && (
             <div
-              id="cl-pane-aktivita"
               role="tabpanel"
               aria-labelledby="cl-tab-aktivita"
               className="tab-content-transition"
@@ -264,7 +284,6 @@ export default function ClientDetailPage() {
 
           {activeTab === 'plany' && (
             <div
-              id="cl-pane-plany"
               role="tabpanel"
               aria-labelledby="cl-tab-plany"
               className="tab-content-transition"
@@ -275,7 +294,6 @@ export default function ClientDetailPage() {
 
           {activeTab === 'checkiny' && (
             <div
-              id="cl-pane-checkiny"
               role="tabpanel"
               aria-labelledby="cl-tab-checkiny"
               className="tab-content-transition"
@@ -286,7 +304,6 @@ export default function ClientDetailPage() {
 
           {activeTab === 'dotazniky' && (
             <div
-              id="cl-pane-dotazniky"
               role="tabpanel"
               aria-labelledby="cl-tab-dotazniky"
               className="tab-content-transition"
@@ -297,7 +314,6 @@ export default function ClientDetailPage() {
 
           {activeTab === 'poznamky' && (
             <div
-              id="cl-pane-poznamky"
               role="tabpanel"
               aria-labelledby="cl-tab-poznamky"
               className="tab-content-transition"

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -1,43 +1,76 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getClientDashboard } from '@/api/nutrition-goals';
-import { getClientTimeline } from '@/api/timeline';
 
-import { PageHeader } from '@/components/layout';
-import { Button, Tag, Dialog, Input, EditableAvatar } from '@/components/ui';
-import { PropertyList, StatsGrid } from '@/components/data';
-import { RecentActivitySection } from '@/components/domain';
-import { QuestionnaireAnswersSection } from '@/components/questionnaire';
-import { WeeklyCheckInSection } from '@/components/weekly-checkin/WeeklyCheckInSection';
+import { getClientDashboard } from '@/api/nutrition-goals';
+import { getClientVerdict } from '@/api/client-verdict';
+import { getPlans } from '@/api/plans';
+import { getTrainingPlans } from '@/api/training-plans';
+
+import { Button, Dialog, Input } from '@/components/ui';
+import { IdentityStrip } from '@/components/clients/IdentityStrip';
+import { ClientTabBar, type ClientTabId } from '@/components/clients/ClientTabBar';
+import {
+  VerdictHeroCard,
+  VerdictHeroCardError,
+  VerdictHeroCardSkeleton,
+} from '@/components/clients/VerdictHeroCard';
+import { ActiveNutritionPlanCard } from '@/components/clients/ActiveNutritionPlanCard';
+import { ActiveTrainingPlanCard } from '@/components/clients/ActiveTrainingPlanCard';
+import { PlanCardPlaceholder } from '@/components/clients/PlanCardPlaceholder';
+import { ProgressSnapshot } from '@/components/clients/ProgressSnapshot';
+import { MereniTab } from '@/components/clients/tabs/MereniTab';
+import { FotkyTab } from '@/components/clients/tabs/FotkyTab';
+import { AktivitaTab } from '@/components/clients/tabs/AktivitaTab';
+import { PlanyTab } from '@/components/clients/tabs/PlanyTab';
+import { CheckinyTab } from '@/components/clients/tabs/CheckinyTab';
+import { DotaznikyTab } from '@/components/clients/tabs/DotaznikyTab';
+import { PoznamkyTab } from '@/components/clients/tabs/PoznamkyTab';
+import type { PlanSummary } from '@/api/plan-types';
+import type { TrainingPlanSummary } from '@/api/training-plan-types';
 
 export default function ClientDetailPage() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  // Edit dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<ClientTabId>('prehled');
 
-  // Timeline pagination limit — starts at 30, bumps by 30 up to 100
-  const [timelineLimit, setTimelineLimit] = useState(30);
+  // ── Server state ─────────────────────────────────────────────────────────────
 
-  const { data: client, isLoading } = useQuery({
+  const { data: client, isLoading: clientLoading } = useQuery({
     queryKey: ['client-dashboard', id],
     queryFn: () => getClientDashboard(id!),
     enabled: !!id,
   });
 
-  const { data: timeline } = useQuery({
-    queryKey: ['client-timeline', id, timelineLimit],
-    queryFn: () => getClientTimeline(id!, timelineLimit),
-    enabled: !!id,
+  const {
+    data: verdict,
+    isError: verdictError,
+    isLoading: verdictLoading,
+  } = useQuery({
+    queryKey: ['client-verdict', id],
+    queryFn: () => getClientVerdict(id!),
+    enabled: !!id && client?.hasRegistered === true,
+    // Non-fatal: 404/403 surfaces as error state, not page crash
+    retry: false,
   });
 
-  const handleTimelineLoadMore = useCallback(() => {
-    setTimelineLimit((prev) => Math.min(prev + 30, 100));
-  }, []);
+  const { data: nutritionPlans } = useQuery({
+    queryKey: ['plans', { clientId: id, status: 'Active' }],
+    queryFn: () => getPlans({ clientId: id, status: 'Active', pageSize: 1 }),
+    enabled: !!id && client?.hasRegistered === true,
+  });
+
+  const { data: trainingPlans } = useQuery({
+    queryKey: ['training-plans', { clientId: id, status: 'Active' }],
+    queryFn: () => getTrainingPlans({ clientId: id, status: 'Active', pageSize: 1 }),
+    enabled: !!id && client?.hasRegistered === true,
+  });
+
+  // ── Derived values ───────────────────────────────────────────────────────────
 
   const clientName = client
     ? `${client.firstName} ${client.lastName}`
@@ -49,41 +82,6 @@ export default function ClientDetailPage() {
 
   const ob = client?.onboarding;
 
-  /** Translate an enum/tag value via clients.values.X, fall back to raw value */
-  const v = useCallback((val: string | null | undefined) => {
-    if (!val) return '—';
-    const key = `clients.values.${val}`;
-    const translated = t(key);
-    return translated !== key ? translated : val;
-  }, [t]);
-
-  // Compliance color helper
-  const complianceColor = useMemo(() => {
-    const cp = client?.compliancePercent;
-    if (cp == null) return 'text-text3';
-    if (cp >= 80) return 'text-green';
-    if (cp >= 60) return 'text-orange';
-    return 'text-red';
-  }, [client?.compliancePercent]);
-
-  // Weight progress
-  const weightProgress = useMemo(() => {
-    if (!client?.weightKg || !client?.latestMeasurement?.weightKg) return null;
-    const diff = client.latestMeasurement.weightKg - client.weightKg;
-    return Math.round(diff * 10) / 10;
-  }, [client]);
-
-  // Goal tag variant
-  const goalTagVariant = useMemo((): 'blue' | 'green' | 'orange' | 'purple' => {
-    const goal = ob?.derivedNutritionGoal || ob?.primaryGoal;
-    if (!goal) return 'blue';
-    const lower = goal.toLowerCase();
-    if (lower.includes('cut') || lower.includes('hubn')) return 'blue';
-    if (lower.includes('bulk') || lower.includes('nabr')) return 'purple';
-    return 'green';
-  }, [ob]);
-
-  // Calculate age from dateOfBirth
   const clientAge = useMemo(() => {
     if (!client?.dateOfBirth) return null;
     const birth = new Date(client.dateOfBirth);
@@ -92,173 +90,21 @@ export default function ClientDetailPage() {
     const m = now.getMonth() - birth.getMonth();
     if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age--;
     return age;
-  }, [client]);
+  }, [client?.dateOfBirth]);
 
-  // Build property list items
-  const propertyItems = useMemo(() => {
-    if (!client) return [];
-    const items: Array<{
-      label: string;
-      icon?: string;
-      value: React.ReactNode;
-      editable?: boolean;
-      onEdit?: (value: string) => void;
-    }> = [];
+  const activeNutritionPlan: (PlanSummary & { globalSettings?: null }) | null =
+    nutritionPlans?.plans?.[0] ?? null;
 
-    // Vek
-    if (clientAge != null) {
-      items.push({
-        label: 'Věk',
-        icon: '📅',
-        value: `${clientAge} let`,
-        editable: false,
-      });
-    }
+  const activeTrainingPlan: TrainingPlanSummary | null =
+    trainingPlans?.plans?.[0] ?? null;
 
-    // Vyska / vaha
-    const height = client.heightCm;
-    const weight = client.latestMeasurement?.weightKg ?? client.weightKg;
-    if (height != null || weight != null) {
-      const weightDiff = weightProgress;
-      items.push({
-        label: 'Výška / váha',
-        icon: '📏',
-        value: (
-          <span>
-            {height != null ? `${height} cm` : ''}
-            {height != null && weight != null ? ' · ' : ''}
-            {weight != null ? `${weight} kg` : ''}
-            {weightDiff != null && weightDiff !== 0 && (
-              <span className={`ml-1.5 text-xs ${weightDiff < 0 ? 'text-green' : 'text-orange'}`}>
-                {weightDiff < 0 ? '↓' : '↑'} {Math.abs(weightDiff)} kg
-              </span>
-            )}
-          </span>
-        ),
-      });
-    }
+  const startWeight = client?.weightKg ?? null;
+  const currentWeight = client?.latestMeasurement?.weightKg ?? startWeight;
+  const targetWeight = ob?.targetWeightKg ?? null;
 
-    // Cilova vaha
-    if (ob?.targetWeightKg != null) {
-      items.push({
-        label: 'Cílová váha',
-        icon: '🎯',
-        value: `${ob.targetWeightKg} kg`,
-        editable: true,
-      });
-    }
+  // ── Loading / error states ───────────────────────────────────────────────────
 
-    // Email
-    if (client.email) {
-      items.push({
-        label: 'Email',
-        icon: '✉',
-        value: <span className="text-blue">{client.email}</span>,
-      });
-    }
-
-    // Aktivni plany
-    items.push({
-      label: 'Aktivní plány',
-      icon: '📋',
-      value: (
-        <span className="flex flex-wrap items-center gap-1.5">
-          <span className="text-text3">{t('clients.noPlans') !== 'clients.noPlans' ? t('clients.noPlans') : 'Žádné plány'}</span>
-        </span>
-      ),
-    });
-
-    // Alergie
-    if (ob?.allergies) {
-      let allergiesDisplay = ob.allergies;
-      try {
-        const arr = JSON.parse(ob.allergies);
-        if (Array.isArray(arr)) allergiesDisplay = arr.join(', ');
-      } catch { /* use as-is */ }
-      items.push({
-        label: 'Alergie',
-        icon: '⚠',
-        value: allergiesDisplay,
-        editable: true,
-      });
-    }
-
-    return items;
-  }, [client, clientAge, weightProgress, ob, t]);
-
-  // Build stats
-  const statsItems = useMemo(() => {
-    if (!client) return [];
-    return [
-      {
-        label: '🔥 Série',
-        value: client.currentStreak,
-        sub: 'dní v řadě',
-        valueColor: client.currentStreak > 0 ? 'text-orange' : undefined,
-      },
-      {
-        label: 'Compliance',
-        value: client.compliancePercent != null ? `${client.compliancePercent} %` : '—',
-        sub: 'za posledních 7 dní',
-        valueColor: complianceColor,
-      },
-      {
-        label: 'Pokrok váhy',
-        value: weightProgress != null && weightProgress !== 0
-          ? `${weightProgress > 0 ? '+' : ''}${weightProgress} kg`
-          : '—',
-        sub: weightProgress != null && weightProgress !== 0
-          ? (weightProgress < 0 ? 'úbytek' : 'přírůstek')
-          : 'beze změny',
-        valueColor: weightProgress != null && weightProgress < 0 ? 'text-green' : weightProgress != null && weightProgress > 0 ? 'text-orange' : undefined,
-      },
-    ];
-  }, [client, complianceColor, weightProgress]);
-
-  // Build weight progress chart data (bar chart)
-  const weightChartData = useMemo(() => {
-    if (!client?.weightKg) return null;
-    const startWeight = client.weightKg;
-    const currentWeight = client.latestMeasurement?.weightKg ?? startWeight;
-    const targetWeight = ob?.targetWeightKg ?? currentWeight;
-
-    const values = [startWeight, currentWeight, targetWeight];
-    const maxVal = Math.max(...values);
-    const minVal = Math.min(...values);
-    // Use 0 as the floor so bars reflect absolute scale, not just relative diff
-    const floor = Math.max(0, minVal - (maxVal - minVal) * 0.5);
-    const range = maxVal - floor || 1;
-
-    return [
-      { label: 'Start', value: startWeight, pct: ((startWeight - floor) / range) * 100 },
-      { label: 'Aktuální', value: currentWeight, pct: ((currentWeight - floor) / range) * 100, highlight: true },
-      { label: 'Cíl', value: targetWeight, pct: ((targetWeight - floor) / range) * 100 },
-    ];
-  }, [client, ob]);
-
-  // Narrow the active locale to the set supported by formatWeight.
-  const activeLocale = useMemo((): 'cs' | 'en' | 'de' => {
-    const lang = i18n.language;
-    if (lang === 'en' || lang === 'de') return lang;
-    return 'cs';
-  }, [i18n.language]);
-
-  // Raw timeline items — passed directly to RecentActivitySection for grouping.
-  // The old flat-list activityItems memo is superseded by the new section component.
-
-  // Subtitle for PageHeader
-  const subtitleNode = useMemo(() => {
-    if (!client) return undefined;
-    const goal = ob?.primaryGoal || ob?.derivedNutritionGoal || client.goals;
-    return (
-      <div className="flex items-center gap-2 mt-1.5">
-        {goal && <Tag variant={goalTagVariant}>{v(goal)}</Tag>}
-      </div>
-    );
-  }, [client, ob, goalTagVariant, v]);
-
-  // Loading state
-  if (isLoading) {
+  if (clientLoading) {
     return (
       <div className="flex items-center justify-center py-24 text-text3">
         {t('common.loading')}
@@ -268,189 +114,241 @@ export default function ClientDetailPage() {
 
   if (!client) return null;
 
-  // Client has not registered yet — show pending invite state
-  const isPending = client.hasRegistered === false;
-
-  if (isPending) {
+  // Pending-invite state: client has not registered yet
+  if (client.hasRegistered === false) {
     return (
       <div className="flex h-full flex-col">
-        <PageHeader icon="👤" title={clientName} subtitle={client.email ?? undefined} />
-        <div style={{ padding: '40px 80px', maxWidth: 600 }}>
-          <div style={{
-            background: 'var(--accent-bg)',
-            border: '1px solid var(--accent-br)',
-            borderRadius: 'var(--radius-md)',
-            padding: '24px 28px',
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-              <span style={{ fontSize: 28 }}>✉️</span>
+        <div className="px-20 py-7">
+          <h1 className="text-text mb-1">{clientName}</h1>
+          <div className="text-[13px] text-text3 mb-5">{client.email}</div>
+          <div
+            className="max-w-[480px] rounded-[var(--radius-md)] p-6"
+            style={{
+              background: 'var(--accent-bg)',
+              border: '1px solid var(--accent-br)',
+            }}
+          >
+            <div className="flex items-center gap-2.5 mb-3">
+              <span className="text-[28px]">✉️</span>
               <div>
-                <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text)' }}>Pozvánka odeslána</div>
-                <div style={{ fontSize: 13, color: 'var(--text2)', marginTop: 2 }}>{client.email}</div>
+                <div className="text-[15px] font-semibold text-text">
+                  {t('clientDetail.pendingInvite.title')}
+                </div>
+                <div className="text-[13px] text-text2 mt-0.5">{client.email}</div>
               </div>
             </div>
-            <div style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.6 }}>
-              Klient zatím nemá vytvořený účet. Na jeho email byla odeslána pozvánka
-              s odkazem pro registraci. Po registraci si klient vyplní své údaje
-              (váha, výška, cíle, alergie) a jeho profil se zde automaticky doplní.
+            <div className="text-[13px] text-text2 leading-relaxed">
+              {t('clientDetail.pendingInvite.description')}
             </div>
-          </div>
-
-          <div style={{
-            marginTop: 20,
-            padding: '16px 20px',
-            background: 'var(--bg2)',
-            borderRadius: 'var(--radius-md)',
-            fontSize: 13,
-            color: 'var(--text3)',
-          }}>
-            <div style={{ fontWeight: 500, color: 'var(--text2)', marginBottom: 6 }}>Co se stane po registraci klienta?</div>
-            <ul style={{ paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <li>Klient vyplní svou anamnézu a osobní údaje</li>
-              <li>Budete moci nastavit jeho výživové cíle a makra</li>
-              <li>Můžete mu vytvořit jídelníček a tréninkový plán</li>
-            </ul>
           </div>
         </div>
       </div>
     );
   }
 
+  // ── Render ───────────────────────────────────────────────────────────────────
+
   return (
     <div className="flex h-full flex-col">
-      {/* Page Header */}
-      <PageHeader
-        icon={
-          <EditableAvatar
-            src={null}
-            initials={clientInitials}
-            size="md"
-            editable={false}
-          />
-        }
-        title={clientName}
-        subtitle={client.email ?? undefined}
-        actions={
-          <div className="flex items-center gap-1.5">
-            {subtitleNode}
-            <Button onClick={() => setEditDialogOpen(true)}>
-              ✏ {t('clients.editProfile')}
-            </Button>
-            <Button variant="primary" onClick={() => navigate(`/messages?clientId=${id}`)}>
-              ✉ {t('clients.sendMessage')}
-            </Button>
-          </div>
-        }
+      {/* Identity strip — pinned above tab bar */}
+      <IdentityStrip
+        client={client}
+        clientId={id!}
+        clientInitials={clientInitials}
+        clientAge={clientAge}
+        onEditProfile={() => setEditDialogOpen(true)}
+        onPhotoDiary={() => {
+          // Photo diary action — to be wired by wave-3 Fotky sub-issue
+        }}
       />
 
-      {/* Page Content */}
+      {/* Gold-chip tab bar */}
+      <ClientTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+
+      {/* Pane content — scrolls independently */}
       <div className="flex-1 overflow-y-auto">
-        <div className="px-20 py-3">
-          {/* Property List */}
-          <PropertyList items={propertyItems} />
+        <div className="px-20 py-5">
 
-          {/* Questionnaire Answers */}
-          <div className="my-3.5">
-            <QuestionnaireAnswersSection clientId={id!} />
-          </div>
+          {/* ── PŘEHLED PANE ── */}
+          {activeTab === 'prehled' && (
+            <div
+              id="cl-pane-prehled"
+              role="tabpanel"
+              aria-labelledby="cl-tab-prehled"
+              className="tab-content-transition"
+            >
+              {/* Verdict hero card */}
+              {verdictLoading && <VerdictHeroCardSkeleton />}
+              {verdictError && <VerdictHeroCardError />}
+              {verdict && !verdictError && (
+                <VerdictHeroCard verdict={verdict} />
+              )}
 
-          {/* Weekly check-in section */}
-          {/* NOTE: id here is the client's publicId (route param). The backend
-              GET /trainer/clients/{clientUserId}/weekly-check-ins/current
-              expects the ApplicationUser.Id (Guid). Until the backend exposes
-              clientUserId in the client dashboard response, this will return
-              empty results and the section stays hidden. A follow-up task
-              should add clientUserId to GetClientDashboardResponse. */}
-          {id && (
-            <WeeklyCheckInSection clientUserId={id} />
-          )}
+              {/* Active plan cards (nutrition + training side by side) */}
+              <div className="grid grid-cols-2 gap-3.5 mb-4">
+                {activeNutritionPlan ? (
+                  <ActiveNutritionPlanCard
+                    plan={activeNutritionPlan}
+                    targetWeightKg={ob?.targetWeightKg}
+                    goalLabel={ob?.derivedNutritionGoal ?? ob?.primaryGoal}
+                    compliancePercent={client.compliancePercent}
+                    onHistoryClick={() => setActiveTab('plany')}
+                  />
+                ) : (
+                  <PlanCardPlaceholder
+                    type="nutrition"
+                    onCreatePlan={() => navigate(`/nutrition/plans/new?clientId=${id}`)}
+                  />
+                )}
 
-          {/* Divider */}
-          <div className="h-px bg-border my-3.5" />
-
-          {/* Stats Grid */}
-          <StatsGrid stats={statsItems} columns={3} />
-
-          {/* Weight Progress Chart */}
-          {weightChartData && (
-            <div className="mb-4">
-              <div className="text-[11px] text-text3 font-medium uppercase tracking-[0.04em] mb-2">
-                Váhový progres
+                {activeTrainingPlan ? (
+                  <ActiveTrainingPlanCard
+                    plan={activeTrainingPlan}
+                    trainingFrequencyActual={verdict?.trainingFrequencyActual}
+                    trainingFrequencyPrescribed={verdict?.trainingFrequencyPrescribed}
+                    prCountThisMonth={verdict?.prCountThisMonth}
+                    onHistoryClick={() => setActiveTab('plany')}
+                  />
+                ) : (
+                  <PlanCardPlaceholder
+                    type="training"
+                    onCreatePlan={() => navigate(`/training/plans/new?clientId=${id}`)}
+                  />
+                )}
               </div>
-              <div className="flex gap-3">
-                {weightChartData.map((bar) => (
-                  <div key={bar.label} className="flex flex-col items-center gap-1 flex-1">
-                    <div className="text-[11px] text-text2 font-medium">{bar.value} kg</div>
-                    <div className="w-full relative" style={{ height: 80 }}>
-                      <div
-                        className="absolute bottom-0 left-0 right-0 rounded"
-                        style={{
-                          height: `${Math.max(bar.pct, 8)}%`,
-                          backgroundColor: bar.highlight ? 'var(--accent)' : 'var(--bg3)',
-                        }}
-                      />
-                    </div>
-                    <div className="text-[11px] text-text3">{bar.label}</div>
-                  </div>
-                ))}
-              </div>
+
+              {/* Progress snapshot */}
+              <ProgressSnapshot
+                startWeight={startWeight}
+                currentWeight={currentWeight}
+                targetWeight={targetWeight}
+                verdict={verdict ?? null}
+                onAllMeasurementsClick={() => setActiveTab('mereni')}
+              />
             </div>
           )}
 
-          {/* Divider */}
-          <div className="h-px bg-border my-3.5" />
+          {/* ── PLACEHOLDER PANES ── (wave-3 children fill these) */}
+          {activeTab === 'mereni' && (
+            <div
+              id="cl-pane-mereni"
+              role="tabpanel"
+              aria-labelledby="cl-tab-mereni"
+              className="tab-content-transition"
+            >
+              <MereniTab />
+            </div>
+          )}
 
-          {/* Recent Activity — day-grouped timeline + summary sidebar */}
-          <RecentActivitySection
-            items={timeline?.items ?? []}
-            limit={timelineLimit}
-            onLoadMore={handleTimelineLoadMore}
-            locale={activeLocale}
-          />
+          {activeTab === 'fotky' && (
+            <div
+              id="cl-pane-fotky"
+              role="tabpanel"
+              aria-labelledby="cl-tab-fotky"
+              className="tab-content-transition"
+            >
+              <FotkyTab />
+            </div>
+          )}
+
+          {activeTab === 'aktivita' && (
+            <div
+              id="cl-pane-aktivita"
+              role="tabpanel"
+              aria-labelledby="cl-tab-aktivita"
+              className="tab-content-transition"
+            >
+              <AktivitaTab />
+            </div>
+          )}
+
+          {activeTab === 'plany' && (
+            <div
+              id="cl-pane-plany"
+              role="tabpanel"
+              aria-labelledby="cl-tab-plany"
+              className="tab-content-transition"
+            >
+              <PlanyTab />
+            </div>
+          )}
+
+          {activeTab === 'checkiny' && (
+            <div
+              id="cl-pane-checkiny"
+              role="tabpanel"
+              aria-labelledby="cl-tab-checkiny"
+              className="tab-content-transition"
+            >
+              <CheckinyTab />
+            </div>
+          )}
+
+          {activeTab === 'dotazniky' && (
+            <div
+              id="cl-pane-dotazniky"
+              role="tabpanel"
+              aria-labelledby="cl-tab-dotazniky"
+              className="tab-content-transition"
+            >
+              <DotaznikyTab />
+            </div>
+          )}
+
+          {activeTab === 'poznamky' && (
+            <div
+              id="cl-pane-poznamky"
+              role="tabpanel"
+              aria-labelledby="cl-tab-poznamky"
+              className="tab-content-transition"
+            >
+              <PoznamkyTab />
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Edit Client Dialog */}
+      {/* Edit client dialog (unchanged from original) */}
       <Dialog
         open={editDialogOpen}
         onClose={() => setEditDialogOpen(false)}
-        title="Upravit profil"
+        title={t('clients.editProfile')}
         footer={
           <>
             <Button variant="ghost" onClick={() => setEditDialogOpen(false)}>
-              Zrušit
+              {t('common.cancel')}
             </Button>
             <Button variant="primary" onClick={() => setEditDialogOpen(false)}>
-              Uložit
+              {t('common.save')}
             </Button>
           </>
         }
       >
         <div className="space-y-0">
           <Input
-            label="Jméno"
+            label={t('common.name')}
             defaultValue={client?.firstName ?? ''}
-            placeholder="Jméno"
+            placeholder={t('common.name')}
           />
           <Input
-            label="Příjmení"
+            label={t('clientDetail.lastName')}
             defaultValue={client?.lastName ?? ''}
-            placeholder="Příjmení"
+            placeholder={t('clientDetail.lastName')}
           />
           <Input
-            label="Email"
+            label={t('common.email')}
             defaultValue={client?.email ?? ''}
-            placeholder="Email"
+            placeholder={t('common.email')}
             type="email"
           />
           <Input
-            label="Výška (cm)"
+            label={t('clientDetail.heightCm')}
             defaultValue={client?.heightCm?.toString() ?? ''}
             placeholder="168"
             type="number"
           />
           <Input
-            label="Váha (kg)"
+            label={t('clientDetail.weightKg')}
             defaultValue={client?.weightKg?.toString() ?? ''}
             placeholder="63"
             type="number"


### PR DESCRIPTION
## Summary
- Replaces the old Notion-style property-list client-detail layout with a pinned identity strip + gold-chip 8-tab bar.
- Default **Přehled** pane: verdict hero (consumes the #485 `/verdict` endpoint), active nutrition + training plan cards with pending-state placeholders, and a progress-snapshot CSS bar chart.
- 7 empty placeholder panes establish the load-bearing `cl-pane-<id>` contract for wave-3 children #487–#492.
- i18n added in cs / en / de.

## Related issue
Fixes #486

## Parent epic
Part of epic #484 — base branch: `feature/484-client-detail-redesign`.

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS (static/build/i18n) — `npm run build` clean, all i18n keys present in cs/en/de, no hardcoded colors, no `any`, 7 placeholder panes with correct ids. Live-visual "matches-prototype" ACs DEFERRED to a consolidated Playwright pass at the epic-PR stage (orchestrator decision).

## Test plan
- [ ] Identity strip renders name, age, height, allergy chip, action buttons
- [ ] 8-tab gold-chip bar switches panes; Přehled is default
- [ ] Verdict hero renders on-track / needs-attention / off-track states + skeleton + error fallback
- [ ] Active nutrition + training plan cards render; placeholders show when no active plan
- [ ] Progress snapshot bar chart + this-month stats render
- [ ] 7 placeholder panes expose stable `cl-pane-<id>` ids for wave-3
- [ ] i18n present in cs / en / de

🤖 Generated with [Claude Code](https://claude.com/claude-code)