### PR TITLE
feat: Client detail Plány tab + list-client-plans endpoint (#490)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansEndpoint.cs
@@ -1,0 +1,232 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+/// <summary>
+/// Returns all nutrition and training plans for a specific client, across all
+/// statuses (Active, Completed, Draft, Archived), sorted newest-first (by StartDate desc,
+/// then DateCreated desc as tiebreaker). Includes a per-plan result summary.
+///
+/// Trainer must have an active ClientProfessionalLink to the client; returns 403 if not
+/// linked (matches GetClientVerdict ownership pattern).
+/// </summary>
+public class ListClientPlansEndpoint(
+    IApplicationDbContext db,
+    IMongoContext mongo,
+    IComplianceService complianceService)
+    : Endpoint<ListClientPlansRequest, ListClientPlansResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/clients/{clientId}/plans");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "List client plans";
+            s.Description = "Returns all nutrition and training plans for a client (all statuses), newest first, with per-plan result summaries.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(ListClientPlansRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerUserId = Guid.Parse(userId);
+
+        // Locate the trainer's professional profile
+        var professionalProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(pp => pp.UserId == trainerUserId, ct);
+
+        if (professionalProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Locate the client profile by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify an active trainer-client link exists; return 403 (not 404) when missing
+        var link = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l =>
+                l.ProfessionalProfileId == professionalProfile.Id &&
+                l.ClientProfileId == clientProfile.Id &&
+                l.IsActive, ct);
+
+        if (link is null)
+        {
+            await Send.ForbiddenAsync(ct);
+            return;
+        }
+
+        // clientProfile.UserId is ApplicationUser.Id (Guid) — used by all Mongo documents
+        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId)
+        var clientUserId = clientProfile.UserId;
+        var clientProfileId = clientProfile.Id;
+
+        // Load all plans from Mongo in parallel
+        var nutritionFilter = Builders<Domain.Documents.NutritionPlan>.Filter
+            .Eq(p => p.ClientId, clientUserId);
+        var trainingFilter = Builders<Domain.Documents.TrainingPlan>.Filter
+            .Eq(p => p.ClientId, clientUserId);
+
+        var nutritionTask = mongo.NutritionPlans
+            .Find(nutritionFilter)
+            .ToListAsync(ct);
+        var trainingTask = mongo.TrainingPlans
+            .Find(trainingFilter)
+            .ToListAsync(ct);
+
+        await Task.WhenAll(nutritionTask, trainingTask);
+        var nutritionPlans = nutritionTask.Result;
+        var trainingPlans = trainingTask.Result;
+
+        // Compute result summaries for training plans:
+        // totalTrainings = count of completed WorkoutLogs with matching PlanId
+        // prCount = count of PersonalRecords with AchievedAt in [plan.StartDate .. plan.DateCompleted ?? now]
+        var trainingPlanIds = trainingPlans.Select(p => p.ExternalId).ToList();
+        var workoutLogs = await mongo.WorkoutLogs
+            .Find(Builders<Domain.Documents.WorkoutLog>.Filter.And(
+                Builders<Domain.Documents.WorkoutLog>.Filter.Eq(l => l.ClientId, clientUserId),
+                Builders<Domain.Documents.WorkoutLog>.Filter.Eq(l => l.IsCompleted, true),
+                Builders<Domain.Documents.WorkoutLog>.Filter.In(l => l.PlanId, trainingPlanIds.Cast<Guid?>())))
+            .ToListAsync(ct);
+
+        // PersonalRecords have no planId; filter by AchievedAt window per plan (computed per plan below)
+        var allPersonalRecords = await mongo.PersonalRecords
+            .Find(Builders<Domain.Documents.PersonalRecord>.Filter.Eq(pr => pr.ClientId, clientUserId))
+            .ToListAsync(ct);
+
+        // Build training plan items
+        var trainingItems = trainingPlans.Select(plan =>
+        {
+            var planLogCount = workoutLogs.Count(l => l.PlanId == plan.ExternalId && l.IsCompleted);
+
+            // PR window: [plan.StartDate .. plan.DateCompleted ?? now]
+            int? prCount = null;
+            if (plan.StartDate.HasValue)
+            {
+                var prWindowEnd = plan.DateCompleted ?? DateTime.UtcNow;
+                prCount = allPersonalRecords.Count(pr =>
+                    pr.AchievedAt >= plan.StartDate.Value &&
+                    pr.AchievedAt <= prWindowEnd);
+            }
+
+            return new ClientPlanItem
+            {
+                PlanId = plan.ExternalId,
+                PlanType = "Training",
+                Name = plan.Name,
+                PeriodStart = plan.StartDate,
+                PeriodEnd = plan.DateCompleted,
+                Status = plan.Status.ToString(),
+                ResultSummary = new ClientPlanResultSummary
+                {
+                    TotalTrainings = planLogCount,
+                    PrCount = prCount,
+                    CompliancePercent = null,
+                    WeightDeltaKg = null
+                }
+            };
+        }).ToList();
+
+        // Build nutrition plan items — compute compliance and weight delta per plan
+        // Body measurements keyed on clientProfile.Id (long PK)
+        var allMeasurements = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(m => m.ClientProfileId == clientProfileId && m.WeightKg != null)
+            .OrderBy(m => m.MeasuredAt)
+            .ToListAsync(ct);
+
+        var nutritionItems = new List<ClientPlanItem>();
+        foreach (var plan in nutritionPlans)
+        {
+            decimal? compliancePercent = null;
+            decimal? weightDeltaKg = null;
+
+            if (plan.StartDate.HasValue)
+            {
+                var periodEnd = plan.DateCompleted ?? DateTime.UtcNow;
+
+                // Nutrition compliance over the plan period via IComplianceService
+                var complianceResult = await complianceService.CalculateComplianceAsync(
+                    clientUserId,
+                    plan.StartDate.Value,
+                    periodEnd,
+                    ct);
+                compliancePercent = complianceResult.NutritionCompliancePercent;
+
+                // Weight delta: first measurement on/after start vs last measurement on/before end
+                var startMeasurement = allMeasurements
+                    .FirstOrDefault(m => m.MeasuredAt >= plan.StartDate.Value && m.MeasuredAt <= periodEnd);
+                var endMeasurement = allMeasurements
+                    .LastOrDefault(m => m.MeasuredAt >= plan.StartDate.Value && m.MeasuredAt <= periodEnd);
+
+                if (startMeasurement != null &&
+                    endMeasurement != null &&
+                    startMeasurement.Id != endMeasurement.Id &&
+                    startMeasurement.WeightKg.HasValue &&
+                    endMeasurement.WeightKg.HasValue)
+                {
+                    weightDeltaKg = endMeasurement.WeightKg.Value - startMeasurement.WeightKg.Value;
+                }
+            }
+
+            nutritionItems.Add(new ClientPlanItem
+            {
+                PlanId = plan.ExternalId,
+                PlanType = "Nutrition",
+                Name = plan.Name,
+                PeriodStart = plan.StartDate,
+                PeriodEnd = plan.DateCompleted,
+                Status = plan.Status.ToString(),
+                ResultSummary = new ClientPlanResultSummary
+                {
+                    TotalTrainings = null,
+                    PrCount = null,
+                    CompliancePercent = compliancePercent,
+                    WeightDeltaKg = weightDeltaKg
+                }
+            });
+        }
+
+        // Merge all plans and sort newest-first:
+        // Primary sort: StartDate desc (null StartDate treated as oldest — draft plans)
+        // Secondary sort: DateCreated desc as tiebreaker
+        var allItems = trainingItems
+            .Concat(nutritionItems)
+            .OrderByDescending(p => p.PeriodStart ?? DateTime.MinValue)
+            .ThenByDescending(p =>
+                // retrieve DateCreated from the original plan for tiebreaker
+                trainingPlans.FirstOrDefault(tp => tp.ExternalId == p.PlanId)?.DateCreated
+                ?? nutritionPlans.FirstOrDefault(np => np.ExternalId == p.PlanId)?.DateCreated
+                ?? DateTime.MinValue)
+            .ToList();
+
+        await Send.OkAsync(new ListClientPlansResponse { Plans = allItems }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansRequest.cs
@@ -1,0 +1,9 @@
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+public class ListClientPlansRequest
+{
+    /// <summary>
+    /// The client's PublicId (Guid), as it appears in the route segment.
+    /// </summary>
+    public Guid ClientId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansResponse.cs
@@ -1,0 +1,91 @@
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+/// <summary>
+/// Combined list of a client's nutrition and training plans returned by
+/// GET /trainer/clients/{clientId}/plans.
+/// </summary>
+public class ListClientPlansResponse
+{
+    /// <summary>
+    /// All plans (nutrition + training) across all statuses, newest first.
+    /// </summary>
+    public List<ClientPlanItem> Plans { get; set; } = [];
+}
+
+/// <summary>
+/// A single plan entry in the combined list.
+/// </summary>
+public class ClientPlanItem
+{
+    /// <summary>
+    /// The plan's public ExternalId (Guid) as stored in MongoDB.
+    /// </summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>
+    /// Discriminates the plan type: "Nutrition" or "Training".
+    /// </summary>
+    public string PlanType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name of the plan.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Monday when Week 1 begins (UTC). Null for plans where StartDate has not been set.
+    /// </summary>
+    public DateTime? PeriodStart { get; set; }
+
+    /// <summary>
+    /// When the plan was marked completed (UTC). Null for active/draft plans and open-ended plans.
+    /// </summary>
+    public DateTime? PeriodEnd { get; set; }
+
+    /// <summary>
+    /// Current plan status as a string: "Draft", "Active", "Completed", "Archived".
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-plan result summary. Null fields indicate the metric is not applicable
+    /// (e.g. compliance is null for training plans; totalTrainings is null for nutrition plans).
+    /// </summary>
+    public ClientPlanResultSummary ResultSummary { get; set; } = new();
+}
+
+/// <summary>
+/// Per-plan result summary. Fields not applicable to the plan type are null.
+/// </summary>
+public class ClientPlanResultSummary
+{
+    // ── Training-plan fields ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Count of WorkoutLogs where PlanId == plan.ExternalId and IsCompleted == true.
+    /// Null for nutrition plans.
+    /// </summary>
+    public int? TotalTrainings { get; set; }
+
+    /// <summary>
+    /// Count of PersonalRecords with AchievedAt in [plan.StartDate .. plan.DateCompleted ?? now].
+    /// Null for nutrition plans or plans without a StartDate.
+    /// </summary>
+    public int? PrCount { get; set; }
+
+    // ── Nutrition-plan fields ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Nutrition compliance % (0-100) over the plan period via IComplianceService.
+    /// Null for training plans, or when the plan has no StartDate.
+    /// </summary>
+    public decimal? CompliancePercent { get; set; }
+
+    /// <summary>
+    /// Body weight delta (kg) from the first BodyMeasurement on/after plan start
+    /// to the last BodyMeasurement on/before plan end (DateCompleted ?? now).
+    /// Positive = weight gained; negative = weight lost.
+    /// Null for training plans, or when fewer than two measurements exist in the window.
+    /// </summary>
+    public decimal? WeightDeltaKg { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+public class ListClientPlansValidator : Validator<ListClientPlansRequest>
+{
+    public ListClientPlansValidator()
+    {
+        RuleFor(x => x.ClientId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansTests.cs
@@ -1,0 +1,570 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+/// <summary>
+/// Tests for <see cref="ListClientPlansEndpoint" />.
+/// </summary>
+public class ListClientPlansTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly IComplianceService _complianceService = Substitute.For<IComplianceService>();
+
+    // ── Happy path — combined list ───────────────────────────────────────────
+
+    [Fact]
+    public async Task List_BothPlanTypes_ReturnsCombinedListNewestFirst()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var olderStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);  // Monday
+        var newerStart = new DateTime(2025, 6, 2, 0, 0, 0, DateTimeKind.Utc);  // Monday
+
+        var nutritionPlan = CreateNutritionPlan(clientUserId, startDate: olderStart, name: "Old Nutrition Plan");
+        var trainingPlan = CreateTrainingPlan(clientUserId, startDate: newerStart, name: "New Training Plan");
+
+        var mongo = BuildMongo(
+            nutritionPlans: [nutritionPlan],
+            trainingPlans: [trainingPlan],
+            workoutLogs: [],
+            personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var plans = ep.Response.Plans;
+        plans.Should().HaveCount(2);
+
+        // Newest-first: trainingPlan (newerStart) should come before nutritionPlan (olderStart)
+        plans[0].PlanId.Should().Be(trainingPlan.ExternalId);
+        plans[0].PlanType.Should().Be("Training");
+        plans[0].Name.Should().Be("New Training Plan");
+        plans[1].PlanId.Should().Be(nutritionPlan.ExternalId);
+        plans[1].PlanType.Should().Be("Nutrition");
+        plans[1].Name.Should().Be("Old Nutrition Plan");
+    }
+
+    [Fact]
+    public async Task List_AllStatuses_ReturnsDraftActiveCompleted()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var start1 = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
+        var start2 = new DateTime(2025, 3, 3, 0, 0, 0, DateTimeKind.Utc);
+        var start3 = new DateTime(2025, 5, 5, 0, 0, 0, DateTimeKind.Utc);
+
+        var draftPlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Draft, startDate: start1, name: "Draft Plan");
+        var activePlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Active, startDate: start2, name: "Active Plan");
+        var completedPlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Completed, startDate: start3, name: "Completed Plan");
+
+        var mongo = BuildMongo(
+            trainingPlans: [draftPlan, activePlan, completedPlan],
+            workoutLogs: [],
+            personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var plans = ep.Response.Plans;
+        plans.Should().HaveCount(3);
+
+        // Verify all statuses are present
+        plans.Select(p => p.Status).Should().BeEquivalentTo(["Draft", "Active", "Completed"]);
+    }
+
+    // ── Training plan result summary ─────────────────────────────────────────
+
+    [Fact]
+    public async Task List_TrainingPlan_ResultSummaryIncludesTotalTrainingsAndPrCount()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var planStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
+        var planId = Guid.NewGuid();
+
+        var trainingPlan = CreateTrainingPlan(clientUserId, externalId: planId, startDate: planStart, name: "Hypertrophy Plan");
+
+        // 3 completed logs for this plan
+        var log1 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
+        var log2 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
+        var log3 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
+        // 1 not completed (should not be counted)
+        var log4 = CreateWorkoutLog(clientUserId, planId, isCompleted: false);
+        // 1 completed but for a different plan (should not be counted)
+        var log5 = CreateWorkoutLog(clientUserId, Guid.NewGuid(), isCompleted: true);
+
+        // 2 PRs in the plan window
+        var pr1 = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(10));
+        var pr2 = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(20));
+        // 1 PR before plan start (should not be counted)
+        var prBefore = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(-5));
+
+        var mongo = BuildMongo(
+            trainingPlans: [trainingPlan],
+            workoutLogs: [log1, log2, log3, log4, log5],
+            personalRecords: [pr1, pr2, prBefore]);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var planItem = ep.Response.Plans.Single();
+        planItem.ResultSummary.TotalTrainings.Should().Be(3);
+        planItem.ResultSummary.PrCount.Should().Be(2);
+        planItem.ResultSummary.CompliancePercent.Should().BeNull();
+        planItem.ResultSummary.WeightDeltaKg.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task List_TrainingPlanNoStartDate_PrCountIsNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var planId = Guid.NewGuid();
+        // No StartDate set — Draft plan
+        var trainingPlan = CreateTrainingPlan(clientUserId, externalId: planId, startDate: null, name: "Draft Plan");
+
+        var pr = CreatePersonalRecord(clientUserId, achievedAt: DateTime.UtcNow.AddDays(-5));
+
+        var mongo = BuildMongo(
+            trainingPlans: [trainingPlan],
+            workoutLogs: [],
+            personalRecords: [pr]);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Plans.Single().ResultSummary.PrCount.Should().BeNull();
+        ep.Response.Plans.Single().ResultSummary.TotalTrainings.Should().Be(0);
+    }
+
+    // ── Nutrition plan result summary ────────────────────────────────────────
+
+    [Fact]
+    public async Task List_NutritionPlan_ResultSummaryIncludesComplianceAndWeightDelta()
+    {
+        var planStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
+        var planEnd = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc);
+        var clientUserId = Guid.NewGuid();
+
+        var nutritionPlan = CreateNutritionPlan(
+            clientUserId,
+            startDate: planStart,
+            dateCompleted: planEnd,
+            name: "Weight Loss Plan");
+
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithId(clientUserId).Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        // Two body measurements within the plan window (distinct Ids required for delta calculation)
+        var measurementStart = new BodyMeasurement
+        {
+            Id = 1,
+            ClientProfileId = clientProfile.Id,
+            MeasuredAt = planStart.AddDays(1),
+            WeightKg = 80.0m
+        };
+        var measurementEnd = new BodyMeasurement
+        {
+            Id = 2,
+            ClientProfileId = clientProfile.Id,
+            MeasuredAt = planEnd.AddDays(-1),
+            WeightKg = 75.5m
+        };
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .With(measurementStart)
+            .With(measurementEnd)
+            .Build();
+
+        _complianceService
+            .CalculateComplianceAsync(clientUserId, planStart, planEnd, Arg.Any<CancellationToken>())
+            .Returns(new ComplianceResult
+            {
+                NutritionCompliancePercent = 87.5m,
+                CompliancePercent = 87.5m
+            });
+
+        var mongo = BuildMongo(
+            nutritionPlans: [nutritionPlan],
+            workoutLogs: [],
+            personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId, setupDefaultCompliance: false);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var planItem = ep.Response.Plans.Single();
+        planItem.ResultSummary.CompliancePercent.Should().Be(87.5m);
+        planItem.ResultSummary.WeightDeltaKg.Should().BeApproximately(-4.5m, 0.01m);
+        planItem.ResultSummary.TotalTrainings.Should().BeNull();
+        planItem.ResultSummary.PrCount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task List_NutritionPlanNoStartDate_ComplianceAndWeightDeltaAreNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var nutritionPlan = CreateNutritionPlan(clientUserId, startDate: null, name: "Draft Nutrition Plan");
+
+        var mongo = BuildMongo(nutritionPlans: [nutritionPlan], workoutLogs: [], personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var planItem = ep.Response.Plans.Single();
+        planItem.ResultSummary.CompliancePercent.Should().BeNull();
+        planItem.ResultSummary.WeightDeltaKg.Should().BeNull();
+    }
+
+    // ── Empty results ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_NoPlans_ReturnsEmptyArray()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        var mongo = BuildMongo(nutritionPlans: [], trainingPlans: [], workoutLogs: [], personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Plans.Should().BeEmpty();
+    }
+
+    // ── Auth & ownership errors ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_NoClaims_Returns401()
+    {
+        var db = new MockDbBuilder().Build();
+        var mongo = BuildMongo();
+
+        var ep = Factory.Create<ListClientPlansEndpoint>(db, mongo, _complianceService);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task List_NotLinkedToClient_Returns403()
+    {
+        // Trainer has a profile but NO link to the client
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
+
+        // No link added to MockDbBuilder
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .Build();
+
+        var mongo = BuildMongo();
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task List_CrossTrainerAccess_Returns403()
+    {
+        // Trainer 2 tries to access trainer 1's client
+        var trainer1Id = Guid.NewGuid();
+        var trainer2Id = _trainerId;
+
+        var trainerProfile1 = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(trainer1Id).Build();
+        var trainerProfile2 = EntityBuilder.ProfessionalProfile.WithId(2).WithUserId(trainer2Id).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+
+        // Only trainer1 is linked to the client
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile1)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile1)
+            .With(trainerProfile2)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var mongo = BuildMongo();
+
+        // trainer2 is calling
+        var ep = CreateEndpoint(db, mongo, trainer2Id);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task List_NonexistentClient_Returns404()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var db = new MockDbBuilder().With(trainerProfile).Build();
+        var mongo = BuildMongo();
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task List_NoTrainerProfile_Returns404()
+    {
+        // Trainer has no ProfessionalProfile
+        var db = new MockDbBuilder().Build();
+        var mongo = BuildMongo();
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private ListClientPlansEndpoint CreateEndpoint(
+        IApplicationDbContext db,
+        IMongoContext mongo,
+        Guid callerId,
+        bool setupDefaultCompliance = true)
+    {
+        if (setupDefaultCompliance)
+        {
+            _complianceService
+                .CalculateComplianceAsync(Arg.Any<Guid>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+                .Returns(new ComplianceResult
+                {
+                    NutritionCompliancePercent = 0m,
+                    CompliancePercent = 0m
+                });
+        }
+
+        return Factory.Create<ListClientPlansEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(callerId),
+            db, mongo, _complianceService);
+    }
+
+    private (IApplicationDbContext db, Application.Domain.Entities.ClientProfile clientProfile)
+        BuildLinkedClientSetup()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        return (db, clientProfile);
+    }
+
+    private static ClaimsPrincipal FakeTrainerPrincipal(Guid userId) =>
+        new(new ClaimsIdentity(
+            EndpointTestHelpers.FakeUserClaims(userId, AppRoles.Trainer)));
+
+    // ── Mongo factory helpers ────────────────────────────────────────────────
+
+    private static IMongoContext BuildMongo(
+        IEnumerable<NutritionPlan>? nutritionPlans = null,
+        IEnumerable<TrainingPlan>? trainingPlans = null,
+        IEnumerable<WorkoutLog>? workoutLogs = null,
+        IEnumerable<PersonalRecord>? personalRecords = null)
+    {
+        // Build collections first — never pass a NSubstitute setup call as an argument
+        // to another Returns() call; NSubstitute's thread-local context would throw.
+        var nutritionCollection = CreateMockCollection(nutritionPlans?.ToList() ?? []);
+        var trainingCollection = CreateMockCollection(trainingPlans?.ToList() ?? []);
+        var workoutCollection = CreateMockCollection(workoutLogs?.ToList() ?? []);
+        var recordsCollection = CreateMockCollection(personalRecords?.ToList() ?? []);
+
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.NutritionPlans.Returns(nutritionCollection);
+        mongo.TrainingPlans.Returns(trainingCollection);
+        mongo.WorkoutLogs.Returns(workoutCollection);
+        mongo.PersonalRecords.Returns(recordsCollection);
+        return mongo;
+    }
+
+    private static IMongoCollection<T> CreateMockCollection<T>(List<T> docs)
+    {
+        var collection = Substitute.For<IMongoCollection<T>>();
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<T>>(),
+                Arg.Any<FindOptions<T, T>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(docs));
+        return collection;
+    }
+
+    private static IAsyncCursor<T> CreateCursor<T>(List<T> docs)
+    {
+        var cursor = Substitute.For<IAsyncCursor<T>>();
+        var moved = false;
+        cursor.Current.Returns(docs);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        return cursor;
+    }
+
+    private static NutritionPlan CreateNutritionPlan(
+        Guid clientId,
+        Guid? externalId = null,
+        DateTime? startDate = null,
+        DateTime? dateCompleted = null,
+        string name = "Test Nutrition Plan",
+        NutritionPlanStatus status = NutritionPlanStatus.Active)
+    {
+        return new NutritionPlan
+        {
+            ExternalId = externalId ?? Guid.NewGuid(),
+            ClientId = clientId,
+            NutritionistId = Guid.NewGuid(),
+            Name = name,
+            Status = status,
+            StartDate = startDate,
+            DateCompleted = dateCompleted,
+            DateCreated = startDate ?? DateTime.UtcNow.AddDays(-30),
+            Version = 1
+        };
+    }
+
+    private static TrainingPlan CreateTrainingPlan(
+        Guid clientId,
+        Guid? externalId = null,
+        DateTime? startDate = null,
+        DateTime? dateCompleted = null,
+        string name = "Test Training Plan",
+        TrainingPlanStatus status = TrainingPlanStatus.Active)
+    {
+        return new TrainingPlan
+        {
+            ExternalId = externalId ?? Guid.NewGuid(),
+            ClientId = clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = name,
+            Status = status,
+            StartDate = startDate,
+            DateCompleted = dateCompleted,
+            DateCreated = startDate ?? DateTime.UtcNow.AddDays(-30),
+            Version = 1
+        };
+    }
+
+    private static WorkoutLog CreateWorkoutLog(
+        Guid clientId,
+        Guid planId,
+        bool isCompleted = true)
+    {
+        return new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            PlanId = planId,
+            IsCompleted = isCompleted,
+            StartedAt = DateTime.UtcNow.AddDays(-5),
+            DateCreated = DateTime.UtcNow.AddDays(-5)
+        };
+    }
+
+    private static PersonalRecord CreatePersonalRecord(
+        Guid clientId,
+        DateTime? achievedAt = null)
+    {
+        return new PersonalRecord
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            ExerciseExternalId = Guid.NewGuid(),
+            ExerciseName = "Bench Press",
+            WeightKg = 100m,
+            Reps = 5,
+            AchievedAt = achievedAt ?? DateTime.UtcNow.AddDays(-3),
+            WorkoutLogId = Guid.NewGuid(),
+            SetNumber = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3)
+        };
+    }
+}

--- a/web/src/api/client-plans.ts
+++ b/web/src/api/client-plans.ts
@@ -1,0 +1,92 @@
+import api from '@/lib/api';
+
+/**
+ * Plan type discriminator — mirrors the backend PlanType string.
+ */
+export type PlanType = 'Nutrition' | 'Training';
+
+/**
+ * Plan status discriminator — mirrors the backend plan status strings.
+ */
+export type PlanStatus = 'Draft' | 'Active' | 'Completed' | 'Archived';
+
+/**
+ * Per-plan result summary. Fields not applicable to the plan type are null.
+ * Mirrors backend ClientPlanResultSummary.
+ *
+ * Training-plan fields: totalTrainings, prCount.
+ * Nutrition-plan fields: compliancePercent, weightDeltaKg.
+ */
+export interface ClientPlanResultSummary {
+  /**
+   * Count of completed WorkoutLogs for this plan.
+   * Null for nutrition plans.
+   */
+  totalTrainings: number | null;
+  /**
+   * Count of PersonalRecords achieved within the plan's date window.
+   * Null for nutrition plans or plans without a StartDate.
+   */
+  prCount: number | null;
+  /**
+   * Nutrition compliance percent (0–100) over the plan period.
+   * Null for training plans or plans without a StartDate.
+   */
+  compliancePercent: number | null;
+  /**
+   * Weight delta (kg) from first to last measurement in the plan window.
+   * Positive = weight gained; negative = weight lost.
+   * Null for training plans or when fewer than two measurements exist.
+   */
+  weightDeltaKg: number | null;
+}
+
+/**
+ * A single plan entry in the combined client plan list.
+ * Mirrors backend ClientPlanItem.
+ */
+export interface ClientPlanItem {
+  /** The plan's public ExternalId (Guid). */
+  planId: string;
+  /** Discriminates the plan type: "Nutrition" or "Training". */
+  planType: PlanType;
+  /** Display name of the plan. */
+  name: string;
+  /** ISO 8601 UTC — the Monday when Week 1 begins. Null when not yet set. */
+  periodStart: string | null;
+  /**
+   * ISO 8601 UTC — when the plan was marked completed.
+   * Null for active/draft plans and open-ended plans.
+   */
+  periodEnd: string | null;
+  /** Current plan status: "Draft" | "Active" | "Completed" | "Archived". */
+  status: PlanStatus;
+  /** Per-plan result metrics. */
+  resultSummary: ClientPlanResultSummary;
+}
+
+/**
+ * Response from GET /trainer/clients/{clientId}/plans.
+ * Mirrors backend ListClientPlansResponse.
+ *
+ * NOTE: generated.ts does not yet contain this type — regen-api will be run
+ * once at the epic-PR stage to reconcile hand-written modules. This is the
+ * hand-authored source of truth for the web client until then.
+ */
+export interface ListClientPlansResponse {
+  /** All plans (nutrition + training), newest first. */
+  plans: ClientPlanItem[];
+}
+
+/**
+ * Fetch the combined plan list (nutrition + training) for a client.
+ * Route: GET /trainer/clients/{clientId}/plans
+ */
+export async function getClientPlans(
+  clientId: string,
+): Promise<ListClientPlansResponse> {
+  const { data } = await api.get<ListClientPlansResponse>(
+    `/trainer/clients/${clientId}/plans`,
+  );
+  return data;
+}

--- a/web/src/components/clients/tabs/PlanyTab.tsx
+++ b/web/src/components/clients/tabs/PlanyTab.tsx
@@ -1,4 +1,259 @@
-/** Placeholder for the Plány tab — filled in by a wave-3 sub-issue. */
-export function PlanyTab() {
-  return <div id="cl-pane-plany" />;
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { getClientPlans } from '@/api/client-plans';
+import type { ClientPlanItem, PlanStatus } from '@/api/client-plans';
+
+interface PlanyTabProps {
+  clientId: string;
+}
+
+// ── Date formatting helpers ───────────────────────────────────────────────────
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString('cs-CZ', {
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatPeriod(periodStart: string | null, periodEnd: string | null): string {
+  const start = formatDate(periodStart);
+  const end = formatDate(periodEnd);
+  if (!start && !end) return '—';
+  if (start && !end) return `${start} →`;
+  if (!start && end) return `→ ${end}`;
+  return `${start} – ${end}`;
+}
+
+// ── Status chip ───────────────────────────────────────────────────────────────
+
+interface StatusChipProps {
+  status: PlanStatus;
+  label: string;
+}
+
+function StatusChip({ status, label }: StatusChipProps) {
+  // Uses the existing global `.tag` + modifier classes from index.css.
+  // Active → green, Completed → gold (accent), Draft/Archived → gray.
+  const modifierMap: Record<PlanStatus, string> = {
+    Active: 'tag-green',
+    Completed: 'tag-acc',
+    Draft: 'tag-gray',
+    Archived: 'tag-gray',
+  };
+  return (
+    <span className={`tag ${modifierMap[status] ?? 'tag-gray'}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Result summary formatter ──────────────────────────────────────────────────
+
+function formatResultSummary(plan: ClientPlanItem, t: TFunction): string {
+  const { planType, resultSummary: r } = plan;
+
+  if (planType === 'Nutrition') {
+    const parts: string[] = [];
+    if (r.compliancePercent != null) {
+      parts.push(
+        t('clientDetail.plany.result.compliance', {
+          pct: r.compliancePercent.toFixed(0),
+        }),
+      );
+    }
+    if (r.weightDeltaKg != null) {
+      const sign = r.weightDeltaKg > 0 ? '+' : '';
+      const val = r.weightDeltaKg.toFixed(1).replace('.', ',');
+      parts.push(
+        t('clientDetail.plany.result.weightDelta', {
+          delta: `${sign}${val}`,
+        }),
+      );
+    }
+    return parts.join(' · ') || '—';
+  }
+
+  if (planType === 'Training') {
+    const parts: string[] = [];
+    if (r.totalTrainings != null) {
+      parts.push(
+        t('clientDetail.plany.result.totalTrainings', {
+          count: r.totalTrainings,
+        }),
+      );
+    }
+    if (r.prCount != null) {
+      parts.push(
+        t('clientDetail.plany.result.prCount', {
+          count: r.prCount,
+        }),
+      );
+    }
+    return parts.join(' · ') || '—';
+  }
+
+  return '—';
+}
+
+// ── Plan type emoji prefix ────────────────────────────────────────────────────
+
+function planTypeEmoji(planType: string): string {
+  return planType === 'Nutrition' ? '🥗' : '🏋️';
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function PlanyTab({ clientId }: PlanyTabProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['client-plans', clientId],
+    queryFn: () => getClientPlans(clientId),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  const plans = data?.plans ?? [];
+  const isEmpty = !isPending && !isError && plans.length === 0;
+
+  function handleRowClick(plan: ClientPlanItem) {
+    if (plan.planType === 'Nutrition') {
+      navigate(`/clients/${clientId}/plans/${plan.planId}`);
+    } else {
+      navigate(`/clients/${clientId}/training-plans/${plan.planId}`);
+    }
+  }
+
+  return (
+    <div id="cl-pane-plany">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3.5">
+        <div className="text-[15px] font-semibold text-text">
+          {t('clientDetail.plany.title')}
+        </div>
+      </div>
+
+      {/* Loading */}
+      {isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error */}
+      {isError && !isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.plany.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📋</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.plany.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.plany.emptyDescription')}
+          </div>
+        </div>
+      )}
+
+      {/* Plans table */}
+      {!isPending && !isError && plans.length > 0 && (
+        <div className="db-wrap overflow-x-auto mb-5">
+          <table className="db-table w-full text-[13px]">
+            <thead>
+              <tr>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.plan')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.type')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.period')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.status')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2">
+                  {t('clientDetail.plany.table.result')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {plans.map((plan) => {
+                const statusLabel = t(
+                  `clientDetail.plany.status.${plan.status.toLowerCase()}`,
+                );
+                return (
+                  <tr
+                    key={plan.planId}
+                    className="border-t border-border cursor-pointer hover:bg-bg-hover transition-colors"
+                    onClick={() => handleRowClick(plan)}
+                    role="link"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowClick(plan);
+                      }
+                    }}
+                    aria-label={`${t('clientDetail.plany.table.openPlan')} ${plan.name}`}
+                  >
+                    <td className="row-title py-2.5 pr-4 font-medium text-text">
+                      <span className="mr-1.5">{planTypeEmoji(plan.planType)}</span>
+                      {plan.name}
+                    </td>
+                    <td className="py-2.5 pr-4 text-text2">
+                      {plan.planType === 'Nutrition'
+                        ? t('clientDetail.plany.typeLabel.nutrition')
+                        : t('clientDetail.plany.typeLabel.training')}
+                    </td>
+                    <td className="py-2.5 pr-4 text-text2 whitespace-nowrap">
+                      {formatPeriod(plan.periodStart, plan.periodEnd)}
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <StatusChip status={plan.status} label={statusLabel} />
+                    </td>
+                    <td className="py-2.5 text-text2">
+                      {formatResultSummary(plan, t)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {!isPending && !isError && (
+        <div className="flex gap-3 mt-2">
+          <button
+            type="button"
+            className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+            onClick={() => navigate(`/clients/${clientId}/nutrition`)}
+          >
+            + {t('clientDetail.plany.actions.newNutrition')}
+          </button>
+          <button
+            type="button"
+            className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+            onClick={() => navigate(`/clients/${clientId}/training`)}
+          >
+            + {t('clientDetail.plany.actions.newTraining')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1777,6 +1777,46 @@
         "chest": "Hrudník"
       }
     },
+    "plany": {
+      "title": "Plány klienta",
+      "errorLoading": "Plány se nepodařilo načíst.",
+      "emptyTitle": "Žádné plány",
+      "emptyDescription": "Klient zatím nemá žádné výživové ani tréninkové plány.",
+      "table": {
+        "plan": "Plán",
+        "type": "Typ",
+        "period": "Období",
+        "status": "Stav",
+        "result": "Výsledek",
+        "openPlan": "Otevřít plán"
+      },
+      "typeLabel": {
+        "nutrition": "Výživa",
+        "training": "Trénink"
+      },
+      "status": {
+        "active": "Aktivní",
+        "completed": "Dokončený",
+        "draft": "Koncept",
+        "archived": "Archivovaný"
+      },
+      "result": {
+        "compliance": "Compliance {{pct}} %",
+        "weightDelta": "váha {{delta}} kg",
+        "totalTrainings_one": "{{count}} trénink",
+        "totalTrainings_few": "{{count}} tréninky",
+        "totalTrainings_many": "{{count}} tréninků",
+        "totalTrainings_other": "{{count}} tréninků",
+        "prCount_one": "{{count}} PR",
+        "prCount_few": "{{count}} PR",
+        "prCount_many": "{{count}} PR",
+        "prCount_other": "{{count}} PR"
+      },
+      "actions": {
+        "newNutrition": "Nový jídelníček",
+        "newTraining": "Nový tréninkový plán"
+      }
+    },
     "fotky": {
       "title": "Foto-deník",
       "countBadge": "{{photos}} fotek · {{plans}} plánů",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1749,6 +1749,46 @@
         "chest": "Brust"
       }
     },
+    "plany": {
+      "title": "Kundenpläne",
+      "errorLoading": "Pläne konnten nicht geladen werden.",
+      "emptyTitle": "Keine Pläne",
+      "emptyDescription": "Dieser Kunde hat noch keine Ernährungs- oder Trainingspläne.",
+      "table": {
+        "plan": "Plan",
+        "type": "Typ",
+        "period": "Zeitraum",
+        "status": "Status",
+        "result": "Ergebnis",
+        "openPlan": "Plan öffnen"
+      },
+      "typeLabel": {
+        "nutrition": "Ernährung",
+        "training": "Training"
+      },
+      "status": {
+        "active": "Aktiv",
+        "completed": "Abgeschlossen",
+        "draft": "Entwurf",
+        "archived": "Archiviert"
+      },
+      "result": {
+        "compliance": "Compliance {{pct}} %",
+        "weightDelta": "Gewicht {{delta}} kg",
+        "totalTrainings_one": "{{count}} Einheit",
+        "totalTrainings_few": "{{count}} Einheiten",
+        "totalTrainings_many": "{{count}} Einheiten",
+        "totalTrainings_other": "{{count}} Einheiten",
+        "prCount_one": "{{count}} PR",
+        "prCount_few": "{{count}} PRs",
+        "prCount_many": "{{count}} PRs",
+        "prCount_other": "{{count}} PRs"
+      },
+      "actions": {
+        "newNutrition": "Neuer Ernährungsplan",
+        "newTraining": "Neuer Trainingsplan"
+      }
+    },
     "fotky": {
       "title": "Foto-Tagebuch",
       "countBadge": "{{photos}} Fotos · {{plans}} Pläne",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1750,6 +1750,46 @@
         "chest": "Chest"
       }
     },
+    "plany": {
+      "title": "Client plans",
+      "errorLoading": "Failed to load plans.",
+      "emptyTitle": "No plans",
+      "emptyDescription": "This client has no nutrition or training plans yet.",
+      "table": {
+        "plan": "Plan",
+        "type": "Type",
+        "period": "Period",
+        "status": "Status",
+        "result": "Result",
+        "openPlan": "Open plan"
+      },
+      "typeLabel": {
+        "nutrition": "Nutrition",
+        "training": "Training"
+      },
+      "status": {
+        "active": "Active",
+        "completed": "Completed",
+        "draft": "Draft",
+        "archived": "Archived"
+      },
+      "result": {
+        "compliance": "Compliance {{pct}}%",
+        "weightDelta": "weight {{delta}} kg",
+        "totalTrainings_one": "{{count}} session",
+        "totalTrainings_few": "{{count}} sessions",
+        "totalTrainings_many": "{{count}} sessions",
+        "totalTrainings_other": "{{count}} sessions",
+        "prCount_one": "{{count}} PR",
+        "prCount_few": "{{count}} PRs",
+        "prCount_many": "{{count}} PRs",
+        "prCount_other": "{{count}} PRs"
+      },
+      "actions": {
+        "newNutrition": "New nutrition plan",
+        "newTraining": "New training plan"
+      }
+    },
     "fotky": {
       "title": "Photo diary",
       "countBadge": "{{photos}} photos · {{plans}} plans",

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -298,7 +298,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-plany"
               className="tab-content-transition"
             >
-              <PlanyTab />
+              <PlanyTab clientId={id!} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Backend: new `GET /trainer/clients/{clientId}/plans` (`Features/Trainers/ListClientPlans/`) — combined nutrition + training plans across all statuses, newest-first, with a per-plan `resultSummary` (training: `totalTrainings` from completed WorkoutLogs by PlanId + `prCount` from PersonalRecords in the plan window; nutrition: `compliancePercent` via `IComplianceService` + `weightDeltaKg` from BodyMeasurements). Ownership enforced via `ClientProfessionalLink` → 403 when not linked. 12 integration tests.
- Web: filled the `cl-pane-plany` (PlanyTab) — clickable table (Plán / Typ / Období / Stav chip / Výsledek), rows navigate to plan detail, two action buttons, empty state. Hand-written `web/src/api/client-plans.ts` mirrors the endpoint shape (consolidated `regen-api` deferred to the epic PR).
- i18n: cs/en/de complete (28 keys each, exact parity).

## Related issue
Fixes #490

## Parent epic (sub-issue PR)
Part of epic #484 — base branch: `feature/484-client-detail-redesign`.

## Scope
cross-cut (backend + web, one issue / one branch)

## QA verdict (from qa-tester)
OVERALL ✅ PASS (`.claude/state/handoff-qa-490.json`).

## Test plan
- [ ] GET endpoint returns combined nutrition + training plans, all statuses, newest first.
- [ ] Each item: planId, planType, name, periodStart, periodEnd (nullable), status, resultSummary (nutrition: compliancePercent/weightDeltaKg; training: totalTrainings/prCount).
- [ ] Ownership check rejects cross-trainer access (403).
- [ ] Integration tests pass; build clean.
- [ ] Plany pane: heading, table with 5 columns, clickable rows → plan detail, status chip colors (Active green / Completed gold / Draft+Archived gray).
- [ ] Two action buttons (+ Nový jídelníček, + Nový tréninkový plán).
- [ ] Empty state when no plans.
- [ ] New UI copy in cs/en/de; no hardcoded colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
