### PR TITLE
feat: Client detail Check-iny + Dotazníky tabs (#491)

### DIFF
--- a/web/src/components/clients/tabs/CheckinyTab.tsx
+++ b/web/src/components/clients/tabs/CheckinyTab.tsx
@@ -1,4 +1,281 @@
-/** Placeholder for the Check-iny tab — filled in by a wave-3 sub-issue. */
-export function CheckinyTab() {
-  return <div id="cl-pane-checkiny" />;
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useMarkCheckInReviewed } from '@/hooks/useWeeklyCheckIns';
+import { CheckInFlagChips } from '@/components/weekly-checkin/CheckInFlagChips';
+import { OverrideDialog } from '@/components/profile/OverrideDialog';
+import {
+  getClientCurrentCheckIn,
+  getCheckInSettings,
+  getCheckInOverrides,
+  type CheckInOverrideDto,
+  type CheckInSettingDto,
+  DAY_OF_WEEK_KEYS,
+  formatTimeDisplay,
+} from '@/api/weekly-checkins';
+
+interface CheckinyTabProps {
+  /** Client's ApplicationUser Id (Guid string) — passed to check-in endpoints. */
+  clientUserId: string;
+}
+
+/** Formats an ISO string to a short localised date. */
+function formatShortDate(iso: string, language: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Formats an ISO string to a date + time display. */
+function formatDateTimeStr(iso: string, language: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function CheckinyTab({ clientUserId }: CheckinyTabProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+
+  const [overrideTarget, setOverrideTarget] = useState<CheckInOverrideDto | null>(null);
+
+  // Current-week check-in(s) for this client
+  const {
+    data: checkInResponse,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['weekly-check-ins', 'client-current', clientUserId, 'all'],
+    queryFn: () => getClientCurrentCheckIn(clientUserId),
+    enabled: Boolean(clientUserId),
+    retry: false,
+  });
+
+  const { mutate: markReviewed, isPending: isMarkingReviewed } = useMarkCheckInReviewed();
+
+  // Settings + overrides for OverrideDialog and schedule description
+  const { data: settingsResponse } = useQuery({
+    queryKey: ['weekly-checkin-settings'],
+    queryFn: getCheckInSettings,
+  });
+  const { data: overridesResponse } = useQuery({
+    queryKey: ['weekly-checkin-overrides'],
+    queryFn: getCheckInOverrides,
+  });
+
+  const settings: CheckInSettingDto[] = settingsResponse?.settings ?? [];
+  const overrides: CheckInOverrideDto[] = overridesResponse?.overrides ?? [];
+  const items = checkInResponse?.checkIns ?? [];
+
+  // Resolve header schedule description from Training profession
+  const trainingOverride = overrides.find(
+    (o) => o.clientUserId === clientUserId && o.profession === 'Training',
+  );
+  const trainingSetting = settings.find((s) => s.profession === 'Training');
+  const effectiveDay = trainingOverride?.dayOfWeek ?? trainingSetting?.dayOfWeek ?? null;
+  const effectiveTime = trainingOverride?.timeOfDay ?? trainingSetting?.timeOfDay ?? null;
+  const scheduleDesc =
+    effectiveDay != null && effectiveTime != null
+      ? `${t(`weeklyCheckIn.day.${DAY_OF_WEEK_KEYS[effectiveDay]}`)} ${formatTimeDisplay(effectiveTime)}`
+      : null;
+
+  /** Constructs a minimal override DTO so OverrideDialog can open for new overrides. */
+  function getOverrideForProfession(profession: 'Training' | 'Nutrition'): CheckInOverrideDto {
+    const existing = overrides.find(
+      (o) => o.clientUserId === clientUserId && o.profession === profession,
+    );
+    if (existing) return existing;
+    return {
+      id: '',
+      clientUserId,
+      clientFirstName: '',
+      clientLastName: '',
+      profession,
+      dayOfWeek: null,
+      timeOfDay: null,
+      enabled: null,
+      addendum: null,
+      deadlineOffsetHours: null,
+    };
+  }
+
+  if (isLoading) {
+    return (
+      <div id="cl-pane-checkiny">
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div id="cl-pane-checkiny">
+      {/* Header row */}
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <div className="text-[15px] font-semibold text-text">
+            {t('clientDetail.checkiny.title')}
+          </div>
+          {scheduleDesc && (
+            <div className="text-[12px] text-text3 mt-0.5">
+              {t('clientDetail.checkiny.scheduleDesc', { schedule: scheduleDesc })}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors shrink-0"
+          onClick={() => setOverrideTarget(getOverrideForProfession('Training'))}
+        >
+          {t('clientDetail.checkiny.scheduleButton')}
+        </button>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.checkiny.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isError && items.length === 0 && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📋</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.checkiny.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.checkiny.emptyDescription')}
+          </div>
+        </div>
+      )}
+
+      {/* Check-in rows */}
+      {!isError && items.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {items.map((checkIn) => {
+            const hasResponded = Boolean(checkIn.respondedAt);
+            const isReviewed = Boolean(checkIn.reviewedByTrainerAt);
+            const professionLabel =
+              checkIn.profession === 'Training'
+                ? t('weeklyCheckIn.professionTraining')
+                : t('weeklyCheckIn.professionNutrition');
+
+            if (hasResponded) {
+              // Completed row — solid border
+              return (
+                <div
+                  key={checkIn.id}
+                  className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5"
+                >
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-accent-bg text-accent border border-accent-br">
+                        {professionLabel}
+                      </span>
+                      <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-green-bg text-green border border-[var(--green-br)]">
+                        {t('clientDetail.checkiny.statusCompleted')}
+                      </span>
+                      {isReviewed && (
+                        <span className="inline-flex items-center gap-1 px-2 py-[2px] rounded-full text-[11px] font-medium bg-bg3 text-text3">
+                          ✓ {t('weeklyCheckIn.plan.reviewedPill')}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-[11px] text-text3 whitespace-nowrap shrink-0">
+                      {formatShortDate(checkIn.weekStartDate, lang)}
+                    </div>
+                  </div>
+
+                  <div className="text-[12px] text-text3 mb-2">
+                    {t('weeklyCheckIn.plan.bannerResponded', {
+                      submittedAt: formatDateTimeStr(checkIn.respondedAt!, lang),
+                    })}
+                  </div>
+
+                  {checkIn.flags.length > 0 && (
+                    <div className="mb-2">
+                      <CheckInFlagChips flags={checkIn.flags} />
+                    </div>
+                  )}
+
+                  {checkIn.note && (
+                    <p className="text-[12px] text-text2 leading-relaxed border-l-2 border-accent pl-2.5 mb-2">
+                      {checkIn.note}
+                    </p>
+                  )}
+
+                  {!isReviewed && (
+                    <button
+                      type="button"
+                      disabled={isMarkingReviewed}
+                      onClick={() => markReviewed(checkIn.id)}
+                      className="mt-1 text-[12px] font-medium text-accent border border-accent-br rounded-[var(--radius-sm)] px-3 py-1 hover:bg-accent-bg transition-colors disabled:opacity-50"
+                    >
+                      {isMarkingReviewed
+                        ? t('common.saving')
+                        : t('weeklyCheckIn.plan.markReviewed')}
+                    </button>
+                  )}
+                </div>
+              );
+            }
+
+            // Pending row — dashed border
+            return (
+              <div
+                key={checkIn.id}
+                className="rounded-[var(--radius-lg)] px-4 py-3.5"
+                style={{ border: '1.5px dashed var(--border)' }}
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-bg3 text-text3">
+                      {professionLabel}
+                    </span>
+                    <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-orange-bg text-orange">
+                      {t('clientDetail.checkiny.statusPending')}
+                    </span>
+                  </div>
+                  <div className="text-[11px] text-text3 whitespace-nowrap shrink-0">
+                    {formatShortDate(checkIn.weekStartDate, lang)}
+                  </div>
+                </div>
+                <div className="text-[12px] text-text3">
+                  {t('weeklyCheckIn.plan.bannerPending', {
+                    sentAt: formatDateTimeStr(checkIn.sentAt, lang),
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* OverrideDialog for per-client schedule settings */}
+      {overrideTarget && (
+        <OverrideDialog
+          override={overrideTarget}
+          settings={settings}
+          onClose={() => setOverrideTarget(null)}
+        />
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/DotaznikyTab.tsx
+++ b/web/src/components/clients/tabs/DotaznikyTab.tsx
@@ -1,4 +1,275 @@
-/** Placeholder for the Dotazníky tab — filled in by a wave-3 sub-issue. */
-export function DotaznikyTab() {
-  return <div id="cl-pane-dotazniky" />;
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getClientQuestionnaireResponses,
+  assignQuestionnaire,
+  type ClientResponseItem,
+} from '@/api/questionnaires';
+import { QuestionnaireSelectDialog } from '@/components/questionnaire/QuestionnaireSelectDialog';
+import { formatAnswerValue } from '@/components/questionnaire/questionnaire-helpers';
+import { useToastStore } from '@/stores/toast';
+
+interface DotaznikyTabProps {
+  /** Client's public ID — used as the clientId param for questionnaire endpoints. */
+  clientId: string;
+}
+
+/** Returns a short localised date string from an ISO string. */
+function formatShortDate(iso: string | null | undefined, language: string): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface ExpandedAnswersProps {
+  item: ClientResponseItem;
+  language: string;
+}
+
+/** Inline expandable answers section for a completed questionnaire row. */
+function ExpandableAnswers({ item, language }: ExpandedAnswersProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  if (item.answers.length === 0) return null;
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-[11px] font-medium text-accent bg-transparent border-none cursor-pointer p-0 hover:underline"
+      >
+        <span
+          className="inline-block transition-transform duration-150"
+          style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+        >
+          ▸
+        </span>
+        {t('clientDetail.dotazniky.viewAnswers')} ({item.answers.length})
+      </button>
+
+      {open && (
+        <div className="mt-2 border border-border rounded-[var(--radius-md)] overflow-hidden">
+          {item.answers.map((answer, idx) => (
+            <div
+              key={answer.questionPublicId}
+              className="px-3 py-2 text-[11px]"
+              style={{
+                borderBottom:
+                  idx < item.answers.length - 1 ? '1px solid var(--border)' : 'none',
+              }}
+            >
+              <div className="text-text3 mb-0.5">{answer.questionLabel}</div>
+              <div className="text-text font-medium">{formatAnswerValue(answer)}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {item.submittedAt && (
+        <div className="text-[11px] text-text3 mt-1">
+          {t('clientDetail.dotazniky.submittedOn', {
+            date: formatShortDate(item.submittedAt, language),
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DotaznikyTab({ clientId }: DotaznikyTabProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['questionnaire-responses', clientId],
+    queryFn: () => getClientQuestionnaireResponses(clientId),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  const assignMutation = useMutation({
+    mutationFn: (qId: string) => assignQuestionnaire(clientId, qId),
+    onSuccess: () => {
+      setAssignDialogOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ['questionnaire-responses', clientId] });
+      addToast(t('clientDetail.dotazniky.assignSuccess'), 'success');
+    },
+    onError: (err: { response?: { status?: number } }) => {
+      if (err?.response?.status === 409) {
+        addToast(t('clientDetail.dotazniky.assignConflict'), 'error');
+      } else {
+        addToast(t('clientDetail.dotazniky.assignError'), 'error');
+      }
+    },
+  });
+
+  const responses = data?.responses ?? [];
+  const submitted = responses.filter((r) => r.status === 'Submitted');
+  const pending = responses.filter(
+    (r) => r.status === 'Pending' || r.status === 'InProgress',
+  );
+
+  // Sort: pending first (newest by dateCreated), then submitted (newest by submittedAt)
+  const sorted: ClientResponseItem[] = [
+    ...pending.sort(
+      (a, b) => new Date(b.dateCreated).getTime() - new Date(a.dateCreated).getTime(),
+    ),
+    ...submitted.sort((a, b) => {
+      const da = a.submittedAt ? new Date(a.submittedAt).getTime() : 0;
+      const db = b.submittedAt ? new Date(b.submittedAt).getTime() : 0;
+      return db - da;
+    }),
+  ];
+
+  if (isLoading) {
+    return (
+      <div id="cl-pane-dotazniky">
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div id="cl-pane-dotazniky">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-[15px] font-semibold text-text">
+          {t('clientDetail.dotazniky.title')}
+        </div>
+        <button
+          type="button"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+          onClick={() => setAssignDialogOpen(true)}
+        >
+          + {t('clientDetail.dotazniky.assignButton')}
+        </button>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.dotazniky.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isError && sorted.length === 0 && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📝</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.dotazniky.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.dotazniky.emptyDescription')}
+          </div>
+          <button
+            type="button"
+            className="mt-1 text-[13px] font-semibold text-accent hover:underline bg-transparent border-none cursor-pointer"
+            onClick={() => setAssignDialogOpen(true)}
+          >
+            + {t('clientDetail.dotazniky.assignFirst')}
+          </button>
+        </div>
+      )}
+
+      {/* Questionnaire rows */}
+      {!isError && sorted.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {sorted.map((item) => {
+            const isSubmitted = item.status === 'Submitted';
+
+            if (isSubmitted) {
+              // Completed row — solid border
+              return (
+                <div
+                  key={item.responsePublicId}
+                  className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <span className="text-[20px] shrink-0">📋</span>
+                      <div className="min-w-0">
+                        <div className="text-[13px] font-semibold text-text truncate">
+                          {item.questionnaireTitle}
+                        </div>
+                        {item.submittedAt && (
+                          <div className="text-[11px] text-text3 mt-0.5">
+                            {formatShortDate(item.submittedAt, lang)}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-green-bg text-green border border-[var(--green-br)] shrink-0">
+                      {t('clientDetail.dotazniky.statusCompleted')}
+                    </span>
+                  </div>
+                  <ExpandableAnswers item={item} language={lang} />
+                </div>
+              );
+            }
+
+            // Pending row — dashed border
+            return (
+              <div
+                key={item.responsePublicId}
+                className="rounded-[var(--radius-lg)] px-4 py-3.5"
+                style={{ border: '1.5px dashed var(--border)' }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <span className="text-[20px] shrink-0 opacity-40">📋</span>
+                    <div className="min-w-0">
+                      <div className="text-[13px] font-semibold text-text2 truncate">
+                        {item.questionnaireTitle}
+                      </div>
+                      <div className="text-[11px] text-text3 mt-0.5">
+                        {t('clientDetail.dotazniky.pendingSubtitle', {
+                          date: formatShortDate(item.dateCreated, lang),
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                  <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-orange-bg text-orange shrink-0">
+                    {t('clientDetail.dotazniky.statusPending')}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Assign questionnaire dialog */}
+      <QuestionnaireSelectDialog
+        open={assignDialogOpen}
+        onClose={() => setAssignDialogOpen(false)}
+        onConfirm={(qId) => assignMutation.mutate(qId)}
+        title={t('questionnaire.sendQuestionnaireTitle')}
+        description={t('questionnaire.sendQuestionnaireDesc')}
+        confirmLabel={
+          assignMutation.isPending
+            ? t('questionnaire.sending')
+            : t('questionnaire.sendQuestionnaire')
+        }
+        isPending={assignMutation.isPending}
+        icon="📋"
+      />
+    </div>
+  );
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1834,6 +1834,32 @@
       "photoAlt": "Fotka klienta",
       "overflowLabel": "zobrazit vše",
       "overflowAriaLabel": "Zobrazit dalších {{count}} fotek"
+    },
+    "checkiny": {
+      "title": "Týdenní check-iny",
+      "scheduleDesc": "Rozvrh: {{schedule}}",
+      "scheduleButton": "Rozvrh check-inů",
+      "errorLoading": "Check-iny se nepodařilo načíst.",
+      "emptyTitle": "Žádné check-iny",
+      "emptyDescription": "Pro tohoto klienta zatím nebyly odeslány žádné týdenní check-iny.",
+      "statusCompleted": "Vyplněno",
+      "statusPending": "Čeká"
+    },
+    "dotazniky": {
+      "title": "Dotazníky",
+      "assignButton": "Přiřadit dotazník",
+      "errorLoading": "Dotazníky se nepodařilo načíst.",
+      "emptyTitle": "Žádné dotazníky",
+      "emptyDescription": "Klientovi zatím nebyl přiřazen žádný dotazník.",
+      "assignFirst": "Přiřadit první dotazník",
+      "assignSuccess": "Dotazník byl úspěšně přiřazen",
+      "assignConflict": "Klient již má dotazník čekající na vyplnění",
+      "assignError": "Nepodařilo se přiřadit dotazník",
+      "statusCompleted": "Vyplněno",
+      "statusPending": "Čeká",
+      "viewAnswers": "Zobrazit odpovědi",
+      "submittedOn": "Odesláno {{date}}",
+      "pendingSubtitle": "Odesláno {{date}} · Čeká na vyplnění"
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1806,6 +1806,32 @@
       "photoAlt": "Kundenfoto",
       "overflowLabel": "alle anzeigen",
       "overflowAriaLabel": "{{count}} weitere Fotos anzeigen"
+    },
+    "checkiny": {
+      "title": "Wöchentliche Check-ins",
+      "scheduleDesc": "Zeitplan: {{schedule}}",
+      "scheduleButton": "Check-in-Zeitplan",
+      "errorLoading": "Check-ins konnten nicht geladen werden.",
+      "emptyTitle": "Keine Check-ins",
+      "emptyDescription": "Für diesen Kunden wurden noch keine wöchentlichen Check-ins gesendet.",
+      "statusCompleted": "Ausgefüllt",
+      "statusPending": "Ausstehend"
+    },
+    "dotazniky": {
+      "title": "Fragebögen",
+      "assignButton": "Fragebogen zuweisen",
+      "errorLoading": "Fragebögen konnten nicht geladen werden.",
+      "emptyTitle": "Keine Fragebögen",
+      "emptyDescription": "Diesem Kunden wurde noch kein Fragebogen zugewiesen.",
+      "assignFirst": "Ersten Fragebogen zuweisen",
+      "assignSuccess": "Fragebogen erfolgreich zugewiesen",
+      "assignConflict": "Für den Kunden ist bereits ein Fragebogen ausstehend",
+      "assignError": "Fragebogen konnte nicht zugewiesen werden",
+      "statusCompleted": "Ausgefüllt",
+      "statusPending": "Ausstehend",
+      "viewAnswers": "Antworten anzeigen",
+      "submittedOn": "Eingereicht am {{date}}",
+      "pendingSubtitle": "Gesendet am {{date}} · Wartet auf Antwort"
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1807,6 +1807,32 @@
       "photoAlt": "Client photo",
       "overflowLabel": "view all",
       "overflowAriaLabel": "View {{count}} more photos"
+    },
+    "checkiny": {
+      "title": "Weekly check-ins",
+      "scheduleDesc": "Schedule: {{schedule}}",
+      "scheduleButton": "Check-in schedule",
+      "errorLoading": "Failed to load check-ins.",
+      "emptyTitle": "No check-ins",
+      "emptyDescription": "No weekly check-ins have been sent to this client yet.",
+      "statusCompleted": "Completed",
+      "statusPending": "Pending"
+    },
+    "dotazniky": {
+      "title": "Questionnaires",
+      "assignButton": "Assign questionnaire",
+      "errorLoading": "Failed to load questionnaires.",
+      "emptyTitle": "No questionnaires",
+      "emptyDescription": "No questionnaire has been assigned to this client yet.",
+      "assignFirst": "Assign first questionnaire",
+      "assignSuccess": "Questionnaire assigned successfully",
+      "assignConflict": "Client already has a questionnaire pending",
+      "assignError": "Failed to assign questionnaire",
+      "statusCompleted": "Completed",
+      "statusPending": "Pending",
+      "viewAnswers": "View answers",
+      "submittedOn": "Submitted {{date}}",
+      "pendingSubtitle": "Sent {{date}} · Waiting for response"
     }
   }
 }

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -308,7 +308,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-checkiny"
               className="tab-content-transition"
             >
-              <CheckinyTab />
+              <CheckinyTab clientUserId={id!} />
             </div>
           )}
 
@@ -318,7 +318,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-dotazniky"
               className="tab-content-transition"
             >
-              <DotaznikyTab />
+              <DotaznikyTab clientId={id!} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Fills the **Check-iny** pane (`cl-pane-checkiny`) and **Dotazníky** pane (`cl-pane-dotazniky`) of the redesigned client-detail page — web-only, two new tab bodies.
- **Dotazníky** (full fidelity): `getClientQuestionnaireResponses`, completed/pending rows, inline `ExpandableAnswers` (mirrors `PlanQuestionnairePanel` — no responses route exists in the router), "+ Přiřadit dotazník" → existing `QuestionnaireSelectDialog` + `assignQuestionnaire` (409 → toast), empty/error states.
- **Check-iny** (reduced scope, design Option A — documented in `handoff-design-491.json`): current-week only via `getClientCurrentCheckIn`, inline render (no detail route), `OverrideDialog` for "Rozvrh check-inů", pending dashed row, empty/error states. Weight/mood columns omitted by design — the data model has no multi-week history or weight/mood fields, and epic #484 explicitly excludes a data-model migration.
- i18n keys added in cs/en/de.

## Related issue
Fixes #491

## Parent epic
Part of epic #484 — base branch: `feature/484-client-detail-redesign`.

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS (`.claude/state/handoff-qa-491.json`).

## Test plan
- [ ] Check-iny pane: header (Týdenní check-iny label + schedule description + Rozvrh check-inů button)
- [ ] Check-iny: completed row (solid border) with status chip; pending row (dashed border) with Naplánováno/Čeká state
- [ ] Check-iny: empty + error states
- [ ] Dotazníky pane: header (Dotazníky label + Přiřadit dotazník button)
- [ ] Dotazníky: completed row (solid border) + inline Zobrazit odpovědi; pending row (dashed border) with subtitle
- [ ] Dotazníky: assign flow opens existing dialog; 409 surfaces a toast
- [ ] Dotazníky: empty state with CTA
- [ ] All new copy present in cs/en/de
- [ ] No hardcoded colors (design tokens only); `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)