### PR TITLE
feat: Client detail — Měření tab

### DIFF
--- a/web/src/api/measurements.ts
+++ b/web/src/api/measurements.ts
@@ -1,0 +1,21 @@
+import api from '@/lib/api';
+import type { GetMeasurementsResponse } from '@/api/generated';
+
+/**
+ * Fetch body measurements for a trainer's client.
+ * Wraps GET /trainer/clients/{clientId}/measurements (read-only trainer endpoint).
+ *
+ * Note: there is no trainer add-measurement endpoint — only clients can POST /client/measurements.
+ * A trainer add-measurement flow is tracked as a future backend+web issue.
+ */
+export async function getClientMeasurements(
+  clientId: string,
+  page = 1,
+  pageSize = 50,
+): Promise<GetMeasurementsResponse> {
+  const { data } = await api.get<GetMeasurementsResponse>(
+    `/trainer/clients/${clientId}/measurements`,
+    { params: { page, pageSize } },
+  );
+  return data;
+}

--- a/web/src/components/clients/tabs/MereniTab.tsx
+++ b/web/src/components/clients/tabs/MereniTab.tsx
@@ -1,4 +1,410 @@
-/** Placeholder for the Měření tab — filled in by sub-issue #487 or later wave-3 work. */
-export function MereniTab() {
-  return <div id="cl-pane-mereni" />;
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useToastStore } from '@/stores/toast';
+import { getClientMeasurements } from '@/api/measurements';
+import type { MeasurementDto } from '@/api/generated';
+
+interface MereniTabProps {
+  clientId: string;
+  targetWeightKg: number | null | undefined;
+}
+
+// ── Delta helpers ─────────────────────────────────────────────────────────────
+
+/** ISO 8601 string → Date */
+function toDate(iso: string | undefined): Date | null {
+  return iso ? new Date(iso) : null;
+}
+
+/** Number of milliseconds in 6 weeks */
+const SIX_WEEKS_MS = 6 * 7 * 24 * 60 * 60 * 1000;
+
+interface StatTile {
+  label: string;
+  value: string;
+  delta: string | null;
+  deltaPositiveIsGood: boolean;
+  /** delta colour: 'green' | 'orange' | null */
+  deltaColor: 'green' | 'orange' | null;
+  accent: boolean;
+  sub: string | null;
+}
+
+function formatNum(
+  v: number | undefined | null,
+  unit: string,
+  decimals = 1,
+): string {
+  if (v == null) return '—';
+  return `${v.toFixed(decimals).replace('.', ',')} ${unit}`;
+}
+
+function formatDelta(
+  diff: number | null,
+  unit: string,
+  decimals = 1,
+): string | null {
+  if (diff == null) return null;
+  const sign = diff < 0 ? '' : '+';
+  return `${sign}${diff.toFixed(decimals).replace('.', ',')} ${unit}`;
+}
+
+/**
+ * Find the reference measurement for delta comparison:
+ * the most recent measurement that is at least 6 weeks before `latest`.
+ */
+function findReferenceBelow6Weeks(
+  sorted: MeasurementDto[],
+  latestDate: Date,
+): MeasurementDto | null {
+  for (let i = 1; i < sorted.length; i++) {
+    const d = toDate(sorted[i].measuredAt);
+    if (d && latestDate.getTime() - d.getTime() >= SIX_WEEKS_MS) {
+      return sorted[i];
+    }
+  }
+  return null;
+}
+
+// ── Bar chart helpers ─────────────────────────────────────────────────────────
+
+interface WeightBar {
+  pct: number;
+  opacity: number;
+}
+
+/**
+ * Build up to 8 bars from the most recent measurements, oldest-first for display.
+ * Uses the same normalization logic as ProgressSnapshot.
+ */
+function buildWeightBars(sorted: MeasurementDto[]): WeightBar[] {
+  const slice = sorted.slice(0, 8).reverse(); // oldest → newest
+  const weights = slice
+    .map((m) => m.weightKg)
+    .filter((w): w is number => w != null);
+  if (weights.length === 0) return [];
+
+  const maxVal = Math.max(...weights);
+  const minVal = Math.min(...weights);
+  const floor = Math.max(0, minVal - (maxVal - minVal) * 0.5);
+  const range = maxVal - floor || 1;
+
+  return slice.map((m, i) => {
+    const w = m.weightKg ?? minVal;
+    const pct = Math.max(((w - floor) / range) * 100, 8);
+    // Opacity ramps from 0.35 (oldest) to 0.7 (newest), matching prototype style
+    const opacity = 0.35 + (i / Math.max(slice.length - 1, 1)) * 0.35;
+    return { pct, opacity };
+  });
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const { data, isError, isPending } = useQuery({
+    queryKey: ['client-measurements', clientId],
+    queryFn: () => getClientMeasurements(clientId),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  // Sorted newest-first
+  const sorted: MeasurementDto[] = useMemo(() => {
+    if (!data?.items) return [];
+    return [...data.items].sort((a, b) => {
+      const da = toDate(a.measuredAt)?.getTime() ?? 0;
+      const db = toDate(b.measuredAt)?.getTime() ?? 0;
+      return db - da;
+    });
+  }, [data?.items]);
+
+  const latest = sorted[0] ?? null;
+
+  // Reference measurement for deltas (>=6 weeks before latest)
+  const refMeasurement: MeasurementDto | null = useMemo(() => {
+    if (!latest?.measuredAt) return null;
+    const latestDate = toDate(latest.measuredAt);
+    if (!latestDate) return null;
+    return findReferenceBelow6Weeks(sorted, latestDate);
+  }, [sorted, latest]);
+
+  // ── Stat tiles ──────────────────────────────────────────────────────────────
+
+  const tiles: StatTile[] = useMemo(() => {
+    const weightDiff =
+      latest?.weightKg != null && refMeasurement?.weightKg != null
+        ? Math.round((latest.weightKg - refMeasurement.weightKg) * 10) / 10
+        : null;
+
+    const fatDiff =
+      latest?.bodyFatPercentage != null &&
+      refMeasurement?.bodyFatPercentage != null
+        ? Math.round(
+            (latest.bodyFatPercentage - refMeasurement.bodyFatPercentage) * 10,
+          ) / 10
+        : null;
+
+    const waistDiff =
+      latest?.waistCm != null && refMeasurement?.waistCm != null
+        ? Math.round((latest.waistCm - refMeasurement.waistCm) * 10) / 10
+        : null;
+
+    const remaining =
+      latest?.weightKg != null && targetWeightKg != null
+        ? Math.round(Math.abs(targetWeightKg - latest.weightKg) * 10) / 10
+        : null;
+
+    return [
+      {
+        label: t('clientDetail.mereni.tiles.currentWeight'),
+        value: formatNum(latest?.weightKg, 'kg'),
+        delta: formatDelta(weightDiff, 'kg'),
+        deltaPositiveIsGood: false,
+        deltaColor:
+          weightDiff == null ? null : weightDiff < 0 ? 'green' : 'orange',
+        accent: false,
+        sub: refMeasurement?.measuredAt
+          ? t('clientDetail.mereni.tiles.comparedToWeeksAgo')
+          : null,
+      },
+      {
+        label: t('clientDetail.mereni.tiles.bodyFat'),
+        value: formatNum(latest?.bodyFatPercentage, '%'),
+        delta: formatDelta(fatDiff, '%'),
+        deltaPositiveIsGood: false,
+        deltaColor:
+          fatDiff == null ? null : fatDiff < 0 ? 'green' : 'orange',
+        accent: false,
+        sub: null,
+      },
+      {
+        label: t('clientDetail.mereni.tiles.waist'),
+        value: formatNum(latest?.waistCm, 'cm', 0),
+        delta: formatDelta(waistDiff, 'cm', 0),
+        deltaPositiveIsGood: false,
+        deltaColor:
+          waistDiff == null ? null : waistDiff < 0 ? 'green' : 'orange',
+        accent: false,
+        sub: null,
+      },
+      {
+        label: t('clientDetail.mereni.tiles.toGoal'),
+        value:
+          remaining != null ? formatNum(remaining, 'kg') : '—',
+        delta: null,
+        deltaPositiveIsGood: true,
+        deltaColor: null,
+        accent: true,
+        sub:
+          targetWeightKg != null
+            ? t('clientDetail.mereni.tiles.goalWeight', {
+                kg: targetWeightKg.toFixed(1).replace('.', ','),
+              })
+            : null,
+      },
+    ];
+  }, [latest, refMeasurement, targetWeightKg, t]);
+
+  // ── Bar chart ──────────────────────────────────────────────────────────────
+
+  const bars = useMemo(() => buildWeightBars(sorted), [sorted]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const hasData = sorted.length > 0;
+
+  return (
+    <div id="cl-pane-mereni">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-3.5">
+        <div className="text-[15px] font-semibold text-text">
+          {t('clientDetail.mereni.title')}
+        </div>
+        <button
+          type="button"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-surface2 transition-colors"
+          onClick={() =>
+            addToast(t('clientDetail.mereni.addMeasurementPlaceholder'), 'success')
+          }
+        >
+          + {t('clientDetail.mereni.addMeasurement')}
+        </button>
+      </div>
+
+      {/* Loading */}
+      {isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error */}
+      {isError && !isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.mereni.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isPending && !isError && !hasData && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📏</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.mereni.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.mereni.emptyDescription')}
+          </div>
+          <button
+            type="button"
+            className="mt-1 text-[13px] font-semibold text-accent hover:underline bg-transparent border-none cursor-pointer"
+            onClick={() =>
+              addToast(t('clientDetail.mereni.addMeasurementPlaceholder'), 'success')
+            }
+          >
+            + {t('clientDetail.mereni.addFirstMeasurement')}
+          </button>
+        </div>
+      )}
+
+      {/* Data sections */}
+      {!isPending && !isError && hasData && (
+        <>
+          {/* 4-col stat tiles */}
+          <div className="grid grid-cols-4 gap-3 mb-[18px]">
+            {tiles.map((tile) => (
+              <div
+                key={tile.label}
+                className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5"
+              >
+                <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium mb-1.5">
+                  {tile.label}
+                </div>
+                <div
+                  className="text-[22px] font-semibold leading-tight"
+                  style={tile.accent ? { color: 'var(--accent)' } : undefined}
+                >
+                  {tile.accent ? (
+                    <span style={{ color: 'var(--accent)' }}>{tile.value}</span>
+                  ) : (
+                    <span className="text-text">{tile.value}</span>
+                  )}
+                </div>
+                {tile.delta && (
+                  <div
+                    className={`text-[11px] mt-1 ${
+                      tile.deltaColor === 'green'
+                        ? 'text-green'
+                        : tile.deltaColor === 'orange'
+                          ? 'text-orange'
+                          : 'text-text3'
+                    }`}
+                  >
+                    {tile.delta}
+                    {tile.sub ? ` ${tile.sub}` : ''}
+                  </div>
+                )}
+                {!tile.delta && tile.sub && (
+                  <div className="text-[11px] text-text3 mt-1">{tile.sub}</div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 8-week weight-trend bar chart */}
+          {bars.length > 0 && (
+            <div className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5 mb-[18px]">
+              <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium mb-3">
+                {t('clientDetail.mereni.chartLabel')}
+              </div>
+              <div
+                className="flex items-end gap-2"
+                style={{ height: '120px', paddingTop: '4px', paddingBottom: '4px' }}
+              >
+                {bars.map((bar, i) => (
+                  <div
+                    key={i}
+                    className="flex-1 rounded-t-sm"
+                    style={{
+                      height: `${bar.pct}%`,
+                      backgroundColor: 'var(--accent)',
+                      opacity: bar.opacity,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Measurement history table */}
+          <div className="db-wrap overflow-x-auto">
+            <table className="db-table w-full text-[13px]">
+              <thead>
+                <tr>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.date')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.weight')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.bodyFat')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.waist')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.hips')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2">
+                    {t('clientDetail.mereni.table.chest')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((m) => {
+                  const date = toDate(m.measuredAt);
+                  const dateStr = date
+                    ? date.toLocaleDateString('cs-CZ', {
+                        day: 'numeric',
+                        month: 'numeric',
+                        year: 'numeric',
+                      })
+                    : '—';
+                  return (
+                    <tr key={m.measurementId ?? m.measuredAt} className="border-t border-border">
+                      <td className="row-title py-2 pr-4 font-medium text-text">
+                        {dateStr}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {m.weightKg != null ? `${m.weightKg} kg` : '—'}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {m.bodyFatPercentage != null
+                          ? `${m.bodyFatPercentage} %`
+                          : '—'}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {m.waistCm != null ? `${m.waistCm} cm` : '—'}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {m.hipsCm != null ? `${m.hipsCm} cm` : '—'}
+                      </td>
+                      <td className="py-2 text-text2">
+                        {m.chestCm != null ? `${m.chestCm} cm` : '—'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/MereniTab.tsx
+++ b/web/src/components/clients/tabs/MereniTab.tsx
@@ -24,7 +24,6 @@ interface StatTile {
   label: string;
   value: string;
   delta: string | null;
-  deltaPositiveIsGood: boolean;
   /** delta colour: 'green' | 'orange' | null */
   deltaColor: 'green' | 'orange' | null;
   accent: boolean;
@@ -46,6 +45,7 @@ function formatDelta(
   decimals = 1,
 ): string | null {
   if (diff == null) return null;
+  if (diff === 0) return `${(0).toFixed(decimals).replace('.', ',')} ${unit}`;
   const sign = diff < 0 ? '' : '+';
   return `${sign}${diff.toFixed(decimals).replace('.', ',')} ${unit}`;
 }
@@ -54,7 +54,7 @@ function formatDelta(
  * Find the reference measurement for delta comparison:
  * the most recent measurement that is at least 6 weeks before `latest`.
  */
-function findReferenceBelow6Weeks(
+function findReferenceAtLeast6WeeksBefore(
   sorted: MeasurementDto[],
   latestDate: Date,
 ): MeasurementDto | null {
@@ -129,7 +129,7 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
     if (!latest?.measuredAt) return null;
     const latestDate = toDate(latest.measuredAt);
     if (!latestDate) return null;
-    return findReferenceBelow6Weeks(sorted, latestDate);
+    return findReferenceAtLeast6WeeksBefore(sorted, latestDate);
   }, [sorted, latest]);
 
   // ── Stat tiles ──────────────────────────────────────────────────────────────
@@ -163,9 +163,12 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
         label: t('clientDetail.mereni.tiles.currentWeight'),
         value: formatNum(latest?.weightKg, 'kg'),
         delta: formatDelta(weightDiff, 'kg'),
-        deltaPositiveIsGood: false,
         deltaColor:
-          weightDiff == null ? null : weightDiff < 0 ? 'green' : 'orange',
+          weightDiff == null || weightDiff === 0
+            ? null
+            : weightDiff < 0
+              ? 'green'
+              : 'orange',
         accent: false,
         sub: refMeasurement?.measuredAt
           ? t('clientDetail.mereni.tiles.comparedToWeeksAgo')
@@ -175,9 +178,12 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
         label: t('clientDetail.mereni.tiles.bodyFat'),
         value: formatNum(latest?.bodyFatPercentage, '%'),
         delta: formatDelta(fatDiff, '%'),
-        deltaPositiveIsGood: false,
         deltaColor:
-          fatDiff == null ? null : fatDiff < 0 ? 'green' : 'orange',
+          fatDiff == null || fatDiff === 0
+            ? null
+            : fatDiff < 0
+              ? 'green'
+              : 'orange',
         accent: false,
         sub: null,
       },
@@ -185,9 +191,12 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
         label: t('clientDetail.mereni.tiles.waist'),
         value: formatNum(latest?.waistCm, 'cm', 0),
         delta: formatDelta(waistDiff, 'cm', 0),
-        deltaPositiveIsGood: false,
         deltaColor:
-          waistDiff == null ? null : waistDiff < 0 ? 'green' : 'orange',
+          waistDiff == null || waistDiff === 0
+            ? null
+            : waistDiff < 0
+              ? 'green'
+              : 'orange',
         accent: false,
         sub: null,
       },
@@ -196,7 +205,6 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
         value:
           remaining != null ? formatNum(remaining, 'kg') : '—',
         delta: null,
-        deltaPositiveIsGood: true,
         deltaColor: null,
         accent: true,
         sub:
@@ -226,7 +234,7 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
         </div>
         <button
           type="button"
-          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-surface2 transition-colors"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
           onClick={() =>
             addToast(t('clientDetail.mereni.addMeasurementPlaceholder'), 'success')
           }
@@ -381,21 +389,19 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
                         {dateStr}
                       </td>
                       <td className="py-2 pr-4 text-text2">
-                        {m.weightKg != null ? `${m.weightKg} kg` : '—'}
+                        {formatNum(m.weightKg, 'kg')}
                       </td>
                       <td className="py-2 pr-4 text-text2">
-                        {m.bodyFatPercentage != null
-                          ? `${m.bodyFatPercentage} %`
-                          : '—'}
+                        {formatNum(m.bodyFatPercentage, '%')}
                       </td>
                       <td className="py-2 pr-4 text-text2">
-                        {m.waistCm != null ? `${m.waistCm} cm` : '—'}
+                        {formatNum(m.waistCm, 'cm', 0)}
                       </td>
                       <td className="py-2 pr-4 text-text2">
-                        {m.hipsCm != null ? `${m.hipsCm} cm` : '—'}
+                        {formatNum(m.hipsCm, 'cm', 0)}
                       </td>
                       <td className="py-2 text-text2">
-                        {m.chestCm != null ? `${m.chestCm} cm` : '—'}
+                        {formatNum(m.chestCm, 'cm', 0)}
                       </td>
                     </tr>
                   );

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1748,6 +1748,32 @@
     "pendingInvite": {
       "title": "Pozvánka odeslána",
       "description": "Klient zatím nemá vytvořený účet. Na jeho email byla odeslána pozvánka s odkazem pro registraci. Po registraci si klient vyplní své údaje a jeho profil se zde automaticky doplní."
+    },
+    "mereni": {
+      "title": "Tělesná měření",
+      "addMeasurement": "Přidat měření",
+      "addMeasurementPlaceholder": "Přidat měření (funkce připravena v klientské aplikaci)",
+      "addFirstMeasurement": "Přidat první měření",
+      "emptyTitle": "Žádná měření",
+      "emptyDescription": "Klient zatím nezaznamenal žádná tělesná měření. Měření lze přidávat z mobilní aplikace.",
+      "errorLoading": "Měření se nepodařilo načíst.",
+      "chartLabel": "Vývoj váhy · posledních 8 týdnů",
+      "tiles": {
+        "currentWeight": "Aktuální váha",
+        "bodyFat": "Tělesný tuk",
+        "waist": "Pas",
+        "toGoal": "Do cíle",
+        "goalWeight": "cíl {{kg}} kg",
+        "comparedToWeeksAgo": "za 6 týd"
+      },
+      "table": {
+        "date": "Datum",
+        "weight": "Váha",
+        "bodyFat": "Tělesný tuk",
+        "waist": "Pas",
+        "hips": "Boky",
+        "chest": "Hrudník"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1720,6 +1720,32 @@
     "pendingInvite": {
       "title": "Einladung gesendet",
       "description": "Der Klient hat noch kein Konto erstellt. Eine Einladung mit Registrierungslink wurde an seine E-Mail-Adresse gesendet. Nach der Registrierung füllt der Klient seine Daten aus und sein Profil wird hier automatisch aktualisiert."
+    },
+    "mereni": {
+      "title": "Körpermessungen",
+      "addMeasurement": "Messung hinzufügen",
+      "addMeasurementPlaceholder": "Messung hinzufügen (in der Client-App verfügbar)",
+      "addFirstMeasurement": "Erste Messung hinzufügen",
+      "emptyTitle": "Keine Messungen",
+      "emptyDescription": "Der Klient hat noch keine Körpermessungen aufgezeichnet. Messungen können über die mobile App hinzugefügt werden.",
+      "errorLoading": "Messungen konnten nicht geladen werden.",
+      "chartLabel": "Gewichtsverlauf · letzte 8 Wochen",
+      "tiles": {
+        "currentWeight": "Aktuelles Gewicht",
+        "bodyFat": "Körperfett",
+        "waist": "Taille",
+        "toGoal": "Zum Ziel",
+        "goalWeight": "Ziel {{kg}} kg",
+        "comparedToWeeksAgo": "über 6 Wo."
+      },
+      "table": {
+        "date": "Datum",
+        "weight": "Gewicht",
+        "bodyFat": "Körperfett",
+        "waist": "Taille",
+        "hips": "Hüfte",
+        "chest": "Brust"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1721,6 +1721,32 @@
     "pendingInvite": {
       "title": "Invitation sent",
       "description": "The client hasn't created an account yet. An invitation with a registration link was sent to their email. After registering, the client will fill in their details and their profile will update here automatically."
+    },
+    "mereni": {
+      "title": "Body measurements",
+      "addMeasurement": "Add measurement",
+      "addMeasurementPlaceholder": "Add measurement (available in the client app)",
+      "addFirstMeasurement": "Add first measurement",
+      "emptyTitle": "No measurements",
+      "emptyDescription": "The client hasn't recorded any body measurements yet. Measurements can be added from the mobile app.",
+      "errorLoading": "Could not load measurements.",
+      "chartLabel": "Weight trend · last 8 weeks",
+      "tiles": {
+        "currentWeight": "Current weight",
+        "bodyFat": "Body fat",
+        "waist": "Waist",
+        "toGoal": "To goal",
+        "goalWeight": "goal {{kg}} kg",
+        "comparedToWeeksAgo": "over 6 wks"
+      },
+      "table": {
+        "date": "Date",
+        "weight": "Weight",
+        "bodyFat": "Body fat",
+        "waist": "Waist",
+        "hips": "Hips",
+        "chest": "Chest"
+      }
     }
   }
 }

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -258,7 +258,10 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-mereni"
               className="tab-content-transition"
             >
-              <MereniTab />
+              <MereniTab
+                clientId={id!}
+                targetWeightKg={ob?.targetWeightKg ?? null}
+              />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Fills the Měření tab (`cl-pane-mereni`) of the redesigned client-detail page.
- 4 stat tiles (Aktuální váha / Tělesný tuk / Pas with 6-week deltas, Do cíle in gold accent from onboarding target weight), 8-week CSS weight bar chart, full history table (Datum / Váha / Tělesný tuk / Pas / Boky / Hrudník, newest-first), empty + loading + error states.
- New `web/src/api/measurements.ts` wrapper over `GET /trainer/clients/{clientId}/measurements`.
- "+ Přidat měření" is a toast placeholder — no trainer add-measurement endpoint exists (deliberate, matches prototype; trainer add-flow is a future backend+web follow-up).

## Related issue
Fixes #487

## Parent epic
Part of epic #484 — base branch: `feature/484-client-detail-redesign`.

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS (`.claude/state/handoff-qa-487.json`).

## Test plan
- [ ] Měření pane (`cl-pane-mereni`) filled: 4-col stat tiles (current weight + 6-wk delta/direction, body fat delta, waist delta cm, Do cíle kg remaining in gold).
- [ ] 8-week weight-trend bar chart (gold accent, varying opacity), label "Vývoj váhy · posledních 8 týdnů".
- [ ] "+ Přidat měření" button present (opens placeholder toast).
- [ ] History table (Datum, Váha, Tělesný tuk, Pas, Boky, Hrudník), newest first, scrollable.
- [ ] Empty state when no measurements (message + CTA).
- [ ] All new copy in cs/en/de.
- [ ] No hardcoded colors; tokens only.
- [ ] npm run build passes (TypeScript clean).
- [ ] Visual match to docs/prototypes/notion/scenes/client.html (#cl-pane-mereni).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
