### PR TITLE
feat: wire Google sign-in on web login page

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ConfigKeys.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ConfigKeys.cs
@@ -74,4 +74,9 @@ public static class ConfigKeys
     /// MongoDB database name.
     /// </summary>
     public const string MongoDbDatabaseName = "MongoDB:DatabaseName";
+
+    /// <summary>
+    /// Google OAuth 2.0 client ID used to verify Google ID tokens.
+    /// </summary>
+    public const string GoogleClientId = "Google:ClientId";
 }

--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -10,6 +10,9 @@ public static class ErrorCodes
     /// <summary>Invalid email or password during login.</summary>
     public const string InvalidCredentials = "INVALID_CREDENTIALS";
 
+    /// <summary>Google-verified email matches a password-only account with no Google external login. The user should sign in with their password.</summary>
+    public const string SocialEmailConflict = "social_email_conflict";
+
     /// <summary>Account is deactivated.</summary>
     public const string AccountDeactivated = "ACCOUNT_DEACTIVATED";
 

--- a/backend/FitnessPlatform.Application/Domain/Entities/UserExternalLogin.cs
+++ b/backend/FitnessPlatform.Application/Domain/Entities/UserExternalLogin.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace FitnessPlatform.Application.Domain.Entities;
+
+/// <summary>
+/// Stores an external OAuth provider identity linked to an application user.
+/// Used to support social login flows (Google, Apple, etc.).
+/// </summary>
+public class UserExternalLogin
+{
+    /// <summary>
+    /// Primary key.
+    /// </summary>
+    public long Id { get; set; }
+
+    /// <summary>
+    /// The application user this external login belongs to.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Navigation property to the linked user.
+    /// </summary>
+    public ApplicationUser User { get; set; } = null!;
+
+    /// <summary>
+    /// The OAuth provider name (e.g. "google", "apple").
+    /// </summary>
+    [MaxLength(50)]
+    public string Provider { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The provider's unique subject identifier for this user (e.g. Google's "sub" claim).
+    /// </summary>
+    [MaxLength(255)]
+    public string Subject { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC timestamp when this external login was created.
+    /// </summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginEndpoint.cs
@@ -1,0 +1,201 @@
+using System.Security.Cryptography;
+using FastEndpoints;
+using FastEndpoints.Security;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Google;
+
+/// <summary>
+/// Endpoint for signing in via Google Identity Services.
+/// Verifies the Google ID token, then either logs in an existing linked account,
+/// provisions a new account from the Google profile, or returns 409 when the
+/// email belongs to a password-only account with no Google link.
+/// </summary>
+public class GoogleSocialLoginEndpoint(
+    IGoogleTokenVerifier googleVerifier,
+    UserManager<ApplicationUser> userManager,
+    IApplicationDbContext db,
+    IConfiguration config) : Endpoint<GoogleSocialLoginRequest, GoogleSocialLoginResponse>
+{
+    private const string GoogleProvider = "google";
+
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/auth/social/google");
+        AllowAnonymous();
+        Options(x => x.RequireRateLimiting(AppPolicies.AuthRateLimit));
+        Summary(s =>
+        {
+            s.Summary = "Google social login";
+            s.Description = "Verifies a Google ID token and returns platform JWT tokens. Provisions a new account if the email is not yet registered.";
+            s.Response<GoogleSocialLoginResponse>(200, "Login successful");
+            s.Responses[400] = "idToken is missing or empty";
+            s.Responses[401] = "Google ID token is invalid, expired, or has wrong audience";
+            s.Responses[403] = "Account is deactivated";
+            s.Responses[409] = "Email belongs to an existing password-only account (social_email_conflict)";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GoogleSocialLoginRequest req, CancellationToken ct)
+    {
+        // 1. Verify the Google ID token (throws on failure).
+        GoogleTokenPayload googlePayload;
+        try
+        {
+            googlePayload = await googleVerifier.VerifyAsync(req.IdToken, ct);
+        }
+        catch (InvalidOperationException)
+        {
+            await this.SendProblemAsync(StatusCodes.Status401Unauthorized,
+                ErrorCodes.InvalidCredentials,
+                "Google ID token is invalid, expired, or has the wrong audience.",
+                ct);
+            return;
+        }
+
+        // 2. Look up the UserExternalLogin row for (google, sub).
+        var externalLogin = await db.UserExternalLogins
+            .FirstOrDefaultAsync(
+                el => el.Provider == GoogleProvider && el.Subject == googlePayload.Subject,
+                ct);
+
+        ApplicationUser user;
+
+        if (externalLogin is not null)
+        {
+            // Happy path A: existing Google link found — load the linked user.
+            var linkedUser = await userManager.FindByIdAsync(externalLogin.UserId.ToString());
+            if (linkedUser is null)
+            {
+                // Orphaned external login — treat as invalid credentials.
+                await this.SendProblemAsync(StatusCodes.Status401Unauthorized,
+                    ErrorCodes.InvalidCredentials,
+                    "Linked account not found.",
+                    ct);
+                return;
+            }
+
+            user = linkedUser;
+        }
+        else
+        {
+            // No Google link yet. Check by email.
+            var existingUser = await userManager.FindByEmailAsync(googlePayload.Email);
+
+            if (existingUser is not null)
+            {
+                // Email exists but no Google link — this is a password-only account.
+                // Return 409 with social_email_conflict so the web prompts the user
+                // to sign in with their password instead.
+                await this.SendProblemAsync(StatusCodes.Status409Conflict,
+                    ErrorCodes.SocialEmailConflict,
+                    "An account with this email already exists. Please sign in with your password.",
+                    ct);
+                return;
+            }
+
+            // Happy path B: new user — provision from Google profile.
+            var nameParts = (googlePayload.Name ?? googlePayload.Email).Split(' ', 2);
+            var firstName = nameParts[0];
+            var lastName = nameParts.Length > 1 ? nameParts[1] : string.Empty;
+
+            var newUser = new ApplicationUser
+            {
+                UserName = googlePayload.Email,
+                Email = googlePayload.Email,
+                EmailConfirmed = true, // Google has already verified the email.
+                FirstName = firstName,
+                LastName = lastName,
+                GdprConsent = true,
+                GdprConsentDate = DateTime.UtcNow
+            };
+
+            // The trainer-portal register flow assigns the Trainer role by default.
+            var createResult = await userManager.CreateAsync(newUser);
+            if (!createResult.Succeeded)
+            {
+                foreach (var error in createResult.Errors)
+                {
+                    AddError(error.Description);
+                }
+                ThrowIfAnyErrors();
+                return;
+            }
+
+            await userManager.AddToRoleAsync(newUser, AppRoles.Trainer);
+
+            // Create the professional profile (mirroring RegisterEndpoint for Trainer role).
+            db.ProfessionalProfiles.Add(new ProfessionalProfile { UserId = newUser.Id });
+
+            // Link the Google identity.
+            db.UserExternalLogins.Add(new UserExternalLogin
+            {
+                UserId = newUser.Id,
+                Provider = GoogleProvider,
+                Subject = googlePayload.Subject,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            await db.SaveChangesAsync(ct);
+            user = newUser;
+        }
+
+        // 3. Check if the account is active.
+        if (!user.IsActive)
+        {
+            this.ThrowErrorWithCode(ErrorCodes.AccountDeactivated, "Account is deactivated.");
+            return;
+        }
+
+        // 4. Issue tokens (same logic as LoginEndpoint).
+        var roles = await userManager.GetRolesAsync(user);
+        var expiresAt = DateTime.UtcNow.AddMinutes(
+            config.GetValue(ConfigKeys.JwtAccessTokenExpirationMinutes, 15));
+
+        var accessToken = JwtBearer.CreateToken(o =>
+        {
+            o.SigningKey = config[ConfigKeys.JwtSecret]!;
+            o.ExpireAt = expiresAt;
+            o.User.Roles.AddRange(roles);
+            o.User.Claims.Add((AppClaims.UserId, user.Id.ToString()));
+            o.User.Claims.Add((AppClaims.Email, user.Email!));
+        });
+
+        var refreshTokenValue = GenerateRefreshToken();
+        var refreshTokenDays = config.GetValue(ConfigKeys.JwtRefreshTokenExpirationDays, 7);
+
+        db.RefreshTokens.Add(new Domain.Entities.RefreshToken
+        {
+            UserId = user.Id,
+            Token = refreshTokenValue,
+            ExpiresAt = DateTime.UtcNow.AddDays(refreshTokenDays)
+        });
+
+        await db.SaveChangesAsync(ct);
+
+        await Send.OkAsync(new GoogleSocialLoginResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshTokenValue,
+            ExpiresAt = expiresAt,
+            EmailConfirmed = user.EmailConfirmed
+        }, ct);
+    }
+
+    /// <summary>
+    /// Generates a cryptographically secure random refresh token string.
+    /// </summary>
+    private static string GenerateRefreshToken()
+    {
+        var randomBytes = RandomNumberGenerator.GetBytes(64);
+        return Convert.ToBase64String(randomBytes);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginEndpoint.cs
@@ -151,7 +151,10 @@ public class GoogleSocialLoginEndpoint(
         // 3. Check if the account is active.
         if (!user.IsActive)
         {
-            this.ThrowErrorWithCode(ErrorCodes.AccountDeactivated, "Account is deactivated.");
+            await this.SendProblemAsync(StatusCodes.Status403Forbidden,
+                ErrorCodes.AccountDeactivated,
+                "Account is deactivated.",
+                ct);
             return;
         }
 

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginRequest.cs
@@ -1,0 +1,12 @@
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Google;
+
+/// <summary>
+/// Request body for <c>POST /auth/social/google</c>.
+/// </summary>
+public class GoogleSocialLoginRequest
+{
+    /// <summary>
+    /// The Google ID token returned by the Google Identity Services flow on the client.
+    /// </summary>
+    public string IdToken { get; set; } = string.Empty;
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginResponse.cs
@@ -1,0 +1,31 @@
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Google;
+
+/// <summary>
+/// Response returned after a successful Google social login.
+/// Shape is intentionally identical to <c>LoginResponse</c> so clients
+/// can reuse the same token-storage logic.
+/// </summary>
+public class GoogleSocialLoginResponse
+{
+    /// <summary>
+    /// JWT access token (short-lived, 15 minutes).
+    /// </summary>
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Refresh token for obtaining new access tokens (7 days).
+    /// </summary>
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Access token expiration time in UTC.
+    /// </summary>
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Whether the user's email address has been verified.
+    /// Always <see langword="true"/> for Google-provisioned accounts because Google
+    /// verifies the email before issuing the ID token.
+    /// </summary>
+    public bool EmailConfirmed { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginValidator.cs
@@ -1,0 +1,20 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Google;
+
+/// <summary>
+/// Validates the request body for <c>POST /auth/social/google</c>.
+/// </summary>
+public class GoogleSocialLoginValidator : Validator<GoogleSocialLoginRequest>
+{
+    /// <summary>
+    /// Initializes the validation rules.
+    /// </summary>
+    public GoogleSocialLoginValidator()
+    {
+        RuleFor(x => x.IdToken)
+            .NotEmpty()
+            .WithMessage("Google ID token is required.");
+    }
+}

--- a/backend/FitnessPlatform.Application/FitnessPlatform.Application.csproj
+++ b/backend/FitnessPlatform.Application/FitnessPlatform.Application.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="FastEndpoints" Version="8.0.1" />
     <PackageReference Include="FastEndpoints.Security" Version="8.0.1" />
     <PackageReference Include="FastEndpoints.Swagger" Version="8.0.1" />

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/ApplicationDbContext.cs
@@ -135,6 +135,11 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     /// </summary>
     public virtual DbSet<PhotoDiaryReminderLog> PhotoDiaryReminderLogs { get; set; } = null!;
 
+    /// <summary>
+    /// External OAuth provider logins linked to application users.
+    /// </summary>
+    public virtual DbSet<UserExternalLogin> UserExternalLogins { get; set; } = null!;
+
     /// <inheritdoc />
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Configurations/UserExternalLoginConfiguration.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Configurations/UserExternalLoginConfiguration.cs
@@ -1,0 +1,22 @@
+using FitnessPlatform.Application.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FitnessPlatform.Application.Infrastructure.Data.Configurations;
+
+/// <summary>
+/// EF Core configuration for <see cref="UserExternalLogin"/>.
+/// </summary>
+public class UserExternalLoginConfiguration : IEntityTypeConfiguration<UserExternalLogin>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<UserExternalLogin> builder)
+    {
+        builder.HasOne(el => el.User)
+            .WithMany()
+            .HasForeignKey(el => el.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(el => new { el.Provider, el.Subject }).IsUnique();
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/IApplicationDbContext.cs
@@ -141,6 +141,11 @@ public interface IApplicationDbContext
     DbSet<PhotoDiaryReminderLog> PhotoDiaryReminderLogs { get; set; }
 
     /// <summary>
+    /// External OAuth provider logins linked to application users.
+    /// </summary>
+    DbSet<UserExternalLogin> UserExternalLogins { get; set; }
+
+    /// <summary>
     /// Saves all changes made in this context to the database.
     /// </summary>
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260608190112_AddUserExternalLogin.Designer.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260608190112_AddUserExternalLogin.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FitnessPlatform.Application.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608190112_AddUserExternalLogin")]
+    partial class AddUserExternalLogin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260608190112_AddUserExternalLogin.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/Migrations/20260608190112_AddUserExternalLogin.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FitnessPlatform.Application.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserExternalLogin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_external_logins",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    provider = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    subject = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_user_external_logins", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_user_external_logins_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_external_logins_provider_subject",
+                table: "user_external_logins",
+                columns: new[] { "provider", "subject" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_external_logins_user_id",
+                table: "user_external_logins",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_external_logins");
+        }
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/GoogleTokenVerifier.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/GoogleTokenVerifier.cs
@@ -31,6 +31,15 @@ public class GoogleTokenVerifier(IConfiguration config) : IGoogleTokenVerifier
             throw new InvalidOperationException("Google ID token verification failed.", ex);
         }
 
+        // Reject tokens whose email has not been verified by Google.
+        // An unverified email could be used to hijack an account via email-matching
+        // or to provision an account under an email the attacker does not own.
+        if (payload.EmailVerified != true)
+        {
+            throw new InvalidOperationException(
+                "Google ID token has an unverified email address (email_verified is not true).");
+        }
+
         return new GoogleTokenPayload(
             Subject: payload.Subject,
             Email: payload.Email,

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/GoogleTokenVerifier.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/GoogleTokenVerifier.cs
@@ -1,0 +1,39 @@
+using Google.Apis.Auth;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Production implementation of <see cref="IGoogleTokenVerifier"/> using
+/// <c>Google.Apis.Auth</c> for offline token verification against Google public keys.
+/// </summary>
+public class GoogleTokenVerifier(IConfiguration config) : IGoogleTokenVerifier
+{
+    /// <inheritdoc />
+    public async Task<GoogleTokenPayload> VerifyAsync(string idToken, CancellationToken ct = default)
+    {
+        var clientId = config[ConfigKeys.GoogleClientId]
+            ?? throw new InvalidOperationException("Google:ClientId is not configured.");
+
+        GoogleJsonWebSignature.Payload payload;
+
+        try
+        {
+            payload = await GoogleJsonWebSignature.ValidateAsync(
+                idToken,
+                new GoogleJsonWebSignature.ValidationSettings
+                {
+                    Audience = [clientId]
+                });
+        }
+        catch (InvalidJwtException ex)
+        {
+            throw new InvalidOperationException("Google ID token verification failed.", ex);
+        }
+
+        return new GoogleTokenPayload(
+            Subject: payload.Subject,
+            Email: payload.Email,
+            Name: payload.Name);
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/IGoogleTokenVerifier.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/IGoogleTokenVerifier.cs
@@ -1,0 +1,28 @@
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Represents the verified claims extracted from a Google ID token.
+/// <para><c>Subject</c>: The Google subject identifier ("sub" claim) — stable, globally unique per user.</para>
+/// <para><c>Email</c>: The user's email address as verified by Google.</para>
+/// <para><c>Name</c>: The user's display name from their Google profile (may be null).</para>
+/// </summary>
+public record GoogleTokenPayload(string Subject, string Email, string? Name);
+
+/// <summary>
+/// Validates a Google ID token and returns the verified payload.
+/// Abstracted so tests can inject a fake without calling Google.
+/// </summary>
+public interface IGoogleTokenVerifier
+{
+    /// <summary>
+    /// Validates <paramref name="idToken"/> against Google's public keys
+    /// and the configured OAuth client ID.
+    /// </summary>
+    /// <param name="idToken">The raw Google ID token from the client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The verified payload on success.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the token is invalid, expired, or the audience does not match.
+    /// </exception>
+    Task<GoogleTokenPayload> VerifyAsync(string idToken, CancellationToken ct = default);
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -208,6 +208,9 @@ builder.Services.AddScoped<ISessionLockService, SessionLockService>();
 // Compliance
 builder.Services.AddScoped<IComplianceService, ComplianceService>();
 
+// Google social login token verification
+builder.Services.AddScoped<IGoogleTokenVerifier, GoogleTokenVerifier>();
+
 // Audit
 builder.Services.AddScoped<IAuditService, AuditService>();
 

--- a/backend/FitnessPlatform.Application/appsettings.json
+++ b/backend/FitnessPlatform.Application/appsettings.json
@@ -24,5 +24,8 @@
       }
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Google": {
+    "ClientId": ""
+  }
 }

--- a/backend/FitnessPlatform.Tests/Builders/MockDbBuilder.cs
+++ b/backend/FitnessPlatform.Tests/Builders/MockDbBuilder.cs
@@ -27,6 +27,7 @@ public class MockDbBuilder
     private readonly List<WeeklyCheckInSetting> _weeklyCheckInSettings = [];
     private readonly List<WeeklyCheckInClientOverride> _weeklyCheckInClientOverrides = [];
     private readonly List<PhotoDiaryRequest> _photoDiaryRequests = [];
+    private readonly List<UserExternalLogin> _userExternalLogins = [];
 
     /// <summary>
     /// Adds an <see cref="ApplicationUser"/> to the mock context.
@@ -104,6 +105,11 @@ public class MockDbBuilder
     public MockDbBuilder With(PhotoDiaryRequest request) { _photoDiaryRequests.Add(request); return this; }
 
     /// <summary>
+    /// Adds a <see cref="UserExternalLogin"/> to the mock context.
+    /// </summary>
+    public MockDbBuilder With(UserExternalLogin externalLogin) { _userExternalLogins.Add(externalLogin); return this; }
+
+    /// <summary>
     /// Builds a mocked <see cref="IApplicationDbContext"/> with all registered entities as queryable DbSets.
     /// </summary>
     public IApplicationDbContext Build()
@@ -127,6 +133,7 @@ public class MockDbBuilder
         var weeklyCheckInSettingsSet = _weeklyCheckInSettings.BuildMockDbSet();
         var weeklyCheckInClientOverridesSet = _weeklyCheckInClientOverrides.BuildMockDbSet();
         var photoDiaryRequestsSet = _photoDiaryRequests.BuildMockDbSet();
+        var userExternalLoginsSet = _userExternalLogins.BuildMockDbSet();
 
         var db = Substitute.For<IApplicationDbContext>();
 
@@ -147,6 +154,7 @@ public class MockDbBuilder
         db.WeeklyCheckInSettings.Returns(weeklyCheckInSettingsSet);
         db.WeeklyCheckInClientOverrides.Returns(weeklyCheckInClientOverridesSet);
         db.PhotoDiaryRequests.Returns(photoDiaryRequestsSet);
+        db.UserExternalLogins.Returns(userExternalLoginsSet);
 
         db.SaveChangesAsync(Arg.Any<CancellationToken>()).Returns(1);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
@@ -1,0 +1,298 @@
+using FastEndpoints;
+using FastEndpoints.Testing;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Features.Auth.SocialLogin.Google;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FitnessPlatform.Tests.Endpoints.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="GoogleSocialLoginEndpoint"/>.
+/// A fake <see cref="IGoogleTokenVerifier"/> is injected so no real Google
+/// network calls are made.
+/// </summary>
+public class GoogleSocialLoginEndpointTests
+{
+    private static readonly string JwtSecret = new('x', 64);
+
+    // Shared Google token payload returned by the fake verifier.
+    private static readonly GoogleTokenPayload ValidPayload = new(
+        Subject: "google-sub-12345",
+        Email: "googleuser@example.com",
+        Name: "Google User");
+
+    private static IConfiguration MakeConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = JwtSecret,
+                ["Jwt:AccessTokenExpirationMinutes"] = "15",
+                ["Jwt:RefreshTokenExpirationDays"] = "7"
+            })
+            .Build();
+
+    private static IGoogleTokenVerifier MakeVerifier(GoogleTokenPayload payload)
+    {
+        var verifier = Substitute.For<IGoogleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(payload);
+        return verifier;
+    }
+
+    private static IGoogleTokenVerifier MakeFailingVerifier()
+    {
+        var verifier = Substitute.For<IGoogleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Token invalid"));
+        return verifier;
+    }
+
+    // ── 400 — FluentValidation rejects missing idToken ────────────────────
+    // This path is enforced by the validator before HandleAsync is reached.
+    // We verify the validator rejects an empty token directly.
+
+    [Fact]
+    public void Validator_EmptyIdToken_HasValidationError()
+    {
+        var validator = new GoogleSocialLoginValidator();
+        var result = validator.Validate(new GoogleSocialLoginRequest { IdToken = "" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GoogleSocialLoginRequest.IdToken));
+    }
+
+    [Fact]
+    public void Validator_NullIdToken_HasValidationError()
+    {
+        var validator = new GoogleSocialLoginValidator();
+        var result = validator.Validate(new GoogleSocialLoginRequest { IdToken = null! });
+        result.IsValid.Should().BeFalse();
+    }
+
+    // ── 401 — invalid Google token ─────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_InvalidGoogleToken_Returns401()
+    {
+        // Arrange
+        var verifier = MakeFailingVerifier();
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act — SendProblemAsync writes the response; it does NOT throw.
+        await ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "bad-token" },
+            CancellationToken.None);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ── 403 — deactivated account ──────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_DeactivatedAccount_ThrowsAccountDeactivatedError()
+    {
+        // Arrange — existing external login for this Google subject
+        var userId = Guid.NewGuid();
+        var inactiveUser = EntityBuilder.User
+            .WithId(userId)
+            .WithEmail(ValidPayload.Email)
+            .Inactive()
+            .Build();
+
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "google",
+            Subject = ValidPayload.Subject
+        };
+
+        var verifier = MakeVerifier(ValidPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        // FindByIdAsync is called after the external login is found.
+        userManager.FindByIdAsync(userId.ToString()).Returns(inactiveUser);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        var act = () => ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "valid-token" },
+            CancellationToken.None);
+
+        // Assert — ThrowErrorWithCode raises a ValidationFailureException with the ACCOUNT_DEACTIVATED code.
+        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
+        ex.Which.Failures.Should().Contain(f => f.ErrorCode == ErrorCodes.AccountDeactivated);
+    }
+
+    // ── 409 — email conflict (password-only account) ───────────────────────
+
+    [Fact]
+    public async Task HandleAsync_ExistingPasswordOnlyAccount_Returns409WithSocialEmailConflict()
+    {
+        // Arrange — existing user with the verified email but NO Google external login
+        var existingUser = EntityBuilder.User
+            .WithEmail(ValidPayload.Email)
+            .Build();
+
+        var verifier = MakeVerifier(ValidPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByEmailAsync(ValidPayload.Email).Returns(existingUser);
+
+        // No UserExternalLogin rows in the DB.
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        await ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "valid-token" },
+            CancellationToken.None);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    // ── 200 — existing Google-linked user ─────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_ExistingGoogleLink_ReturnsTokens()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = EntityBuilder.User
+            .WithId(userId)
+            .WithEmail(ValidPayload.Email)
+            .Build();
+
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "google",
+            Subject = ValidPayload.Subject
+        };
+
+        var verifier = MakeVerifier(ValidPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        // FindByIdAsync is called after the external login is found.
+        userManager.FindByIdAsync(userId.ToString()).Returns(user);
+        userManager.GetRolesAsync(user).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        await ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "valid-token" },
+            CancellationToken.None);
+
+        // Assert
+        ep.ValidationFailed.Should().BeFalse();
+        ep.Response.AccessToken.Should().NotBeNullOrEmpty();
+        ep.Response.RefreshToken.Should().NotBeNullOrEmpty();
+        ep.Response.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+        db.RefreshTokens.Received(1).Add(Arg.Is<RefreshToken>(rt => rt.UserId == userId));
+        await db.Received().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ── 200 — new user provisioning ───────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NewUser_ProvisionesAccountAndReturnsTokens()
+    {
+        // Arrange — no existing user or external login
+        var verifier = MakeVerifier(ValidPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+
+        // FindByEmailAsync returns null → no existing account
+        userManager.FindByEmailAsync(ValidPayload.Email).Returns((ApplicationUser?)null);
+
+        // CreateAsync succeeds and sets up the user object
+        userManager.CreateAsync(Arg.Any<ApplicationUser>())
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer)
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+        // GetRolesAsync needs to return roles for token creation
+        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        await ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "valid-token" },
+            CancellationToken.None);
+
+        // Assert
+        ep.ValidationFailed.Should().BeFalse();
+        ep.Response.AccessToken.Should().NotBeNullOrEmpty();
+        ep.Response.RefreshToken.Should().NotBeNullOrEmpty();
+        ep.Response.EmailConfirmed.Should().BeTrue(); // Google verified the email
+
+        // A UserExternalLogin row must have been added
+        db.UserExternalLogins.Received(1).Add(Arg.Is<UserExternalLogin>(el =>
+            el.Provider == "google" && el.Subject == ValidPayload.Subject));
+
+        // A ProfessionalProfile must have been created (Trainer role provisioning)
+        db.ProfessionalProfiles.Received(1).Add(Arg.Any<ProfessionalProfile>());
+    }
+
+    // ── 200 — email matches existing google-linked account (returning user) ──
+
+    [Fact]
+    public async Task HandleAsync_EmailMatchesExistingGoogleLinkedAccount_ReturnsTokens()
+    {
+        // Arrange — external login exists for the same sub (returning user)
+        var userId = Guid.NewGuid();
+        var user = EntityBuilder.User
+            .WithId(userId)
+            .WithEmail(ValidPayload.Email)
+            .Build();
+
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "google",
+            Subject = ValidPayload.Subject
+        };
+
+        var verifier = MakeVerifier(ValidPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByIdAsync(userId.ToString()).Returns(user);
+        userManager.GetRolesAsync(user).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        await ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "valid-token" },
+            CancellationToken.None);
+
+        // Assert — no 409; returns tokens
+        ep.ValidationFailed.Should().BeFalse();
+        ep.HttpContext.Response.StatusCode.Should().NotBe(StatusCodes.Status409Conflict);
+        ep.Response.AccessToken.Should().NotBeNullOrEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
@@ -137,7 +137,7 @@ public class GoogleSocialLoginEndpointTests
     // ── 403 — deactivated account ──────────────────────────────────────────
 
     [Fact]
-    public async Task HandleAsync_DeactivatedAccount_ThrowsAccountDeactivatedError()
+    public async Task HandleAsync_DeactivatedAccount_Returns403WithAccountDeactivatedCode()
     {
         // Arrange — existing external login for this Google subject
         var userId = Guid.NewGuid();
@@ -165,14 +165,13 @@ public class GoogleSocialLoginEndpointTests
         var config = MakeConfig();
         var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
 
-        // Act
-        var act = () => ep.HandleAsync(
+        // Act — SendProblemAsync writes the response and does NOT throw.
+        await ep.HandleAsync(
             new GoogleSocialLoginRequest { IdToken = "valid-token" },
             CancellationToken.None);
 
-        // Assert — ThrowErrorWithCode raises a ValidationFailureException with the ACCOUNT_DEACTIVATED code.
-        var ex = await act.Should().ThrowAsync<ValidationFailureException>();
-        ex.Which.Failures.Should().Contain(f => f.ErrorCode == ErrorCodes.AccountDeactivated);
+        // Assert — status must be 403 (not 400) and error code must be present.
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
     }
 
     // ── 409 — email conflict (password-only account) ───────────────────────

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
@@ -96,6 +96,44 @@ public class GoogleSocialLoginEndpointTests
         ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
     }
 
+    /// <summary>
+    /// Covers the email_verified=false security fix in GoogleTokenVerifier.
+    ///
+    /// GoogleTokenVerifier.VerifyAsync now throws InvalidOperationException when
+    /// payload.EmailVerified != true (i.e. Google did not verify the email address).
+    /// Since offline unit-testing of GoogleJsonWebSignature.ValidateAsync with a
+    /// real signed JWT is not feasible, we verify the endpoint contract: any
+    /// InvalidOperationException thrown by the verifier — including one triggered
+    /// by an unverified email — is mapped to 401 invalid_credentials.
+    ///
+    /// To see the verifier guard at source, inspect:
+    ///   Infrastructure/Services/GoogleTokenVerifier.cs — the "email_verified" check.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_VerifierThrowsForUnverifiedEmail_Returns401WithInvalidCredentials()
+    {
+        // Arrange — simulate the InvalidOperationException GoogleTokenVerifier now
+        // raises when payload.EmailVerified is false or null.
+        var verifier = Substitute.For<IGoogleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException(
+                "Google ID token has an unverified email address (email_verified is not true)."));
+
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<GoogleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        await ep.HandleAsync(
+            new GoogleSocialLoginRequest { IdToken = "token-with-unverified-email" },
+            CancellationToken.None);
+
+        // Assert — 401, not 200/409/403. The unverified-email path must never
+        // proceed to account lookup or provisioning.
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
     // ── 403 — deactivated account ──────────────────────────────────────────
 
     [Fact]

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
@@ -64,7 +64,7 @@ public class GoogleSocialLoginEndpointTests
         var validator = new GoogleSocialLoginValidator();
         var result = validator.Validate(new GoogleSocialLoginRequest { IdToken = "" });
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == nameof(GoogleSocialLoginRequest.IdToken));
+        result.Errors.Should().Contain(e => string.Equals(e.PropertyName, nameof(GoogleSocialLoginRequest.IdToken), StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,9 +11,9 @@
         "@dnd-kit/dom": "^0.3.2",
         "@dnd-kit/helpers": "^0.3.2",
         "@dnd-kit/react": "^0.3.2",
-        "@floating-ui/dom": "^1.7.6",
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",
+        "@react-oauth/google": "^0.13.5",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-table": "^8.21.3",
         "@tiptap/extension-placeholder": "^3.20.4",
@@ -1034,18 +1034,8 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
@@ -1053,7 +1043,8 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
@@ -1220,6 +1211,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1034,8 +1034,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
       }
     },
@@ -1043,8 +1053,7 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "@dnd-kit/react": "^0.3.2",
     "@hookform/resolvers": "^5.2.2",
     "@microsoft/signalr": "^10.0.0",
+    "@react-oauth/google": "^0.13.5",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-table": "^8.21.3",
     "@tiptap/extension-placeholder": "^3.20.4",

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -1,0 +1,17 @@
+import type { LoginResponse } from '@/api/client';
+import api from '@/lib/api';
+
+/**
+ * POST /auth/social/google
+ * Sends a Google ID token JWT to the backend, which verifies it via
+ * GoogleJsonWebSignature.ValidateAsync and returns platform JWT tokens.
+ *
+ * @param idToken - The credential JWT from @react-oauth/google's GoogleLogin
+ *                  onSuccess callback (credentialResponse.credential).
+ *                  This is an ID token, NOT an OAuth access token.
+ *                  Note: do NOT pass an OAuth access token — the backend will reject it.
+ */
+export async function googleSocialLogin(idToken: string): Promise<LoginResponse> {
+  const { data } = await api.post<LoginResponse>('/auth/social/google', { idToken });
+  return data;
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -97,7 +97,8 @@
     "verifyEmailResent": "Ověřovací e-mail byl odeslán znovu.",
     "verifyEmailSuccess": "E-mail byl úspěšně ověřen.",
     "verifyEmailExpired": "Odkaz vypršel. Nechte si odeslat nový.",
-    "verifyEmailInvalid": "Neplatný ověřovací odkaz."
+    "verifyEmailInvalid": "Neplatný ověřovací odkaz.",
+    "googleLoading": "Přihlašuji přes Google..."
   },
   "downloadApp": {
     "title": "Stáhněte si aplikaci",
@@ -806,7 +807,8 @@
     "SECTION_ALREADY_COMPLETED": "Tato část tréninku byla již dokončena klientem — úpravy nejsou možné.",
     "COMPLETED_AT_IN_FUTURE": "Datum dokončení nesmí být v budoucnosti.",
     "COMPLETED_AT_BEFORE_PLAN_START": "Datum dokončení nesmí být před začátkem plánu.",
-    "session_locked": "Trénink je aktuálně uzamčen — uložení selhalo."
+    "session_locked": "Trénink je aktuálně uzamčen — uložení selhalo.",
+    "social_email_conflict": "Tento e-mail je registrován s heslem. Přihlaste se emailem a heslem."
   },
   "nutritionGoals": {
     "title": "Cíle & makra",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -97,7 +97,8 @@
     "verifyEmailResent": "Bestätigungs-E-Mail erneut gesendet.",
     "verifyEmailSuccess": "E-Mail erfolgreich bestätigt.",
     "verifyEmailExpired": "Link abgelaufen. Fordern Sie einen neuen an.",
-    "verifyEmailInvalid": "Ungültiger Bestätigungslink."
+    "verifyEmailInvalid": "Ungültiger Bestätigungslink.",
+    "googleLoading": "Anmeldung mit Google..."
   },
   "downloadApp": {
     "title": "App herunterladen",
@@ -796,7 +797,8 @@
     "SECTION_ALREADY_COMPLETED": "Dieser Abschnitt wurde bereits vom Klienten abgeschlossen und kann nicht bearbeitet werden.",
     "COMPLETED_AT_IN_FUTURE": "Das Abschlussdatum darf nicht in der Zukunft liegen.",
     "COMPLETED_AT_BEFORE_PLAN_START": "Das Abschlussdatum darf nicht vor dem Startdatum des Plans liegen.",
-    "session_locked": "Einheit ist derzeit gesperrt — Speichern fehlgeschlagen."
+    "session_locked": "Einheit ist derzeit gesperrt — Speichern fehlgeschlagen.",
+    "social_email_conflict": "Diese E-Mail ist mit einem Passwort registriert. Bitte melden Sie sich mit E-Mail und Passwort an."
   },
   "nutritionGoals": {
     "title": "Ziele & Makros",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -97,7 +97,8 @@
     "verifyEmailResent": "Verification email resent.",
     "verifyEmailSuccess": "Email verified successfully.",
     "verifyEmailExpired": "Link expired. Request a new one.",
-    "verifyEmailInvalid": "Invalid verification link."
+    "verifyEmailInvalid": "Invalid verification link.",
+    "googleLoading": "Signing in with Google..."
   },
   "downloadApp": {
     "title": "Download the app",
@@ -797,7 +798,8 @@
     "SECTION_ALREADY_COMPLETED": "This section has already been completed by the client and cannot be edited.",
     "COMPLETED_AT_IN_FUTURE": "Completion date cannot be in the future.",
     "COMPLETED_AT_BEFORE_PLAN_START": "Completion date cannot be before the plan's start date.",
-    "session_locked": "Session is currently locked — save failed."
+    "session_locked": "Session is currently locked — save failed.",
+    "social_email_conflict": "This email is registered with a password. Please sign in with your email and password."
   },
   "nutritionGoals": {
     "title": "Goals & Macros",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,7 @@ import '@/lib/polyfills';
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import './index.css';
 import './styles/dialog-animations.css';
 import './i18n';
@@ -14,7 +15,9 @@ import { ErrorBoundary } from './ErrorBoundary';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID ?? ''}>
+        <App />
+      </GoogleOAuthProvider>
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -4,13 +4,15 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { GoogleLogin } from '@react-oauth/google';
 import { useAuthStore } from '@/stores/auth';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 import { DarkModeToggle } from '@/components/DarkModeToggle';
 import { apiClient } from '@/api/client';
-import { showError } from '@/lib/api-errors';
+import { showError, showApiError } from '@/lib/api-errors';
 import type { LoginResponse } from '@/api/client';
 import { INVITE_TOKEN_KEY } from '@/pages/InviteAcceptPage';
+import { googleSocialLogin } from '@/api/auth';
 
 export default function LoginPage() {
   const { t } = useTranslation();
@@ -19,6 +21,7 @@ export default function LoginPage() {
   const login = useAuthStore((s) => s.login);
   const setTokens = useAuthStore((s) => s.setTokens);
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [inviteStatus, setInviteStatus] = useState<'accepted' | 'failed' | null>(null);
   const justRegistered = (location.state as { registered?: boolean })?.registered;
@@ -90,6 +93,53 @@ export default function LoginPage() {
       showError('auth.loginError');
     } finally {
       setLoading(false);
+    }
+  };
+
+  /**
+   * Called by the invisible <GoogleLogin> component after the Google credential
+   * dialog completes. credentialResponse.credential is the ID token JWT that the
+   * backend verifies via GoogleJsonWebSignature.ValidateAsync — not an OAuth
+   * access token.
+   */
+  const handleGoogleSuccess = async (credentialResponse: { credential?: string }) => {
+    if (!credentialResponse.credential) return;
+    setGoogleLoading(true);
+    try {
+      const res: LoginResponse = await googleSocialLogin(credentialResponse.credential);
+      setTokens(res.accessToken!, res.refreshToken!);
+      const profile = await apiClient.getProfileEndpoint();
+      const emailConfirmed = res.emailConfirmed ?? true;
+
+      login(
+        {
+          publicId: profile.userId!,
+          email: profile.email!,
+          firstName: profile.firstName!,
+          lastName: profile.lastName!,
+          roles: profile.roles ?? [],
+          emailConfirmed,
+          avatarBlobUrl: profile.avatarBlobUrl ?? null,
+        },
+        res.accessToken!,
+        res.refreshToken!,
+      );
+
+      // Google has verified the email, so emailConfirmed is always true for
+      // new accounts. Still check in case an existing linked account was
+      // somehow unverified.
+      if (!emailConfirmed) {
+        navigate('/verify-email', { replace: true });
+        return;
+      }
+
+      const roles = profile.roles ?? [];
+      const isClientOnly = roles.includes('Client') && !roles.some((r: string) => ['Trainer', 'Nutritionist', 'Admin'].includes(r));
+      navigate(isClientOnly ? '/download-app' : '/dashboard', { replace: true });
+    } catch (err) {
+      showApiError(err, 'auth.loginError');
+    } finally {
+      setGoogleLoading(false);
     }
   };
 
@@ -209,15 +259,49 @@ export default function LoginPage() {
         <div className="auth-divider">nebo</div>
 
         {/* Social Buttons */}
-        <button type="button" className="auth-social">
-          <svg width="18" height="18" viewBox="0 0 24 24">
-            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
-            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-          </svg>
-          Pokračovat přes Google
-        </button>
+        {/*
+          The custom-styled button is the visible surface; the <GoogleLogin>
+          component sits invisibly on top (opacity 0, pointer-events: all) so
+          Google's credential dialog fires when the user clicks the button area.
+          The onSuccess callback receives credentialResponse.credential — the
+          ID token JWT — which is what POST /auth/social/google expects.
+        */}
+        <div style={{ position: 'relative' }}>
+          <button
+            type="button"
+            className="auth-social"
+            disabled={googleLoading}
+            style={{ width: '100%' }}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24">
+              <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+              <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+              <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+              <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+            </svg>
+            {googleLoading ? t('auth.googleLoading') : 'Pokračovat přes Google'}
+          </button>
+          {/* Invisible GoogleLogin overlay — renders a 0-opacity button that
+              fills the same space. When clicked it opens Google's credential
+              popup and calls onSuccess with the ID token credential. */}
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              opacity: 0,
+              overflow: 'hidden',
+              pointerEvents: googleLoading ? 'none' : 'all',
+            }}
+            aria-hidden="true"
+          >
+            <GoogleLogin
+              onSuccess={handleGoogleSuccess}
+              onError={() => showError('auth.loginError')}
+              width="100%"
+              useOneTap={false}
+            />
+          </div>
+        </div>
 
         <button type="button" className="auth-social">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
## Summary
- Adds `POST /auth/social/google`: verifies a Google ID token (offline, via `Google.Apis.Auth`), then links/logs in an existing account, provisions a new Trainer account, or returns `409 social_email_conflict` for a password-only email.
- New `UserExternalLogin` entity + EF migration (`user_external_logins`, unique index on `(provider, subject)`).
- Web LoginPage wires the previously-dead "Pokračovat přes Google" button via `@react-oauth/google` (`<GoogleOAuthProvider>` + invisible `<GoogleLogin>` overlay, ID-token credential flow); standard post-login redirect (client→/download-app, staff→/dashboard, unverified→/verify-email).
- Security hardening: `GoogleTokenVerifier` rejects tokens whose `email_verified` claim is not true (→401), closing an unverified-email account-takeover vector.
- i18n: `auth.googleLoading` + `apiErrors.social_email_conflict` added in cs/en/de.

## Related issue
Fixes #479

## Scope
cross-cut (backend + web)

## QA verdict (from qa-tester)
OVERALL ⚠️ INTERACTIVE-REQUIRED — 6/8 ACs machine-verified; full `FitnessPlatform.Tests.Endpoints.Auth` 41/41 green + web build clean. The 2 open ACs are the live Google OAuth round-trip (environment-bound: no real client id / Google account in the harness), not code defects.

## Merge note
⚠️ Diff adds an EF migration (`backend/**/Migrations/20260608190112_AddUserExternalLogin`) → merge exclusion list, human-merge-only. Standalone PR to `develop` also requires separate same-turn user authorization. This PR is reviewed but NOT auto-merged.

## Test plan
- [ ] Clicking "Pokračovat přes Google" initiates GIS flow and obtains a Google ID token.
- [ ] `POST /auth/social/google` verifies the token and returns the standard LoginResponse shape.
- [ ] Verified email matching an existing linked account returns tokens for that user.
- [ ] Verified email with no account provisions a new user and returns tokens.
- [ ] Verified email on a password-only account returns `social_email_conflict`; web surfaces a cs/en/de message.
- [ ] Tokens stored via useAuthStore; redirect: client→/download-app, staff→/dashboard, unverified→/verify-email.
- [ ] New strings present in cs/en/de.
- [ ] Apple button (lines 222-227, #480) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)