### PR TITLE
feat: Redesign trainer-portal client detail page (verdict-first, tabbed) — epic #484

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ClientDashboardConstants.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ClientDashboardConstants.cs
@@ -1,0 +1,40 @@
+namespace FitnessPlatform.Application.Domain.Constants;
+
+/// <summary>
+/// Named constants for client dashboard / verdict calculations.
+/// Centralised here so thresholds are documented and testable in isolation.
+/// </summary>
+public static class ClientDashboardConstants
+{
+    /// <summary>
+    /// Number of days without any activity (workout log, meal log, or measurement)
+    /// that causes the inactivity signal to fire and the verdict to become OffTrack.
+    /// </summary>
+    public const int InactivityThresholdDays = 14;
+
+    /// <summary>
+    /// Compliance percentage at or above which the nutrition signal is considered "on track".
+    /// </summary>
+    public const decimal ComplianceOnTrackThreshold = 85m;
+
+    /// <summary>
+    /// Compliance percentage above which the signal is "needs attention" (60-84%).
+    /// Below this threshold it becomes OffTrack.
+    /// </summary>
+    public const decimal ComplianceNeedsAttentionThreshold = 60m;
+
+    /// <summary>
+    /// Weight delta (kg) above which the Away direction triggers OffTrack.
+    /// </summary>
+    public const decimal WeightOffTrackDeltaKg = 1m;
+
+    /// <summary>
+    /// Weight change (kg) below which movement is considered Stable.
+    /// </summary>
+    public const decimal WeightStableBandKg = 0.5m;
+
+    /// <summary>
+    /// Number of days in the rolling window used to compute nutrition compliance.
+    /// </summary>
+    public const int ComplianceWindowDays = 30;
+}

--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -251,6 +251,10 @@ public static class ErrorCodes
     /// <summary>completedAt is before the plan's start date; history cannot be written before the plan began.</summary>
     public const string CompletedAtBeforePlanStart = "COMPLETED_AT_BEFORE_PLAN_START";
 
+    // ── Trainer Notes ─────────────────────────────────────────────────
+    /// <summary>Trainer note not found or belongs to a different trainer/client.</summary>
+    public const string TrainerNoteNotFound = "TRAINER_NOTE_NOT_FOUND";
+
     // ── Validation (generic) ─────────────────────────────────────────
     /// <summary>Required field is missing.</summary>
     public const string Required = "REQUIRED";

--- a/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/MongoCollections.cs
@@ -69,4 +69,10 @@ public static class MongoCollections
     /// Session log entries — photos and notes attached to a specific training session diary entry.
     /// </summary>
     public const string SessionLogs = "sessionLogs";
+
+    /// <summary>
+    /// Trainer notes — private notes written by a trainer about a client.
+    /// Collection name is snake_case per issue #492 specification.
+    /// </summary>
+    public const string TrainerNotes = "trainer_notes";
 }

--- a/backend/FitnessPlatform.Application/Domain/Documents/TrainerNote.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/TrainerNote.cs
@@ -1,0 +1,54 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace FitnessPlatform.Application.Domain.Documents;
+
+/// <summary>
+/// MongoDB document representing a private note written by a trainer about a client.
+/// Notes are never exposed to the client — only the authoring trainer can read/edit/delete them.
+/// </summary>
+public class TrainerNote
+{
+    /// <summary>
+    /// MongoDB internal identifier.
+    /// </summary>
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public ObjectId Id { get; set; }
+
+    /// <summary>
+    /// Public-facing identifier used in API requests and responses.
+    /// </summary>
+    [BsonElement("externalId")]
+    public Guid ExternalId { get; set; }
+
+    /// <summary>
+    /// The client this note is about (matches ClientProfile.PublicId / ApplicationUser.Id).
+    /// </summary>
+    [BsonElement("clientId")]
+    public Guid ClientId { get; set; }
+
+    /// <summary>
+    /// The trainer who authored this note (matches ApplicationUser.Id).
+    /// </summary>
+    [BsonElement("trainerId")]
+    public Guid TrainerId { get; set; }
+
+    /// <summary>
+    /// The note body. Maximum 2000 characters.
+    /// </summary>
+    [BsonElement("text")]
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC timestamp when the document was created.
+    /// </summary>
+    [BsonElement("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// UTC timestamp when the document was last updated.
+    /// </summary>
+    [BsonElement("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/ClientVerdict.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/ClientVerdict.cs
@@ -1,0 +1,23 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Represents the on-track verdict for a client as assessed by the trainer dashboard.
+/// </summary>
+public enum ClientVerdict
+{
+    /// <summary>
+    /// All active signals are within target thresholds.
+    /// </summary>
+    OnTrack,
+
+    /// <summary>
+    /// Exactly one active signal is off target.
+    /// </summary>
+    NeedsAttention,
+
+    /// <summary>
+    /// At least one critical threshold is breached: compliance below 60%,
+    /// inactivity for more than N days, or weight moving Away by more than 1 kg.
+    /// </summary>
+    OffTrack
+}

--- a/backend/FitnessPlatform.Application/Domain/Enums/WeightDirection.cs
+++ b/backend/FitnessPlatform.Application/Domain/Enums/WeightDirection.cs
@@ -1,0 +1,22 @@
+namespace FitnessPlatform.Application.Domain.Enums;
+
+/// <summary>
+/// Indicates the direction a client's weight is moving relative to their target.
+/// </summary>
+public enum WeightDirection
+{
+    /// <summary>
+    /// Weight is moving toward the client's target weight.
+    /// </summary>
+    Towards,
+
+    /// <summary>
+    /// Weight is moving away from the client's target weight.
+    /// </summary>
+    Away,
+
+    /// <summary>
+    /// Weight change is negligible (within ±0.5 kg) or no target/measurements available.
+    /// </summary>
+    Stable
+}

--- a/backend/FitnessPlatform.Application/Domain/Interfaces/IClientVerdictService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Interfaces/IClientVerdictService.cs
@@ -1,0 +1,79 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Domain.Interfaces;
+
+/// <summary>
+/// Computes the on-track verdict and supporting signals for a single client.
+/// </summary>
+public interface IClientVerdictService
+{
+    /// <summary>
+    /// Calculates the verdict and all dashboard signals for the given client.
+    /// </summary>
+    /// <param name="clientUserId">
+    /// The client's <c>ApplicationUser.Id</c> (Guid) — used for MongoDB queries
+    /// (WorkoutLog, MealLog, NutritionPlan, TrainingPlan, PersonalRecord).
+    /// </param>
+    /// <param name="clientProfileId">
+    /// The client's <c>ClientProfile.Id</c> (long) — used for PostgreSQL queries
+    /// (BodyMeasurement is keyed on ClientProfileId).
+    /// </param>
+    /// <param name="targetWeightKg">
+    /// The client's target weight in kg from onboarding, or null if not set.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A <see cref="ClientVerdictResult"/> with all computed signals.</returns>
+    Task<ClientVerdictResult> ComputeAsync(
+        Guid clientUserId,
+        long clientProfileId,
+        decimal? targetWeightKg,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// Computed signals and verdict for a single client.
+/// </summary>
+public class ClientVerdictResult
+{
+    /// <summary>Overall on-track verdict.</summary>
+    public ClientVerdict Verdict { get; set; }
+
+    /// <summary>
+    /// Nutrition plan compliance percent (0-100), or null when no active nutrition plan exists.
+    /// Uses NutritionCompliancePercent only — never the combined CompliancePercent which collapses
+    /// to 0 when no plan is active.
+    /// </summary>
+    public decimal? CompliancePercent { get; set; }
+
+    /// <summary>
+    /// Delta between the client's current weight and their target weight, in kg.
+    /// Null when no measurements exist or no target weight is set.
+    /// </summary>
+    public decimal? WeightDeltaToGoal { get; set; }
+
+    /// <summary>Weight direction relative to the target.</summary>
+    public WeightDirection WeightDirection { get; set; } = WeightDirection.Stable;
+
+    /// <summary>
+    /// Number of distinct workout log sessions completed in the current ISO week
+    /// (Monday–Sunday). Null when no active training plan exists.
+    /// </summary>
+    public int? TrainingFrequencyActual { get; set; }
+
+    /// <summary>
+    /// Number of sessions prescribed per week in the active training plan's current
+    /// published week. Null when no active training plan exists.
+    /// </summary>
+    public int? TrainingFrequencyPrescribed { get; set; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent activity (workout log, meal log, or measurement).
+    /// Null when no activity exists.
+    /// </summary>
+    public DateTime? LastActiveAt { get; set; }
+
+    /// <summary>
+    /// Number of personal records achieved in the current calendar month.
+    /// </summary>
+    public int PrCountThisMonth { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Domain/Services/ClientVerdictService.cs
+++ b/backend/FitnessPlatform.Application/Domain/Services/ClientVerdictService.cs
@@ -1,0 +1,347 @@
+using System.Runtime.CompilerServices;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+[assembly: InternalsVisibleTo("FitnessPlatform.Tests")]
+
+namespace FitnessPlatform.Application.Domain.Services;
+
+/// <summary>
+/// Computes the on-track verdict and supporting dashboard signals for a single client.
+/// Aggregates data from PostgreSQL (BodyMeasurement) and MongoDB (NutritionPlan, TrainingPlan,
+/// WorkoutLog, MealLog, PersonalRecord) without duplicating compliance calculation logic.
+///
+/// EF Core's DbContext is NOT thread-safe. All queries against <see cref="IApplicationDbContext"/>
+/// are executed sequentially. MongoDB collections are thread-safe and may be queried in parallel.
+/// </summary>
+public class ClientVerdictService(
+    IApplicationDbContext db,
+    IMongoContext mongo,
+    IComplianceService complianceService)
+    : IClientVerdictService
+{
+    /// <inheritdoc />
+    public async Task<ClientVerdictResult> ComputeAsync(
+        Guid clientUserId,
+        long clientProfileId,
+        decimal? targetWeightKg,
+        CancellationToken ct)
+    {
+        // ── EF queries — must be serialized (DbContext is not thread-safe) ──
+        // Fold both BodyMeasurements usages into a single query that serves:
+        //   - ComputeWeightSignal: top-2 measurements with WeightKg != null
+        //   - ComputeLastActiveAt: most recent MeasuredAt (any measurement)
+        // We take the top-2 WeightKg-non-null rows, then separately the most-recent MeasuredAt.
+        // Both filters share the clientProfileId predicate so one round-trip suffices.
+
+        // Take the 2 most recent measurements that have a weight reading.
+        var recentWeightMeasurements = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(bm => bm.ClientProfileId == clientProfileId && bm.WeightKg != null)
+            .OrderByDescending(bm => bm.MeasuredAt)
+            .Select(bm => new { bm.WeightKg, bm.MeasuredAt })
+            .Take(2)
+            .ToListAsync(ct);
+
+        // Also take the single most recent measurement regardless of whether WeightKg is set,
+        // to capture lastActiveAt from a non-weight measurement (e.g. body-fat only).
+        var latestAnyMeasurementDate = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(bm => bm.ClientProfileId == clientProfileId)
+            .OrderByDescending(bm => bm.MeasuredAt)
+            .Select(bm => (DateTime?)bm.MeasuredAt)
+            .FirstOrDefaultAsync(ct);
+
+        // ── MongoDB queries — thread-safe, run in parallel ──────────────────
+        var complianceTask = ComputeComplianceAsync(clientUserId, ct);
+        var trainingTask = ComputeTrainingFrequencyAsync(clientUserId, ct);
+        var latestWorkoutTask = FetchLatestWorkoutCompletedAtAsync(clientUserId, ct);
+        var latestMealTask = FetchLatestMealLogTimestampAsync(clientUserId, ct);
+        var prCountTask = ComputePrCountThisMonthAsync(clientUserId, ct);
+
+        await Task.WhenAll(complianceTask, trainingTask, latestWorkoutTask, latestMealTask, prCountTask);
+
+        var (compliancePercent, hasActiveNutritionPlan) = complianceTask.Result;
+        var (frequencyActual, frequencyPrescribed, hasActiveTrainingPlan) = trainingTask.Result;
+        DateTime? latestWorkoutAt = latestWorkoutTask.Result;
+        DateTime? latestMealAt = latestMealTask.Result;
+        var prCountThisMonth = prCountTask.Result;
+
+        // ── Derive weight signal from the pre-fetched EF data ───────────────
+        var (weightDeltaToGoal, weightDirection, hasWeightSignal) =
+            DeriveWeightSignal(recentWeightMeasurements.Select(m => (m.WeightKg!.Value, m.MeasuredAt)).ToList(), targetWeightKg);
+
+        // ── Coalesce lastActiveAt from all three sources ─────────────────────
+        var lastActiveAt = CoalesceLastActiveAt(latestWorkoutAt, latestMealAt, latestAnyMeasurementDate);
+
+        var verdict = ComputeVerdict(
+            compliancePercent, hasActiveNutritionPlan,
+            weightDirection, weightDeltaToGoal, hasWeightSignal,
+            frequencyActual, frequencyPrescribed, hasActiveTrainingPlan,
+            lastActiveAt);
+
+        return new ClientVerdictResult
+        {
+            Verdict = verdict,
+            CompliancePercent = hasActiveNutritionPlan ? compliancePercent : null,
+            WeightDeltaToGoal = hasWeightSignal ? weightDeltaToGoal : null,
+            WeightDirection = weightDirection,
+            TrainingFrequencyActual = hasActiveTrainingPlan ? frequencyActual : null,
+            TrainingFrequencyPrescribed = hasActiveTrainingPlan ? frequencyPrescribed : null,
+            LastActiveAt = lastActiveAt,
+            PrCountThisMonth = prCountThisMonth
+        };
+    }
+
+    // ── Signal computation ──────────────────────────────────────────────────
+
+    private async Task<(decimal? compliancePercent, bool hasActivePlan)> ComputeComplianceAsync(
+        Guid clientUserId, CancellationToken ct)
+    {
+        // Check for an active nutrition plan first to avoid collapsing to 0% when no plan exists.
+        var nutritionPlanFilter = Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientUserId)
+            & Builders<NutritionPlan>.Filter.Eq(p => p.Status, NutritionPlanStatus.Active);
+
+        using var planCursor = await mongo.NutritionPlans.FindAsync(nutritionPlanFilter, cancellationToken: ct);
+        var activePlan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (activePlan is null)
+            return (null, false);
+
+        // Use NutritionCompliancePercent (not combined CompliancePercent) as specified in AC.
+        // Calculate over the last ComplianceWindowDays days to cover most nutrition plan periods.
+        var from = DateTime.UtcNow.Date.AddDays(-ClientDashboardConstants.ComplianceWindowDays);
+        var to = DateTime.UtcNow.Date.AddDays(1).AddTicks(-1);
+        var complianceResult = await complianceService.CalculateComplianceAsync(clientUserId, from, to, ct);
+
+        return (complianceResult.NutritionCompliancePercent, true);
+    }
+
+    /// <summary>
+    /// Derives the weight signal from pre-fetched measurement rows.
+    /// Pure computation — no I/O.
+    /// </summary>
+    private static (decimal? weightDeltaToGoal, WeightDirection weightDirection, bool hasSignal)
+        DeriveWeightSignal(List<(decimal WeightKg, DateTime MeasuredAt)> measurements, decimal? targetWeightKg)
+    {
+        if (targetWeightKg is null || measurements.Count == 0)
+            return (null, WeightDirection.Stable, false);
+
+        var latestWeight = measurements[0].WeightKg;
+        var deltaToGoal = latestWeight - targetWeightKg.Value;
+
+        WeightDirection direction;
+
+        if (measurements.Count < 2)
+        {
+            // Only one measurement: can only compute delta, direction is Stable.
+            direction = WeightDirection.Stable;
+        }
+        else
+        {
+            var previousWeight = measurements[1].WeightKg;
+            var change = latestWeight - previousWeight;
+
+            if (Math.Abs(change) < ClientDashboardConstants.WeightStableBandKg)
+            {
+                direction = WeightDirection.Stable;
+            }
+            else
+            {
+                // "Towards" means moving closer to target.
+                // If target < current (need to lose weight), weight going down is Towards.
+                // If target > current (need to gain weight), weight going up is Towards.
+                var movingTowardTarget = (targetWeightKg.Value < latestWeight && change < 0)
+                    || (targetWeightKg.Value > latestWeight && change > 0);
+
+                direction = movingTowardTarget ? WeightDirection.Towards : WeightDirection.Away;
+            }
+        }
+
+        return (deltaToGoal, direction, true);
+    }
+
+    private async Task<(int? actual, int? prescribed, bool hasActivePlan)> ComputeTrainingFrequencyAsync(
+        Guid clientUserId, CancellationToken ct)
+    {
+        // Check for an active training plan.
+        var trainingPlanFilter = Builders<TrainingPlan>.Filter.Eq(p => p.ClientId, clientUserId)
+            & Builders<TrainingPlan>.Filter.Eq(p => p.Status, TrainingPlanStatus.Active);
+
+        using var planCursor = await mongo.TrainingPlans.FindAsync(trainingPlanFilter, cancellationToken: ct);
+        var activePlan = await planCursor.FirstOrDefaultAsync(ct);
+
+        if (activePlan is null)
+            return (null, null, false);
+
+        // Derive prescribed sessions: count sessions in any published week.
+        // Use the first published week as the representative weekly schedule.
+        var publishedWeek = activePlan.Weeks
+            .Where(w => w.Status == WeekStatus.Published)
+            .OrderBy(w => w.WeekNumber)
+            .FirstOrDefault();
+
+        int prescribed = publishedWeek?.Sessions.Count ?? 0;
+
+        // Actual sessions this ISO week (Monday–Sunday).
+        var today = DateTime.UtcNow.Date;
+        var dayOfWeek = (int)today.DayOfWeek;
+        if (dayOfWeek == 0) dayOfWeek = 7; // Sunday = 7
+        var weekStart = today.AddDays(-(dayOfWeek - 1));
+        var weekEnd = weekStart.AddDays(7);
+
+        var workoutFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserId)
+            & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true)
+            & Builders<WorkoutLog>.Filter.Gte(w => w.CompletedAt, (DateTime?)weekStart)
+            & Builders<WorkoutLog>.Filter.Lt(w => w.CompletedAt, (DateTime?)weekEnd);
+
+        using var workoutCursor = await mongo.WorkoutLogs.FindAsync(workoutFilter, cancellationToken: ct);
+        var completedLogs = await workoutCursor.ToListAsync(ct);
+        int actual = completedLogs.Count;
+
+        return (actual, prescribed, true);
+    }
+
+    private async Task<DateTime?> FetchLatestWorkoutCompletedAtAsync(Guid clientUserId, CancellationToken ct)
+    {
+        var workoutFilter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientUserId)
+            & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true);
+
+        using var workoutCursor = await mongo.WorkoutLogs.FindAsync(
+            workoutFilter,
+            new FindOptions<WorkoutLog> { Sort = Builders<WorkoutLog>.Sort.Descending(w => w.CompletedAt), Limit = 1 },
+            ct);
+        var latestWorkout = await workoutCursor.FirstOrDefaultAsync(ct);
+
+        return latestWorkout?.CompletedAt;
+    }
+
+    private async Task<DateTime?> FetchLatestMealLogTimestampAsync(Guid clientUserId, CancellationToken ct)
+    {
+        // Sort by EatenAt descending so the comparison field matches the sort field.
+        // A backdated or edited entry cannot produce a stale lastActiveAt at the boundary.
+        var mealFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientUserId)
+            & Builders<MealLog>.Filter.Ne(l => l.EatenAt, (DateTime?)null);
+
+        using var mealCursor = await mongo.MealLogs.FindAsync(
+            mealFilter,
+            new FindOptions<MealLog> { Sort = Builders<MealLog>.Sort.Descending(l => l.EatenAt), Limit = 1 },
+            ct);
+        var latestMealLog = await mealCursor.FirstOrDefaultAsync(ct);
+
+        if (latestMealLog is not null)
+            return latestMealLog.EatenAt;
+
+        // Fall back: any meal log without EatenAt, sorted by LogDate.
+        var fallbackFilter = Builders<MealLog>.Filter.Eq(l => l.ClientId, clientUserId);
+        using var fallbackCursor = await mongo.MealLogs.FindAsync(
+            fallbackFilter,
+            new FindOptions<MealLog> { Sort = Builders<MealLog>.Sort.Descending(l => l.LogDate), Limit = 1 },
+            ct);
+        var fallbackLog = await fallbackCursor.FirstOrDefaultAsync(ct);
+        return fallbackLog?.LogDate;
+    }
+
+    private async Task<int> ComputePrCountThisMonthAsync(Guid clientUserId, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var monthEnd = monthStart.AddMonths(1);
+
+        // PersonalRecord.ClientId is the client's ApplicationUser.Id (same as clientUserId).
+        var prFilter = Builders<PersonalRecord>.Filter.Eq(r => r.ClientId, clientUserId)
+            & Builders<PersonalRecord>.Filter.Gte(r => r.AchievedAt, monthStart)
+            & Builders<PersonalRecord>.Filter.Lt(r => r.AchievedAt, monthEnd);
+
+        using var prCursor = await mongo.PersonalRecords.FindAsync(prFilter, cancellationToken: ct);
+        var prs = await prCursor.ToListAsync(ct);
+        return prs.Count;
+    }
+
+    /// <summary>
+    /// Coalesces the three lastActiveAt sources into the most recent timestamp.
+    /// Pure computation — no I/O.
+    /// </summary>
+    private static DateTime? CoalesceLastActiveAt(
+        DateTime? latestWorkoutAt,
+        DateTime? latestMealAt,
+        DateTime? latestMeasurementAt)
+    {
+        var candidates = new[] { latestWorkoutAt, latestMealAt, latestMeasurementAt }
+            .Where(d => d.HasValue)
+            .Select(d => d!.Value)
+            .OrderByDescending(d => d)
+            .ToList();
+
+        return candidates.Count > 0 ? candidates[0] : null;
+    }
+
+    // ── Verdict logic ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Computes the overall verdict from the pre-computed signals.
+    /// Pure computation — no I/O. Internal visibility to allow direct unit testing.
+    /// </summary>
+    internal static ClientVerdict ComputeVerdict(
+        decimal? compliancePercent, bool hasActiveNutritionPlan,
+        WeightDirection weightDirection, decimal? weightDeltaToGoal, bool hasWeightSignal,
+        int? frequencyActual, int? frequencyPrescribed, bool hasActiveTrainingPlan,
+        DateTime? lastActiveAt)
+    {
+        // ── OffTrack hard thresholds (any one triggers OffTrack) ─────────────
+
+        // Inactivity threshold: no activity in > N days (strict greater-than; exactly N days is NOT OffTrack).
+        if (lastActiveAt.HasValue)
+        {
+            var daysSinceActivity = (DateTime.UtcNow - lastActiveAt.Value).TotalDays;
+            if (daysSinceActivity > ClientDashboardConstants.InactivityThresholdDays)
+                return ClientVerdict.OffTrack;
+        }
+        else
+        {
+            // No activity at all counts as inactive; only flag OffTrack if any active plan exists
+            if (hasActiveNutritionPlan || hasActiveTrainingPlan)
+                return ClientVerdict.OffTrack;
+        }
+
+        // Compliance below 60% is OffTrack
+        if (hasActiveNutritionPlan && compliancePercent.HasValue && compliancePercent.Value < ClientDashboardConstants.ComplianceNeedsAttentionThreshold)
+            return ClientVerdict.OffTrack;
+
+        // Weight Away with delta > 1 kg is OffTrack
+        if (hasWeightSignal && weightDirection == WeightDirection.Away && weightDeltaToGoal.HasValue
+            && Math.Abs(weightDeltaToGoal.Value) > ClientDashboardConstants.WeightOffTrackDeltaKg)
+            return ClientVerdict.OffTrack;
+
+        // ── Count signals that are "off" (but not OffTrack level) ────────────
+
+        var offSignals = 0;
+
+        // Compliance 60-84 is a NeedsAttention signal
+        if (hasActiveNutritionPlan && compliancePercent.HasValue
+            && compliancePercent.Value < ClientDashboardConstants.ComplianceOnTrackThreshold)
+            offSignals++;
+
+        // Weight Stable or Away (even small Away) is a NeedsAttention signal
+        if (hasWeightSignal && weightDirection != WeightDirection.Towards)
+            offSignals++;
+
+        // Training actual < prescribed is a NeedsAttention signal
+        if (hasActiveTrainingPlan && frequencyActual.HasValue && frequencyPrescribed.HasValue
+            && frequencyActual.Value < frequencyPrescribed.Value)
+            offSignals++;
+
+        if (offSignals == 0)
+            return ClientVerdict.OnTrack;
+
+        // One or more soft signals off but not OffTrack level -> NeedsAttention.
+        // The spec says OffTrack only for specific hard thresholds; multiple soft misses = NeedsAttention.
+        return ClientVerdict.NeedsAttention;
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteEndpoint.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.CreateNote;
+
+/// <summary>
+/// Creates a private note for a client. Only accessible to Trainers who have an active link with the client.
+/// </summary>
+public class CreateNoteEndpoint(IApplicationDbContext db, IMongoContext mongo)
+    : Endpoint<CreateNoteRequest, CreateNoteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/trainer/clients/{ClientId}/notes");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Create a trainer note for a client";
+            s.Description = "Creates a private note visible only to the authoring trainer.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(CreateNoteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+
+        // Explicitly deny Client-role callers (defense-in-depth: the Roles attribute enforces this
+        // at the HTTP layer, but this guard makes unit tests deterministic and prevents leakage
+        // if the route is ever accidentally reused by a client-facing path)
+        if (User.IsInRole(AppRoles.Client)) { await Send.ForbiddenAsync(ct); return; }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Resolve trainer's professional profile
+        var trainerProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == trainerId, ct);
+        if (trainerProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Resolve client by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+        if (clientProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Ownership check: trainer must have an active link with the client
+        var hasLink = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .AnyAsync(l => l.ProfessionalProfileId == trainerProfile.Id
+                        && l.ClientProfileId == clientProfile.Id
+                        && l.IsActive, ct);
+        if (!hasLink) { await Send.ForbiddenAsync(ct); return; }
+
+        var now = DateTime.UtcNow;
+        var note = new TrainerNote
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientProfile.UserId,
+            TrainerId = trainerId,
+            Text = req.Text,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await mongo.TrainerNotes.InsertOneAsync(note, cancellationToken: ct);
+
+        await Send.ResponseAsync(new CreateNoteResponse
+        {
+            NoteId = note.ExternalId,
+            CreatedAt = note.CreatedAt
+        }, 201, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteRequest.cs
@@ -1,0 +1,7 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.CreateNote;
+
+public class CreateNoteRequest
+{
+    public Guid ClientId { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteResponse.cs
@@ -1,0 +1,7 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.CreateNote;
+
+public class CreateNoteResponse
+{
+    public Guid NoteId { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/CreateNote/CreateNoteValidator.cs
@@ -1,0 +1,21 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.CreateNote;
+
+public class CreateNoteValidator : Validator<CreateNoteRequest>
+{
+    public CreateNoteValidator()
+    {
+        RuleFor(x => x.ClientId)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.Text)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required)
+            .MaximumLength(2000)
+            .WithErrorCode(ErrorCodes.OutOfRange);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/DeleteNote/DeleteNoteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/DeleteNote/DeleteNoteEndpoint.cs
@@ -1,0 +1,77 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.DeleteNote;
+
+/// <summary>
+/// Deletes a trainer note. Only the authoring trainer may delete.
+/// </summary>
+public class DeleteNoteEndpoint(IApplicationDbContext db, IMongoContext mongo)
+    : Endpoint<DeleteNoteRequest>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Delete("/trainer/clients/{ClientId}/notes/{NoteId}");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Delete a trainer note";
+            s.Description = "Permanently deletes a private trainer note. Only the authoring trainer may delete.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(DeleteNoteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+
+        // Explicitly deny Client-role callers (defense-in-depth beyond the Roles attribute)
+        if (User.IsInRole(AppRoles.Client)) { await Send.ForbiddenAsync(ct); return; }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Resolve trainer's professional profile
+        var trainerProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == trainerId, ct);
+        if (trainerProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Resolve client by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+        if (clientProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Ownership check: trainer must have an active link with the client
+        var hasLink = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .AnyAsync(l => l.ProfessionalProfileId == trainerProfile.Id
+                        && l.ClientProfileId == clientProfile.Id
+                        && l.IsActive, ct);
+        if (!hasLink) { await Send.ForbiddenAsync(ct); return; }
+
+        // Delete — filter by externalId + trainerId + clientId to prevent cross-trainer delete
+        var deleteFilter = Builders<Domain.Documents.TrainerNote>.Filter.And(
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ExternalId, req.NoteId),
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.TrainerId, trainerId),
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ClientId, clientProfile.UserId));
+
+        var result = await mongo.TrainerNotes.DeleteOneAsync(deleteFilter, cancellationToken: ct);
+
+        if (result.DeletedCount == 0)
+        {
+            await this.SendProblemAsync(404, ErrorCodes.TrainerNoteNotFound, "Note not found.", ct);
+            return;
+        }
+
+        await Send.NoContentAsync(ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/DeleteNote/DeleteNoteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/DeleteNote/DeleteNoteRequest.cs
@@ -1,0 +1,7 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.DeleteNote;
+
+public class DeleteNoteRequest
+{
+    public Guid ClientId { get; set; }
+    public Guid NoteId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/DeleteNote/DeleteNoteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/DeleteNote/DeleteNoteValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.DeleteNote;
+
+public class DeleteNoteValidator : Validator<DeleteNoteRequest>
+{
+    public DeleteNoteValidator()
+    {
+        RuleFor(x => x.ClientId)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.NoteId)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteEndpoint.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.EditNote;
+
+/// <summary>
+/// Edits the text of an existing trainer note. Only the authoring trainer may edit.
+/// </summary>
+public class EditNoteEndpoint(IApplicationDbContext db, IMongoContext mongo)
+    : Endpoint<EditNoteRequest, EditNoteResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Patch("/trainer/clients/{ClientId}/notes/{NoteId}");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "Edit a trainer note";
+            s.Description = "Updates the text of a private trainer note. Only the authoring trainer may edit.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(EditNoteRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+
+        // Explicitly deny Client-role callers (defense-in-depth beyond the Roles attribute)
+        if (User.IsInRole(AppRoles.Client)) { await Send.ForbiddenAsync(ct); return; }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Resolve trainer's professional profile
+        var trainerProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == trainerId, ct);
+        if (trainerProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Resolve client by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+        if (clientProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Ownership check: trainer must have an active link with the client
+        var hasLink = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .AnyAsync(l => l.ProfessionalProfileId == trainerProfile.Id
+                        && l.ClientProfileId == clientProfile.Id
+                        && l.IsActive, ct);
+        if (!hasLink) { await Send.ForbiddenAsync(ct); return; }
+
+        // Find the note — must belong to this trainer and this client
+        var noteFilter = Builders<Domain.Documents.TrainerNote>.Filter.And(
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ExternalId, req.NoteId),
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.TrainerId, trainerId),
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ClientId, clientProfile.UserId));
+
+        var note = await mongo.TrainerNotes.Find(noteFilter).FirstOrDefaultAsync(ct);
+        if (note is null)
+        {
+            await this.SendProblemAsync(404, ErrorCodes.TrainerNoteNotFound, "Note not found.", ct);
+            return;
+        }
+
+        var updatedAt = DateTime.UtcNow;
+
+        var update = Builders<Domain.Documents.TrainerNote>.Update
+            .Set(n => n.Text, req.Text)
+            .Set(n => n.UpdatedAt, updatedAt);
+
+        await mongo.TrainerNotes.UpdateOneAsync(
+            Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ExternalId, req.NoteId),
+            update,
+            cancellationToken: ct);
+
+        await Send.OkAsync(new EditNoteResponse
+        {
+            NoteId = note.ExternalId,
+            Text = req.Text,
+            UpdatedAt = updatedAt
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteRequest.cs
@@ -1,0 +1,8 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.EditNote;
+
+public class EditNoteRequest
+{
+    public Guid ClientId { get; set; }
+    public Guid NoteId { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteResponse.cs
@@ -1,0 +1,8 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.EditNote;
+
+public class EditNoteResponse
+{
+    public Guid NoteId { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public DateTime UpdatedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/EditNote/EditNoteValidator.cs
@@ -1,0 +1,25 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.EditNote;
+
+public class EditNoteValidator : Validator<EditNoteRequest>
+{
+    public EditNoteValidator()
+    {
+        RuleFor(x => x.ClientId)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.NoteId)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.Text)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required)
+            .MaximumLength(2000)
+            .WithErrorCode(ErrorCodes.OutOfRange);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesEndpoint.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.ListNotes;
+
+/// <summary>
+/// Lists trainer notes for a client, ordered by createdAt descending (newest first), paginated.
+/// </summary>
+public class ListNotesEndpoint(IApplicationDbContext db, IMongoContext mongo)
+    : Endpoint<ListNotesRequest, ListNotesResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/clients/{ClientId}/notes");
+        Roles(AppRoles.Trainer);
+        Summary(s =>
+        {
+            s.Summary = "List trainer notes for a client";
+            s.Description = "Returns paginated notes, newest first. Sets X-Total-Count header.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(ListNotesRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null) { await Send.UnauthorizedAsync(ct); return; }
+
+        // Explicitly deny Client-role callers (defense-in-depth beyond the Roles attribute)
+        if (User.IsInRole(AppRoles.Client)) { await Send.ForbiddenAsync(ct); return; }
+
+        var trainerId = Guid.Parse(userId);
+
+        // Resolve trainer's professional profile
+        var trainerProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.UserId == trainerId, ct);
+        if (trainerProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Resolve client by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+        if (clientProfile is null) { await Send.NotFoundAsync(ct); return; }
+
+        // Ownership check: trainer must have an active link with the client
+        var hasLink = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .AnyAsync(l => l.ProfessionalProfileId == trainerProfile.Id
+                        && l.ClientProfileId == clientProfile.Id
+                        && l.IsActive, ct);
+        if (!hasLink) { await Send.ForbiddenAsync(ct); return; }
+
+        var clientUserId = clientProfile.UserId;
+
+        // Count total matching notes for pagination header
+        var totalCount = await mongo.TrainerNotes.CountDocumentsAsync(
+            Builders<Domain.Documents.TrainerNote>.Filter.And(
+                Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ClientId, clientUserId),
+                Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.TrainerId, trainerId)),
+            cancellationToken: ct);
+
+        HttpContext.Response.Headers["X-Total-Count"] = totalCount.ToString();
+
+        // Fetch paginated notes ordered newest-first
+        var notes = await mongo.TrainerNotes
+            .Find(Builders<Domain.Documents.TrainerNote>.Filter.And(
+                Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.ClientId, clientUserId),
+                Builders<Domain.Documents.TrainerNote>.Filter.Eq(n => n.TrainerId, trainerId)))
+            .SortByDescending(n => n.CreatedAt)
+            .Skip((req.Page - 1) * req.PageSize)
+            .Limit(req.PageSize)
+            .ToListAsync(ct);
+
+        await Send.OkAsync(new ListNotesResponse
+        {
+            Notes = notes.Select(n => new NoteDto
+            {
+                NoteId = n.ExternalId,
+                Text = n.Text,
+                CreatedAt = n.CreatedAt,
+                UpdatedAt = n.UpdatedAt
+            }).ToList()
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesRequest.cs
@@ -1,0 +1,8 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.ListNotes;
+
+public class ListNotesRequest
+{
+    public Guid ClientId { get; set; }
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 20;
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesResponse.cs
@@ -1,0 +1,14 @@
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.ListNotes;
+
+public class ListNotesResponse
+{
+    public List<NoteDto> Notes { get; set; } = [];
+}
+
+public class NoteDto
+{
+    public Guid NoteId { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ClientNotes/ListNotes/ListNotesValidator.cs
@@ -1,0 +1,23 @@
+using FastEndpoints;
+using FluentValidation;
+using FitnessPlatform.Application.Domain.Constants;
+
+namespace FitnessPlatform.Application.Features.Trainers.ClientNotes.ListNotes;
+
+public class ListNotesValidator : Validator<ListNotesRequest>
+{
+    public ListNotesValidator()
+    {
+        RuleFor(x => x.ClientId)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required);
+
+        RuleFor(x => x.Page)
+            .GreaterThanOrEqualTo(1)
+            .WithErrorCode(ErrorCodes.OutOfRange);
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100)
+            .WithErrorCode(ErrorCodes.OutOfRange);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictEndpoint.cs
@@ -1,0 +1,105 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+/// <summary>
+/// Returns the on-track verdict and supporting signals for a specific client.
+/// Trainer must have an active link to the client. Returns 403 if not linked.
+/// </summary>
+public class GetClientVerdictEndpoint(
+    IApplicationDbContext db,
+    IClientVerdictService verdictService)
+    : Endpoint<GetClientVerdictRequest, GetClientVerdictResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/clients/{clientId}/verdict");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "Get client on-track verdict";
+            s.Description = "Returns the on-track verdict and supporting signals (compliance, weight, training frequency, activity, PRs) for a specific client managed by the authenticated trainer.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(GetClientVerdictRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerUserId = Guid.Parse(userId);
+
+        // Locate the trainer's professional profile
+        var professionalProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(pp => pp.UserId == trainerUserId, ct);
+
+        if (professionalProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Locate the client profile by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .Include(cp => cp.OnboardingData)
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify an active trainer-client link exists; return 403 (not 404) when missing
+        var link = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l =>
+                l.ProfessionalProfileId == professionalProfile.Id &&
+                l.ClientProfileId == clientProfile.Id &&
+                l.IsActive, ct);
+
+        if (link is null)
+        {
+            await Send.ForbiddenAsync(ct);
+            return;
+        }
+
+        var targetWeightKg = clientProfile.OnboardingData?.TargetWeightKg;
+
+        // clientProfile.UserId is the ApplicationUser.Id (Guid) used by all Mongo documents
+        // (WorkoutLog, MealLog, NutritionPlan, TrainingPlan, PersonalRecord).
+        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId).
+        var result = await verdictService.ComputeAsync(
+            clientUserId: clientProfile.UserId,
+            clientProfileId: clientProfile.Id,
+            targetWeightKg: targetWeightKg,
+            ct: ct);
+
+        await Send.OkAsync(new GetClientVerdictResponse
+        {
+            Verdict = result.Verdict,
+            CompliancePercent = result.CompliancePercent,
+            WeightDeltaToGoal = result.WeightDeltaToGoal,
+            WeightDirection = result.WeightDirection,
+            TrainingFrequencyActual = result.TrainingFrequencyActual,
+            TrainingFrequencyPrescribed = result.TrainingFrequencyPrescribed,
+            LastActiveAt = result.LastActiveAt,
+            PrCountThisMonth = result.PrCountThisMonth
+        }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictRequest.cs
@@ -1,0 +1,6 @@
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+public class GetClientVerdictRequest
+{
+    public Guid ClientId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictResponse.cs
@@ -1,0 +1,46 @@
+using FitnessPlatform.Application.Domain.Enums;
+
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+public class GetClientVerdictResponse
+{
+    /// <summary>
+    /// Overall on-track verdict for the client.
+    /// </summary>
+    public ClientVerdict Verdict { get; set; }
+
+    /// <summary>
+    /// Nutrition plan compliance percent (0-100), or null when no active nutrition plan.
+    /// </summary>
+    public decimal? CompliancePercent { get; set; }
+
+    /// <summary>
+    /// Delta between current weight and target weight in kg, or null when no measurements/target.
+    /// </summary>
+    public decimal? WeightDeltaToGoal { get; set; }
+
+    /// <summary>
+    /// Direction the client's weight is moving relative to their target.
+    /// </summary>
+    public WeightDirection WeightDirection { get; set; }
+
+    /// <summary>
+    /// Number of workout sessions completed in the current ISO week, or null when no active training plan.
+    /// </summary>
+    public int? TrainingFrequencyActual { get; set; }
+
+    /// <summary>
+    /// Number of sessions prescribed per week in the active training plan, or null when no active training plan.
+    /// </summary>
+    public int? TrainingFrequencyPrescribed { get; set; }
+
+    /// <summary>
+    /// UTC timestamp of the most recent activity (workout log, meal log, or measurement), or null.
+    /// </summary>
+    public DateTime? LastActiveAt { get; set; }
+
+    /// <summary>
+    /// Number of personal records achieved in the current calendar month.
+    /// </summary>
+    public int PrCountThisMonth { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientVerdict/GetClientVerdictValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+
+public class GetClientVerdictValidator : Validator<GetClientVerdictRequest>
+{
+    public GetClientVerdictValidator()
+    {
+        RuleFor(x => x.ClientId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansEndpoint.cs
@@ -1,0 +1,232 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+/// <summary>
+/// Returns all nutrition and training plans for a specific client, across all
+/// statuses (Active, Completed, Draft, Archived), sorted newest-first (by StartDate desc,
+/// then DateCreated desc as tiebreaker). Includes a per-plan result summary.
+///
+/// Trainer must have an active ClientProfessionalLink to the client; returns 403 if not
+/// linked (matches GetClientVerdict ownership pattern).
+/// </summary>
+public class ListClientPlansEndpoint(
+    IApplicationDbContext db,
+    IMongoContext mongo,
+    IComplianceService complianceService)
+    : Endpoint<ListClientPlansRequest, ListClientPlansResponse>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("/trainer/clients/{clientId}/plans");
+        Roles(AppRoles.Trainer, AppRoles.Nutritionist);
+        Summary(s =>
+        {
+            s.Summary = "List client plans";
+            s.Description = "Returns all nutrition and training plans for a client (all statuses), newest first, with per-plan result summaries.";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(ListClientPlansRequest req, CancellationToken ct)
+    {
+        var userId = User.FindFirstValue(AppClaims.UserId);
+        if (userId is null)
+        {
+            await Send.UnauthorizedAsync(ct);
+            return;
+        }
+
+        var trainerUserId = Guid.Parse(userId);
+
+        // Locate the trainer's professional profile
+        var professionalProfile = await db.ProfessionalProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(pp => pp.UserId == trainerUserId, ct);
+
+        if (professionalProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Locate the client profile by PublicId
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
+        // Verify an active trainer-client link exists; return 403 (not 404) when missing
+        var link = await db.ClientProfessionalLinks
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l =>
+                l.ProfessionalProfileId == professionalProfile.Id &&
+                l.ClientProfileId == clientProfile.Id &&
+                l.IsActive, ct);
+
+        if (link is null)
+        {
+            await Send.ForbiddenAsync(ct);
+            return;
+        }
+
+        // clientProfile.UserId is ApplicationUser.Id (Guid) — used by all Mongo documents
+        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId)
+        var clientUserId = clientProfile.UserId;
+        var clientProfileId = clientProfile.Id;
+
+        // Load all plans from Mongo in parallel
+        var nutritionFilter = Builders<Domain.Documents.NutritionPlan>.Filter
+            .Eq(p => p.ClientId, clientUserId);
+        var trainingFilter = Builders<Domain.Documents.TrainingPlan>.Filter
+            .Eq(p => p.ClientId, clientUserId);
+
+        var nutritionTask = mongo.NutritionPlans
+            .Find(nutritionFilter)
+            .ToListAsync(ct);
+        var trainingTask = mongo.TrainingPlans
+            .Find(trainingFilter)
+            .ToListAsync(ct);
+
+        await Task.WhenAll(nutritionTask, trainingTask);
+        var nutritionPlans = nutritionTask.Result;
+        var trainingPlans = trainingTask.Result;
+
+        // Compute result summaries for training plans:
+        // totalTrainings = count of completed WorkoutLogs with matching PlanId
+        // prCount = count of PersonalRecords with AchievedAt in [plan.StartDate .. plan.DateCompleted ?? now]
+        var trainingPlanIds = trainingPlans.Select(p => p.ExternalId).ToList();
+        var workoutLogs = await mongo.WorkoutLogs
+            .Find(Builders<Domain.Documents.WorkoutLog>.Filter.And(
+                Builders<Domain.Documents.WorkoutLog>.Filter.Eq(l => l.ClientId, clientUserId),
+                Builders<Domain.Documents.WorkoutLog>.Filter.Eq(l => l.IsCompleted, true),
+                Builders<Domain.Documents.WorkoutLog>.Filter.In(l => l.PlanId, trainingPlanIds.Cast<Guid?>())))
+            .ToListAsync(ct);
+
+        // PersonalRecords have no planId; filter by AchievedAt window per plan (computed per plan below)
+        var allPersonalRecords = await mongo.PersonalRecords
+            .Find(Builders<Domain.Documents.PersonalRecord>.Filter.Eq(pr => pr.ClientId, clientUserId))
+            .ToListAsync(ct);
+
+        // Build training plan items
+        var trainingItems = trainingPlans.Select(plan =>
+        {
+            var planLogCount = workoutLogs.Count(l => l.PlanId == plan.ExternalId && l.IsCompleted);
+
+            // PR window: [plan.StartDate .. plan.DateCompleted ?? now]
+            int? prCount = null;
+            if (plan.StartDate.HasValue)
+            {
+                var prWindowEnd = plan.DateCompleted ?? DateTime.UtcNow;
+                prCount = allPersonalRecords.Count(pr =>
+                    pr.AchievedAt >= plan.StartDate.Value &&
+                    pr.AchievedAt <= prWindowEnd);
+            }
+
+            return new ClientPlanItem
+            {
+                PlanId = plan.ExternalId,
+                PlanType = "Training",
+                Name = plan.Name,
+                PeriodStart = plan.StartDate,
+                PeriodEnd = plan.DateCompleted,
+                Status = plan.Status.ToString(),
+                ResultSummary = new ClientPlanResultSummary
+                {
+                    TotalTrainings = planLogCount,
+                    PrCount = prCount,
+                    CompliancePercent = null,
+                    WeightDeltaKg = null
+                }
+            };
+        }).ToList();
+
+        // Build nutrition plan items — compute compliance and weight delta per plan
+        // Body measurements keyed on clientProfile.Id (long PK)
+        var allMeasurements = await db.BodyMeasurements
+            .AsNoTracking()
+            .Where(m => m.ClientProfileId == clientProfileId && m.WeightKg != null)
+            .OrderBy(m => m.MeasuredAt)
+            .ToListAsync(ct);
+
+        var nutritionItems = new List<ClientPlanItem>();
+        foreach (var plan in nutritionPlans)
+        {
+            decimal? compliancePercent = null;
+            decimal? weightDeltaKg = null;
+
+            if (plan.StartDate.HasValue)
+            {
+                var periodEnd = plan.DateCompleted ?? DateTime.UtcNow;
+
+                // Nutrition compliance over the plan period via IComplianceService
+                var complianceResult = await complianceService.CalculateComplianceAsync(
+                    clientUserId,
+                    plan.StartDate.Value,
+                    periodEnd,
+                    ct);
+                compliancePercent = complianceResult.NutritionCompliancePercent;
+
+                // Weight delta: first measurement on/after start vs last measurement on/before end
+                var startMeasurement = allMeasurements
+                    .FirstOrDefault(m => m.MeasuredAt >= plan.StartDate.Value && m.MeasuredAt <= periodEnd);
+                var endMeasurement = allMeasurements
+                    .LastOrDefault(m => m.MeasuredAt >= plan.StartDate.Value && m.MeasuredAt <= periodEnd);
+
+                if (startMeasurement != null &&
+                    endMeasurement != null &&
+                    startMeasurement.Id != endMeasurement.Id &&
+                    startMeasurement.WeightKg.HasValue &&
+                    endMeasurement.WeightKg.HasValue)
+                {
+                    weightDeltaKg = endMeasurement.WeightKg.Value - startMeasurement.WeightKg.Value;
+                }
+            }
+
+            nutritionItems.Add(new ClientPlanItem
+            {
+                PlanId = plan.ExternalId,
+                PlanType = "Nutrition",
+                Name = plan.Name,
+                PeriodStart = plan.StartDate,
+                PeriodEnd = plan.DateCompleted,
+                Status = plan.Status.ToString(),
+                ResultSummary = new ClientPlanResultSummary
+                {
+                    TotalTrainings = null,
+                    PrCount = null,
+                    CompliancePercent = compliancePercent,
+                    WeightDeltaKg = weightDeltaKg
+                }
+            });
+        }
+
+        // Merge all plans and sort newest-first:
+        // Primary sort: StartDate desc (null StartDate treated as oldest — draft plans)
+        // Secondary sort: DateCreated desc as tiebreaker
+        var allItems = trainingItems
+            .Concat(nutritionItems)
+            .OrderByDescending(p => p.PeriodStart ?? DateTime.MinValue)
+            .ThenByDescending(p =>
+                // retrieve DateCreated from the original plan for tiebreaker
+                trainingPlans.FirstOrDefault(tp => tp.ExternalId == p.PlanId)?.DateCreated
+                ?? nutritionPlans.FirstOrDefault(np => np.ExternalId == p.PlanId)?.DateCreated
+                ?? DateTime.MinValue)
+            .ToList();
+
+        await Send.OkAsync(new ListClientPlansResponse { Plans = allItems }, ct);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansRequest.cs
@@ -1,0 +1,9 @@
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+public class ListClientPlansRequest
+{
+    /// <summary>
+    /// The client's PublicId (Guid), as it appears in the route segment.
+    /// </summary>
+    public Guid ClientId { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansResponse.cs
@@ -1,0 +1,91 @@
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+/// <summary>
+/// Combined list of a client's nutrition and training plans returned by
+/// GET /trainer/clients/{clientId}/plans.
+/// </summary>
+public class ListClientPlansResponse
+{
+    /// <summary>
+    /// All plans (nutrition + training) across all statuses, newest first.
+    /// </summary>
+    public List<ClientPlanItem> Plans { get; set; } = [];
+}
+
+/// <summary>
+/// A single plan entry in the combined list.
+/// </summary>
+public class ClientPlanItem
+{
+    /// <summary>
+    /// The plan's public ExternalId (Guid) as stored in MongoDB.
+    /// </summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>
+    /// Discriminates the plan type: "Nutrition" or "Training".
+    /// </summary>
+    public string PlanType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name of the plan.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The Monday when Week 1 begins (UTC). Null for plans where StartDate has not been set.
+    /// </summary>
+    public DateTime? PeriodStart { get; set; }
+
+    /// <summary>
+    /// When the plan was marked completed (UTC). Null for active/draft plans and open-ended plans.
+    /// </summary>
+    public DateTime? PeriodEnd { get; set; }
+
+    /// <summary>
+    /// Current plan status as a string: "Draft", "Active", "Completed", "Archived".
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-plan result summary. Null fields indicate the metric is not applicable
+    /// (e.g. compliance is null for training plans; totalTrainings is null for nutrition plans).
+    /// </summary>
+    public ClientPlanResultSummary ResultSummary { get; set; } = new();
+}
+
+/// <summary>
+/// Per-plan result summary. Fields not applicable to the plan type are null.
+/// </summary>
+public class ClientPlanResultSummary
+{
+    // ── Training-plan fields ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Count of WorkoutLogs where PlanId == plan.ExternalId and IsCompleted == true.
+    /// Null for nutrition plans.
+    /// </summary>
+    public int? TotalTrainings { get; set; }
+
+    /// <summary>
+    /// Count of PersonalRecords with AchievedAt in [plan.StartDate .. plan.DateCompleted ?? now].
+    /// Null for nutrition plans or plans without a StartDate.
+    /// </summary>
+    public int? PrCount { get; set; }
+
+    // ── Nutrition-plan fields ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Nutrition compliance % (0-100) over the plan period via IComplianceService.
+    /// Null for training plans, or when the plan has no StartDate.
+    /// </summary>
+    public decimal? CompliancePercent { get; set; }
+
+    /// <summary>
+    /// Body weight delta (kg) from the first BodyMeasurement on/after plan start
+    /// to the last BodyMeasurement on/before plan end (DateCompleted ?? now).
+    /// Positive = weight gained; negative = weight lost.
+    /// Null for training plans, or when fewer than two measurements exist in the window.
+    /// </summary>
+    public decimal? WeightDeltaKg { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+
+public class ListClientPlansValidator : Validator<ListClientPlansRequest>
+{
+    public ListClientPlansValidator()
+    {
+        RuleFor(x => x.ClientId).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/IMongoContext.cs
@@ -75,4 +75,10 @@ public interface IMongoContext
     /// Keyed by (ClientId = ClientProfile.PublicId, PlanId, SessionId, LogDate).
     /// </summary>
     IMongoCollection<SessionLog> SessionLogs { get; }
+
+    /// <summary>
+    /// Trainer notes — private notes written by a trainer about a client.
+    /// Never exposed to client-authenticated callers.
+    /// </summary>
+    IMongoCollection<TrainerNote> TrainerNotes { get; }
 }

--- a/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Data/MongoDb/MongoContext.cs
@@ -28,6 +28,7 @@ public class MongoContext : IMongoContext
         SectionTemplates = database.GetCollection<SectionTemplate>(MongoCollections.SectionTemplates);
         SessionLocks = database.GetCollection<SessionLock>(MongoCollections.SessionLocks);
         SessionLogs = database.GetCollection<SessionLog>(MongoCollections.SessionLogs);
+        TrainerNotes = database.GetCollection<TrainerNote>(MongoCollections.TrainerNotes);
     }
 
     /// <inheritdoc />
@@ -68,4 +69,7 @@ public class MongoContext : IMongoContext
 
     /// <inheritdoc />
     public IMongoCollection<SessionLog> SessionLogs { get; }
+
+    /// <inheritdoc />
+    public IMongoCollection<TrainerNote> TrainerNotes { get; }
 }

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -5,6 +5,7 @@ using FastEndpoints.Swagger;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Domain.Services;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.HealthChecks;
@@ -207,6 +208,9 @@ builder.Services.AddScoped<ISessionLockService, SessionLockService>();
 
 // Compliance
 builder.Services.AddScoped<IComplianceService, ComplianceService>();
+
+// Client verdict
+builder.Services.AddScoped<IClientVerdictService, ClientVerdictService>();
 
 // Audit
 builder.Services.AddScoped<IAuditService, AuditService>();

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/ClientNotesTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/ClientNotesTests.cs
@@ -1,0 +1,635 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Features.Trainers.ClientNotes.CreateNote;
+using FitnessPlatform.Application.Features.Trainers.ClientNotes.DeleteNote;
+using FitnessPlatform.Application.Features.Trainers.ClientNotes.EditNote;
+using FitnessPlatform.Application.Features.Trainers.ClientNotes.ListNotes;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+/// <summary>
+/// Tests for the ClientNotes slice:
+///   POST   /trainer/clients/{clientId}/notes
+///   GET    /trainer/clients/{clientId}/notes
+///   PATCH  /trainer/clients/{clientId}/notes/{noteId}
+///   DELETE /trainer/clients/{clientId}/notes/{noteId}
+/// </summary>
+public class ClientNotesTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+
+    // ── POST /trainer/clients/{clientId}/notes ───────────────────────────────
+
+    [Fact]
+    public async Task Create_HappyPath_Returns201WithNoteId()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateCreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new CreateNoteRequest { ClientId = clientProfile.PublicId, Text = "Great progress today." },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+        ep.Response.NoteId.Should().NotBeEmpty();
+        ep.Response.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Create_ClientAuthenticated_Returns403()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = Factory.Create<CreateNoteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeClientPrincipal(_trainerId),
+            db, mongo);
+
+        await ep.HandleAsync(
+            new CreateNoteRequest { ClientId = clientProfile.PublicId, Text = "Should fail." },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task Create_NotLinkedToClient_Returns403()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        // No link
+        var db = new MockDbBuilder().With(trainerProfile).With(clientProfile).Build();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateCreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new CreateNoteRequest { ClientId = clientProfile.PublicId, Text = "No link." },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task Create_NonexistentClient_Returns404()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var db = new MockDbBuilder().With(trainerProfile).Build();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateCreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new CreateNoteRequest { ClientId = Guid.NewGuid(), Text = "Ghost." },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task Create_TextTooLong_Returns400()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateCreateEndpoint(db, mongo, _trainerId);
+
+        var tooLong = new string('x', 2001);
+
+        await ep.HandleAsync(
+            new CreateNoteRequest { ClientId = clientProfile.PublicId, Text = tooLong },
+            TestContext.Current.CancellationToken);
+
+        // Validator fires before HandleAsync is called in real HTTP, but in unit tests we verify
+        // the validator separately. The endpoint validator is registered as a Validator<> — the
+        // Factory test setup does NOT auto-run validators before HandleAsync. The 2000-char
+        // constraint is verified via direct validator unit test below.
+        // This test verifies the validator rule is defined correctly.
+        var validator = new CreateNoteValidator();
+        var result = await validator.ValidateAsync(
+            new CreateNoteRequest { ClientId = clientProfile.PublicId, Text = tooLong },
+            TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorCode == ErrorCodes.OutOfRange);
+    }
+
+    // ── GET /trainer/clients/{clientId}/notes ────────────────────────────────
+
+    [Fact]
+    public async Task List_HappyPath_ReturnsBothNotes()
+    {
+        // Note: NSubstitute mocks cannot evaluate Mongo filter/sort expressions — the mock
+        // returns all docs in insertion order. Actual sort-by-createdAt is an integration concern.
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        var note1 = CreateNote(clientProfile.UserId, _trainerId, text: "Note A.");
+        var note2 = CreateNote(clientProfile.UserId, _trainerId, text: "Note B.");
+
+        var mongo = BuildReadableMongo([note1, note2]);
+
+        var ep = CreateListEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new ListNotesRequest { ClientId = clientProfile.PublicId, Page = 1, PageSize = 20 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Notes.Should().HaveCount(2);
+        ep.Response.Notes.Select(n => n.NoteId).Should().BeEquivalentTo([note1.ExternalId, note2.ExternalId]);
+    }
+
+    [Fact]
+    public async Task List_XTotalCountHeader_ReflectsTotalNoteCount()
+    {
+        // The mock returns a fixed list regardless of Skip/Limit (NSubstitute can't simulate
+        // server-side LINQ evaluation). This test verifies that the X-Total-Count header is
+        // set from CountDocumentsAsync, which the mock returns as the collection size.
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        var notes = Enumerable.Range(0, 5)
+            .Select(i => CreateNote(clientProfile.UserId, _trainerId, createdAt: DateTime.UtcNow.AddHours(-i)))
+            .ToList();
+
+        var mongo = BuildReadableMongo(notes);
+
+        var ep = CreateListEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new ListNotesRequest { ClientId = clientProfile.PublicId, Page = 1, PageSize = 20 },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        // X-Total-Count comes from CountDocumentsAsync which returns the mock list size (5)
+        ep.HttpContext.Response.Headers["X-Total-Count"].ToString().Should().Be("5");
+    }
+
+    [Fact]
+    public async Task List_ClientAuthenticated_Returns403()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var mongo = BuildReadableMongo([]);
+
+        var ep = Factory.Create<ListNotesEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeClientPrincipal(_trainerId),
+            db, mongo);
+
+        await ep.HandleAsync(
+            new ListNotesRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task List_CrossTrainerAccess_Returns403()
+    {
+        var trainer1Id = Guid.NewGuid();
+        var trainer2Id = _trainerId; // the calling trainer
+
+        var trainerProfile1 = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(trainer1Id).Build();
+        var trainerProfile2 = EntityBuilder.ProfessionalProfile.WithId(2).WithUserId(trainer2Id).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+
+        // Only trainer1 is linked to the client
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile1)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile1)
+            .With(trainerProfile2)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var mongo = BuildReadableMongo([]);
+
+        // trainer2 is calling
+        var ep = CreateListEndpoint(db, mongo, trainer2Id);
+
+        await ep.HandleAsync(
+            new ListNotesRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task List_NonexistentClient_Returns404()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var db = new MockDbBuilder().With(trainerProfile).Build();
+        var mongo = BuildReadableMongo([]);
+
+        var ep = CreateListEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new ListNotesRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── PATCH /trainer/clients/{clientId}/notes/{noteId} ────────────────────
+
+    [Fact]
+    public async Task Edit_HappyPath_Returns200WithUpdatedText()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        var note = CreateNote(clientProfile.UserId, _trainerId, text: "Original text.");
+        var mongo = BuildWritableMongo([note]);
+
+        var ep = CreateEditEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new EditNoteRequest
+            {
+                ClientId = clientProfile.PublicId,
+                NoteId = note.ExternalId,
+                Text = "Updated text."
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.NoteId.Should().Be(note.ExternalId);
+        ep.Response.Text.Should().Be("Updated text.");
+        ep.Response.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task Edit_ClientAuthenticated_Returns403()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = Factory.Create<EditNoteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeClientPrincipal(_trainerId),
+            db, mongo);
+
+        await ep.HandleAsync(
+            new EditNoteRequest { ClientId = clientProfile.PublicId, NoteId = Guid.NewGuid(), Text = "x" },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task Edit_NoteNotFound_Returns404()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        // Empty notes collection — note won't be found
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateEditEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new EditNoteRequest
+            {
+                ClientId = clientProfile.PublicId,
+                NoteId = Guid.NewGuid(),
+                Text = "Does not exist."
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task Edit_CrossTrainerNote_Returns404()
+    {
+        // Trainer2 tries to edit a note authored by trainer1.
+        // NSubstitute mocks cannot evaluate Mongo filter expressions, so we simulate
+        // "note not found for trainer2" by providing an empty collection (no match).
+        // The real Mongo query filters by (ExternalId AND TrainerId AND ClientId), which
+        // ensures trainer2 cannot see trainer1's notes in production.
+        var trainer1Id = Guid.NewGuid();
+        var trainer2Id = _trainerId;
+
+        var trainerProfile1 = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(trainer1Id).Build();
+        var trainerProfile2 = EntityBuilder.ProfessionalProfile.WithId(2).WithUserId(trainer2Id).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+
+        // Both trainers are linked to the client
+        var link1 = EntityBuilder.ClientProfessionalLink.WithId(41).WithClientProfile(clientProfile).WithProfessionalProfile(trainerProfile1).Build();
+        var link2 = EntityBuilder.ClientProfessionalLink.WithId(42).WithClientProfile(clientProfile).WithProfessionalProfile(trainerProfile2).Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile1)
+            .With(trainerProfile2)
+            .With(clientProfile)
+            .With(link1)
+            .With(link2)
+            .Build();
+
+        // Empty mongo = find returns no note, simulating trainer2's filter finding nothing
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateEditEndpoint(db, mongo, trainer2Id);
+
+        await ep.HandleAsync(
+            new EditNoteRequest
+            {
+                ClientId = clientProfile.PublicId,
+                NoteId = Guid.NewGuid(),
+                Text = "Hijacked."
+            },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── DELETE /trainer/clients/{clientId}/notes/{noteId} ───────────────────
+
+    [Fact]
+    public async Task Delete_HappyPath_Returns204()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var note = CreateNote(clientProfile.UserId, _trainerId);
+        var mongo = BuildWritableMongo([note]);
+
+        var ep = CreateDeleteEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new DeleteNoteRequest { ClientId = clientProfile.PublicId, NoteId = note.ExternalId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(204);
+    }
+
+    [Fact]
+    public async Task Delete_ClientAuthenticated_Returns403()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var mongo = BuildWritableMongo([]);
+
+        var ep = Factory.Create<DeleteNoteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeClientPrincipal(_trainerId),
+            db, mongo);
+
+        await ep.HandleAsync(
+            new DeleteNoteRequest { ClientId = clientProfile.PublicId, NoteId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task Delete_NoteNotFound_Returns404()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        // Empty notes — delete will find nothing
+        var mongo = BuildWritableMongo([]);
+
+        var ep = CreateDeleteEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new DeleteNoteRequest { ClientId = clientProfile.PublicId, NoteId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task Delete_NotLinkedToClient_Returns403()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        // No link
+        var db = new MockDbBuilder().With(trainerProfile).With(clientProfile).Build();
+        var note = CreateNote(clientProfile.UserId, _trainerId);
+        var mongo = BuildWritableMongo([note]);
+
+        var ep = CreateDeleteEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(
+            new DeleteNoteRequest { ClientId = clientProfile.PublicId, NoteId = note.ExternalId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    // ── Validator unit tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateValidator_TextExceeds2000_Fails()
+    {
+        var validator = new CreateNoteValidator();
+        var result = await validator.ValidateAsync(new CreateNoteRequest
+        {
+            ClientId = Guid.NewGuid(),
+            Text = new string('a', 2001)
+        }, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorCode == ErrorCodes.OutOfRange);
+    }
+
+    [Fact]
+    public async Task EditValidator_TextExceeds2000_Fails()
+    {
+        var validator = new EditNoteValidator();
+        var result = await validator.ValidateAsync(new EditNoteRequest
+        {
+            ClientId = Guid.NewGuid(),
+            NoteId = Guid.NewGuid(),
+            Text = new string('a', 2001)
+        }, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorCode == ErrorCodes.OutOfRange);
+    }
+
+    [Fact]
+    public async Task CreateValidator_TextExactly2000_Passes()
+    {
+        var validator = new CreateNoteValidator();
+        var result = await validator.ValidateAsync(new CreateNoteRequest
+        {
+            ClientId = Guid.NewGuid(),
+            Text = new string('a', 2000)
+        }, TestContext.Current.CancellationToken);
+        result.IsValid.Should().BeTrue();
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    private (IApplicationDbContext db, Application.Domain.Entities.ClientProfile clientProfile)
+        BuildLinkedClientSetup()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        return (db, clientProfile);
+    }
+
+    private CreateNoteEndpoint CreateCreateEndpoint(IApplicationDbContext db, IMongoContext mongo, Guid callerId) =>
+        Factory.Create<CreateNoteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(callerId),
+            db, mongo);
+
+    private ListNotesEndpoint CreateListEndpoint(IApplicationDbContext db, IMongoContext mongo, Guid callerId) =>
+        Factory.Create<ListNotesEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(callerId),
+            db, mongo);
+
+    private EditNoteEndpoint CreateEditEndpoint(IApplicationDbContext db, IMongoContext mongo, Guid callerId) =>
+        Factory.Create<EditNoteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(callerId),
+            db, mongo);
+
+    private DeleteNoteEndpoint CreateDeleteEndpoint(IApplicationDbContext db, IMongoContext mongo, Guid callerId) =>
+        Factory.Create<DeleteNoteEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(callerId),
+            db, mongo);
+
+    private static ClaimsPrincipal FakeTrainerPrincipal(Guid userId) =>
+        new(new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(userId, AppRoles.Trainer)));
+
+    private static ClaimsPrincipal FakeClientPrincipal(Guid userId) =>
+        new(new ClaimsIdentity(EndpointTestHelpers.FakeUserClaims(userId, AppRoles.Client)));
+
+    // ── Mongo factory helpers ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a mock IMongoContext where TrainerNotes supports reads (FindAsync + CountDocumentsAsync).
+    /// </summary>
+    private static IMongoContext BuildReadableMongo(List<TrainerNote> notes)
+    {
+        var collection = CreateReadableCollection(notes);
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.TrainerNotes.Returns(collection);
+        return mongo;
+    }
+
+    /// <summary>
+    /// Creates a mock IMongoContext where TrainerNotes supports reads AND writes
+    /// (InsertOneAsync, UpdateOneAsync, DeleteOneAsync, FindAsync, CountDocumentsAsync).
+    /// For DeleteOneAsync: returns DeletedCount=1 when the note ExternalId matches the filter (simulated);
+    /// returns DeletedCount=0 when the notes list is empty.
+    /// </summary>
+    private static IMongoContext BuildWritableMongo(List<TrainerNote> notes)
+    {
+        var collection = CreateWritableCollection(notes);
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.TrainerNotes.Returns(collection);
+        return mongo;
+    }
+
+    private static IMongoCollection<TrainerNote> CreateReadableCollection(List<TrainerNote> docs)
+    {
+        var collection = Substitute.For<IMongoCollection<TrainerNote>>();
+
+        // FindAsync — returns all docs (filter evaluation happens in real Mongo; mock returns all)
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<TrainerNote>>(),
+                Arg.Any<FindOptions<TrainerNote, TrainerNote>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(docs));
+
+        // CountDocumentsAsync — returns total count of provided docs
+        collection.CountDocumentsAsync(
+                Arg.Any<FilterDefinition<TrainerNote>>(),
+                Arg.Any<CountOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(docs.Count);
+
+        return collection;
+    }
+
+    private static IMongoCollection<TrainerNote> CreateWritableCollection(List<TrainerNote> docs)
+    {
+        var collection = CreateReadableCollection(docs);
+
+        // InsertOneAsync — no-op (note is already in memory list for read checks)
+        collection.InsertOneAsync(
+                Arg.Any<TrainerNote>(),
+                Arg.Any<InsertOneOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        // UpdateOneAsync — returns ModifiedCount=1
+        var updateResult = Substitute.For<UpdateResult>();
+        updateResult.ModifiedCount.Returns(1L);
+        collection.UpdateOneAsync(
+                Arg.Any<FilterDefinition<TrainerNote>>(),
+                Arg.Any<UpdateDefinition<TrainerNote>>(),
+                Arg.Any<UpdateOptions>(),
+                Arg.Any<CancellationToken>())
+            .Returns(updateResult);
+
+        // DeleteOneAsync — returns DeletedCount matching whether docs list has any entries
+        var deleteResult = Substitute.For<DeleteResult>();
+        deleteResult.DeletedCount.Returns(docs.Count > 0 ? 1L : 0L);
+        collection.DeleteOneAsync(
+                Arg.Any<FilterDefinition<TrainerNote>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(deleteResult);
+
+        return collection;
+    }
+
+    private static IAsyncCursor<T> CreateCursor<T>(List<T> docs)
+    {
+        var cursor = Substitute.For<IAsyncCursor<T>>();
+        var moved = false;
+        cursor.Current.Returns(docs);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        return cursor;
+    }
+
+    private static TrainerNote CreateNote(
+        Guid clientUserId,
+        Guid trainerId,
+        string text = "A test note.",
+        DateTime? createdAt = null)
+    {
+        var now = createdAt ?? DateTime.UtcNow;
+        return new TrainerNote
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientUserId,
+            TrainerId = trainerId,
+            Text = text,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientVerdictTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientVerdictTests.cs
@@ -1,0 +1,380 @@
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Trainers.GetClientVerdict;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+public class GetClientVerdictTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly IClientVerdictService _verdictService = Substitute.For<IClientVerdictService>();
+
+    // ── Happy path — OnTrack ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_FullOnTrack_Returns200WithOnTrackVerdict()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            clientProfile.UserId,
+            clientProfile.Id,
+            Arg.Any<decimal?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OnTrack,
+                CompliancePercent = 92m,
+                WeightDeltaToGoal = -2.5m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1),
+                PrCountThisMonth = 2
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OnTrack);
+        ep.Response.CompliancePercent.Should().Be(92m);
+        ep.Response.WeightDirection.Should().Be(WeightDirection.Towards);
+        ep.Response.TrainingFrequencyActual.Should().Be(3);
+        ep.Response.TrainingFrequencyPrescribed.Should().Be(3);
+        ep.Response.PrCountThisMonth.Should().Be(2);
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    // ── NeedsAttention — single-signal variants ─────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_ComplianceBelow85_Returns200WithNeedsAttention()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.NeedsAttention,
+                CompliancePercent = 72m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.NeedsAttention);
+        ep.Response.CompliancePercent.Should().Be(72m);
+    }
+
+    [Fact]
+    public async Task GetVerdict_WeightStable_Returns200WithNeedsAttention()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.NeedsAttention,
+                CompliancePercent = 90m,
+                WeightDeltaToGoal = 0.3m,
+                WeightDirection = WeightDirection.Stable,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.NeedsAttention);
+        ep.Response.WeightDirection.Should().Be(WeightDirection.Stable);
+    }
+
+    [Fact]
+    public async Task GetVerdict_FrequencyBelowPrescribed_Returns200WithNeedsAttention()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.NeedsAttention,
+                CompliancePercent = 90m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 2,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.NeedsAttention);
+        ep.Response.TrainingFrequencyActual.Should().Be(2);
+        ep.Response.TrainingFrequencyPrescribed.Should().Be(3);
+    }
+
+    // ── OffTrack variants ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_ComplianceBelow60_Returns200WithOffTrack()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OffTrack,
+                CompliancePercent = 45m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OffTrack);
+        ep.Response.CompliancePercent.Should().Be(45m);
+    }
+
+    [Fact]
+    public async Task GetVerdict_Inactivity14Days_Returns200WithOffTrack()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OffTrack,
+                CompliancePercent = null,
+                WeightDirection = WeightDirection.Stable,
+                LastActiveAt = DateTime.UtcNow.AddDays(-(ClientDashboardConstants.InactivityThresholdDays + 1))
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public async Task GetVerdict_WeightAwayDeltaAbove1Kg_Returns200WithOffTrack()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OffTrack,
+                CompliancePercent = 88m,
+                WeightDeltaToGoal = 1.5m,
+                WeightDirection = WeightDirection.Away,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.Verdict.Should().Be(ClientVerdict.OffTrack);
+        ep.Response.WeightDirection.Should().Be(WeightDirection.Away);
+    }
+
+    // ── Null-exclusion paths ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_NoActiveNutritionPlan_CompliancePercent_IsNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OnTrack,
+                CompliancePercent = null,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = 3,
+                TrainingFrequencyPrescribed = 3,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.CompliancePercent.Should().BeNull();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task GetVerdict_NoActiveTrainingPlan_FrequencySignals_AreNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        _verdictService.ComputeAsync(
+            Arg.Any<Guid>(), Arg.Any<long>(),
+            Arg.Any<decimal?>(), Arg.Any<CancellationToken>())
+            .Returns(new ClientVerdictResult
+            {
+                Verdict = ClientVerdict.OnTrack,
+                CompliancePercent = 90m,
+                WeightDirection = WeightDirection.Towards,
+                TrainingFrequencyActual = null,
+                TrainingFrequencyPrescribed = null,
+                LastActiveAt = DateTime.UtcNow.AddDays(-1)
+            });
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.Response.TrainingFrequencyActual.Should().BeNull();
+        ep.Response.TrainingFrequencyPrescribed.Should().BeNull();
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+    }
+
+    // ── Auth & ownership errors ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetVerdict_NoClaims_Returns401()
+    {
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task GetVerdict_NotLinkedToClient_Returns403()
+    {
+        // Trainer has a profile but NO link to the client
+        var trainerId = _trainerId;
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(trainerId).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
+
+        // No link added to MockDbBuilder — trainer has no active link
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .Build();
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task GetVerdict_NonexistentClient_Returns404()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var db = new MockDbBuilder().With(trainerProfile).Build();
+
+        var ep = Factory.Create<GetClientVerdictEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(_trainerId),
+            db, _verdictService);
+
+        await ep.HandleAsync(new GetClientVerdictRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private (IApplicationDbContext db, FitnessPlatform.Application.Domain.Entities.ClientProfile clientProfile)
+        BuildLinkedClientSetup()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com")
+            .WithFirstName("Test").WithLastName("Client").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        return (db, clientProfile);
+    }
+
+    private static System.Security.Claims.ClaimsPrincipal FakeTrainerPrincipal(Guid userId) =>
+        new(new System.Security.Claims.ClaimsIdentity(
+            EndpointTestHelpers.FakeUserClaims(userId, AppRoles.Trainer)));
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansTests.cs
@@ -1,0 +1,570 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Trainers.ListClientPlans;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+/// <summary>
+/// Tests for <see cref="ListClientPlansEndpoint" />.
+/// </summary>
+public class ListClientPlansTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly IComplianceService _complianceService = Substitute.For<IComplianceService>();
+
+    // ── Happy path — combined list ───────────────────────────────────────────
+
+    [Fact]
+    public async Task List_BothPlanTypes_ReturnsCombinedListNewestFirst()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var olderStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);  // Monday
+        var newerStart = new DateTime(2025, 6, 2, 0, 0, 0, DateTimeKind.Utc);  // Monday
+
+        var nutritionPlan = CreateNutritionPlan(clientUserId, startDate: olderStart, name: "Old Nutrition Plan");
+        var trainingPlan = CreateTrainingPlan(clientUserId, startDate: newerStart, name: "New Training Plan");
+
+        var mongo = BuildMongo(
+            nutritionPlans: [nutritionPlan],
+            trainingPlans: [trainingPlan],
+            workoutLogs: [],
+            personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var plans = ep.Response.Plans;
+        plans.Should().HaveCount(2);
+
+        // Newest-first: trainingPlan (newerStart) should come before nutritionPlan (olderStart)
+        plans[0].PlanId.Should().Be(trainingPlan.ExternalId);
+        plans[0].PlanType.Should().Be("Training");
+        plans[0].Name.Should().Be("New Training Plan");
+        plans[1].PlanId.Should().Be(nutritionPlan.ExternalId);
+        plans[1].PlanType.Should().Be("Nutrition");
+        plans[1].Name.Should().Be("Old Nutrition Plan");
+    }
+
+    [Fact]
+    public async Task List_AllStatuses_ReturnsDraftActiveCompleted()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var start1 = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
+        var start2 = new DateTime(2025, 3, 3, 0, 0, 0, DateTimeKind.Utc);
+        var start3 = new DateTime(2025, 5, 5, 0, 0, 0, DateTimeKind.Utc);
+
+        var draftPlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Draft, startDate: start1, name: "Draft Plan");
+        var activePlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Active, startDate: start2, name: "Active Plan");
+        var completedPlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Completed, startDate: start3, name: "Completed Plan");
+
+        var mongo = BuildMongo(
+            trainingPlans: [draftPlan, activePlan, completedPlan],
+            workoutLogs: [],
+            personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var plans = ep.Response.Plans;
+        plans.Should().HaveCount(3);
+
+        // Verify all statuses are present
+        plans.Select(p => p.Status).Should().BeEquivalentTo(["Draft", "Active", "Completed"]);
+    }
+
+    // ── Training plan result summary ─────────────────────────────────────────
+
+    [Fact]
+    public async Task List_TrainingPlan_ResultSummaryIncludesTotalTrainingsAndPrCount()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var planStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
+        var planId = Guid.NewGuid();
+
+        var trainingPlan = CreateTrainingPlan(clientUserId, externalId: planId, startDate: planStart, name: "Hypertrophy Plan");
+
+        // 3 completed logs for this plan
+        var log1 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
+        var log2 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
+        var log3 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
+        // 1 not completed (should not be counted)
+        var log4 = CreateWorkoutLog(clientUserId, planId, isCompleted: false);
+        // 1 completed but for a different plan (should not be counted)
+        var log5 = CreateWorkoutLog(clientUserId, Guid.NewGuid(), isCompleted: true);
+
+        // 2 PRs in the plan window
+        var pr1 = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(10));
+        var pr2 = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(20));
+        // 1 PR before plan start (should not be counted)
+        var prBefore = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(-5));
+
+        var mongo = BuildMongo(
+            trainingPlans: [trainingPlan],
+            workoutLogs: [log1, log2, log3, log4, log5],
+            personalRecords: [pr1, pr2, prBefore]);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var planItem = ep.Response.Plans.Single();
+        planItem.ResultSummary.TotalTrainings.Should().Be(3);
+        planItem.ResultSummary.PrCount.Should().Be(2);
+        planItem.ResultSummary.CompliancePercent.Should().BeNull();
+        planItem.ResultSummary.WeightDeltaKg.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task List_TrainingPlanNoStartDate_PrCountIsNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var planId = Guid.NewGuid();
+        // No StartDate set — Draft plan
+        var trainingPlan = CreateTrainingPlan(clientUserId, externalId: planId, startDate: null, name: "Draft Plan");
+
+        var pr = CreatePersonalRecord(clientUserId, achievedAt: DateTime.UtcNow.AddDays(-5));
+
+        var mongo = BuildMongo(
+            trainingPlans: [trainingPlan],
+            workoutLogs: [],
+            personalRecords: [pr]);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Plans.Single().ResultSummary.PrCount.Should().BeNull();
+        ep.Response.Plans.Single().ResultSummary.TotalTrainings.Should().Be(0);
+    }
+
+    // ── Nutrition plan result summary ────────────────────────────────────────
+
+    [Fact]
+    public async Task List_NutritionPlan_ResultSummaryIncludesComplianceAndWeightDelta()
+    {
+        var planStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
+        var planEnd = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc);
+        var clientUserId = Guid.NewGuid();
+
+        var nutritionPlan = CreateNutritionPlan(
+            clientUserId,
+            startDate: planStart,
+            dateCompleted: planEnd,
+            name: "Weight Loss Plan");
+
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithId(clientUserId).Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        // Two body measurements within the plan window (distinct Ids required for delta calculation)
+        var measurementStart = new BodyMeasurement
+        {
+            Id = 1,
+            ClientProfileId = clientProfile.Id,
+            MeasuredAt = planStart.AddDays(1),
+            WeightKg = 80.0m
+        };
+        var measurementEnd = new BodyMeasurement
+        {
+            Id = 2,
+            ClientProfileId = clientProfile.Id,
+            MeasuredAt = planEnd.AddDays(-1),
+            WeightKg = 75.5m
+        };
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .With(measurementStart)
+            .With(measurementEnd)
+            .Build();
+
+        _complianceService
+            .CalculateComplianceAsync(clientUserId, planStart, planEnd, Arg.Any<CancellationToken>())
+            .Returns(new ComplianceResult
+            {
+                NutritionCompliancePercent = 87.5m,
+                CompliancePercent = 87.5m
+            });
+
+        var mongo = BuildMongo(
+            nutritionPlans: [nutritionPlan],
+            workoutLogs: [],
+            personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId, setupDefaultCompliance: false);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var planItem = ep.Response.Plans.Single();
+        planItem.ResultSummary.CompliancePercent.Should().Be(87.5m);
+        planItem.ResultSummary.WeightDeltaKg.Should().BeApproximately(-4.5m, 0.01m);
+        planItem.ResultSummary.TotalTrainings.Should().BeNull();
+        planItem.ResultSummary.PrCount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task List_NutritionPlanNoStartDate_ComplianceAndWeightDeltaAreNull()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientUserId = clientProfile.UserId;
+
+        var nutritionPlan = CreateNutritionPlan(clientUserId, startDate: null, name: "Draft Nutrition Plan");
+
+        var mongo = BuildMongo(nutritionPlans: [nutritionPlan], workoutLogs: [], personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        var planItem = ep.Response.Plans.Single();
+        planItem.ResultSummary.CompliancePercent.Should().BeNull();
+        planItem.ResultSummary.WeightDeltaKg.Should().BeNull();
+    }
+
+    // ── Empty results ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_NoPlans_ReturnsEmptyArray()
+    {
+        var (db, clientProfile) = BuildLinkedClientSetup();
+
+        var mongo = BuildMongo(nutritionPlans: [], trainingPlans: [], workoutLogs: [], personalRecords: []);
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Plans.Should().BeEmpty();
+    }
+
+    // ── Auth & ownership errors ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_NoClaims_Returns401()
+    {
+        var db = new MockDbBuilder().Build();
+        var mongo = BuildMongo();
+
+        var ep = Factory.Create<ListClientPlansEndpoint>(db, mongo, _complianceService);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(401);
+    }
+
+    [Fact]
+    public async Task List_NotLinkedToClient_Returns403()
+    {
+        // Trainer has a profile but NO link to the client
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
+
+        // No link added to MockDbBuilder
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .Build();
+
+        var mongo = BuildMongo();
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task List_CrossTrainerAccess_Returns403()
+    {
+        // Trainer 2 tries to access trainer 1's client
+        var trainer1Id = Guid.NewGuid();
+        var trainer2Id = _trainerId;
+
+        var trainerProfile1 = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(trainer1Id).Build();
+        var trainerProfile2 = EntityBuilder.ProfessionalProfile.WithId(2).WithUserId(trainer2Id).Build();
+        var clientUser = EntityBuilder.User.Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+
+        // Only trainer1 is linked to the client
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile1)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile1)
+            .With(trainerProfile2)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var mongo = BuildMongo();
+
+        // trainer2 is calling
+        var ep = CreateEndpoint(db, mongo, trainer2Id);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = clientProfile.PublicId },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task List_NonexistentClient_Returns404()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var db = new MockDbBuilder().With(trainerProfile).Build();
+        var mongo = BuildMongo();
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task List_NoTrainerProfile_Returns404()
+    {
+        // Trainer has no ProfessionalProfile
+        var db = new MockDbBuilder().Build();
+        var mongo = BuildMongo();
+
+        var ep = CreateEndpoint(db, mongo, _trainerId);
+
+        await ep.HandleAsync(new ListClientPlansRequest { ClientId = Guid.NewGuid() },
+            TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private ListClientPlansEndpoint CreateEndpoint(
+        IApplicationDbContext db,
+        IMongoContext mongo,
+        Guid callerId,
+        bool setupDefaultCompliance = true)
+    {
+        if (setupDefaultCompliance)
+        {
+            _complianceService
+                .CalculateComplianceAsync(Arg.Any<Guid>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+                .Returns(new ComplianceResult
+                {
+                    NutritionCompliancePercent = 0m,
+                    CompliancePercent = 0m
+                });
+        }
+
+        return Factory.Create<ListClientPlansEndpoint>(
+            ctx => ctx.Request.HttpContext.User = FakeTrainerPrincipal(callerId),
+            db, mongo, _complianceService);
+    }
+
+    private (IApplicationDbContext db, Application.Domain.Entities.ClientProfile clientProfile)
+        BuildLinkedClientSetup()
+    {
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com").Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(42)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        return (db, clientProfile);
+    }
+
+    private static ClaimsPrincipal FakeTrainerPrincipal(Guid userId) =>
+        new(new ClaimsIdentity(
+            EndpointTestHelpers.FakeUserClaims(userId, AppRoles.Trainer)));
+
+    // ── Mongo factory helpers ────────────────────────────────────────────────
+
+    private static IMongoContext BuildMongo(
+        IEnumerable<NutritionPlan>? nutritionPlans = null,
+        IEnumerable<TrainingPlan>? trainingPlans = null,
+        IEnumerable<WorkoutLog>? workoutLogs = null,
+        IEnumerable<PersonalRecord>? personalRecords = null)
+    {
+        // Build collections first — never pass a NSubstitute setup call as an argument
+        // to another Returns() call; NSubstitute's thread-local context would throw.
+        var nutritionCollection = CreateMockCollection(nutritionPlans?.ToList() ?? []);
+        var trainingCollection = CreateMockCollection(trainingPlans?.ToList() ?? []);
+        var workoutCollection = CreateMockCollection(workoutLogs?.ToList() ?? []);
+        var recordsCollection = CreateMockCollection(personalRecords?.ToList() ?? []);
+
+        var mongo = Substitute.For<IMongoContext>();
+        mongo.NutritionPlans.Returns(nutritionCollection);
+        mongo.TrainingPlans.Returns(trainingCollection);
+        mongo.WorkoutLogs.Returns(workoutCollection);
+        mongo.PersonalRecords.Returns(recordsCollection);
+        return mongo;
+    }
+
+    private static IMongoCollection<T> CreateMockCollection<T>(List<T> docs)
+    {
+        var collection = Substitute.For<IMongoCollection<T>>();
+        collection.FindAsync(
+                Arg.Any<FilterDefinition<T>>(),
+                Arg.Any<FindOptions<T, T>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => CreateCursor(docs));
+        return collection;
+    }
+
+    private static IAsyncCursor<T> CreateCursor<T>(List<T> docs)
+    {
+        var cursor = Substitute.For<IAsyncCursor<T>>();
+        var moved = false;
+        cursor.Current.Returns(docs);
+        cursor.MoveNext(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        cursor.MoveNextAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            if (moved) return false;
+            moved = true;
+            return docs.Count > 0;
+        });
+        return cursor;
+    }
+
+    private static NutritionPlan CreateNutritionPlan(
+        Guid clientId,
+        Guid? externalId = null,
+        DateTime? startDate = null,
+        DateTime? dateCompleted = null,
+        string name = "Test Nutrition Plan",
+        NutritionPlanStatus status = NutritionPlanStatus.Active)
+    {
+        return new NutritionPlan
+        {
+            ExternalId = externalId ?? Guid.NewGuid(),
+            ClientId = clientId,
+            NutritionistId = Guid.NewGuid(),
+            Name = name,
+            Status = status,
+            StartDate = startDate,
+            DateCompleted = dateCompleted,
+            DateCreated = startDate ?? DateTime.UtcNow.AddDays(-30),
+            Version = 1
+        };
+    }
+
+    private static TrainingPlan CreateTrainingPlan(
+        Guid clientId,
+        Guid? externalId = null,
+        DateTime? startDate = null,
+        DateTime? dateCompleted = null,
+        string name = "Test Training Plan",
+        TrainingPlanStatus status = TrainingPlanStatus.Active)
+    {
+        return new TrainingPlan
+        {
+            ExternalId = externalId ?? Guid.NewGuid(),
+            ClientId = clientId,
+            TrainerId = Guid.NewGuid(),
+            Name = name,
+            Status = status,
+            StartDate = startDate,
+            DateCompleted = dateCompleted,
+            DateCreated = startDate ?? DateTime.UtcNow.AddDays(-30),
+            Version = 1
+        };
+    }
+
+    private static WorkoutLog CreateWorkoutLog(
+        Guid clientId,
+        Guid planId,
+        bool isCompleted = true)
+    {
+        return new WorkoutLog
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            PlanId = planId,
+            IsCompleted = isCompleted,
+            StartedAt = DateTime.UtcNow.AddDays(-5),
+            DateCreated = DateTime.UtcNow.AddDays(-5)
+        };
+    }
+
+    private static PersonalRecord CreatePersonalRecord(
+        Guid clientId,
+        DateTime? achievedAt = null)
+    {
+        return new PersonalRecord
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = clientId,
+            ExerciseExternalId = Guid.NewGuid(),
+            ExerciseName = "Bench Press",
+            WeightKg = 100m,
+            Reps = 5,
+            AchievedAt = achievedAt ?? DateTime.UtcNow.AddDays(-3),
+            WorkoutLogId = Guid.NewGuid(),
+            SetNumber = 1,
+            DateCreated = DateTime.UtcNow.AddDays(-3)
+        };
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/WorkoutLogCompletionUniquenessTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/WorkoutLogCompletionUniquenessTests.cs
@@ -509,4 +509,5 @@ internal sealed class BackfillTestMongoContext : IMongoContext
     public IMongoCollection<SectionTemplate> SectionTemplates => _db.GetCollection<SectionTemplate>("sectionTemplates");
     public IMongoCollection<SessionLock> SessionLocks         => _db.GetCollection<SessionLock>("sessionLocks");
     public IMongoCollection<SessionLog> SessionLogs           => _db.GetCollection<SessionLog>("sessionLogs");
+    public IMongoCollection<TrainerNote> TrainerNotes         => _db.GetCollection<TrainerNote>("trainer_notes");
 }

--- a/backend/FitnessPlatform.Tests/Services/ClientVerdictServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/ClientVerdictServiceTests.cs
@@ -1,0 +1,275 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Services;
+
+namespace FitnessPlatform.Tests.Services;
+
+/// <summary>
+/// Pure unit tests for <see cref="ClientVerdictService.ComputeVerdict"/>.
+/// No Docker required — no I/O, pure threshold logic.
+/// Covers every verdict branch required by issue #485 AC.
+/// </summary>
+public class ClientVerdictServiceTests
+{
+    // ── Shared helpers ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Calls ComputeVerdict with safe defaults for signals not under test.
+    /// All plans active by default; all signals "on track".
+    /// Pass <c>explicitLastActiveAt: null</c> to test the no-activity path.
+    /// </summary>
+    private static ClientVerdict Compute(
+        decimal? compliancePercent = 90m,
+        bool hasActiveNutritionPlan = true,
+        WeightDirection weightDirection = WeightDirection.Towards,
+        decimal? weightDeltaToGoal = -1m,
+        bool hasWeightSignal = true,
+        int? frequencyActual = 3,
+        int? frequencyPrescribed = 3,
+        bool hasActiveTrainingPlan = true,
+        DateTime? lastActiveAt = null,
+        bool noActivity = false)
+    {
+        // If the caller explicitly wants null (no activity), honour it.
+        // Otherwise default to "active yesterday" so inactivity doesn't interfere.
+        DateTime? resolvedLastActiveAt = noActivity ? null : (lastActiveAt ?? DateTime.UtcNow.AddDays(-1));
+
+        return ClientVerdictService.ComputeVerdict(
+            compliancePercent, hasActiveNutritionPlan,
+            weightDirection, weightDeltaToGoal, hasWeightSignal,
+            frequencyActual, frequencyPrescribed, hasActiveTrainingPlan,
+            resolvedLastActiveAt);
+    }
+
+    // ── Full OnTrack ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_AllSignalsGreen_ReturnsOnTrack()
+    {
+        var verdict = Compute(
+            compliancePercent: 92m,
+            weightDirection: WeightDirection.Towards,
+            weightDeltaToGoal: -0.5m,
+            frequencyActual: 3,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    // ── Single-signal NeedsAttention ──────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_ComplianceBetween60And84_ReturnsNeedsAttention()
+    {
+        // Compliance in [60, 84] is a soft signal — NeedsAttention, not OffTrack.
+        var verdict = Compute(compliancePercent: 72m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_ComplianceAt60_ReturnsNeedsAttention()
+    {
+        // Exactly 60% — the boundary between OffTrack (<60) and NeedsAttention ([60,84]).
+        var verdict = Compute(compliancePercent: 60m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightStable_ReturnsNeedsAttention()
+    {
+        var verdict = Compute(
+            weightDirection: WeightDirection.Stable,
+            weightDeltaToGoal: 0.2m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightAwaySmallDelta_ReturnsNeedsAttention()
+    {
+        // Away but delta <= WeightOffTrackDeltaKg (1 kg) is soft, not hard OffTrack.
+        var verdict = Compute(
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 0.8m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_FrequencyBelowPrescribed_ReturnsNeedsAttention()
+    {
+        var verdict = Compute(
+            frequencyActual: 2,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    // ── Multiple soft signals ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_TwoSoftSignalsOff_ReturnsNeedsAttention()
+    {
+        // Multiple soft signals still NeedsAttention — no hard threshold crossed.
+        var verdict = Compute(
+            compliancePercent: 75m,     // soft: [60, 84]
+            weightDirection: WeightDirection.Stable,
+            frequencyActual: 3,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    // ── OffTrack hard thresholds ──────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_ComplianceBelow60_ReturnsOffTrack()
+    {
+        var verdict = Compute(compliancePercent: 45m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_ComplianceAt59_ReturnsOffTrack()
+    {
+        // Just below the 60% threshold.
+        var verdict = Compute(compliancePercent: 59.9m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightAwayDeltaAbove1Kg_ReturnsOffTrack()
+    {
+        var verdict = Compute(
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 1.5m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_WeightAwayDeltaExactly1Kg_ReturnsNeedsAttention()
+    {
+        // Exactly 1 kg Away is NOT OffTrack — threshold is strict greater-than.
+        var verdict = Compute(
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 1.0m);
+
+        verdict.Should().Be(ClientVerdict.NeedsAttention);
+    }
+
+    [Fact]
+    public void ComputeVerdict_Inactivity_MoreThan14Days_ReturnsOffTrack()
+    {
+        // 15 days since last activity — strictly > 14 days.
+        var lastActive = DateTime.UtcNow.AddDays(-(ClientDashboardConstants.InactivityThresholdDays + 1));
+        var verdict = Compute(lastActiveAt: lastActive);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_Inactivity_Exactly14Days_ReturnsNotOffTrack()
+    {
+        // Exactly 14 days — the boundary: the code uses strict > so 14 days is NOT OffTrack.
+        // Give a small buffer (14 days minus a few seconds) to avoid floating-point edge in CI.
+        var lastActive = DateTime.UtcNow.AddDays(-ClientDashboardConstants.InactivityThresholdDays).AddSeconds(10);
+        var verdict = Compute(lastActiveAt: lastActive);
+
+        verdict.Should().NotBe(ClientVerdict.OffTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoActivity_WithActivePlan_ReturnsOffTrack()
+    {
+        // No activity at all + active plan = OffTrack.
+        var verdict = Compute(
+            noActivity: true,
+            hasActiveNutritionPlan: true,
+            compliancePercent: 90m);
+
+        verdict.Should().Be(ClientVerdict.OffTrack);
+    }
+
+    // ── Null-exclusion paths ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ComputeVerdict_NoActiveNutritionPlan_ComplianceExcluded_ReturnsOnTrack()
+    {
+        // No nutrition plan: compliancePercent signal is excluded — should still be OnTrack
+        // if all other signals are green.
+        var verdict = Compute(
+            compliancePercent: null,
+            hasActiveNutritionPlan: false,
+            weightDirection: WeightDirection.Towards,
+            frequencyActual: 3,
+            frequencyPrescribed: 3);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoActiveTrainingPlan_FrequencyExcluded_ReturnsOnTrack()
+    {
+        // No training plan: frequency signal is excluded — should still be OnTrack
+        // if all other signals are green.
+        var verdict = Compute(
+            compliancePercent: 90m,
+            hasActiveNutritionPlan: true,
+            frequencyActual: null,
+            frequencyPrescribed: null,
+            hasActiveTrainingPlan: false,
+            weightDirection: WeightDirection.Towards);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoWeightSignal_WeightExcluded_ReturnsOnTrack()
+    {
+        // No measurements or no target weight: weight signal excluded.
+        var verdict = Compute(
+            compliancePercent: 90m,
+            hasWeightSignal: false,
+            weightDirection: WeightDirection.Stable,
+            weightDeltaToGoal: null);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    [Fact]
+    public void ComputeVerdict_NoBotchPlans_NoActivity_ReturnsOnTrack()
+    {
+        // No active plans at all and no activity: no inactivity flag because no plans.
+        var verdict = Compute(
+            noActivity: true,
+            hasActiveNutritionPlan: false,
+            compliancePercent: null,
+            hasActiveTrainingPlan: false,
+            frequencyActual: null,
+            frequencyPrescribed: null,
+            hasWeightSignal: false,
+            weightDeltaToGoal: null);
+
+        verdict.Should().Be(ClientVerdict.OnTrack);
+    }
+
+    // ── WeightDirection.Away with no weight signal (edge case) ───────────────
+
+    [Fact]
+    public void ComputeVerdict_WeightAwayButNoSignal_DoesNotFlagOffTrack()
+    {
+        // hasWeightSignal=false means the weight signal is excluded even if Away+delta>1.
+        var verdict = Compute(
+            hasWeightSignal: false,
+            weightDirection: WeightDirection.Away,
+            weightDeltaToGoal: 5m);
+
+        verdict.Should().NotBe(ClientVerdict.OffTrack);
+    }
+}

--- a/web/src/api/client-plans.ts
+++ b/web/src/api/client-plans.ts
@@ -1,0 +1,92 @@
+import api from '@/lib/api';
+
+/**
+ * Plan type discriminator — mirrors the backend PlanType string.
+ */
+export type PlanType = 'Nutrition' | 'Training';
+
+/**
+ * Plan status discriminator — mirrors the backend plan status strings.
+ */
+export type PlanStatus = 'Draft' | 'Active' | 'Completed' | 'Archived';
+
+/**
+ * Per-plan result summary. Fields not applicable to the plan type are null.
+ * Mirrors backend ClientPlanResultSummary.
+ *
+ * Training-plan fields: totalTrainings, prCount.
+ * Nutrition-plan fields: compliancePercent, weightDeltaKg.
+ */
+export interface ClientPlanResultSummary {
+  /**
+   * Count of completed WorkoutLogs for this plan.
+   * Null for nutrition plans.
+   */
+  totalTrainings: number | null;
+  /**
+   * Count of PersonalRecords achieved within the plan's date window.
+   * Null for nutrition plans or plans without a StartDate.
+   */
+  prCount: number | null;
+  /**
+   * Nutrition compliance percent (0–100) over the plan period.
+   * Null for training plans or plans without a StartDate.
+   */
+  compliancePercent: number | null;
+  /**
+   * Weight delta (kg) from first to last measurement in the plan window.
+   * Positive = weight gained; negative = weight lost.
+   * Null for training plans or when fewer than two measurements exist.
+   */
+  weightDeltaKg: number | null;
+}
+
+/**
+ * A single plan entry in the combined client plan list.
+ * Mirrors backend ClientPlanItem.
+ */
+export interface ClientPlanItem {
+  /** The plan's public ExternalId (Guid). */
+  planId: string;
+  /** Discriminates the plan type: "Nutrition" or "Training". */
+  planType: PlanType;
+  /** Display name of the plan. */
+  name: string;
+  /** ISO 8601 UTC — the Monday when Week 1 begins. Null when not yet set. */
+  periodStart: string | null;
+  /**
+   * ISO 8601 UTC — when the plan was marked completed.
+   * Null for active/draft plans and open-ended plans.
+   */
+  periodEnd: string | null;
+  /** Current plan status: "Draft" | "Active" | "Completed" | "Archived". */
+  status: PlanStatus;
+  /** Per-plan result metrics. */
+  resultSummary: ClientPlanResultSummary;
+}
+
+/**
+ * Response from GET /trainer/clients/{clientId}/plans.
+ * Mirrors backend ListClientPlansResponse.
+ *
+ * NOTE: generated.ts does not yet contain this type — regen-api will be run
+ * once at the epic-PR stage to reconcile hand-written modules. This is the
+ * hand-authored source of truth for the web client until then.
+ */
+export interface ListClientPlansResponse {
+  /** All plans (nutrition + training), newest first. */
+  plans: ClientPlanItem[];
+}
+
+/**
+ * Fetch the combined plan list (nutrition + training) for a client.
+ * Route: GET /trainer/clients/{clientId}/plans
+ */
+export async function getClientPlans(
+  clientId: string,
+): Promise<ListClientPlansResponse> {
+  const { data } = await api.get<ListClientPlansResponse>(
+    `/trainer/clients/${clientId}/plans`,
+  );
+  return data;
+}

--- a/web/src/api/client-verdict.ts
+++ b/web/src/api/client-verdict.ts
@@ -1,0 +1,48 @@
+import api from '@/lib/api';
+
+/**
+ * On-track verdict for a client as assessed by the trainer dashboard.
+ * Mirrors backend ClientVerdict enum.
+ */
+export type ClientVerdict = 'OnTrack' | 'NeedsAttention' | 'OffTrack';
+
+/**
+ * Direction a client's weight is moving relative to their target.
+ * Mirrors backend WeightDirection enum.
+ */
+export type WeightDirection = 'Towards' | 'Away' | 'Stable';
+
+/**
+ * Response from GET /trainer/clients/{clientId}/verdict.
+ * NOTE: generated.ts does not yet contain this type — regen-api
+ * must be run once the backend is accessible on :5001 (epic branch).
+ * Until then this hand-authored mirror of GetClientVerdictResponse.cs
+ * is the source of truth for the web client.
+ */
+export interface ClientVerdictResponse {
+  verdict: ClientVerdict;
+  /** Nutrition plan compliance percent (0-100), or null when no active plan. */
+  compliancePercent: number | null;
+  /** Delta between current weight and target weight in kg, positive = above target. */
+  weightDeltaToGoal: number | null;
+  /** Direction the weight is moving relative to the goal. */
+  weightDirection: WeightDirection;
+  /** Sessions completed this ISO week, or null when no active training plan. */
+  trainingFrequencyActual: number | null;
+  /** Sessions prescribed per week in active training plan, or null. */
+  trainingFrequencyPrescribed: number | null;
+  /** UTC timestamp of the most recent activity, or null. */
+  lastActiveAt: string | null;
+  /** Number of personal records achieved in the current calendar month. */
+  prCountThisMonth: number;
+}
+
+/** Fetch the on-track verdict for a client. */
+export async function getClientVerdict(
+  clientId: string,
+): Promise<ClientVerdictResponse> {
+  const { data } = await api.get<ClientVerdictResponse>(
+    `/trainer/clients/${clientId}/verdict`,
+  );
+  return data;
+}

--- a/web/src/api/measurements.ts
+++ b/web/src/api/measurements.ts
@@ -1,0 +1,21 @@
+import api from '@/lib/api';
+import type { GetMeasurementsResponse } from '@/api/generated';
+
+/**
+ * Fetch body measurements for a trainer's client.
+ * Wraps GET /trainer/clients/{clientId}/measurements (read-only trainer endpoint).
+ *
+ * Note: there is no trainer add-measurement endpoint — only clients can POST /client/measurements.
+ * A trainer add-measurement flow is tracked as a future backend+web issue.
+ */
+export async function getClientMeasurements(
+  clientId: string,
+  page = 1,
+  pageSize = 50,
+): Promise<GetMeasurementsResponse> {
+  const { data } = await api.get<GetMeasurementsResponse>(
+    `/trainer/clients/${clientId}/measurements`,
+    { params: { page, pageSize } },
+  );
+  return data;
+}

--- a/web/src/api/trainer-notes.ts
+++ b/web/src/api/trainer-notes.ts
@@ -1,0 +1,67 @@
+import api from '@/lib/api';
+
+export interface TrainerNote {
+  noteId: string;
+  text: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateNoteResponse {
+  noteId: string;
+  createdAt: string;
+}
+
+export interface ListNotesResponse {
+  notes: TrainerNote[];
+  totalCount: number;
+}
+
+export async function createNote(
+  clientId: string,
+  text: string,
+): Promise<CreateNoteResponse> {
+  const { data } = await api.post<CreateNoteResponse>(
+    `/trainer/clients/${clientId}/notes`,
+    { text },
+  );
+  return data;
+}
+
+export async function listNotes(
+  clientId: string,
+  page = 1,
+  pageSize = 20,
+): Promise<ListNotesResponse> {
+  const { data, headers } = await api.get<{ notes: TrainerNote[] }>(
+    `/trainer/clients/${clientId}/notes`,
+    { params: { page, pageSize } },
+  );
+  const totalCount = parseInt(headers['x-total-count'] ?? '0', 10);
+  return { notes: data.notes ?? [], totalCount };
+}
+
+export interface EditNoteResponse {
+  noteId: string;
+  text: string;
+  updatedAt: string;
+}
+
+export async function updateNote(
+  clientId: string,
+  noteId: string,
+  text: string,
+): Promise<EditNoteResponse> {
+  const { data } = await api.patch<EditNoteResponse>(
+    `/trainer/clients/${clientId}/notes/${noteId}`,
+    { text },
+  );
+  return data;
+}
+
+export async function deleteNote(
+  clientId: string,
+  noteId: string,
+): Promise<void> {
+  await api.delete(`/trainer/clients/${clientId}/notes/${noteId}`);
+}

--- a/web/src/components/clients/ActiveNutritionPlanCard.tsx
+++ b/web/src/components/clients/ActiveNutritionPlanCard.tsx
@@ -1,0 +1,118 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { PlanSummary, GlobalNutritionSettings } from '@/api/plan-types';
+
+interface ActiveNutritionPlanCardProps {
+  plan: PlanSummary;
+  /** Macro targets from the plan detail. PlanSummary does not carry globalSettings. */
+  globalSettings?: GlobalNutritionSettings | null;
+  targetWeightKg?: number | null;
+  goalLabel?: string | null;
+  compliancePercent?: number | null;
+  onHistoryClick: () => void;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('cs-CZ', { day: 'numeric', month: 'numeric', year: 'numeric' });
+}
+
+export function ActiveNutritionPlanCard({
+  plan,
+  globalSettings,
+  targetWeightKg,
+  goalLabel,
+  compliancePercent,
+  onHistoryClick,
+}: ActiveNutritionPlanCardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const gs = globalSettings;
+  const periodStart = formatDate(plan.startDate);
+  const periodEnd = formatDate(plan.dateCompleted);
+  const period = periodStart && periodEnd
+    ? `${periodStart} – ${periodEnd}`
+    : periodStart
+      ? t('clientDetail.prehled.planCard.from', { date: periodStart })
+      : '';
+
+  const complianceColor = compliancePercent != null
+    ? compliancePercent >= 80
+      ? 'text-green bg-green-bg'
+      : compliancePercent >= 60
+        ? 'text-orange bg-orange-bg'
+        : 'text-red bg-red-bg'
+    : 'text-text3 bg-bg3';
+
+  return (
+    <div
+      onClick={() => navigate(`/nutrition/plans/${plan.planId}`)}
+      className="border border-border rounded-[var(--radius-lg)] p-4 cursor-pointer transition-[border-color] hover:border-accent-br"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/nutrition/plans/${plan.planId}`); }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="text-[14px] font-bold text-text">🥗 {plan.name}</div>
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-bg text-green">
+          {t('clientDetail.prehled.planCard.active')}
+        </span>
+      </div>
+
+      {/* Period */}
+      {period && (
+        <div className="text-[11px] text-text3 mb-2.5">{period}</div>
+      )}
+
+      {/* Goal */}
+      {(goalLabel || targetWeightKg != null) && (
+        <div className="text-[13px] text-text2 mb-1.5">
+          {t('clientDetail.prehled.planCard.goal')}:{' '}
+          {goalLabel && <b className="text-text">{goalLabel}</b>}
+          {goalLabel && targetWeightKg != null && ' → '}
+          {targetWeightKg != null && (
+            <b className="text-text">
+              {t('clientDetail.prehled.planCard.targetWeight', { kg: targetWeightKg })}
+            </b>
+          )}
+        </div>
+      )}
+
+      {/* Macros */}
+      {gs?.dailyKcal != null && (
+        <div className="text-[16px] font-bold text-accent tracking-[-0.01em] mb-2.5">
+          {gs.dailyKcal} kcal
+          {gs.proteinGrams != null && ` · ${gs.proteinGrams} P`}
+          {gs.carbsGrams != null && ` / ${gs.carbsGrams} C`}
+          {gs.fatGrams != null && ` / ${gs.fatGrams} F`}
+        </div>
+      )}
+
+      {/* Compliance pills */}
+      {compliancePercent != null && (
+        <div className="flex gap-1.5 mb-3">
+          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${complianceColor}`}>
+            {t('clientDetail.prehled.planCard.compliance', { pct: compliancePercent })}
+          </span>
+        </div>
+      )}
+
+      {/* Footer links */}
+      <div className="flex items-center justify-between mt-auto pt-0.5">
+        <span className="text-[12px] font-semibold text-accent">
+          {t('clientDetail.prehled.planCard.openNutrition')} →
+        </span>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onHistoryClick(); }}
+          className="text-[12px] text-text3 bg-transparent border-none cursor-pointer hover:text-text2 transition-colors"
+        >
+          {t('clientDetail.prehled.planCard.history')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/ActiveTrainingPlanCard.tsx
+++ b/web/src/components/clients/ActiveTrainingPlanCard.tsx
@@ -1,0 +1,119 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { TrainingPlanSummary } from '@/api/training-plan-types';
+import type { TopPrRecord } from '@/components/domain/RecentActivity/useRecentActivityAggregates';
+
+interface ActiveTrainingPlanCardProps {
+  plan: TrainingPlanSummary;
+  /** Number of sessions completed this week. */
+  trainingFrequencyActual?: number | null;
+  /** Sessions prescribed per week. */
+  trainingFrequencyPrescribed?: number | null;
+  /** Number of PRs achieved this month. */
+  prCountThisMonth?: number;
+  /** Top personal record this month derived from the client timeline. */
+  topPr?: TopPrRecord | null;
+  onHistoryClick: () => void;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('cs-CZ', { day: 'numeric', month: 'numeric', year: 'numeric' });
+}
+
+export function ActiveTrainingPlanCard({
+  plan,
+  trainingFrequencyActual,
+  trainingFrequencyPrescribed,
+  prCountThisMonth,
+  topPr,
+  onHistoryClick,
+}: ActiveTrainingPlanCardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const periodStart = formatDate(plan.startDate);
+  const period = periodStart
+    ? t('clientDetail.prehled.planCard.from', { date: periodStart })
+    : '';
+
+  const frequencyLabel = trainingFrequencyPrescribed != null
+    ? t('clientDetail.prehled.trainingCard.weeklyFrequency', { count: trainingFrequencyPrescribed })
+    : null;
+
+  const thisWeekLabel = trainingFrequencyActual != null
+    ? t('clientDetail.prehled.trainingCard.thisWeek', { count: trainingFrequencyActual })
+    : null;
+
+  return (
+    <div
+      onClick={() => navigate(`/training/plans/${plan.planId}`)}
+      className="border border-border rounded-[var(--radius-lg)] p-4 cursor-pointer transition-[border-color] hover:border-accent-br"
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/training/plans/${plan.planId}`); }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="text-[14px] font-bold text-text">🏋️ {plan.name}</div>
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-bg text-green">
+          {t('clientDetail.prehled.planCard.active')}
+        </span>
+      </div>
+
+      {/* Period */}
+      {period && (
+        <div className="text-[11px] text-text3 mb-2.5">{period}</div>
+      )}
+
+      {/* Description + frequency */}
+      {(plan.description || frequencyLabel) && (
+        <div className="text-[13px] text-text2 mb-1.5">
+          {frequencyLabel && <b className="text-text">{frequencyLabel}</b>}
+          {plan.description && frequencyLabel && ' · '}
+          {plan.description && <b className="text-text">{plan.description}</b>}
+        </div>
+      )}
+
+      {/* PR count + top PR */}
+      {prCountThisMonth != null && (
+        <div className="text-[16px] font-bold text-accent tracking-[-0.01em] mb-1">
+          {t('clientDetail.prehled.trainingCard.prThisMonth', { count: prCountThisMonth })}
+        </div>
+      )}
+      {topPr && (
+        <div className="text-[12px] text-text2 mb-2.5">
+          {t('clientDetail.prehled.trainingCard.topPr', {
+            name: topPr.exerciseName,
+            kg: topPr.weightKg,
+            reps: topPr.reps,
+          })}
+        </div>
+      )}
+
+      {/* Pills */}
+      <div className="flex gap-1.5 mb-3 flex-wrap">
+        {thisWeekLabel && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-green-bg text-green">
+            {thisWeekLabel}
+          </span>
+        )}
+      </div>
+
+      {/* Footer links */}
+      <div className="flex items-center justify-between mt-auto pt-0.5">
+        <span className="text-[12px] font-semibold text-accent">
+          {t('clientDetail.prehled.trainingCard.openTraining')} →
+        </span>
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onHistoryClick(); }}
+          className="text-[12px] text-text3 bg-transparent border-none cursor-pointer hover:text-text2 transition-colors"
+        >
+          {t('clientDetail.prehled.planCard.history')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/ClientTabBar.tsx
+++ b/web/src/components/clients/ClientTabBar.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from 'react-i18next';
+
+export type ClientTabId =
+  | 'prehled'
+  | 'mereni'
+  | 'fotky'
+  | 'aktivita'
+  | 'plany'
+  | 'checkiny'
+  | 'dotazniky'
+  | 'poznamky';
+
+interface ClientTabBarProps {
+  activeTab: ClientTabId;
+  onTabChange: (tab: ClientTabId) => void;
+}
+
+interface TabDef {
+  id: ClientTabId;
+  labelKey: string;
+}
+
+const TABS: TabDef[] = [
+  { id: 'prehled',    labelKey: 'clientDetail.tabs.prehled' },
+  { id: 'mereni',     labelKey: 'clientDetail.tabs.mereni' },
+  { id: 'fotky',      labelKey: 'clientDetail.tabs.fotky' },
+  { id: 'aktivita',   labelKey: 'clientDetail.tabs.aktivita' },
+  { id: 'plany',      labelKey: 'clientDetail.tabs.plany' },
+  { id: 'checkiny',   labelKey: 'clientDetail.tabs.checkiny' },
+  { id: 'dotazniky',  labelKey: 'clientDetail.tabs.dotazniky' },
+  { id: 'poznamky',   labelKey: 'clientDetail.tabs.poznamky' },
+];
+
+export function ClientTabBar({ activeTab, onTabChange }: ClientTabBarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="flex items-center gap-1 px-20 py-2 border-b border-border"
+      role="tablist"
+      aria-label={t('clientDetail.tabBarLabel')}
+    >
+      {TABS.map((tab) => {
+        const isActive = tab.id === activeTab;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`cl-pane-${tab.id}`}
+            id={`cl-tab-${tab.id}`}
+            onClick={() => onTabChange(tab.id)}
+            className={
+              isActive
+                ? 'inline-flex items-center px-3 py-1 rounded-full text-[13px] font-medium cursor-pointer bg-accent text-white border-none'
+                : 'inline-flex items-center px-3 py-1 rounded-full text-[13px] font-medium cursor-pointer bg-transparent text-text2 border-none hover:text-text transition-colors'
+            }
+          >
+            {t(tab.labelKey)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/clients/IdentityStrip.tsx
+++ b/web/src/components/clients/IdentityStrip.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui';
+import type { ClientDashboard } from '@/api/nutrition-goals';
+
+interface IdentityStripProps {
+  client: ClientDashboard;
+  clientId: string;
+  clientInitials: string;
+  clientAge: number | null;
+  onEditProfile: () => void;
+  onPhotoDiary: () => void;
+}
+
+export function IdentityStrip({
+  client,
+  clientId,
+  clientInitials,
+  clientAge,
+  onEditProfile,
+  onPhotoDiary,
+}: IdentityStripProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const ob = client.onboarding;
+  const allergiesRaw = ob?.allergies ?? null;
+  let allergiesDisplay: string | null = null;
+  if (allergiesRaw) {
+    try {
+      const arr = JSON.parse(allergiesRaw) as unknown;
+      if (Array.isArray(arr)) {
+        allergiesDisplay = arr.join(', ');
+      } else {
+        allergiesDisplay = allergiesRaw;
+      }
+    } catch {
+      allergiesDisplay = allergiesRaw;
+    }
+  }
+
+  const clientName = `${client.firstName} ${client.lastName}`;
+  const height = client.heightCm;
+
+  return (
+    <div className="flex items-center gap-3.5 px-20 py-5 pb-3.5 max-w-[1200px]">
+      {/* Avatar with camera badge */}
+      <div className="relative flex-shrink-0">
+        <div
+          className="w-12 h-12 rounded-full bg-bg3 flex items-center justify-center font-semibold text-[18px] text-text2"
+          aria-label={clientInitials}
+        >
+          {clientInitials}
+        </div>
+        <button
+          type="button"
+          onClick={onPhotoDiary}
+          title={t('clientDetail.photoDiary')}
+          className="absolute -right-0.5 -bottom-0.5 w-5 h-5 rounded-full bg-accent border-2 border-bg flex items-center justify-center text-white text-[9px] cursor-pointer"
+        >
+          📷
+        </button>
+      </div>
+
+      {/* Name + meta line */}
+      <div className="min-w-0 flex-1">
+        <h1 className="text-[21px] font-bold tracking-[-0.02em] leading-[1.15] text-text">
+          {clientName}
+        </h1>
+        <div className="flex items-center gap-2 mt-0.5 text-[13px] text-text3">
+          {clientAge != null && (
+            <span>
+              {t('clientDetail.ageYears', { count: clientAge })}
+            </span>
+          )}
+          {clientAge != null && height != null && (
+            <span className="text-text4">·</span>
+          )}
+          {height != null && (
+            <span>{height} cm</span>
+          )}
+          {allergiesDisplay && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-orange-bg text-orange">
+              ⚠ {allergiesDisplay}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="ml-auto flex items-center gap-1.5">
+        <Button onClick={onPhotoDiary}>
+          📸 {t('clientDetail.photoDiary')}
+        </Button>
+        <Button onClick={onEditProfile}>
+          ✏ {t('clients.editProfile')}
+        </Button>
+        <Button
+          variant="primary"
+          onClick={() => navigate(`/messages?clientId=${clientId}`)}
+        >
+          ✉ {t('clientDetail.writeMessage')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/PlanCardPlaceholder.tsx
+++ b/web/src/components/clients/PlanCardPlaceholder.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from 'react-i18next';
+
+interface PlanCardPlaceholderProps {
+  type: 'nutrition' | 'training';
+  onCreatePlan?: () => void;
+}
+
+export function PlanCardPlaceholder({ type, onCreatePlan }: PlanCardPlaceholderProps) {
+  const { t } = useTranslation();
+
+  const icon = type === 'nutrition' ? '🥗' : '🏋️';
+  const labelKey = type === 'nutrition'
+    ? 'clientDetail.prehled.noActivePlan.nutrition'
+    : 'clientDetail.prehled.noActivePlan.training';
+  const ctaKey = type === 'nutrition'
+    ? 'clientDetail.prehled.noActivePlan.createNutrition'
+    : 'clientDetail.prehled.noActivePlan.createTraining';
+
+  return (
+    <div className="border border-border border-dashed rounded-[var(--radius-lg)] p-4 flex flex-col items-center justify-center gap-2 text-center min-h-[140px]">
+      <div className="text-[28px] opacity-40">{icon}</div>
+      <div className="text-[13px] text-text3">{t(labelKey)}</div>
+      {onCreatePlan && (
+        <button
+          type="button"
+          onClick={onCreatePlan}
+          className="mt-1 text-[12px] font-medium text-accent hover:underline bg-transparent border-none cursor-pointer"
+        >
+          {t(ctaKey)}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/clients/ProgressSnapshot.tsx
+++ b/web/src/components/clients/ProgressSnapshot.tsx
@@ -1,0 +1,147 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ClientVerdictResponse } from '@/api/client-verdict';
+
+interface WeightBar {
+  pct: number;
+  highlight: boolean;
+}
+
+interface ProgressSnapshotProps {
+  startWeight?: number | null;
+  currentWeight?: number | null;
+  targetWeight?: number | null;
+  verdict?: ClientVerdictResponse | null;
+  onAllMeasurementsClick: () => void;
+}
+
+export function ProgressSnapshot({
+  startWeight,
+  currentWeight,
+  targetWeight,
+  verdict,
+  onAllMeasurementsClick,
+}: ProgressSnapshotProps) {
+  const { t } = useTranslation();
+
+  // Build bar chart data from the weight series (same algorithm as old page)
+  const bars = useMemo((): WeightBar[] => {
+    if (startWeight == null || currentWeight == null) return [];
+
+    const tgt = targetWeight ?? currentWeight;
+    const values = [startWeight, currentWeight, tgt];
+    const maxVal = Math.max(...values);
+    const minVal = Math.min(...values);
+    const floor = Math.max(0, minVal - (maxVal - minVal) * 0.5);
+    const range = maxVal - floor || 1;
+
+    return [
+      { pct: ((startWeight - floor) / range) * 100, highlight: false },
+      { pct: ((currentWeight - floor) / range) * 100, highlight: true },
+      { pct: ((tgt - floor) / range) * 100, highlight: false },
+    ];
+  }, [startWeight, currentWeight, targetWeight]);
+
+  const weightDelta = startWeight != null && currentWeight != null
+    ? Math.round((currentWeight - startWeight) * 10) / 10
+    : null;
+  const remaining = currentWeight != null && targetWeight != null
+    ? Math.round(Math.abs(targetWeight - currentWeight) * 10) / 10
+    : null;
+
+  const prTotal = verdict?.prCountThisMonth ?? 0;
+
+  return (
+    <div className="grid gap-3.5" style={{ gridTemplateColumns: '1.5fr 1fr' }}>
+      {/* Weight progress bar chart */}
+      <div className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5">
+        <div className="flex items-center justify-between mb-2.5">
+          <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium">
+            {t('clientDetail.prehled.progress.weightTitle')}
+          </div>
+          <button
+            type="button"
+            onClick={onAllMeasurementsClick}
+            className="text-[11px] font-semibold text-accent bg-transparent border-none cursor-pointer hover:underline"
+          >
+            {t('clientDetail.prehled.progress.allMeasurements')} →
+          </button>
+        </div>
+
+        {bars.length > 0 ? (
+          <>
+            <div className="flex items-end gap-1.5 h-[72px] py-1">
+              {bars.map((bar, i) => (
+                <div
+                  key={i}
+                  className="flex-1 rounded-t-sm"
+                  style={{
+                    height: `${Math.max(bar.pct, 8)}%`,
+                    backgroundColor: 'var(--accent)',
+                    opacity: bar.highlight ? 0.7 : 0.45,
+                  }}
+                />
+              ))}
+            </div>
+            <div className="flex items-baseline justify-between mt-2">
+              <div className="text-[13px] text-text2">
+                {startWeight} → <b className="text-text">{currentWeight} kg</b>
+                {weightDelta != null && weightDelta !== 0 && (
+                  <span className={`ml-1.5 text-[11px] ${weightDelta < 0 ? 'text-green' : 'text-orange'}`}>
+                    ({weightDelta < 0 ? '' : '+'}{weightDelta} kg)
+                  </span>
+                )}
+              </div>
+              {remaining != null && targetWeight != null && (
+                <div className="text-[12px] text-green">
+                  {t('clientDetail.prehled.progress.remaining', { kg: remaining })}
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="text-[13px] text-text3 py-6 text-center">
+            {t('clientDetail.prehled.progress.noData')}
+          </div>
+        )}
+      </div>
+
+      {/* This month stats tile */}
+      <div className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5">
+        <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium mb-2.5">
+          {t('clientDetail.prehled.progress.thisMonth')}
+        </div>
+        <div className="flex flex-col gap-1.5 text-[13px]">
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              🏆 {t('clientDetail.prehled.progress.stats.prTotal')}
+            </span>
+            <b className="text-[15px]">{prTotal}</b>
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              🏋️ {t('clientDetail.prehled.progress.stats.workouts')}
+            </span>
+            <b className="text-[15px]">
+              {verdict?.trainingFrequencyActual != null ? verdict.trainingFrequencyActual : '—'}
+            </b>
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              📏 {t('clientDetail.prehled.progress.stats.measurements')}
+            </span>
+            <b className="text-[15px]">—</b>
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-text2">
+              🥗 {t('clientDetail.prehled.progress.stats.completedDays')}
+            </span>
+            <b className="text-[15px]">
+              {verdict?.compliancePercent != null ? `${verdict.compliancePercent} %` : '—'}
+            </b>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/VerdictHeroCard.tsx
+++ b/web/src/components/clients/VerdictHeroCard.tsx
@@ -1,0 +1,153 @@
+import { useTranslation } from 'react-i18next';
+import type { ClientVerdictResponse } from '@/api/client-verdict';
+
+interface VerdictHeroCardProps {
+  verdict: ClientVerdictResponse;
+}
+
+export function VerdictHeroCard({ verdict }: VerdictHeroCardProps) {
+  const { t } = useTranslation();
+
+  const isOnTrack = verdict.verdict === 'OnTrack';
+  const isNeedsAttention = verdict.verdict === 'NeedsAttention';
+
+  const borderClass = isOnTrack
+    ? 'border-green-bg'
+    : isNeedsAttention
+      ? 'border-orange-bg'
+      : 'border-red-bg';
+
+  const bgClass = isOnTrack
+    ? 'bg-green-bg'
+    : isNeedsAttention
+      ? 'bg-orange-bg'
+      : 'bg-red-bg';
+
+  const emoji = isOnTrack ? '✅' : isNeedsAttention ? '⚠️' : '🔴';
+
+  const labelKey = isOnTrack
+    ? 'clientDetail.verdict.onTrack.label'
+    : isNeedsAttention
+      ? 'clientDetail.verdict.needsAttention.label'
+      : 'clientDetail.verdict.offTrack.label';
+
+  const subtitleKey = isOnTrack
+    ? 'clientDetail.verdict.onTrack.subtitle'
+    : isNeedsAttention
+      ? 'clientDetail.verdict.needsAttention.subtitle'
+      : 'clientDetail.verdict.offTrack.subtitle';
+
+  const valueColorClass = isOnTrack
+    ? 'text-green'
+    : isNeedsAttention
+      ? 'text-orange'
+      : 'text-red';
+
+  const labelColorClass = isOnTrack
+    ? 'text-green'
+    : isNeedsAttention
+      ? 'text-orange'
+      : 'text-red';
+
+  // Format weight delta signal
+  const weightSignal = verdict.weightDeltaToGoal != null
+    ? `${verdict.weightDeltaToGoal < 0 ? '' : '+'}${verdict.weightDeltaToGoal.toFixed(1)} kg ${verdict.weightDirection === 'Towards' ? '↘' : verdict.weightDirection === 'Away' ? '↗' : '→'}`
+    : '—';
+
+  // Training frequency signal
+  const trainingSignal = verdict.trainingFrequencyActual != null && verdict.trainingFrequencyPrescribed != null
+    ? `${verdict.trainingFrequencyActual} / ${verdict.trainingFrequencyPrescribed}`
+    : '—';
+
+  return (
+    <div
+      className={`flex items-center gap-4 flex-wrap border ${borderClass} ${bgClass} rounded-[var(--radius-lg)] px-5 py-4 mb-4`}
+      style={{ borderColor: `var(--${isOnTrack ? 'green' : isNeedsAttention ? 'orange' : 'red'}-br)` }}
+    >
+      {/* Emoji + label */}
+      <div className="flex items-center gap-2.5">
+        <div className="text-[24px] leading-none">{emoji}</div>
+        <div>
+          <div className={`text-[17px] font-bold tracking-[-0.01em] ${labelColorClass}`}>
+            {t(labelKey)}
+          </div>
+          <div className="text-[12px] text-text3 mt-0.5">
+            {t(subtitleKey)}
+          </div>
+        </div>
+      </div>
+
+      {/* Signal stats */}
+      <div className="flex gap-6 ml-auto flex-wrap">
+        {/* Compliance */}
+        <div className="text-center">
+          <div className={`text-[17px] font-bold leading-none ${verdict.compliancePercent != null ? valueColorClass : 'text-text3'}`}>
+            {verdict.compliancePercent != null ? `${verdict.compliancePercent} %` : '—'}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.compliance')}
+          </div>
+        </div>
+
+        {/* Weight delta */}
+        <div className="text-center">
+          <div className={`text-[17px] font-bold leading-none ${verdict.weightDeltaToGoal != null ? valueColorClass : 'text-text3'}`}>
+            {weightSignal}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.weightDelta')}
+          </div>
+        </div>
+
+        {/* Training frequency */}
+        <div className="text-center">
+          <div className="text-[17px] font-bold leading-none text-text">
+            {trainingSignal}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.trainingsPerWeek')}
+          </div>
+        </div>
+
+        {/* PR this month */}
+        <div className="text-center">
+          <div className="text-[17px] font-bold leading-none text-text">
+            {verdict.prCountThisMonth}
+          </div>
+          <div className="text-[10px] uppercase tracking-[0.04em] text-text3 mt-0.5">
+            {t('clientDetail.verdict.signals.prThisMonth')}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Fallback rendered when the verdict query fails (404/403). */
+export function VerdictHeroCardError() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2.5 border border-border bg-bg2 rounded-[var(--radius-lg)] px-5 py-4 mb-4">
+      <div className="text-[20px] leading-none text-text3">—</div>
+      <div className="text-[13px] text-text3">{t('clientDetail.verdict.unavailable')}</div>
+    </div>
+  );
+}
+
+/** Skeleton loading state for the verdict hero. */
+export function VerdictHeroCardSkeleton() {
+  return (
+    <div className="flex items-center gap-4 border border-border bg-bg2 rounded-[var(--radius-lg)] px-5 py-4 mb-4 animate-pulse">
+      <div className="w-6 h-6 bg-bg3 rounded-full" />
+      <div className="h-4 bg-bg3 rounded w-32" />
+      <div className="ml-auto flex gap-6">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="text-center">
+            <div className="h-5 bg-bg3 rounded w-12 mb-1" />
+            <div className="h-2.5 bg-bg3 rounded w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/clients/tabs/AktivitaTab.tsx
+++ b/web/src/components/clients/tabs/AktivitaTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Aktivita tab — filled in by a wave-3 sub-issue. */
+export function AktivitaTab() {
+  return <div id="cl-pane-aktivita" />;
+}

--- a/web/src/components/clients/tabs/AktivitaTab.tsx
+++ b/web/src/components/clients/tabs/AktivitaTab.tsx
@@ -1,4 +1,259 @@
-/** Placeholder for the Aktivita tab — filled in by a wave-3 sub-issue. */
-export function AktivitaTab() {
-  return <div id="cl-pane-aktivita" />;
+import { useId, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { cn } from '@/lib/cn';
+import { getClientTimeline } from '@/api/timeline';
+import { DayCard } from '@/components/domain/RecentActivity/DayCard';
+import {
+  useRecentActivityAggregates,
+  dayGroupMatchesFilter,
+  type FilterType,
+} from '@/components/domain/RecentActivity/useRecentActivityAggregates';
+
+/** Maximum items the timeline endpoint returns. Disables "Zobrazit více" at this cap. */
+const LIMIT_MAX = 100;
+
+/** Initial number of timeline items to load. */
+const LIMIT_INITIAL = 30;
+
+/** Increment per "Zobrazit více" click. */
+const LIMIT_INCREMENT = 30;
+
+interface FilterChipDef {
+  id: FilterType;
+  label: string;
+}
+
+/** Returns a YYYY-MM string for the current calendar month. */
+function currentMonthKey(): string {
+  const now = new Date();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  return `${now.getFullYear()}-${m}`;
+}
+
+/** Format a YYYY-MM key into a localised "Month Year" string using Intl. */
+function formatMonthLabel(monthKey: string, locale: string): string {
+  const [year, month] = monthKey.split('-').map(Number);
+  const date = new Date(year, month - 1, 1);
+  return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
+}
+
+interface AktivitaTabProps {
+  clientId: string;
+}
+
+export function AktivitaTab({ clientId }: AktivitaTabProps) {
+  const { t, i18n } = useTranslation();
+  const monthSelectId = useId();
+
+  const [limit, setLimit] = useState(LIMIT_INITIAL);
+  const [activeFilter, setActiveFilter] = useState<FilterType>('all');
+  const [selectedMonthKey, setSelectedMonthKey] = useState<string>(currentMonthKey);
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['client-timeline', clientId, limit],
+    queryFn: () => getClientTimeline(clientId, limit),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  // Stabilise the array reference: produce a new value only when `data` changes.
+  // A plain `data?.items ?? []` would create a new array on every render while
+  // `data` is undefined (the entire loading phase), which feeds instability into
+  // `availableMonths` and triggers the "adjust state during render" guard on
+  // every render — causing the "Too many re-renders" crash.
+  const items = useMemo(() => data?.items ?? [], [data]);
+
+  const aggregates = useRecentActivityAggregates(items);
+
+  const filterChips: FilterChipDef[] = [
+    { id: 'all', label: t('clients.recentActivity.filterAll') },
+    { id: 'pr', label: t('clients.recentActivity.filterPr') },
+    { id: 'workout', label: t('clients.recentActivity.filterWorkout') },
+    { id: 'measurement', label: t('clients.recentActivity.filterMeasurement') },
+    { id: 'meal', label: t('clients.recentActivity.filterMeal') },
+  ];
+
+  /**
+   * Unique YYYY-MM values present in the loaded items, sorted newest-first.
+   * Always includes the current month so the picker has a default even when
+   * no items have loaded for this month yet.
+   */
+  const availableMonths = useMemo<string[]>(() => {
+    const monthSet = new Set<string>();
+    for (const item of items) {
+      monthSet.add(item.occurredAt.substring(0, 7));
+    }
+    monthSet.add(currentMonthKey());
+    return Array.from(monthSet).sort((a, b) => b.localeCompare(a));
+  }, [items]);
+
+  // Durable state normalisation — "adjust state during render" idiom (React docs).
+  // When availableMonths changes and selectedMonthKey is no longer present, reset
+  // to the most recent month. React discards the in-progress render and immediately
+  // re-renders with the corrected state — no intermediate commit, no visual flash.
+  const [prevAvailableMonths, setPrevAvailableMonths] = useState(availableMonths);
+  if (availableMonths !== prevAvailableMonths) {
+    setPrevAvailableMonths(availableMonths);
+    if (!availableMonths.includes(selectedMonthKey)) {
+      setSelectedMonthKey(availableMonths[0] ?? currentMonthKey());
+    }
+  }
+
+  // Render-path safety: ensure the select value always matches an available option.
+  const effectiveMonthKey = availableMonths.includes(selectedMonthKey)
+    ? selectedMonthKey
+    : (availableMonths[0] ?? currentMonthKey());
+
+  const filteredGroups = useMemo(
+    () =>
+      aggregates.dayGroups
+        .filter((g) => dayGroupMatchesFilter(g, activeFilter))
+        .filter((g) => g.dateKey.startsWith(effectiveMonthKey)),
+    [aggregates.dayGroups, activeFilter, effectiveMonthKey],
+  );
+
+  const canLoadMore = limit < LIMIT_MAX && items.length >= limit;
+  const isEmpty = !isPending && !isError && items.length === 0;
+  const isFilterEmpty = !isPending && !isError && items.length > 0 && filteredGroups.length === 0;
+
+  // Pass i18n.language directly — Intl.DateTimeFormat accepts any BCP-47 tag
+  // (including region variants like "en-US"). The previous cast to a narrow
+  // union was incorrect and the `?? 'cs'` fallback was dead (strings are never
+  // nullish).
+  const locale = i18n.language;
+
+  return (
+    <div id="cl-pane-aktivita">
+      {/* Loading state */}
+      {isPending && (
+        <div className="py-12 text-center text-[13px] text-text3">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error state — mirrors MereniTab pattern */}
+      {isError && !isPending && (
+        <div className="py-12 text-center text-[13px] text-text3">
+          {t('clients.recentActivity.errorLoading')}
+        </div>
+      )}
+
+      {/* Content — filter bar, cards, footer */}
+      {!isPending && !isError && (
+        <>
+          {/* Filter chip bar */}
+          <div className="flex gap-1.5 mb-3 flex-wrap">
+            {filterChips.map((chip) => (
+              <button
+                key={chip.id}
+                type="button"
+                onClick={() => setActiveFilter(chip.id)}
+                className={cn(
+                  'flex items-center gap-1 px-2.5 py-1 rounded-full text-xs border border-border-md bg-bg text-text2 cursor-pointer transition-colors hover:bg-bg-hover',
+                  chip.id === activeFilter &&
+                    'bg-accent-bg text-accent font-medium border-accent-br',
+                )}
+              >
+                {chip.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Empty state — no items at all */}
+          {isEmpty && (
+            <div className="py-12 text-center">
+              <p className="text-[13px] text-text3 mb-2">
+                {t('clients.recentActivity.empty')}
+              </p>
+            </div>
+          )}
+
+          {/* Filter/month yields no matches — show message + reset CTA */}
+          {isFilterEmpty && (
+            <div className="py-8 text-center">
+              <p className="text-[13px] text-text3 mb-2">
+                {t('clients.recentActivity.noEventsForFilter')}
+              </p>
+              {activeFilter !== 'all' && (
+                <button
+                  type="button"
+                  onClick={() => setActiveFilter('all')}
+                  className="text-[13px] font-medium text-accent hover:underline bg-transparent border-none cursor-pointer"
+                >
+                  {t('clients.recentActivity.resetFilter')}
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Day cards — reverse-chronological */}
+          {filteredGroups.length > 0 && (
+            <div className="mb-3">
+              {filteredGroups.map((group, idx) => (
+                <DayCard
+                  key={group.dateKey}
+                  group={group}
+                  filter={activeFilter}
+                  defaultExpanded={idx === 0}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Footer: Zobrazit více + month picker — only when items loaded */}
+          {!isEmpty && (
+            <div className="flex items-center gap-3 mt-1 flex-wrap">
+              <button
+                type="button"
+                disabled={!canLoadMore}
+                onClick={
+                  canLoadMore
+                    ? () => setLimit((prev) => Math.min(prev + LIMIT_INCREMENT, LIMIT_MAX))
+                    : undefined
+                }
+                className={cn(
+                  'px-3 py-1.5 text-[13px] rounded-md border border-border-md text-text2 transition-colors',
+                  canLoadMore
+                    ? 'hover:bg-bg-hover cursor-pointer'
+                    : 'opacity-40 cursor-not-allowed',
+                )}
+              >
+                {t('clients.recentActivity.loadMore')}
+              </button>
+
+              {/* Month picker chip */}
+              <div className="flex items-center gap-1 relative">
+                <label htmlFor={monthSelectId} className="text-[13px] text-text2">
+                  {t('clients.recentActivity.monthPickerPrefix')}
+                </label>
+                <div className="relative inline-flex items-center">
+                  <select
+                    id={monthSelectId}
+                    value={effectiveMonthKey}
+                    onChange={(e) => setSelectedMonthKey(e.target.value)}
+                    className={cn(
+                      'appearance-none pl-2 pr-6 py-1 text-[13px] rounded-md',
+                      'border border-border-md bg-accent-bg text-accent font-medium',
+                      'cursor-pointer focus:outline-none focus:ring-1 focus:ring-accent',
+                    )}
+                  >
+                    {availableMonths.map((mk) => (
+                      <option key={mk} value={mk}>
+                        {formatMonthLabel(mk, locale)}
+                      </option>
+                    ))}
+                  </select>
+                  {/* Decorative caret */}
+                  <span aria-hidden="true" className="pointer-events-none absolute right-1.5 text-accent text-[10px]">
+                    ▾
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/CheckinyTab.tsx
+++ b/web/src/components/clients/tabs/CheckinyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Check-iny tab — filled in by a wave-3 sub-issue. */
+export function CheckinyTab() {
+  return <div id="cl-pane-checkiny" />;
+}

--- a/web/src/components/clients/tabs/CheckinyTab.tsx
+++ b/web/src/components/clients/tabs/CheckinyTab.tsx
@@ -1,4 +1,281 @@
-/** Placeholder for the Check-iny tab — filled in by a wave-3 sub-issue. */
-export function CheckinyTab() {
-  return <div id="cl-pane-checkiny" />;
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useMarkCheckInReviewed } from '@/hooks/useWeeklyCheckIns';
+import { CheckInFlagChips } from '@/components/weekly-checkin/CheckInFlagChips';
+import { OverrideDialog } from '@/components/profile/OverrideDialog';
+import {
+  getClientCurrentCheckIn,
+  getCheckInSettings,
+  getCheckInOverrides,
+  type CheckInOverrideDto,
+  type CheckInSettingDto,
+  DAY_OF_WEEK_KEYS,
+  formatTimeDisplay,
+} from '@/api/weekly-checkins';
+
+interface CheckinyTabProps {
+  /** Client's ApplicationUser Id (Guid string) — passed to check-in endpoints. */
+  clientUserId: string;
+}
+
+/** Formats an ISO string to a short localised date. */
+function formatShortDate(iso: string, language: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/** Formats an ISO string to a date + time display. */
+function formatDateTimeStr(iso: string, language: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function CheckinyTab({ clientUserId }: CheckinyTabProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+
+  const [overrideTarget, setOverrideTarget] = useState<CheckInOverrideDto | null>(null);
+
+  // Current-week check-in(s) for this client
+  const {
+    data: checkInResponse,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['weekly-check-ins', 'client-current', clientUserId, 'all'],
+    queryFn: () => getClientCurrentCheckIn(clientUserId),
+    enabled: Boolean(clientUserId),
+    retry: false,
+  });
+
+  const { mutate: markReviewed, isPending: isMarkingReviewed } = useMarkCheckInReviewed();
+
+  // Settings + overrides for OverrideDialog and schedule description
+  const { data: settingsResponse } = useQuery({
+    queryKey: ['weekly-checkin-settings'],
+    queryFn: getCheckInSettings,
+  });
+  const { data: overridesResponse } = useQuery({
+    queryKey: ['weekly-checkin-overrides'],
+    queryFn: getCheckInOverrides,
+  });
+
+  const settings: CheckInSettingDto[] = settingsResponse?.settings ?? [];
+  const overrides: CheckInOverrideDto[] = overridesResponse?.overrides ?? [];
+  const items = checkInResponse?.checkIns ?? [];
+
+  // Resolve header schedule description from Training profession
+  const trainingOverride = overrides.find(
+    (o) => o.clientUserId === clientUserId && o.profession === 'Training',
+  );
+  const trainingSetting = settings.find((s) => s.profession === 'Training');
+  const effectiveDay = trainingOverride?.dayOfWeek ?? trainingSetting?.dayOfWeek ?? null;
+  const effectiveTime = trainingOverride?.timeOfDay ?? trainingSetting?.timeOfDay ?? null;
+  const scheduleDesc =
+    effectiveDay != null && effectiveTime != null
+      ? `${t(`weeklyCheckIn.day.${DAY_OF_WEEK_KEYS[effectiveDay]}`)} ${formatTimeDisplay(effectiveTime)}`
+      : null;
+
+  /** Constructs a minimal override DTO so OverrideDialog can open for new overrides. */
+  function getOverrideForProfession(profession: 'Training' | 'Nutrition'): CheckInOverrideDto {
+    const existing = overrides.find(
+      (o) => o.clientUserId === clientUserId && o.profession === profession,
+    );
+    if (existing) return existing;
+    return {
+      id: '',
+      clientUserId,
+      clientFirstName: '',
+      clientLastName: '',
+      profession,
+      dayOfWeek: null,
+      timeOfDay: null,
+      enabled: null,
+      addendum: null,
+      deadlineOffsetHours: null,
+    };
+  }
+
+  if (isLoading) {
+    return (
+      <div id="cl-pane-checkiny">
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div id="cl-pane-checkiny">
+      {/* Header row */}
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <div className="text-[15px] font-semibold text-text">
+            {t('clientDetail.checkiny.title')}
+          </div>
+          {scheduleDesc && (
+            <div className="text-[12px] text-text3 mt-0.5">
+              {t('clientDetail.checkiny.scheduleDesc', { schedule: scheduleDesc })}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors shrink-0"
+          onClick={() => setOverrideTarget(getOverrideForProfession('Training'))}
+        >
+          {t('clientDetail.checkiny.scheduleButton')}
+        </button>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.checkiny.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isError && items.length === 0 && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📋</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.checkiny.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.checkiny.emptyDescription')}
+          </div>
+        </div>
+      )}
+
+      {/* Check-in rows */}
+      {!isError && items.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {items.map((checkIn) => {
+            const hasResponded = Boolean(checkIn.respondedAt);
+            const isReviewed = Boolean(checkIn.reviewedByTrainerAt);
+            const professionLabel =
+              checkIn.profession === 'Training'
+                ? t('weeklyCheckIn.professionTraining')
+                : t('weeklyCheckIn.professionNutrition');
+
+            if (hasResponded) {
+              // Completed row — solid border
+              return (
+                <div
+                  key={checkIn.id}
+                  className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5"
+                >
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-accent-bg text-accent border border-accent-br">
+                        {professionLabel}
+                      </span>
+                      <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-green-bg text-green border border-[var(--green-br)]">
+                        {t('clientDetail.checkiny.statusCompleted')}
+                      </span>
+                      {isReviewed && (
+                        <span className="inline-flex items-center gap-1 px-2 py-[2px] rounded-full text-[11px] font-medium bg-bg3 text-text3">
+                          ✓ {t('weeklyCheckIn.plan.reviewedPill')}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-[11px] text-text3 whitespace-nowrap shrink-0">
+                      {formatShortDate(checkIn.weekStartDate, lang)}
+                    </div>
+                  </div>
+
+                  <div className="text-[12px] text-text3 mb-2">
+                    {t('weeklyCheckIn.plan.bannerResponded', {
+                      submittedAt: formatDateTimeStr(checkIn.respondedAt!, lang),
+                    })}
+                  </div>
+
+                  {checkIn.flags.length > 0 && (
+                    <div className="mb-2">
+                      <CheckInFlagChips flags={checkIn.flags} />
+                    </div>
+                  )}
+
+                  {checkIn.note && (
+                    <p className="text-[12px] text-text2 leading-relaxed border-l-2 border-accent pl-2.5 mb-2">
+                      {checkIn.note}
+                    </p>
+                  )}
+
+                  {!isReviewed && (
+                    <button
+                      type="button"
+                      disabled={isMarkingReviewed}
+                      onClick={() => markReviewed(checkIn.id)}
+                      className="mt-1 text-[12px] font-medium text-accent border border-accent-br rounded-[var(--radius-sm)] px-3 py-1 hover:bg-accent-bg transition-colors disabled:opacity-50"
+                    >
+                      {isMarkingReviewed
+                        ? t('common.saving')
+                        : t('weeklyCheckIn.plan.markReviewed')}
+                    </button>
+                  )}
+                </div>
+              );
+            }
+
+            // Pending row — dashed border
+            return (
+              <div
+                key={checkIn.id}
+                className="rounded-[var(--radius-lg)] px-4 py-3.5"
+                style={{ border: '1.5px dashed var(--border)' }}
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-bg3 text-text3">
+                      {professionLabel}
+                    </span>
+                    <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-orange-bg text-orange">
+                      {t('clientDetail.checkiny.statusPending')}
+                    </span>
+                  </div>
+                  <div className="text-[11px] text-text3 whitespace-nowrap shrink-0">
+                    {formatShortDate(checkIn.weekStartDate, lang)}
+                  </div>
+                </div>
+                <div className="text-[12px] text-text3">
+                  {t('weeklyCheckIn.plan.bannerPending', {
+                    sentAt: formatDateTimeStr(checkIn.sentAt, lang),
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* OverrideDialog for per-client schedule settings */}
+      {overrideTarget && (
+        <OverrideDialog
+          override={overrideTarget}
+          settings={settings}
+          onClose={() => setOverrideTarget(null)}
+        />
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/DotaznikyTab.tsx
+++ b/web/src/components/clients/tabs/DotaznikyTab.tsx
@@ -1,4 +1,275 @@
-/** Placeholder for the Dotazníky tab — filled in by a wave-3 sub-issue. */
-export function DotaznikyTab() {
-  return <div id="cl-pane-dotazniky" />;
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getClientQuestionnaireResponses,
+  assignQuestionnaire,
+  type ClientResponseItem,
+} from '@/api/questionnaires';
+import { QuestionnaireSelectDialog } from '@/components/questionnaire/QuestionnaireSelectDialog';
+import { formatAnswerValue } from '@/components/questionnaire/questionnaire-helpers';
+import { useToastStore } from '@/stores/toast';
+
+interface DotaznikyTabProps {
+  /** Client's public ID — used as the clientId param for questionnaire endpoints. */
+  clientId: string;
+}
+
+/** Returns a short localised date string from an ISO string. */
+function formatShortDate(iso: string | null | undefined, language: string): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleDateString(language, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface ExpandedAnswersProps {
+  item: ClientResponseItem;
+  language: string;
+}
+
+/** Inline expandable answers section for a completed questionnaire row. */
+function ExpandableAnswers({ item, language }: ExpandedAnswersProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  if (item.answers.length === 0) return null;
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-[11px] font-medium text-accent bg-transparent border-none cursor-pointer p-0 hover:underline"
+      >
+        <span
+          className="inline-block transition-transform duration-150"
+          style={{ transform: open ? 'rotate(90deg)' : 'none' }}
+        >
+          ▸
+        </span>
+        {t('clientDetail.dotazniky.viewAnswers')} ({item.answers.length})
+      </button>
+
+      {open && (
+        <div className="mt-2 border border-border rounded-[var(--radius-md)] overflow-hidden">
+          {item.answers.map((answer, idx) => (
+            <div
+              key={answer.questionPublicId}
+              className="px-3 py-2 text-[11px]"
+              style={{
+                borderBottom:
+                  idx < item.answers.length - 1 ? '1px solid var(--border)' : 'none',
+              }}
+            >
+              <div className="text-text3 mb-0.5">{answer.questionLabel}</div>
+              <div className="text-text font-medium">{formatAnswerValue(answer)}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {item.submittedAt && (
+        <div className="text-[11px] text-text3 mt-1">
+          {t('clientDetail.dotazniky.submittedOn', {
+            date: formatShortDate(item.submittedAt, language),
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DotaznikyTab({ clientId }: DotaznikyTabProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+  const queryClient = useQueryClient();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['questionnaire-responses', clientId],
+    queryFn: () => getClientQuestionnaireResponses(clientId),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  const assignMutation = useMutation({
+    mutationFn: (qId: string) => assignQuestionnaire(clientId, qId),
+    onSuccess: () => {
+      setAssignDialogOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ['questionnaire-responses', clientId] });
+      addToast(t('clientDetail.dotazniky.assignSuccess'), 'success');
+    },
+    onError: (err: { response?: { status?: number } }) => {
+      if (err?.response?.status === 409) {
+        addToast(t('clientDetail.dotazniky.assignConflict'), 'error');
+      } else {
+        addToast(t('clientDetail.dotazniky.assignError'), 'error');
+      }
+    },
+  });
+
+  const responses = data?.responses ?? [];
+  const submitted = responses.filter((r) => r.status === 'Submitted');
+  const pending = responses.filter(
+    (r) => r.status === 'Pending' || r.status === 'InProgress',
+  );
+
+  // Sort: pending first (newest by dateCreated), then submitted (newest by submittedAt)
+  const sorted: ClientResponseItem[] = [
+    ...pending.sort(
+      (a, b) => new Date(b.dateCreated).getTime() - new Date(a.dateCreated).getTime(),
+    ),
+    ...submitted.sort((a, b) => {
+      const da = a.submittedAt ? new Date(a.submittedAt).getTime() : 0;
+      const db = b.submittedAt ? new Date(b.submittedAt).getTime() : 0;
+      return db - da;
+    }),
+  ];
+
+  if (isLoading) {
+    return (
+      <div id="cl-pane-dotazniky">
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div id="cl-pane-dotazniky">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-[15px] font-semibold text-text">
+          {t('clientDetail.dotazniky.title')}
+        </div>
+        <button
+          type="button"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+          onClick={() => setAssignDialogOpen(true)}
+        >
+          + {t('clientDetail.dotazniky.assignButton')}
+        </button>
+      </div>
+
+      {/* Error state */}
+      {isError && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.dotazniky.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isError && sorted.length === 0 && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📝</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.dotazniky.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.dotazniky.emptyDescription')}
+          </div>
+          <button
+            type="button"
+            className="mt-1 text-[13px] font-semibold text-accent hover:underline bg-transparent border-none cursor-pointer"
+            onClick={() => setAssignDialogOpen(true)}
+          >
+            + {t('clientDetail.dotazniky.assignFirst')}
+          </button>
+        </div>
+      )}
+
+      {/* Questionnaire rows */}
+      {!isError && sorted.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {sorted.map((item) => {
+            const isSubmitted = item.status === 'Submitted';
+
+            if (isSubmitted) {
+              // Completed row — solid border
+              return (
+                <div
+                  key={item.responsePublicId}
+                  className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <span className="text-[20px] shrink-0">📋</span>
+                      <div className="min-w-0">
+                        <div className="text-[13px] font-semibold text-text truncate">
+                          {item.questionnaireTitle}
+                        </div>
+                        {item.submittedAt && (
+                          <div className="text-[11px] text-text3 mt-0.5">
+                            {formatShortDate(item.submittedAt, lang)}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-green-bg text-green border border-[var(--green-br)] shrink-0">
+                      {t('clientDetail.dotazniky.statusCompleted')}
+                    </span>
+                  </div>
+                  <ExpandableAnswers item={item} language={lang} />
+                </div>
+              );
+            }
+
+            // Pending row — dashed border
+            return (
+              <div
+                key={item.responsePublicId}
+                className="rounded-[var(--radius-lg)] px-4 py-3.5"
+                style={{ border: '1.5px dashed var(--border)' }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2.5 min-w-0">
+                    <span className="text-[20px] shrink-0 opacity-40">📋</span>
+                    <div className="min-w-0">
+                      <div className="text-[13px] font-semibold text-text2 truncate">
+                        {item.questionnaireTitle}
+                      </div>
+                      <div className="text-[11px] text-text3 mt-0.5">
+                        {t('clientDetail.dotazniky.pendingSubtitle', {
+                          date: formatShortDate(item.dateCreated, lang),
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                  <span className="inline-flex items-center px-2 py-[2px] rounded-full text-[11px] font-medium bg-orange-bg text-orange shrink-0">
+                    {t('clientDetail.dotazniky.statusPending')}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Assign questionnaire dialog */}
+      <QuestionnaireSelectDialog
+        open={assignDialogOpen}
+        onClose={() => setAssignDialogOpen(false)}
+        onConfirm={(qId) => assignMutation.mutate(qId)}
+        title={t('questionnaire.sendQuestionnaireTitle')}
+        description={t('questionnaire.sendQuestionnaireDesc')}
+        confirmLabel={
+          assignMutation.isPending
+            ? t('questionnaire.sending')
+            : t('questionnaire.sendQuestionnaire')
+        }
+        isPending={assignMutation.isPending}
+        icon="📋"
+      />
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/DotaznikyTab.tsx
+++ b/web/src/components/clients/tabs/DotaznikyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Dotazníky tab — filled in by a wave-3 sub-issue. */
+export function DotaznikyTab() {
+  return <div id="cl-pane-dotazniky" />;
+}

--- a/web/src/components/clients/tabs/FotkyTab.tsx
+++ b/web/src/components/clients/tabs/FotkyTab.tsx
@@ -1,4 +1,486 @@
-/** Placeholder for the Fotky tab — filled in by a wave-3 sub-issue. */
-export function FotkyTab() {
-  return <div id="cl-pane-fotky" />;
+/**
+ * FotkyTab — Photo-diary overview pane for the client detail page.
+ *
+ * Shows the most recent 8 photos across all plans as a thumbnail grid,
+ * a category + plan chip filter bar (client-side), a diary-request CTA,
+ * and a "Otevřít galerii" link that navigates to the active nutrition
+ * plan's photos tab.  If no active nutrition plan exists the gallery CTA
+ * is disabled and the +N overflow tile is hidden.
+ *
+ * Data sources (do not modify):
+ *   - getClientPhotoGroups  (web/src/api/client-photos.ts)
+ *   - listDiaryRequests     (web/src/api/diary-requests.ts)
+ * Dialog:
+ *   - RequestDiaryDialog    (web/src/components/diary/RequestDiaryDialog.tsx)
+ */
+
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/cn';
+import { apiClient } from '@/api/client';
+import { PlanPhotoCategory } from '@/api/generated';
+import type { PlanPhotoResponse2 } from '@/api/client-photos';
+import { listDiaryRequests } from '@/api/diary-requests';
+import { RequestDiaryDialog } from '@/components/diary/RequestDiaryDialog';
+import type { PlanSummary } from '@/api/plan-types';
+import type { TrainingPlanSummary } from '@/api/training-plan-types';
+
+// How many thumbnails to show before the overflow tile.
+const MAX_VISIBLE = 8;
+
+// ── Category emoji map ────────────────────────────────────────────────────────
+
+const CATEGORY_EMOJI: Record<PlanPhotoCategory, string> = {
+  [PlanPhotoCategory.Food]: '🍽️',
+  [PlanPhotoCategory.Body]: '📏',
+  [PlanPhotoCategory.FreeForm]: '📷',
+};
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+export interface FotkyTabProps {
+  clientId: string;
+  /** Resolved display name for the client (used in the diary dialog). */
+  clientName: string;
+  /** Resolved initials for the client avatar in the diary dialog. */
+  clientInitials: string;
+  /**
+   * Internal integer PK of ClientProfessionalLink — passed directly to
+   * RequestDiaryDialog (same as PlanPhotosTab pattern).
+   */
+  linkId?: number | null;
+  /**
+   * Active nutrition plan summary fetched by ClientDetailPage.
+   * Used for the "Otevřít galerii" CTA and plan chips.
+   */
+  activeNutritionPlan?: PlanSummary | null;
+  /**
+   * Active training plan summary fetched by ClientDetailPage.
+   * Used for plan chips.
+   */
+  activeTrainingPlan?: TrainingPlanSummary | null;
+}
+
+// ── Filter chip type ──────────────────────────────────────────────────────────
+
+type PhotoFilter =
+  | 'all'
+  | PlanPhotoCategory.Food
+  | PlanPhotoCategory.Body
+  | string; // planId chip
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function FotkyTab({
+  clientId,
+  clientName,
+  clientInitials,
+  linkId,
+  activeNutritionPlan,
+  activeTrainingPlan,
+}: FotkyTabProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const [activeFilter, setActiveFilter] = useState<PhotoFilter>('all');
+  const [diaryDialogOpen, setDiaryDialogOpen] = useState(false);
+
+  // ── Photo query (flat, most recent 50) ──────────────────────────────────────
+  // We call the underlying apiClient directly with groupByMonth=false so we get
+  // a flat array.  Types are imported from client-photos.ts (not generated.ts).
+  const { data: photoData, isPending: photosLoading, isError: photosError } = useQuery({
+    queryKey: ['client-photos-flat', clientId],
+    queryFn: () =>
+      apiClient.getTrainerClientPhotosEndpoint(
+        clientId,
+        1,   // page
+        50,  // pageSize
+        false, // groupByMonth — flat list
+      ),
+    enabled: Boolean(clientId),
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  // `GetTrainerClientPhotosResponse.photos` holds the flat array when
+  // groupByMonth=false is passed.
+  const allPhotos: PlanPhotoResponse2[] = useMemo(
+    () => photoData?.photos ?? [],
+    [photoData],
+  );
+
+  // ── Diary requests query ─────────────────────────────────────────────────────
+  // Mirror the PlanPhotosTab.hasInFlightDiary guard: fetch all requests for
+  // this link (no planId filter) and check for in-flight statuses.
+  const { data: diaryRequests = [] } = useQuery({
+    queryKey: ['diary-requests', { clientId }],
+    queryFn: () => listDiaryRequests({ linkId: linkId ?? undefined }),
+    enabled: Boolean(clientId),
+    staleTime: 30_000,
+  });
+
+  const hasInFlightDiary = diaryRequests.some(
+    (r) => r.status === 'Pending' || r.status === 'Accepted' || r.status === 'InProgress',
+  );
+
+  const hasActiveDiary = hasInFlightDiary;
+
+  // ── Plan chips — derived from active plan summaries ──────────────────────────
+  // Photos carry a planId (Mongo external id) that we match against active plan
+  // summaries passed in by ClientDetailPage.  Only plans that actually have at
+  // least one photo get a chip.  Photos with no matching plan fall under "Vše".
+
+  interface PlanChip {
+    planId: string;
+    name: string;
+    count: number;
+  }
+
+  const planChips: PlanChip[] = useMemo(() => {
+    const planMap = new Map<string, string>();
+    if (activeNutritionPlan?.planId) {
+      planMap.set(activeNutritionPlan.planId, activeNutritionPlan.name);
+    }
+    if (activeTrainingPlan?.planId) {
+      planMap.set(activeTrainingPlan.planId, activeTrainingPlan.name);
+    }
+
+    // Count photos per planId
+    const countMap = new Map<string, number>();
+    for (const p of allPhotos) {
+      if (p.planId) {
+        countMap.set(p.planId, (countMap.get(p.planId) ?? 0) + 1);
+      }
+    }
+
+    // Only emit chips for plans that appear in both the summary map AND photos
+    const chips: PlanChip[] = [];
+    for (const [pid, name] of planMap.entries()) {
+      const cnt = countMap.get(pid) ?? 0;
+      if (cnt > 0) {
+        chips.push({ planId: pid, name, count: cnt });
+      }
+    }
+    return chips;
+  }, [allPhotos, activeNutritionPlan, activeTrainingPlan]);
+
+  // ── Filter categories (Food / Body — no FreeForm chip per spec) ──────────────
+  const CATEGORY_CHIPS: Array<{ key: PlanPhotoCategory.Food | PlanPhotoCategory.Body; labelKey: string }> = [
+    { key: PlanPhotoCategory.Food, labelKey: 'clientDetail.fotky.categoryFood' },
+    { key: PlanPhotoCategory.Body, labelKey: 'clientDetail.fotky.categoryBody' },
+  ];
+
+  // ── Derived counts ────────────────────────────────────────────────────────────
+  const totalCount = allPhotos.length;
+
+  // Distinct plan ids among returned photos
+  const planCount = useMemo(
+    () => new Set(allPhotos.map((p) => p.planId).filter(Boolean)).size,
+    [allPhotos],
+  );
+
+  // Per-category counts for chips
+  const catCounts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const p of allPhotos) {
+      if (p.category != null) c[p.category] = (c[p.category] ?? 0) + 1;
+    }
+    return c;
+  }, [allPhotos]);
+
+  // ── Client-side filtered photos ───────────────────────────────────────────────
+  const filteredPhotos: PlanPhotoResponse2[] = useMemo(() => {
+    if (activeFilter === 'all') return allPhotos;
+    if (
+      activeFilter === PlanPhotoCategory.Food ||
+      activeFilter === PlanPhotoCategory.Body
+    ) {
+      return allPhotos.filter((p) => p.category === activeFilter);
+    }
+    // Plan-id chip
+    return allPhotos.filter((p) => p.planId === activeFilter);
+  }, [allPhotos, activeFilter]);
+
+  // Show the most recent MAX_VISIBLE, then a +N overflow tile if more exist
+  const visiblePhotos = filteredPhotos.slice(0, MAX_VISIBLE);
+  const overflowCount = Math.max(0, filteredPhotos.length - MAX_VISIBLE);
+
+  // ── Gallery navigation ────────────────────────────────────────────────────────
+  // Navigate to the active nutrition plan page (/clients/:id/plans/:planId).
+  // If no active plan exists the CTA is disabled and overflow tile is hidden.
+  const galleryTarget = activeNutritionPlan
+    ? `/clients/${clientId}/plans/${activeNutritionPlan.planId}`
+    : null;
+
+  function handleOpenGallery() {
+    if (galleryTarget) navigate(galleryTarget);
+  }
+
+  // ── Date formatter (cs-CZ, matching MereniTab / PlanPhotosTab pattern) ────────
+  function formatDate(iso: string | undefined): string {
+    if (!iso) return '—';
+    return new Date(iso).toLocaleDateString('cs-CZ', {
+      day: 'numeric',
+      month: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  // ── Category label for thumbnail caption ─────────────────────────────────────
+  function categoryLabel(cat: PlanPhotoCategory | undefined): string {
+    switch (cat) {
+      case PlanPhotoCategory.Food:
+        return t('clientDetail.fotky.categoryFood');
+      case PlanPhotoCategory.Body:
+        return t('clientDetail.fotky.categoryBody');
+      default:
+        return '';
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+
+  return (
+    <div id="cl-pane-fotky">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-3.5">
+        <div className="flex items-center gap-3">
+          <div className="text-[15px] font-semibold text-text">
+            {t('clientDetail.fotky.title')}
+          </div>
+          {totalCount > 0 && (
+            <div className="text-[12px] text-text3">
+              {t('clientDetail.fotky.countBadge', {
+                photos: totalCount,
+                plans: planCount,
+              })}
+            </div>
+          )}
+          {hasActiveDiary && (
+            <span
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium border"
+              style={{
+                background: 'var(--green-bg)',
+                borderColor: 'var(--green-br)',
+                color: 'var(--green)',
+              }}
+            >
+              <span>●</span>
+              {t('clientDetail.fotky.activeDiary')}
+            </span>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={hasInFlightDiary}
+            onClick={() => setDiaryDialogOpen(true)}
+            className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title={
+              hasInFlightDiary
+                ? t('diary.request.alreadyPending')
+                : undefined
+            }
+          >
+            📸 {t('clientDetail.fotky.newRequest')}
+          </button>
+          <button
+            type="button"
+            disabled={!galleryTarget}
+            onClick={handleOpenGallery}
+            className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title={
+              !galleryTarget
+                ? t('clientDetail.fotky.noActivePlanTooltip')
+                : undefined
+            }
+          >
+            🖼️ {t('clientDetail.fotky.openGallery')}
+          </button>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {photosLoading && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error — non-fatal, mirror MereniTab pattern */}
+      {photosError && !photosLoading && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.fotky.errorLoading')}
+        </div>
+      )}
+
+      {/* Content — only when loaded without error */}
+      {!photosLoading && !photosError && (
+        <>
+          {/* Filter chip bar */}
+          {totalCount > 0 && (
+            <div className="flex items-center gap-1.5 mb-4 flex-wrap">
+              {/* Vše chip */}
+              <button
+                type="button"
+                onClick={() => setActiveFilter('all')}
+                className={cn(
+                  'inline-flex items-center gap-1 px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+                  activeFilter === 'all'
+                    ? 'bg-accent text-bg border-accent'
+                    : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+                )}
+              >
+                {t('clientDetail.fotky.filterAll')}
+                <span className="tabular-nums opacity-80">({totalCount})</span>
+              </button>
+
+              {/* Food / Body category chips (no FreeForm) */}
+              {CATEGORY_CHIPS.map(({ key, labelKey }) => {
+                const count = catCounts[key] ?? 0;
+                if (count === 0) return null;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setActiveFilter(key)}
+                    className={cn(
+                      'inline-flex items-center gap-1 px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+                      activeFilter === key
+                        ? 'bg-accent text-bg border-accent'
+                        : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+                    )}
+                  >
+                    {t(labelKey)}
+                    <span className="tabular-nums opacity-80">({count})</span>
+                  </button>
+                );
+              })}
+
+              {/* One chip per active/recent plan that has photos */}
+              {planChips.map(({ planId, name, count }) => (
+                <button
+                  key={planId}
+                  type="button"
+                  onClick={() => setActiveFilter(planId)}
+                  className={cn(
+                    'inline-flex items-center gap-1 px-3 py-1 rounded-full text-[12px] font-medium transition-colors border',
+                    activeFilter === planId
+                      ? 'bg-accent text-bg border-accent'
+                      : 'bg-bg2 text-text3 border-border hover:bg-bg3 hover:text-text2',
+                  )}
+                >
+                  {name}
+                  <span className="tabular-nums opacity-80">({count})</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {totalCount === 0 && (
+            <div className="flex flex-col items-center gap-3 py-16 text-center">
+              <div className="text-[32px] opacity-40">📷</div>
+              <div className="text-[14px] font-medium text-text2">
+                {t('clientDetail.fotky.emptyTitle')}
+              </div>
+              <div className="text-[13px] text-text3 max-w-xs">
+                {t('clientDetail.fotky.emptyDescription')}
+              </div>
+              <button
+                type="button"
+                disabled={hasInFlightDiary}
+                onClick={() => setDiaryDialogOpen(true)}
+                className="mt-1 text-[13px] font-semibold hover:underline bg-transparent border-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{ color: 'var(--accent)' }}
+              >
+                📸 {t('clientDetail.fotky.emptyRequestCta')}
+              </button>
+            </div>
+          )}
+
+          {/* Thumbnail grid — auto-fill min 140px columns, 1:1 aspect */}
+          {totalCount > 0 && (
+            <div
+              className="grid gap-2"
+              style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))' }}
+            >
+              {visiblePhotos.map((photo, idx) => {
+                const dateIso = photo.takenAt ?? photo.uploadedAt;
+                const emoji = photo.category ? CATEGORY_EMOJI[photo.category] : '📷';
+                const catLbl = categoryLabel(photo.category);
+                return (
+                  <div
+                    key={photo.id ?? idx}
+                    className="flex flex-col overflow-hidden border border-border rounded-[var(--radius-md)] bg-bg2"
+                  >
+                    {/* Thumbnail — 1:1 aspect */}
+                    <div
+                      className="relative w-full"
+                      style={{ aspectRatio: '1 / 1' }}
+                    >
+                      {photo.blobUrl ? (
+                        <img
+                          src={photo.blobUrl}
+                          alt={photo.description ?? `${t('clientDetail.fotky.photoAlt')} ${idx + 1}`}
+                          className="absolute inset-0 h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="absolute inset-0 flex items-center justify-center text-[32px] opacity-50">
+                          {emoji}
+                        </div>
+                      )}
+                    </div>
+                    {/* Date + type caption */}
+                    <div className="px-2 py-1.5">
+                      <div className="text-[11px] text-text3 tabular-nums">
+                        {formatDate(dateIso)}
+                      </div>
+                      {catLbl && (
+                        <div className="text-[10px] text-text3 mt-0.5 truncate">
+                          {catLbl}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+
+              {/* +N overflow tile — only shown when gallery navigation is possible */}
+              {overflowCount > 0 && galleryTarget && (
+                <button
+                  type="button"
+                  onClick={handleOpenGallery}
+                  className="flex flex-col items-center justify-center overflow-hidden border border-border rounded-[var(--radius-md)] bg-bg2 hover:bg-bg3 transition-colors cursor-pointer"
+                  style={{ aspectRatio: '1 / 1' }}
+                  aria-label={t('clientDetail.fotky.overflowAriaLabel', { count: overflowCount })}
+                >
+                  <div className="text-[22px] font-semibold" style={{ color: 'var(--accent)' }}>
+                    +{overflowCount}
+                  </div>
+                  <div className="text-[11px] text-text3 mt-1">
+                    {t('clientDetail.fotky.overflowLabel')}
+                  </div>
+                </button>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Diary request dialog */}
+      <RequestDiaryDialog
+        open={diaryDialogOpen}
+        onClose={() => setDiaryDialogOpen(false)}
+        linkId={linkId}
+        clientName={clientName}
+        clientInitials={clientInitials}
+      />
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/FotkyTab.tsx
+++ b/web/src/components/clients/tabs/FotkyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Fotky tab — filled in by a wave-3 sub-issue. */
+export function FotkyTab() {
+  return <div id="cl-pane-fotky" />;
+}

--- a/web/src/components/clients/tabs/MereniTab.tsx
+++ b/web/src/components/clients/tabs/MereniTab.tsx
@@ -1,4 +1,416 @@
-/** Placeholder for the Měření tab — filled in by sub-issue #487 or later wave-3 work. */
-export function MereniTab() {
-  return <div id="cl-pane-mereni" />;
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useToastStore } from '@/stores/toast';
+import { getClientMeasurements } from '@/api/measurements';
+import type { MeasurementDto } from '@/api/generated';
+
+interface MereniTabProps {
+  clientId: string;
+  targetWeightKg: number | null | undefined;
+}
+
+// ── Delta helpers ─────────────────────────────────────────────────────────────
+
+/** ISO 8601 string → Date */
+function toDate(iso: string | undefined): Date | null {
+  return iso ? new Date(iso) : null;
+}
+
+/** Number of milliseconds in 6 weeks */
+const SIX_WEEKS_MS = 6 * 7 * 24 * 60 * 60 * 1000;
+
+interface StatTile {
+  label: string;
+  value: string;
+  delta: string | null;
+  /** delta colour: 'green' | 'orange' | null */
+  deltaColor: 'green' | 'orange' | null;
+  accent: boolean;
+  sub: string | null;
+}
+
+function formatNum(
+  v: number | undefined | null,
+  unit: string,
+  decimals = 1,
+): string {
+  if (v == null) return '—';
+  return `${v.toFixed(decimals).replace('.', ',')} ${unit}`;
+}
+
+function formatDelta(
+  diff: number | null,
+  unit: string,
+  decimals = 1,
+): string | null {
+  if (diff == null) return null;
+  if (diff === 0) return `${(0).toFixed(decimals).replace('.', ',')} ${unit}`;
+  const sign = diff < 0 ? '' : '+';
+  return `${sign}${diff.toFixed(decimals).replace('.', ',')} ${unit}`;
+}
+
+/**
+ * Find the reference measurement for delta comparison:
+ * the most recent measurement that is at least 6 weeks before `latest`.
+ */
+function findReferenceAtLeast6WeeksBefore(
+  sorted: MeasurementDto[],
+  latestDate: Date,
+): MeasurementDto | null {
+  for (let i = 1; i < sorted.length; i++) {
+    const d = toDate(sorted[i].measuredAt);
+    if (d && latestDate.getTime() - d.getTime() >= SIX_WEEKS_MS) {
+      return sorted[i];
+    }
+  }
+  return null;
+}
+
+// ── Bar chart helpers ─────────────────────────────────────────────────────────
+
+interface WeightBar {
+  pct: number;
+  opacity: number;
+}
+
+/**
+ * Build up to 8 bars from the most recent measurements, oldest-first for display.
+ * Uses the same normalization logic as ProgressSnapshot.
+ */
+function buildWeightBars(sorted: MeasurementDto[]): WeightBar[] {
+  const slice = sorted.slice(0, 8).reverse(); // oldest → newest
+  const weights = slice
+    .map((m) => m.weightKg)
+    .filter((w): w is number => w != null);
+  if (weights.length === 0) return [];
+
+  const maxVal = Math.max(...weights);
+  const minVal = Math.min(...weights);
+  const floor = Math.max(0, minVal - (maxVal - minVal) * 0.5);
+  const range = maxVal - floor || 1;
+
+  return slice.map((m, i) => {
+    const w = m.weightKg ?? minVal;
+    const pct = Math.max(((w - floor) / range) * 100, 8);
+    // Opacity ramps from 0.35 (oldest) to 0.7 (newest), matching prototype style
+    const opacity = 0.35 + (i / Math.max(slice.length - 1, 1)) * 0.35;
+    return { pct, opacity };
+  });
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+
+  const { data, isError, isPending } = useQuery({
+    queryKey: ['client-measurements', clientId],
+    queryFn: () => getClientMeasurements(clientId),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  // Sorted newest-first
+  const sorted: MeasurementDto[] = useMemo(() => {
+    if (!data?.items) return [];
+    return [...data.items].sort((a, b) => {
+      const da = toDate(a.measuredAt)?.getTime() ?? 0;
+      const db = toDate(b.measuredAt)?.getTime() ?? 0;
+      return db - da;
+    });
+  }, [data?.items]);
+
+  const latest = sorted[0] ?? null;
+
+  // Reference measurement for deltas (>=6 weeks before latest)
+  const refMeasurement: MeasurementDto | null = useMemo(() => {
+    if (!latest?.measuredAt) return null;
+    const latestDate = toDate(latest.measuredAt);
+    if (!latestDate) return null;
+    return findReferenceAtLeast6WeeksBefore(sorted, latestDate);
+  }, [sorted, latest]);
+
+  // ── Stat tiles ──────────────────────────────────────────────────────────────
+
+  const tiles: StatTile[] = useMemo(() => {
+    const weightDiff =
+      latest?.weightKg != null && refMeasurement?.weightKg != null
+        ? Math.round((latest.weightKg - refMeasurement.weightKg) * 10) / 10
+        : null;
+
+    const fatDiff =
+      latest?.bodyFatPercentage != null &&
+      refMeasurement?.bodyFatPercentage != null
+        ? Math.round(
+            (latest.bodyFatPercentage - refMeasurement.bodyFatPercentage) * 10,
+          ) / 10
+        : null;
+
+    const waistDiff =
+      latest?.waistCm != null && refMeasurement?.waistCm != null
+        ? Math.round((latest.waistCm - refMeasurement.waistCm) * 10) / 10
+        : null;
+
+    const remaining =
+      latest?.weightKg != null && targetWeightKg != null
+        ? Math.round(Math.abs(targetWeightKg - latest.weightKg) * 10) / 10
+        : null;
+
+    return [
+      {
+        label: t('clientDetail.mereni.tiles.currentWeight'),
+        value: formatNum(latest?.weightKg, 'kg'),
+        delta: formatDelta(weightDiff, 'kg'),
+        deltaColor:
+          weightDiff == null || weightDiff === 0
+            ? null
+            : weightDiff < 0
+              ? 'green'
+              : 'orange',
+        accent: false,
+        sub: refMeasurement?.measuredAt
+          ? t('clientDetail.mereni.tiles.comparedToWeeksAgo')
+          : null,
+      },
+      {
+        label: t('clientDetail.mereni.tiles.bodyFat'),
+        value: formatNum(latest?.bodyFatPercentage, '%'),
+        delta: formatDelta(fatDiff, '%'),
+        deltaColor:
+          fatDiff == null || fatDiff === 0
+            ? null
+            : fatDiff < 0
+              ? 'green'
+              : 'orange',
+        accent: false,
+        sub: null,
+      },
+      {
+        label: t('clientDetail.mereni.tiles.waist'),
+        value: formatNum(latest?.waistCm, 'cm', 0),
+        delta: formatDelta(waistDiff, 'cm', 0),
+        deltaColor:
+          waistDiff == null || waistDiff === 0
+            ? null
+            : waistDiff < 0
+              ? 'green'
+              : 'orange',
+        accent: false,
+        sub: null,
+      },
+      {
+        label: t('clientDetail.mereni.tiles.toGoal'),
+        value:
+          remaining != null ? formatNum(remaining, 'kg') : '—',
+        delta: null,
+        deltaColor: null,
+        accent: true,
+        sub:
+          targetWeightKg != null
+            ? t('clientDetail.mereni.tiles.goalWeight', {
+                kg: targetWeightKg.toFixed(1).replace('.', ','),
+              })
+            : null,
+      },
+    ];
+  }, [latest, refMeasurement, targetWeightKg, t]);
+
+  // ── Bar chart ──────────────────────────────────────────────────────────────
+
+  const bars = useMemo(() => buildWeightBars(sorted), [sorted]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const hasData = sorted.length > 0;
+
+  return (
+    <div id="cl-pane-mereni">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-3.5">
+        <div className="text-[15px] font-semibold text-text">
+          {t('clientDetail.mereni.title')}
+        </div>
+        <button
+          type="button"
+          className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+          onClick={() =>
+            addToast(t('clientDetail.mereni.addMeasurementPlaceholder'), 'success')
+          }
+        >
+          + {t('clientDetail.mereni.addMeasurement')}
+        </button>
+      </div>
+
+      {/* Loading */}
+      {isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error */}
+      {isError && !isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.mereni.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isPending && !isError && !hasData && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📏</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.mereni.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.mereni.emptyDescription')}
+          </div>
+          <button
+            type="button"
+            className="mt-1 text-[13px] font-semibold text-accent hover:underline bg-transparent border-none cursor-pointer"
+            onClick={() =>
+              addToast(t('clientDetail.mereni.addMeasurementPlaceholder'), 'success')
+            }
+          >
+            + {t('clientDetail.mereni.addFirstMeasurement')}
+          </button>
+        </div>
+      )}
+
+      {/* Data sections */}
+      {!isPending && !isError && hasData && (
+        <>
+          {/* 4-col stat tiles */}
+          <div className="grid grid-cols-4 gap-3 mb-[18px]">
+            {tiles.map((tile) => (
+              <div
+                key={tile.label}
+                className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5"
+              >
+                <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium mb-1.5">
+                  {tile.label}
+                </div>
+                <div
+                  className="text-[22px] font-semibold leading-tight"
+                  style={tile.accent ? { color: 'var(--accent)' } : undefined}
+                >
+                  {tile.accent ? (
+                    <span style={{ color: 'var(--accent)' }}>{tile.value}</span>
+                  ) : (
+                    <span className="text-text">{tile.value}</span>
+                  )}
+                </div>
+                {tile.delta && (
+                  <div
+                    className={`text-[11px] mt-1 ${
+                      tile.deltaColor === 'green'
+                        ? 'text-green'
+                        : tile.deltaColor === 'orange'
+                          ? 'text-orange'
+                          : 'text-text3'
+                    }`}
+                  >
+                    {tile.delta}
+                    {tile.sub ? ` ${tile.sub}` : ''}
+                  </div>
+                )}
+                {!tile.delta && tile.sub && (
+                  <div className="text-[11px] text-text3 mt-1">{tile.sub}</div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 8-week weight-trend bar chart */}
+          {bars.length > 0 && (
+            <div className="border border-border rounded-[var(--radius-lg)] px-4 py-3.5 mb-[18px]">
+              <div className="text-[11px] text-text3 uppercase tracking-[0.04em] font-medium mb-3">
+                {t('clientDetail.mereni.chartLabel')}
+              </div>
+              <div
+                className="flex items-end gap-2"
+                style={{ height: '120px', paddingTop: '4px', paddingBottom: '4px' }}
+              >
+                {bars.map((bar, i) => (
+                  <div
+                    key={i}
+                    className="flex-1 rounded-t-sm"
+                    style={{
+                      height: `${bar.pct}%`,
+                      backgroundColor: 'var(--accent)',
+                      opacity: bar.opacity,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Measurement history table */}
+          <div className="db-wrap overflow-x-auto">
+            <table className="db-table w-full text-[13px]">
+              <thead>
+                <tr>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.date')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.weight')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.bodyFat')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.waist')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                    {t('clientDetail.mereni.table.hips')}
+                  </th>
+                  <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2">
+                    {t('clientDetail.mereni.table.chest')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((m) => {
+                  const date = toDate(m.measuredAt);
+                  const dateStr = date
+                    ? date.toLocaleDateString('cs-CZ', {
+                        day: 'numeric',
+                        month: 'numeric',
+                        year: 'numeric',
+                      })
+                    : '—';
+                  return (
+                    <tr key={m.measurementId ?? m.measuredAt} className="border-t border-border">
+                      <td className="row-title py-2 pr-4 font-medium text-text">
+                        {dateStr}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {formatNum(m.weightKg, 'kg')}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {formatNum(m.bodyFatPercentage, '%')}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {formatNum(m.waistCm, 'cm', 0)}
+                      </td>
+                      <td className="py-2 pr-4 text-text2">
+                        {formatNum(m.hipsCm, 'cm', 0)}
+                      </td>
+                      <td className="py-2 text-text2">
+                        {formatNum(m.chestCm, 'cm', 0)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/MereniTab.tsx
+++ b/web/src/components/clients/tabs/MereniTab.tsx
@@ -112,15 +112,16 @@ export function MereniTab({ clientId, targetWeightKg }: MereniTabProps) {
     retry: false,
   });
 
+  const items = data?.items;
   // Sorted newest-first
   const sorted: MeasurementDto[] = useMemo(() => {
-    if (!data?.items) return [];
-    return [...data.items].sort((a, b) => {
+    if (!items) return [];
+    return [...items].sort((a, b) => {
       const da = toDate(a.measuredAt)?.getTime() ?? 0;
       const db = toDate(b.measuredAt)?.getTime() ?? 0;
       return db - da;
     });
-  }, [data?.items]);
+  }, [items]);
 
   const latest = sorted[0] ?? null;
 

--- a/web/src/components/clients/tabs/MereniTab.tsx
+++ b/web/src/components/clients/tabs/MereniTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Měření tab — filled in by sub-issue #487 or later wave-3 work. */
+export function MereniTab() {
+  return <div id="cl-pane-mereni" />;
+}

--- a/web/src/components/clients/tabs/PlanyTab.tsx
+++ b/web/src/components/clients/tabs/PlanyTab.tsx
@@ -1,4 +1,259 @@
-/** Placeholder for the Plány tab — filled in by a wave-3 sub-issue. */
-export function PlanyTab() {
-  return <div id="cl-pane-plany" />;
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { getClientPlans } from '@/api/client-plans';
+import type { ClientPlanItem, PlanStatus } from '@/api/client-plans';
+
+interface PlanyTabProps {
+  clientId: string;
+}
+
+// ── Date formatting helpers ───────────────────────────────────────────────────
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString('cs-CZ', {
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatPeriod(periodStart: string | null, periodEnd: string | null): string {
+  const start = formatDate(periodStart);
+  const end = formatDate(periodEnd);
+  if (!start && !end) return '—';
+  if (start && !end) return `${start} →`;
+  if (!start && end) return `→ ${end}`;
+  return `${start} – ${end}`;
+}
+
+// ── Status chip ───────────────────────────────────────────────────────────────
+
+interface StatusChipProps {
+  status: PlanStatus;
+  label: string;
+}
+
+function StatusChip({ status, label }: StatusChipProps) {
+  // Uses the existing global `.tag` + modifier classes from index.css.
+  // Active → green, Completed → gold (accent), Draft/Archived → gray.
+  const modifierMap: Record<PlanStatus, string> = {
+    Active: 'tag-green',
+    Completed: 'tag-acc',
+    Draft: 'tag-gray',
+    Archived: 'tag-gray',
+  };
+  return (
+    <span className={`tag ${modifierMap[status] ?? 'tag-gray'}`}>
+      {label}
+    </span>
+  );
+}
+
+// ── Result summary formatter ──────────────────────────────────────────────────
+
+function formatResultSummary(plan: ClientPlanItem, t: TFunction): string {
+  const { planType, resultSummary: r } = plan;
+
+  if (planType === 'Nutrition') {
+    const parts: string[] = [];
+    if (r.compliancePercent != null) {
+      parts.push(
+        t('clientDetail.plany.result.compliance', {
+          pct: r.compliancePercent.toFixed(0),
+        }),
+      );
+    }
+    if (r.weightDeltaKg != null) {
+      const sign = r.weightDeltaKg > 0 ? '+' : '';
+      const val = r.weightDeltaKg.toFixed(1).replace('.', ',');
+      parts.push(
+        t('clientDetail.plany.result.weightDelta', {
+          delta: `${sign}${val}`,
+        }),
+      );
+    }
+    return parts.join(' · ') || '—';
+  }
+
+  if (planType === 'Training') {
+    const parts: string[] = [];
+    if (r.totalTrainings != null) {
+      parts.push(
+        t('clientDetail.plany.result.totalTrainings', {
+          count: r.totalTrainings,
+        }),
+      );
+    }
+    if (r.prCount != null) {
+      parts.push(
+        t('clientDetail.plany.result.prCount', {
+          count: r.prCount,
+        }),
+      );
+    }
+    return parts.join(' · ') || '—';
+  }
+
+  return '—';
+}
+
+// ── Plan type emoji prefix ────────────────────────────────────────────────────
+
+function planTypeEmoji(planType: string): string {
+  return planType === 'Nutrition' ? '🥗' : '🏋️';
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function PlanyTab({ clientId }: PlanyTabProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['client-plans', clientId],
+    queryFn: () => getClientPlans(clientId),
+    enabled: Boolean(clientId),
+    retry: false,
+  });
+
+  const plans = data?.plans ?? [];
+  const isEmpty = !isPending && !isError && plans.length === 0;
+
+  function handleRowClick(plan: ClientPlanItem) {
+    if (plan.planType === 'Nutrition') {
+      navigate(`/clients/${clientId}/plans/${plan.planId}`);
+    } else {
+      navigate(`/clients/${clientId}/training-plans/${plan.planId}`);
+    }
+  }
+
+  return (
+    <div id="cl-pane-plany">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3.5">
+        <div className="text-[15px] font-semibold text-text">
+          {t('clientDetail.plany.title')}
+        </div>
+      </div>
+
+      {/* Loading */}
+      {isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error */}
+      {isError && !isPending && (
+        <div className="text-[13px] text-text3 py-12 text-center">
+          {t('clientDetail.plany.errorLoading')}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <div className="text-[32px] opacity-40">📋</div>
+          <div className="text-[14px] font-medium text-text2">
+            {t('clientDetail.plany.emptyTitle')}
+          </div>
+          <div className="text-[13px] text-text3 max-w-xs">
+            {t('clientDetail.plany.emptyDescription')}
+          </div>
+        </div>
+      )}
+
+      {/* Plans table */}
+      {!isPending && !isError && plans.length > 0 && (
+        <div className="db-wrap overflow-x-auto mb-5">
+          <table className="db-table w-full text-[13px]">
+            <thead>
+              <tr>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.plan')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.type')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.period')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2 pr-4">
+                  {t('clientDetail.plany.table.status')}
+                </th>
+                <th className="text-left text-[11px] text-text3 font-medium uppercase tracking-[0.04em] py-2">
+                  {t('clientDetail.plany.table.result')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {plans.map((plan) => {
+                const statusLabel = t(
+                  `clientDetail.plany.status.${plan.status.toLowerCase()}`,
+                );
+                return (
+                  <tr
+                    key={plan.planId}
+                    className="border-t border-border cursor-pointer hover:bg-bg-hover transition-colors"
+                    onClick={() => handleRowClick(plan)}
+                    role="link"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRowClick(plan);
+                      }
+                    }}
+                    aria-label={`${t('clientDetail.plany.table.openPlan')} ${plan.name}`}
+                  >
+                    <td className="row-title py-2.5 pr-4 font-medium text-text">
+                      <span className="mr-1.5">{planTypeEmoji(plan.planType)}</span>
+                      {plan.name}
+                    </td>
+                    <td className="py-2.5 pr-4 text-text2">
+                      {plan.planType === 'Nutrition'
+                        ? t('clientDetail.plany.typeLabel.nutrition')
+                        : t('clientDetail.plany.typeLabel.training')}
+                    </td>
+                    <td className="py-2.5 pr-4 text-text2 whitespace-nowrap">
+                      {formatPeriod(plan.periodStart, plan.periodEnd)}
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      <StatusChip status={plan.status} label={statusLabel} />
+                    </td>
+                    <td className="py-2.5 text-text2">
+                      {formatResultSummary(plan, t)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      {!isPending && !isError && (
+        <div className="flex gap-3 mt-2">
+          <button
+            type="button"
+            className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+            onClick={() => navigate(`/clients/${clientId}/nutrition`)}
+          >
+            + {t('clientDetail.plany.actions.newNutrition')}
+          </button>
+          <button
+            type="button"
+            className="text-[13px] font-medium text-text2 border border-border rounded-[var(--radius-sm)] px-3 py-1.5 hover:bg-bg-hover transition-colors"
+            onClick={() => navigate(`/clients/${clientId}/training`)}
+          >
+            + {t('clientDetail.plany.actions.newTraining')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/PlanyTab.tsx
+++ b/web/src/components/clients/tabs/PlanyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Plány tab — filled in by a wave-3 sub-issue. */
+export function PlanyTab() {
+  return <div id="cl-pane-plany" />;
+}

--- a/web/src/components/clients/tabs/PoznamkyTab.tsx
+++ b/web/src/components/clients/tabs/PoznamkyTab.tsx
@@ -1,4 +1,308 @@
-/** Placeholder for the Poznámky tab — filled in by a wave-3 sub-issue. */
-export function PoznamkyTab() {
-  return <div id="cl-pane-poznamky" />;
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useToastStore } from '@/stores/toast';
+import {
+  createNote,
+  listNotes,
+  updateNote,
+  deleteNote,
+  type TrainerNote,
+} from '@/api/trainer-notes';
+
+interface PoznamkyTabProps {
+  clientId: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('cs-CZ', {
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric',
+  });
+}
+
+// ── Sub-component: a single editable note card ────────────────────────────────
+
+interface NoteCardProps {
+  note: TrainerNote;
+  clientId: string;
+}
+
+function NoteCard({ note, clientId }: NoteCardProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState(note.text);
+
+  const updateMutation = useMutation({
+    mutationFn: (text: string) => updateNote(clientId, note.noteId, text),
+    onMutate: async (text: string) => {
+      await queryClient.cancelQueries({
+        queryKey: ['trainer-notes', clientId],
+      });
+      const previous = queryClient.getQueryData<TrainerNote[]>([
+        'trainer-notes',
+        clientId,
+      ]);
+      queryClient.setQueryData<TrainerNote[]>(
+        ['trainer-notes', clientId],
+        (old) =>
+          old?.map((n) =>
+            n.noteId === note.noteId
+              ? { ...n, text, updatedAt: new Date().toISOString() }
+              : n,
+          ) ?? [],
+      );
+      return { previous };
+    },
+    onError: (_err, _text, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['trainer-notes', clientId], context.previous);
+      }
+      addToast(t('clientDetail.poznamky.updateError'), 'error');
+    },
+    onSuccess: () => {
+      addToast(t('clientDetail.poznamky.updateSuccess'), 'success');
+      setEditing(false);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['trainer-notes', clientId] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteNote(clientId, note.noteId),
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ['trainer-notes', clientId],
+      });
+      const previous = queryClient.getQueryData<TrainerNote[]>([
+        'trainer-notes',
+        clientId,
+      ]);
+      queryClient.setQueryData<TrainerNote[]>(
+        ['trainer-notes', clientId],
+        (old) => old?.filter((n) => n.noteId !== note.noteId) ?? [],
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['trainer-notes', clientId], context.previous);
+      }
+      addToast(t('clientDetail.poznamky.deleteError'), 'error');
+    },
+    onSuccess: () => {
+      addToast(t('clientDetail.poznamky.deleteSuccess'), 'success');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['trainer-notes', clientId] });
+    },
+  });
+
+  if (editing) {
+    return (
+      <div className="border border-border rounded-[var(--radius-md)] bg-bg2 px-3 py-3 flex flex-col gap-2">
+        <textarea
+          className="w-full text-[13px] text-text bg-transparent border border-border rounded-[var(--radius-sm)] px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-accent"
+          rows={3}
+          value={editText}
+          onChange={(e) => setEditText(e.target.value)}
+          maxLength={2000}
+          autoFocus
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="text-[12px] text-text3 px-3 py-1.5 border border-border rounded-[var(--radius-sm)] hover:bg-bg-hover transition-colors"
+            onClick={() => {
+              setEditing(false);
+              setEditText(note.text);
+            }}
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            disabled={updateMutation.isPending || !editText.trim()}
+            className="text-[12px] font-medium text-text px-3 py-1.5 border border-border rounded-[var(--radius-sm)] bg-bg2 hover:bg-bg-hover transition-colors disabled:opacity-50"
+            onClick={() => updateMutation.mutate(editText)}
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-border rounded-[var(--radius-md)] bg-bg2 px-3 py-3 flex items-start gap-2 group">
+      <div className="text-[16px] mt-0.5 shrink-0">📌</div>
+      <div className="flex-1 min-w-0">
+        <div className="text-[13px] text-text whitespace-pre-wrap break-words">
+          {note.text}
+        </div>
+        <div className="text-[11px] text-text3 mt-1">{formatDate(note.createdAt)}</div>
+      </div>
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+        <button
+          type="button"
+          aria-label={t('clientDetail.poznamky.editAriaLabel')}
+          className="text-[11px] text-text3 hover:text-text px-2 py-1 rounded-[var(--radius-sm)] hover:bg-bg-hover transition-colors"
+          onClick={() => setEditing(true)}
+        >
+          {t('clientDetail.poznamky.editLabel')}
+        </button>
+        <button
+          type="button"
+          aria-label={t('clientDetail.poznamky.deleteAriaLabel')}
+          disabled={deleteMutation.isPending}
+          className="text-[11px] text-text3 hover:text-red px-2 py-1 rounded-[var(--radius-sm)] hover:bg-bg-hover transition-colors disabled:opacity-50"
+          onClick={() => deleteMutation.mutate()}
+        >
+          {t('clientDetail.poznamky.deleteLabel')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function PoznamkyTab({ clientId }: PoznamkyTabProps) {
+  const { t } = useTranslation();
+  const addToast = useToastStore((s) => s.addToast);
+  const queryClient = useQueryClient();
+  const [newText, setNewText] = useState('');
+
+  const { data: notes, isPending, isError } = useQuery({
+    queryKey: ['trainer-notes', clientId],
+    queryFn: async () => {
+      const result = await listNotes(clientId);
+      return result.notes;
+    },
+    enabled: Boolean(clientId),
+    initialData: undefined,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (text: string) => createNote(clientId, text),
+    onMutate: async (text: string) => {
+      await queryClient.cancelQueries({
+        queryKey: ['trainer-notes', clientId],
+      });
+      const previous = queryClient.getQueryData<TrainerNote[]>([
+        'trainer-notes',
+        clientId,
+      ]);
+      const optimisticNote: TrainerNote = {
+        noteId: `optimistic-${Date.now()}`,
+        text,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      queryClient.setQueryData<TrainerNote[]>(
+        ['trainer-notes', clientId],
+        (old) => [optimisticNote, ...(old ?? [])],
+      );
+      setNewText('');
+      return { previous };
+    },
+    onError: (_err, _text, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['trainer-notes', clientId], context.previous);
+      }
+      addToast(t('clientDetail.poznamky.createError'), 'error');
+    },
+    onSuccess: () => {
+      addToast(t('clientDetail.poznamky.createSuccess'), 'success');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['trainer-notes', clientId] });
+    },
+  });
+
+  const handleSubmit = () => {
+    const trimmed = newText.trim();
+    if (!trimmed) return;
+    createMutation.mutate(trimmed);
+  };
+
+  return (
+    <div id="cl-pane-poznamky">
+      {/* Heading */}
+      <div className="text-[15px] font-semibold text-text mb-1.5">
+        {t('clientDetail.poznamky.title')}{' '}
+        <span className="text-[12px] font-normal text-text3">
+          {t('clientDetail.poznamky.subtitle')}
+        </span>
+      </div>
+
+      {/* Add-note box */}
+      <div className="border border-border rounded-[var(--radius-md)] px-3 py-3 mb-3.5">
+        <textarea
+          className="w-full text-[13px] text-text bg-transparent border-none resize-none focus:outline-none placeholder:text-text3"
+          rows={2}
+          placeholder={t('clientDetail.poznamky.placeholder')}
+          value={newText}
+          onChange={(e) => setNewText(e.target.value)}
+          maxLength={2000}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              handleSubmit();
+            }
+          }}
+        />
+        <div className="flex justify-end mt-1">
+          <button
+            type="button"
+            disabled={createMutation.isPending || !newText.trim()}
+            className="text-[13px] font-medium text-text px-3 py-1.5 border border-border rounded-[var(--radius-sm)] bg-bg2 hover:bg-bg-hover transition-colors disabled:opacity-50"
+            onClick={handleSubmit}
+          >
+            {t('clientDetail.poznamky.saveButton')}
+          </button>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {isPending && (
+        <div className="text-[13px] text-text3 py-8 text-center">
+          {t('common.loading')}
+        </div>
+      )}
+
+      {/* Error state */}
+      {!isPending && isError && (
+        <div className="text-[13px] text-red py-8 text-center">
+          {t('clientDetail.poznamky.errorLoading')}
+        </div>
+      )}
+
+      {/* Note list (newest first) */}
+      {!isPending && !isError && notes && notes.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {notes.map((note) => (
+            <NoteCard key={note.noteId} note={note} clientId={clientId} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state — show nothing extra; add-note box is always visible */}
+      {!isPending && !isError && (!notes || notes.length === 0) && (
+        <div className="text-[13px] text-text3 text-center py-6">
+          {t('clientDetail.poznamky.emptyState')}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/web/src/components/clients/tabs/PoznamkyTab.tsx
+++ b/web/src/components/clients/tabs/PoznamkyTab.tsx
@@ -1,0 +1,4 @@
+/** Placeholder for the Poznámky tab — filled in by a wave-3 sub-issue. */
+export function PoznamkyTab() {
+  return <div id="cl-pane-poznamky" />;
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1834,6 +1834,32 @@
       "photoAlt": "Fotka klienta",
       "overflowLabel": "zobrazit vše",
       "overflowAriaLabel": "Zobrazit dalších {{count}} fotek"
+    },
+    "checkiny": {
+      "title": "Týdenní check-iny",
+      "scheduleDesc": "Rozvrh: {{schedule}}",
+      "scheduleButton": "Rozvrh check-inů",
+      "errorLoading": "Check-iny se nepodařilo načíst.",
+      "emptyTitle": "Žádné check-iny",
+      "emptyDescription": "Pro tohoto klienta zatím nebyly odeslány žádné týdenní check-iny.",
+      "statusCompleted": "Vyplněno",
+      "statusPending": "Čeká"
+    },
+    "dotazniky": {
+      "title": "Dotazníky",
+      "assignButton": "Přiřadit dotazník",
+      "errorLoading": "Dotazníky se nepodařilo načíst.",
+      "emptyTitle": "Žádné dotazníky",
+      "emptyDescription": "Klientovi zatím nebyl přiřazen žádný dotazník.",
+      "assignFirst": "Přiřadit první dotazník",
+      "assignSuccess": "Dotazník byl úspěšně přiřazen",
+      "assignConflict": "Klient již má dotazník čekající na vyplnění",
+      "assignError": "Nepodařilo se přiřadit dotazník",
+      "statusCompleted": "Vyplněno",
+      "statusPending": "Čeká",
+      "viewAnswers": "Zobrazit odpovědi",
+      "submittedOn": "Odesláno {{date}}",
+      "pendingSubtitle": "Odesláno {{date}} · Čeká na vyplnění"
     }
   }
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1774,6 +1774,24 @@
         "hips": "Boky",
         "chest": "Hrudník"
       }
+    },
+    "fotky": {
+      "title": "Foto-deník",
+      "countBadge": "{{photos}} fotek · {{plans}} plánů",
+      "activeDiary": "Aktivní deník",
+      "newRequest": "Nová žádost",
+      "openGallery": "Otevřít galerii",
+      "noActivePlanTooltip": "Žádný aktivní plán — galerie není k dispozici",
+      "filterAll": "Vše",
+      "categoryFood": "Jídla",
+      "categoryBody": "Postava",
+      "emptyTitle": "Zatím žádné fotky",
+      "emptyDescription": "Požádejte klienta o sdílení fotek jídel nebo pokroku.",
+      "emptyRequestCta": "Odeslat žádost o foto-deník",
+      "errorLoading": "Fotky se nepodařilo načíst",
+      "photoAlt": "Fotka klienta",
+      "overflowLabel": "zobrazit vše",
+      "overflowAriaLabel": "Zobrazit dalších {{count}} fotek"
     }
   }
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1860,6 +1860,24 @@
       "viewAnswers": "Zobrazit odpovědi",
       "submittedOn": "Odesláno {{date}}",
       "pendingSubtitle": "Odesláno {{date}} · Čeká na vyplnění"
+    },
+    "poznamky": {
+      "title": "Poznámky trenéra",
+      "subtitle": "· soukromé, klient nevidí",
+      "placeholder": "Přidat poznámku…",
+      "saveButton": "Uložit poznámku",
+      "emptyState": "Zatím žádné poznámky.",
+      "createSuccess": "Poznámka uložena",
+      "createError": "Poznámku se nepodařilo uložit",
+      "updateSuccess": "Poznámka upravena",
+      "updateError": "Poznámku se nepodařilo upravit",
+      "deleteSuccess": "Poznámka smazána",
+      "deleteError": "Poznámku se nepodařilo smazat",
+      "editLabel": "Upravit",
+      "deleteLabel": "Smazat",
+      "editAriaLabel": "Upravit poznámku",
+      "deleteAriaLabel": "Smazat poznámku",
+      "errorLoading": "Poznámky se nepodařilo načíst"
     }
   }
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -276,7 +276,9 @@
       "repsLabel_few": "{{count}}× opakování",
       "repsLabel_many": "{{count}}× opakování",
       "repsLabel_other": "{{count}}× opakování",
-      "monthPickerPrefix": "📅 Měsíc:"
+      "monthPickerPrefix": "📅 Měsíc:",
+      "resetFilter": "Zobrazit vše",
+      "errorLoading": "Nepodařilo se načíst aktivitu"
     },
     "values": {
       "Male": "Muž",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1748,6 +1748,32 @@
     "pendingInvite": {
       "title": "Pozvánka odeslána",
       "description": "Klient zatím nemá vytvořený účet. Na jeho email byla odeslána pozvánka s odkazem pro registraci. Po registraci si klient vyplní své údaje a jeho profil se zde automaticky doplní."
+    },
+    "mereni": {
+      "title": "Tělesná měření",
+      "addMeasurement": "Přidat měření",
+      "addMeasurementPlaceholder": "Přidat měření (funkce připravena v klientské aplikaci)",
+      "addFirstMeasurement": "Přidat první měření",
+      "emptyTitle": "Žádná měření",
+      "emptyDescription": "Klient zatím nezaznamenal žádná tělesná měření. Měření lze přidávat z mobilní aplikace.",
+      "errorLoading": "Měření se nepodařilo načíst.",
+      "chartLabel": "Vývoj váhy · posledních 8 týdnů",
+      "tiles": {
+        "currentWeight": "Aktuální váha",
+        "bodyFat": "Tělesný tuk",
+        "waist": "Pas",
+        "toGoal": "Do cíle",
+        "goalWeight": "cíl {{kg}} kg",
+        "comparedToWeeksAgo": "za 6 týd"
+      },
+      "table": {
+        "date": "Datum",
+        "weight": "Váha",
+        "bodyFat": "Tělesný tuk",
+        "waist": "Pas",
+        "hips": "Boky",
+        "chest": "Hrudník"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1777,6 +1777,46 @@
         "chest": "Hrudník"
       }
     },
+    "plany": {
+      "title": "Plány klienta",
+      "errorLoading": "Plány se nepodařilo načíst.",
+      "emptyTitle": "Žádné plány",
+      "emptyDescription": "Klient zatím nemá žádné výživové ani tréninkové plány.",
+      "table": {
+        "plan": "Plán",
+        "type": "Typ",
+        "period": "Období",
+        "status": "Stav",
+        "result": "Výsledek",
+        "openPlan": "Otevřít plán"
+      },
+      "typeLabel": {
+        "nutrition": "Výživa",
+        "training": "Trénink"
+      },
+      "status": {
+        "active": "Aktivní",
+        "completed": "Dokončený",
+        "draft": "Koncept",
+        "archived": "Archivovaný"
+      },
+      "result": {
+        "compliance": "Compliance {{pct}} %",
+        "weightDelta": "váha {{delta}} kg",
+        "totalTrainings_one": "{{count}} trénink",
+        "totalTrainings_few": "{{count}} tréninky",
+        "totalTrainings_many": "{{count}} tréninků",
+        "totalTrainings_other": "{{count}} tréninků",
+        "prCount_one": "{{count}} PR",
+        "prCount_few": "{{count}} PR",
+        "prCount_many": "{{count}} PR",
+        "prCount_other": "{{count}} PR"
+      },
+      "actions": {
+        "newNutrition": "Nový jídelníček",
+        "newTraining": "Nový tréninkový plán"
+      }
+    },
     "fotky": {
       "title": "Foto-deník",
       "countBadge": "{{photos}} fotek · {{plans}} plánů",

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1656,5 +1656,98 @@
       "inviteCheckboxWarning": "Žádost o foto-deník bude odeslána po úspěšném vytvoření pozvánky.",
       "inviteDiaryFailed": "Pozvánka odeslána, ale žádost o foto-deník se nepodařila. Můžete ji odeslat později z detailu klienta."
     }
+  },
+  "clientDetail": {
+    "photoDiary": "Foto-deník",
+    "writeMessage": "Napsat",
+    "lastName": "Příjmení",
+    "heightCm": "Výška (cm)",
+    "weightKg": "Váha (kg)",
+    "tabBarLabel": "Záložky klienta",
+    "ageYears_one": "{{count}} rok",
+    "ageYears_few": "{{count}} roky",
+    "ageYears_many": "{{count}} let",
+    "ageYears_other": "{{count}} let",
+    "tabs": {
+      "prehled": "Přehled",
+      "mereni": "Měření",
+      "fotky": "Fotky",
+      "aktivita": "Aktivita",
+      "plany": "Plány",
+      "checkiny": "Check-iny",
+      "dotazniky": "Dotazníky",
+      "poznamky": "Poznámky"
+    },
+    "verdict": {
+      "unavailable": "Hodnocení není k dispozici",
+      "onTrack": {
+        "label": "Na dobré cestě",
+        "subtitle": "Plány aktivní a aktuální"
+      },
+      "needsAttention": {
+        "label": "Vyžaduje pozornost",
+        "subtitle": "Jeden ukazatel mimo cíl"
+      },
+      "offTrack": {
+        "label": "Mimo plán",
+        "subtitle": "Kritická odchylka — klient potřebuje pomoc"
+      },
+      "signals": {
+        "compliance": "Compliance",
+        "weightDelta": "K cíli",
+        "trainingsPerWeek": "Tréninky/týd",
+        "prThisMonth": "PR tento měsíc"
+      }
+    },
+    "prehled": {
+      "noActivePlan": {
+        "nutrition": "Žádný aktivní jídelníček",
+        "training": "Žádný aktivní tréninkový plán",
+        "createNutrition": "Vytvořit jídelníček →",
+        "createTraining": "Vytvořit tréninkový plán →"
+      },
+      "planCard": {
+        "active": "Aktivní",
+        "goal": "Cíl",
+        "targetWeight": "cílová váha {{kg}} kg",
+        "compliance": "Compliance {{pct}} %",
+        "openNutrition": "Otevřít jídelníček",
+        "history": "Historie plánů",
+        "from": "od {{date}}"
+      },
+      "trainingCard": {
+        "weeklyFrequency_one": "{{count}} trénink týdně",
+        "weeklyFrequency_few": "{{count}} tréninky týdně",
+        "weeklyFrequency_many": "{{count}} tréninků týdně",
+        "weeklyFrequency_other": "{{count}} tréninků týdně",
+        "thisWeek_one": "{{count}}× tento týden",
+        "thisWeek_few": "{{count}}× tento týden",
+        "thisWeek_many": "{{count}}× tento týden",
+        "thisWeek_other": "{{count}}× tento týden",
+        "prThisMonth_one": "{{count}} PR tento měsíc",
+        "prThisMonth_few": "{{count}} PR tento měsíc",
+        "prThisMonth_many": "{{count}} PR tento měsíc",
+        "prThisMonth_other": "{{count}} PR tento měsíc",
+        "topPr": "🏆 Top PR: {{name}} — {{kg}} kg × {{reps}} opak.",
+        "openTraining": "Otevřít tréninkový plán"
+      },
+      "progress": {
+        "weightTitle": "Pokrok váhy k cíli",
+        "allMeasurements": "Všechna měření",
+        "remaining": "zbývá {{kg}} kg k cíli",
+        "noData": "Žádná měření",
+        "thisMonth": "Tento měsíc",
+        "stats": {
+          "prTotal": "PR celkem",
+          "workouts": "Tréninky",
+          "measurements": "Měření",
+          "completedDays": "Splněno dní"
+        }
+      }
+    },
+    "pendingInvite": {
+      "title": "Pozvánka odeslána",
+      "description": "Klient zatím nemá vytvořený účet. Na jeho email byla odeslána pozvánka s odkazem pro registraci. Po registraci si klient vyplní své údaje a jeho profil se zde automaticky doplní."
+    }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1806,6 +1806,32 @@
       "photoAlt": "Kundenfoto",
       "overflowLabel": "alle anzeigen",
       "overflowAriaLabel": "{{count}} weitere Fotos anzeigen"
+    },
+    "checkiny": {
+      "title": "Wöchentliche Check-ins",
+      "scheduleDesc": "Zeitplan: {{schedule}}",
+      "scheduleButton": "Check-in-Zeitplan",
+      "errorLoading": "Check-ins konnten nicht geladen werden.",
+      "emptyTitle": "Keine Check-ins",
+      "emptyDescription": "Für diesen Kunden wurden noch keine wöchentlichen Check-ins gesendet.",
+      "statusCompleted": "Ausgefüllt",
+      "statusPending": "Ausstehend"
+    },
+    "dotazniky": {
+      "title": "Fragebögen",
+      "assignButton": "Fragebogen zuweisen",
+      "errorLoading": "Fragebögen konnten nicht geladen werden.",
+      "emptyTitle": "Keine Fragebögen",
+      "emptyDescription": "Diesem Kunden wurde noch kein Fragebogen zugewiesen.",
+      "assignFirst": "Ersten Fragebogen zuweisen",
+      "assignSuccess": "Fragebogen erfolgreich zugewiesen",
+      "assignConflict": "Für den Kunden ist bereits ein Fragebogen ausstehend",
+      "assignError": "Fragebogen konnte nicht zugewiesen werden",
+      "statusCompleted": "Ausgefüllt",
+      "statusPending": "Ausstehend",
+      "viewAnswers": "Antworten anzeigen",
+      "submittedOn": "Eingereicht am {{date}}",
+      "pendingSubtitle": "Gesendet am {{date}} · Wartet auf Antwort"
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1832,6 +1832,24 @@
       "viewAnswers": "Antworten anzeigen",
       "submittedOn": "Eingereicht am {{date}}",
       "pendingSubtitle": "Gesendet am {{date}} · Wartet auf Antwort"
+    },
+    "poznamky": {
+      "title": "Trainer-Notizen",
+      "subtitle": "· privat, der Kunde sieht dies nicht",
+      "placeholder": "Notiz hinzufügen…",
+      "saveButton": "Notiz speichern",
+      "emptyState": "Noch keine Notizen.",
+      "createSuccess": "Notiz gespeichert",
+      "createError": "Notiz konnte nicht gespeichert werden",
+      "updateSuccess": "Notiz aktualisiert",
+      "updateError": "Notiz konnte nicht aktualisiert werden",
+      "deleteSuccess": "Notiz gelöscht",
+      "deleteError": "Notiz konnte nicht gelöscht werden",
+      "editLabel": "Bearbeiten",
+      "deleteLabel": "Löschen",
+      "editAriaLabel": "Notiz bearbeiten",
+      "deleteAriaLabel": "Notiz löschen",
+      "errorLoading": "Notizen konnten nicht geladen werden"
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -266,7 +266,9 @@
       "mealCount_other": "🥗 {{count}} Ernährungspläne",
       "repsLabel_one": "{{count}}× Wiederholung",
       "repsLabel_other": "{{count}}× Wiederholungen",
-      "monthPickerPrefix": "📅 Monat:"
+      "monthPickerPrefix": "📅 Monat:",
+      "resetFilter": "Alles anzeigen",
+      "errorLoading": "Aktivität konnte nicht geladen werden"
     },
     "values": {
       "Male": "Männlich",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1720,6 +1720,32 @@
     "pendingInvite": {
       "title": "Einladung gesendet",
       "description": "Der Klient hat noch kein Konto erstellt. Eine Einladung mit Registrierungslink wurde an seine E-Mail-Adresse gesendet. Nach der Registrierung füllt der Klient seine Daten aus und sein Profil wird hier automatisch aktualisiert."
+    },
+    "mereni": {
+      "title": "Körpermessungen",
+      "addMeasurement": "Messung hinzufügen",
+      "addMeasurementPlaceholder": "Messung hinzufügen (in der Client-App verfügbar)",
+      "addFirstMeasurement": "Erste Messung hinzufügen",
+      "emptyTitle": "Keine Messungen",
+      "emptyDescription": "Der Klient hat noch keine Körpermessungen aufgezeichnet. Messungen können über die mobile App hinzugefügt werden.",
+      "errorLoading": "Messungen konnten nicht geladen werden.",
+      "chartLabel": "Gewichtsverlauf · letzte 8 Wochen",
+      "tiles": {
+        "currentWeight": "Aktuelles Gewicht",
+        "bodyFat": "Körperfett",
+        "waist": "Taille",
+        "toGoal": "Zum Ziel",
+        "goalWeight": "Ziel {{kg}} kg",
+        "comparedToWeeksAgo": "über 6 Wo."
+      },
+      "table": {
+        "date": "Datum",
+        "weight": "Gewicht",
+        "bodyFat": "Körperfett",
+        "waist": "Taille",
+        "hips": "Hüfte",
+        "chest": "Brust"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1746,6 +1746,24 @@
         "hips": "Hüfte",
         "chest": "Brust"
       }
+    },
+    "fotky": {
+      "title": "Foto-Tagebuch",
+      "countBadge": "{{photos}} Fotos · {{plans}} Pläne",
+      "activeDiary": "Aktives Tagebuch",
+      "newRequest": "Neue Anfrage",
+      "openGallery": "Galerie öffnen",
+      "noActivePlanTooltip": "Kein aktiver Plan — Galerie nicht verfügbar",
+      "filterAll": "Alle",
+      "categoryFood": "Essen",
+      "categoryBody": "Körper",
+      "emptyTitle": "Noch keine Fotos",
+      "emptyDescription": "Bitten Sie den Kunden, Fotos von Mahlzeiten oder Fortschritten zu teilen.",
+      "emptyRequestCta": "Foto-Tagebuch-Anfrage senden",
+      "errorLoading": "Fotos konnten nicht geladen werden",
+      "photoAlt": "Kundenfoto",
+      "overflowLabel": "alle anzeigen",
+      "overflowAriaLabel": "{{count}} weitere Fotos anzeigen"
     }
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1749,6 +1749,46 @@
         "chest": "Brust"
       }
     },
+    "plany": {
+      "title": "Kundenpläne",
+      "errorLoading": "Pläne konnten nicht geladen werden.",
+      "emptyTitle": "Keine Pläne",
+      "emptyDescription": "Dieser Kunde hat noch keine Ernährungs- oder Trainingspläne.",
+      "table": {
+        "plan": "Plan",
+        "type": "Typ",
+        "period": "Zeitraum",
+        "status": "Status",
+        "result": "Ergebnis",
+        "openPlan": "Plan öffnen"
+      },
+      "typeLabel": {
+        "nutrition": "Ernährung",
+        "training": "Training"
+      },
+      "status": {
+        "active": "Aktiv",
+        "completed": "Abgeschlossen",
+        "draft": "Entwurf",
+        "archived": "Archiviert"
+      },
+      "result": {
+        "compliance": "Compliance {{pct}} %",
+        "weightDelta": "Gewicht {{delta}} kg",
+        "totalTrainings_one": "{{count}} Einheit",
+        "totalTrainings_few": "{{count}} Einheiten",
+        "totalTrainings_many": "{{count}} Einheiten",
+        "totalTrainings_other": "{{count}} Einheiten",
+        "prCount_one": "{{count}} PR",
+        "prCount_few": "{{count}} PRs",
+        "prCount_many": "{{count}} PRs",
+        "prCount_other": "{{count}} PRs"
+      },
+      "actions": {
+        "newNutrition": "Neuer Ernährungsplan",
+        "newTraining": "Neuer Trainingsplan"
+      }
+    },
     "fotky": {
       "title": "Foto-Tagebuch",
       "countBadge": "{{photos}} Fotos · {{plans}} Pläne",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1636,5 +1636,90 @@
       "inviteCheckboxWarning": "Die Fototagebuch-Anfrage wird nach erfolgreicher Erstellung der Einladung gesendet.",
       "inviteDiaryFailed": "Einladung gesendet, aber Fototagebuch-Anfrage fehlgeschlagen. Sie können sie später über das Klientendetail senden."
     }
+  },
+  "clientDetail": {
+    "photoDiary": "Fototagebuch",
+    "writeMessage": "Schreiben",
+    "lastName": "Nachname",
+    "heightCm": "Körpergröße (cm)",
+    "weightKg": "Gewicht (kg)",
+    "tabBarLabel": "Klienten-Reiter",
+    "ageYears_one": "{{count}} Jahr",
+    "ageYears_other": "{{count}} Jahre",
+    "tabs": {
+      "prehled": "Übersicht",
+      "mereni": "Messungen",
+      "fotky": "Fotos",
+      "aktivita": "Aktivität",
+      "plany": "Pläne",
+      "checkiny": "Check-ins",
+      "dotazniky": "Fragebögen",
+      "poznamky": "Notizen"
+    },
+    "verdict": {
+      "unavailable": "Bewertung nicht verfügbar",
+      "onTrack": {
+        "label": "Auf Kurs",
+        "subtitle": "Pläne aktiv und aktuell"
+      },
+      "needsAttention": {
+        "label": "Benötigt Aufmerksamkeit",
+        "subtitle": "Ein Indikator außerhalb des Ziels"
+      },
+      "offTrack": {
+        "label": "Außer Plan",
+        "subtitle": "Kritische Abweichung — Klient braucht Unterstützung"
+      },
+      "signals": {
+        "compliance": "Compliance",
+        "weightDelta": "Zum Ziel",
+        "trainingsPerWeek": "Einheiten/Woche",
+        "prThisMonth": "PBs diesen Monat"
+      }
+    },
+    "prehled": {
+      "noActivePlan": {
+        "nutrition": "Kein aktiver Ernährungsplan",
+        "training": "Kein aktiver Trainingsplan",
+        "createNutrition": "Ernährungsplan erstellen →",
+        "createTraining": "Trainingsplan erstellen →"
+      },
+      "planCard": {
+        "active": "Aktiv",
+        "goal": "Ziel",
+        "targetWeight": "Zielgewicht {{kg}} kg",
+        "compliance": "Compliance {{pct}} %",
+        "openNutrition": "Ernährungsplan öffnen",
+        "history": "Planhistorie",
+        "from": "ab {{date}}"
+      },
+      "trainingCard": {
+        "weeklyFrequency_one": "{{count}} Einheit/Woche",
+        "weeklyFrequency_other": "{{count}} Einheiten/Woche",
+        "thisWeek_one": "{{count}}× diese Woche",
+        "thisWeek_other": "{{count}}× diese Woche",
+        "prThisMonth_one": "{{count}} PB diesen Monat",
+        "prThisMonth_other": "{{count}} PBs diesen Monat",
+        "topPr": "🏆 Top PB: {{name}} — {{kg}} kg × {{reps}} Whd.",
+        "openTraining": "Trainingsplan öffnen"
+      },
+      "progress": {
+        "weightTitle": "Gewichtsfortschritt zum Ziel",
+        "allMeasurements": "Alle Messungen",
+        "remaining": "{{kg}} kg bis zum Ziel",
+        "noData": "Keine Messungen",
+        "thisMonth": "Diesen Monat",
+        "stats": {
+          "prTotal": "PBs gesamt",
+          "workouts": "Trainings",
+          "measurements": "Messungen",
+          "completedDays": "Erfüllte Tage"
+        }
+      }
+    },
+    "pendingInvite": {
+      "title": "Einladung gesendet",
+      "description": "Der Klient hat noch kein Konto erstellt. Eine Einladung mit Registrierungslink wurde an seine E-Mail-Adresse gesendet. Nach der Registrierung füllt der Klient seine Daten aus und sein Profil wird hier automatisch aktualisiert."
+    }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1747,6 +1747,24 @@
         "hips": "Hips",
         "chest": "Chest"
       }
+    },
+    "fotky": {
+      "title": "Photo diary",
+      "countBadge": "{{photos}} photos · {{plans}} plans",
+      "activeDiary": "Active diary",
+      "newRequest": "New request",
+      "openGallery": "Open gallery",
+      "noActivePlanTooltip": "No active plan — gallery not available",
+      "filterAll": "All",
+      "categoryFood": "Food",
+      "categoryBody": "Body",
+      "emptyTitle": "No photos yet",
+      "emptyDescription": "Ask your client to share photos of their meals or progress.",
+      "emptyRequestCta": "Send photo diary request",
+      "errorLoading": "Failed to load photos",
+      "photoAlt": "Client photo",
+      "overflowLabel": "view all",
+      "overflowAriaLabel": "View {{count}} more photos"
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1721,6 +1721,32 @@
     "pendingInvite": {
       "title": "Invitation sent",
       "description": "The client hasn't created an account yet. An invitation with a registration link was sent to their email. After registering, the client will fill in their details and their profile will update here automatically."
+    },
+    "mereni": {
+      "title": "Body measurements",
+      "addMeasurement": "Add measurement",
+      "addMeasurementPlaceholder": "Add measurement (available in the client app)",
+      "addFirstMeasurement": "Add first measurement",
+      "emptyTitle": "No measurements",
+      "emptyDescription": "The client hasn't recorded any body measurements yet. Measurements can be added from the mobile app.",
+      "errorLoading": "Could not load measurements.",
+      "chartLabel": "Weight trend · last 8 weeks",
+      "tiles": {
+        "currentWeight": "Current weight",
+        "bodyFat": "Body fat",
+        "waist": "Waist",
+        "toGoal": "To goal",
+        "goalWeight": "goal {{kg}} kg",
+        "comparedToWeeksAgo": "over 6 wks"
+      },
+      "table": {
+        "date": "Date",
+        "weight": "Weight",
+        "bodyFat": "Body fat",
+        "waist": "Waist",
+        "hips": "Hips",
+        "chest": "Chest"
+      }
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1637,5 +1637,90 @@
       "inviteCheckboxWarning": "Diary request will be sent after the invite is successfully created.",
       "inviteDiaryFailed": "Invite sent, but diary request failed. You can send it later from the client detail."
     }
+  },
+  "clientDetail": {
+    "photoDiary": "Photo diary",
+    "writeMessage": "Message",
+    "lastName": "Last name",
+    "heightCm": "Height (cm)",
+    "weightKg": "Weight (kg)",
+    "tabBarLabel": "Client tabs",
+    "ageYears_one": "{{count}} year",
+    "ageYears_other": "{{count}} years",
+    "tabs": {
+      "prehled": "Overview",
+      "mereni": "Measurements",
+      "fotky": "Photos",
+      "aktivita": "Activity",
+      "plany": "Plans",
+      "checkiny": "Check-ins",
+      "dotazniky": "Questionnaires",
+      "poznamky": "Notes"
+    },
+    "verdict": {
+      "unavailable": "Verdict unavailable",
+      "onTrack": {
+        "label": "On Track",
+        "subtitle": "Plans active and up to date"
+      },
+      "needsAttention": {
+        "label": "Needs Attention",
+        "subtitle": "One indicator off target"
+      },
+      "offTrack": {
+        "label": "Off Plan",
+        "subtitle": "Critical deviation — client needs support"
+      },
+      "signals": {
+        "compliance": "Compliance",
+        "weightDelta": "To goal",
+        "trainingsPerWeek": "Sessions/week",
+        "prThisMonth": "PRs this month"
+      }
+    },
+    "prehled": {
+      "noActivePlan": {
+        "nutrition": "No active nutrition plan",
+        "training": "No active training plan",
+        "createNutrition": "Create nutrition plan →",
+        "createTraining": "Create training plan →"
+      },
+      "planCard": {
+        "active": "Active",
+        "goal": "Goal",
+        "targetWeight": "target weight {{kg}} kg",
+        "compliance": "Compliance {{pct}} %",
+        "openNutrition": "Open nutrition plan",
+        "history": "Plan history",
+        "from": "from {{date}}"
+      },
+      "trainingCard": {
+        "weeklyFrequency_one": "{{count}} session/week",
+        "weeklyFrequency_other": "{{count}} sessions/week",
+        "thisWeek_one": "{{count}}× this week",
+        "thisWeek_other": "{{count}}× this week",
+        "prThisMonth_one": "{{count}} PR this month",
+        "prThisMonth_other": "{{count}} PRs this month",
+        "topPr": "🏆 Top PR: {{name}} — {{kg}} kg × {{reps}} reps",
+        "openTraining": "Open training plan"
+      },
+      "progress": {
+        "weightTitle": "Weight progress to goal",
+        "allMeasurements": "All measurements",
+        "remaining": "{{kg}} kg remaining to goal",
+        "noData": "No measurements",
+        "thisMonth": "This month",
+        "stats": {
+          "prTotal": "Total PRs",
+          "workouts": "Workouts",
+          "measurements": "Measurements",
+          "completedDays": "Completed days"
+        }
+      }
+    },
+    "pendingInvite": {
+      "title": "Invitation sent",
+      "description": "The client hasn't created an account yet. An invitation with a registration link was sent to their email. After registering, the client will fill in their details and their profile will update here automatically."
+    }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1750,6 +1750,46 @@
         "chest": "Chest"
       }
     },
+    "plany": {
+      "title": "Client plans",
+      "errorLoading": "Failed to load plans.",
+      "emptyTitle": "No plans",
+      "emptyDescription": "This client has no nutrition or training plans yet.",
+      "table": {
+        "plan": "Plan",
+        "type": "Type",
+        "period": "Period",
+        "status": "Status",
+        "result": "Result",
+        "openPlan": "Open plan"
+      },
+      "typeLabel": {
+        "nutrition": "Nutrition",
+        "training": "Training"
+      },
+      "status": {
+        "active": "Active",
+        "completed": "Completed",
+        "draft": "Draft",
+        "archived": "Archived"
+      },
+      "result": {
+        "compliance": "Compliance {{pct}}%",
+        "weightDelta": "weight {{delta}} kg",
+        "totalTrainings_one": "{{count}} session",
+        "totalTrainings_few": "{{count}} sessions",
+        "totalTrainings_many": "{{count}} sessions",
+        "totalTrainings_other": "{{count}} sessions",
+        "prCount_one": "{{count}} PR",
+        "prCount_few": "{{count}} PRs",
+        "prCount_many": "{{count}} PRs",
+        "prCount_other": "{{count}} PRs"
+      },
+      "actions": {
+        "newNutrition": "New nutrition plan",
+        "newTraining": "New training plan"
+      }
+    },
     "fotky": {
       "title": "Photo diary",
       "countBadge": "{{photos}} photos · {{plans}} plans",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -266,7 +266,9 @@
       "mealCount_other": "🥗 {{count}} meal plans",
       "repsLabel_one": "{{count}}× rep",
       "repsLabel_other": "{{count}}× reps",
-      "monthPickerPrefix": "📅 Month:"
+      "monthPickerPrefix": "📅 Month:",
+      "resetFilter": "Show all",
+      "errorLoading": "Failed to load activity"
     },
     "values": {
       "Male": "Male",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1807,6 +1807,32 @@
       "photoAlt": "Client photo",
       "overflowLabel": "view all",
       "overflowAriaLabel": "View {{count}} more photos"
+    },
+    "checkiny": {
+      "title": "Weekly check-ins",
+      "scheduleDesc": "Schedule: {{schedule}}",
+      "scheduleButton": "Check-in schedule",
+      "errorLoading": "Failed to load check-ins.",
+      "emptyTitle": "No check-ins",
+      "emptyDescription": "No weekly check-ins have been sent to this client yet.",
+      "statusCompleted": "Completed",
+      "statusPending": "Pending"
+    },
+    "dotazniky": {
+      "title": "Questionnaires",
+      "assignButton": "Assign questionnaire",
+      "errorLoading": "Failed to load questionnaires.",
+      "emptyTitle": "No questionnaires",
+      "emptyDescription": "No questionnaire has been assigned to this client yet.",
+      "assignFirst": "Assign first questionnaire",
+      "assignSuccess": "Questionnaire assigned successfully",
+      "assignConflict": "Client already has a questionnaire pending",
+      "assignError": "Failed to assign questionnaire",
+      "statusCompleted": "Completed",
+      "statusPending": "Pending",
+      "viewAnswers": "View answers",
+      "submittedOn": "Submitted {{date}}",
+      "pendingSubtitle": "Sent {{date}} · Waiting for response"
     }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1833,6 +1833,24 @@
       "viewAnswers": "View answers",
       "submittedOn": "Submitted {{date}}",
       "pendingSubtitle": "Sent {{date}} · Waiting for response"
+    },
+    "poznamky": {
+      "title": "Trainer notes",
+      "subtitle": "· private, client cannot see",
+      "placeholder": "Add a note…",
+      "saveButton": "Save note",
+      "emptyState": "No notes yet.",
+      "createSuccess": "Note saved",
+      "createError": "Failed to save note",
+      "updateSuccess": "Note updated",
+      "updateError": "Failed to update note",
+      "deleteSuccess": "Note deleted",
+      "deleteError": "Failed to delete note",
+      "editLabel": "Edit",
+      "deleteLabel": "Delete",
+      "editAriaLabel": "Edit note",
+      "deleteAriaLabel": "Delete note",
+      "errorLoading": "Failed to load notes"
     }
   }
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -46,6 +46,7 @@
   --purple-bg: rgba(105, 64, 165, 0.08);
   --orange:    #ad5700;
   --orange-bg: rgba(173, 87, 0, 0.08);
+  --orange-br: rgba(173, 87, 0, 0.2);
 
   /* Diary request status-chip tokens.
      Active-but-unfinished statuses (Pending / Accepted / InProgress) all use

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -258,7 +258,10 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-mereni"
               className="tab-content-transition"
             >
-              <MereniTab />
+              <MereniTab
+                clientId={id!}
+                targetWeightKg={ob?.targetWeightKg ?? null}
+              />
             </div>
           )}
 

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -328,7 +328,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-poznamky"
               className="tab-content-transition"
             >
-              <PoznamkyTab />
+              <PoznamkyTab clientId={id!} />
             </div>
           )}
         </div>

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -298,7 +298,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-plany"
               className="tab-content-transition"
             >
-              <PlanyTab />
+              <PlanyTab clientId={id!} />
             </div>
           )}
 

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -1,43 +1,78 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { getClientDashboard } from '@/api/nutrition-goals';
-import { getClientTimeline } from '@/api/timeline';
 
-import { PageHeader } from '@/components/layout';
-import { Button, Tag, Dialog, Input, EditableAvatar } from '@/components/ui';
-import { PropertyList, StatsGrid } from '@/components/data';
-import { RecentActivitySection } from '@/components/domain';
-import { QuestionnaireAnswersSection } from '@/components/questionnaire';
-import { WeeklyCheckInSection } from '@/components/weekly-checkin/WeeklyCheckInSection';
+import { getClientDashboard } from '@/api/nutrition-goals';
+import { getClientVerdict } from '@/api/client-verdict';
+import { getPlans, getPlan } from '@/api/plans';
+import { getTrainingPlans } from '@/api/training-plans';
+import { getClientTimeline } from '@/api/timeline';
+import { useRecentActivityAggregates } from '@/components/domain/RecentActivity/useRecentActivityAggregates';
+
+import { Button, Dialog, Input } from '@/components/ui';
+import { IdentityStrip } from '@/components/clients/IdentityStrip';
+import { ClientTabBar, type ClientTabId } from '@/components/clients/ClientTabBar';
+import {
+  VerdictHeroCard,
+  VerdictHeroCardError,
+  VerdictHeroCardSkeleton,
+} from '@/components/clients/VerdictHeroCard';
+import { ActiveNutritionPlanCard } from '@/components/clients/ActiveNutritionPlanCard';
+import { ActiveTrainingPlanCard } from '@/components/clients/ActiveTrainingPlanCard';
+import { PlanCardPlaceholder } from '@/components/clients/PlanCardPlaceholder';
+import { ProgressSnapshot } from '@/components/clients/ProgressSnapshot';
+import { MereniTab } from '@/components/clients/tabs/MereniTab';
+import { FotkyTab } from '@/components/clients/tabs/FotkyTab';
+import { AktivitaTab } from '@/components/clients/tabs/AktivitaTab';
+import { PlanyTab } from '@/components/clients/tabs/PlanyTab';
+import { CheckinyTab } from '@/components/clients/tabs/CheckinyTab';
+import { DotaznikyTab } from '@/components/clients/tabs/DotaznikyTab';
+import { PoznamkyTab } from '@/components/clients/tabs/PoznamkyTab';
+import type { PlanSummary } from '@/api/plan-types';
+import type { TrainingPlanSummary } from '@/api/training-plan-types';
 
 export default function ClientDetailPage() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  // Edit dialog state
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<ClientTabId>('prehled');
 
-  // Timeline pagination limit — starts at 30, bumps by 30 up to 100
-  const [timelineLimit, setTimelineLimit] = useState(30);
+  // ── Server state ─────────────────────────────────────────────────────────────
 
-  const { data: client, isLoading } = useQuery({
+  const { data: client, isLoading: clientLoading } = useQuery({
     queryKey: ['client-dashboard', id],
     queryFn: () => getClientDashboard(id!),
     enabled: !!id,
   });
 
-  const { data: timeline } = useQuery({
-    queryKey: ['client-timeline', id, timelineLimit],
-    queryFn: () => getClientTimeline(id!, timelineLimit),
-    enabled: !!id,
+  const {
+    data: verdict,
+    isError: verdictError,
+    isLoading: verdictLoading,
+  } = useQuery({
+    queryKey: ['client-verdict', id],
+    queryFn: () => getClientVerdict(id!),
+    enabled: !!id && client?.hasRegistered === true,
+    // Non-fatal: 404/403 surfaces as error state, not page crash
+    retry: false,
   });
 
-  const handleTimelineLoadMore = useCallback(() => {
-    setTimelineLimit((prev) => Math.min(prev + 30, 100));
-  }, []);
+  const { data: nutritionPlans } = useQuery({
+    queryKey: ['plans', { clientId: id, status: 'Active' }],
+    queryFn: () => getPlans({ clientId: id, status: 'Active', pageSize: 1 }),
+    enabled: !!id && client?.hasRegistered === true,
+  });
+
+  const { data: trainingPlans } = useQuery({
+    queryKey: ['training-plans', { clientId: id, status: 'Active' }],
+    queryFn: () => getTrainingPlans({ clientId: id, status: 'Active', pageSize: 1 }),
+    enabled: !!id && client?.hasRegistered === true,
+  });
+
+  // ── Derived values ───────────────────────────────────────────────────────────
 
   const clientName = client
     ? `${client.firstName} ${client.lastName}`
@@ -49,41 +84,6 @@ export default function ClientDetailPage() {
 
   const ob = client?.onboarding;
 
-  /** Translate an enum/tag value via clients.values.X, fall back to raw value */
-  const v = useCallback((val: string | null | undefined) => {
-    if (!val) return '—';
-    const key = `clients.values.${val}`;
-    const translated = t(key);
-    return translated !== key ? translated : val;
-  }, [t]);
-
-  // Compliance color helper
-  const complianceColor = useMemo(() => {
-    const cp = client?.compliancePercent;
-    if (cp == null) return 'text-text3';
-    if (cp >= 80) return 'text-green';
-    if (cp >= 60) return 'text-orange';
-    return 'text-red';
-  }, [client?.compliancePercent]);
-
-  // Weight progress
-  const weightProgress = useMemo(() => {
-    if (!client?.weightKg || !client?.latestMeasurement?.weightKg) return null;
-    const diff = client.latestMeasurement.weightKg - client.weightKg;
-    return Math.round(diff * 10) / 10;
-  }, [client]);
-
-  // Goal tag variant
-  const goalTagVariant = useMemo((): 'blue' | 'green' | 'orange' | 'purple' => {
-    const goal = ob?.derivedNutritionGoal || ob?.primaryGoal;
-    if (!goal) return 'blue';
-    const lower = goal.toLowerCase();
-    if (lower.includes('cut') || lower.includes('hubn')) return 'blue';
-    if (lower.includes('bulk') || lower.includes('nabr')) return 'purple';
-    return 'green';
-  }, [ob]);
-
-  // Calculate age from dateOfBirth
   const clientAge = useMemo(() => {
     if (!client?.dateOfBirth) return null;
     const birth = new Date(client.dateOfBirth);
@@ -92,173 +92,38 @@ export default function ClientDetailPage() {
     const m = now.getMonth() - birth.getMonth();
     if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age--;
     return age;
-  }, [client]);
+  }, [client?.dateOfBirth]);
 
-  // Build property list items
-  const propertyItems = useMemo(() => {
-    if (!client) return [];
-    const items: Array<{
-      label: string;
-      icon?: string;
-      value: React.ReactNode;
-      editable?: boolean;
-      onEdit?: (value: string) => void;
-    }> = [];
+  const activeNutritionPlanSummary: PlanSummary | null =
+    nutritionPlans?.plans?.[0] ?? null;
 
-    // Vek
-    if (clientAge != null) {
-      items.push({
-        label: 'Věk',
-        icon: '📅',
-        value: `${clientAge} let`,
-        editable: false,
-      });
-    }
+  const activeTrainingPlan: TrainingPlanSummary | null =
+    trainingPlans?.plans?.[0] ?? null;
 
-    // Vyska / vaha
-    const height = client.heightCm;
-    const weight = client.latestMeasurement?.weightKg ?? client.weightKg;
-    if (height != null || weight != null) {
-      const weightDiff = weightProgress;
-      items.push({
-        label: 'Výška / váha',
-        icon: '📏',
-        value: (
-          <span>
-            {height != null ? `${height} cm` : ''}
-            {height != null && weight != null ? ' · ' : ''}
-            {weight != null ? `${weight} kg` : ''}
-            {weightDiff != null && weightDiff !== 0 && (
-              <span className={`ml-1.5 text-xs ${weightDiff < 0 ? 'text-green' : 'text-orange'}`}>
-                {weightDiff < 0 ? '↓' : '↑'} {Math.abs(weightDiff)} kg
-              </span>
-            )}
-          </span>
-        ),
-      });
-    }
+  // Fetch the active nutrition plan detail to get globalSettings (macros).
+  // PlanSummary does not carry globalSettings — the detail does.
+  const { data: activeNutritionPlanDetail } = useQuery({
+    queryKey: ['plan', activeNutritionPlanSummary?.planId],
+    queryFn: () => getPlan(activeNutritionPlanSummary!.planId),
+    enabled: !!activeNutritionPlanSummary?.planId,
+  });
 
-    // Cilova vaha
-    if (ob?.targetWeightKg != null) {
-      items.push({
-        label: 'Cílová váha',
-        icon: '🎯',
-        value: `${ob.targetWeightKg} kg`,
-        editable: true,
-      });
-    }
+  // Fetch the client timeline so we can derive the top PR for the training card.
+  const { data: timelineData } = useQuery({
+    queryKey: ['client-timeline', id],
+    queryFn: () => getClientTimeline(id!, 50),
+    enabled: !!id && client?.hasRegistered === true,
+  });
 
-    // Email
-    if (client.email) {
-      items.push({
-        label: 'Email',
-        icon: '✉',
-        value: <span className="text-blue">{client.email}</span>,
-      });
-    }
+  const { topPr } = useRecentActivityAggregates(timelineData?.items ?? []);
 
-    // Aktivni plany
-    items.push({
-      label: 'Aktivní plány',
-      icon: '📋',
-      value: (
-        <span className="flex flex-wrap items-center gap-1.5">
-          <span className="text-text3">{t('clients.noPlans') !== 'clients.noPlans' ? t('clients.noPlans') : 'Žádné plány'}</span>
-        </span>
-      ),
-    });
+  const startWeight = client?.weightKg ?? null;
+  const currentWeight = client?.latestMeasurement?.weightKg ?? startWeight;
+  const targetWeight = ob?.targetWeightKg ?? null;
 
-    // Alergie
-    if (ob?.allergies) {
-      let allergiesDisplay = ob.allergies;
-      try {
-        const arr = JSON.parse(ob.allergies);
-        if (Array.isArray(arr)) allergiesDisplay = arr.join(', ');
-      } catch { /* use as-is */ }
-      items.push({
-        label: 'Alergie',
-        icon: '⚠',
-        value: allergiesDisplay,
-        editable: true,
-      });
-    }
+  // ── Loading / error states ───────────────────────────────────────────────────
 
-    return items;
-  }, [client, clientAge, weightProgress, ob, t]);
-
-  // Build stats
-  const statsItems = useMemo(() => {
-    if (!client) return [];
-    return [
-      {
-        label: '🔥 Série',
-        value: client.currentStreak,
-        sub: 'dní v řadě',
-        valueColor: client.currentStreak > 0 ? 'text-orange' : undefined,
-      },
-      {
-        label: 'Compliance',
-        value: client.compliancePercent != null ? `${client.compliancePercent} %` : '—',
-        sub: 'za posledních 7 dní',
-        valueColor: complianceColor,
-      },
-      {
-        label: 'Pokrok váhy',
-        value: weightProgress != null && weightProgress !== 0
-          ? `${weightProgress > 0 ? '+' : ''}${weightProgress} kg`
-          : '—',
-        sub: weightProgress != null && weightProgress !== 0
-          ? (weightProgress < 0 ? 'úbytek' : 'přírůstek')
-          : 'beze změny',
-        valueColor: weightProgress != null && weightProgress < 0 ? 'text-green' : weightProgress != null && weightProgress > 0 ? 'text-orange' : undefined,
-      },
-    ];
-  }, [client, complianceColor, weightProgress]);
-
-  // Build weight progress chart data (bar chart)
-  const weightChartData = useMemo(() => {
-    if (!client?.weightKg) return null;
-    const startWeight = client.weightKg;
-    const currentWeight = client.latestMeasurement?.weightKg ?? startWeight;
-    const targetWeight = ob?.targetWeightKg ?? currentWeight;
-
-    const values = [startWeight, currentWeight, targetWeight];
-    const maxVal = Math.max(...values);
-    const minVal = Math.min(...values);
-    // Use 0 as the floor so bars reflect absolute scale, not just relative diff
-    const floor = Math.max(0, minVal - (maxVal - minVal) * 0.5);
-    const range = maxVal - floor || 1;
-
-    return [
-      { label: 'Start', value: startWeight, pct: ((startWeight - floor) / range) * 100 },
-      { label: 'Aktuální', value: currentWeight, pct: ((currentWeight - floor) / range) * 100, highlight: true },
-      { label: 'Cíl', value: targetWeight, pct: ((targetWeight - floor) / range) * 100 },
-    ];
-  }, [client, ob]);
-
-  // Narrow the active locale to the set supported by formatWeight.
-  const activeLocale = useMemo((): 'cs' | 'en' | 'de' => {
-    const lang = i18n.language;
-    if (lang === 'en' || lang === 'de') return lang;
-    return 'cs';
-  }, [i18n.language]);
-
-  // Raw timeline items — passed directly to RecentActivitySection for grouping.
-  // The old flat-list activityItems memo is superseded by the new section component.
-
-  // Subtitle for PageHeader
-  const subtitleNode = useMemo(() => {
-    if (!client) return undefined;
-    const goal = ob?.primaryGoal || ob?.derivedNutritionGoal || client.goals;
-    return (
-      <div className="flex items-center gap-2 mt-1.5">
-        {goal && <Tag variant={goalTagVariant}>{v(goal)}</Tag>}
-      </div>
-    );
-  }, [client, ob, goalTagVariant, v]);
-
-  // Loading state
-  if (isLoading) {
+  if (clientLoading) {
     return (
       <div className="flex items-center justify-center py-24 text-text3">
         {t('common.loading')}
@@ -268,189 +133,238 @@ export default function ClientDetailPage() {
 
   if (!client) return null;
 
-  // Client has not registered yet — show pending invite state
-  const isPending = client.hasRegistered === false;
-
-  if (isPending) {
+  // Pending-invite state: client has not registered yet
+  if (client.hasRegistered === false) {
     return (
       <div className="flex h-full flex-col">
-        <PageHeader icon="👤" title={clientName} subtitle={client.email ?? undefined} />
-        <div style={{ padding: '40px 80px', maxWidth: 600 }}>
-          <div style={{
-            background: 'var(--accent-bg)',
-            border: '1px solid var(--accent-br)',
-            borderRadius: 'var(--radius-md)',
-            padding: '24px 28px',
-          }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
-              <span style={{ fontSize: 28 }}>✉️</span>
+        <div className="px-20 py-7">
+          <h1 className="text-text mb-1">{clientName}</h1>
+          <div className="text-[13px] text-text3 mb-5">{client.email}</div>
+          <div
+            className="max-w-[480px] rounded-[var(--radius-md)] p-6"
+            style={{
+              background: 'var(--accent-bg)',
+              border: '1px solid var(--accent-br)',
+            }}
+          >
+            <div className="flex items-center gap-2.5 mb-3">
+              <span className="text-[28px]">✉️</span>
               <div>
-                <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--text)' }}>Pozvánka odeslána</div>
-                <div style={{ fontSize: 13, color: 'var(--text2)', marginTop: 2 }}>{client.email}</div>
+                <div className="text-[15px] font-semibold text-text">
+                  {t('clientDetail.pendingInvite.title')}
+                </div>
+                <div className="text-[13px] text-text2 mt-0.5">{client.email}</div>
               </div>
             </div>
-            <div style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.6 }}>
-              Klient zatím nemá vytvořený účet. Na jeho email byla odeslána pozvánka
-              s odkazem pro registraci. Po registraci si klient vyplní své údaje
-              (váha, výška, cíle, alergie) a jeho profil se zde automaticky doplní.
+            <div className="text-[13px] text-text2 leading-relaxed">
+              {t('clientDetail.pendingInvite.description')}
             </div>
-          </div>
-
-          <div style={{
-            marginTop: 20,
-            padding: '16px 20px',
-            background: 'var(--bg2)',
-            borderRadius: 'var(--radius-md)',
-            fontSize: 13,
-            color: 'var(--text3)',
-          }}>
-            <div style={{ fontWeight: 500, color: 'var(--text2)', marginBottom: 6 }}>Co se stane po registraci klienta?</div>
-            <ul style={{ paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <li>Klient vyplní svou anamnézu a osobní údaje</li>
-              <li>Budete moci nastavit jeho výživové cíle a makra</li>
-              <li>Můžete mu vytvořit jídelníček a tréninkový plán</li>
-            </ul>
           </div>
         </div>
       </div>
     );
   }
 
+  // ── Render ───────────────────────────────────────────────────────────────────
+
   return (
     <div className="flex h-full flex-col">
-      {/* Page Header */}
-      <PageHeader
-        icon={
-          <EditableAvatar
-            src={null}
-            initials={clientInitials}
-            size="md"
-            editable={false}
-          />
-        }
-        title={clientName}
-        subtitle={client.email ?? undefined}
-        actions={
-          <div className="flex items-center gap-1.5">
-            {subtitleNode}
-            <Button onClick={() => setEditDialogOpen(true)}>
-              ✏ {t('clients.editProfile')}
-            </Button>
-            <Button variant="primary" onClick={() => navigate(`/messages?clientId=${id}`)}>
-              ✉ {t('clients.sendMessage')}
-            </Button>
-          </div>
-        }
+      {/* Identity strip — pinned above tab bar */}
+      <IdentityStrip
+        client={client}
+        clientId={id!}
+        clientInitials={clientInitials}
+        clientAge={clientAge}
+        onEditProfile={() => setEditDialogOpen(true)}
+        onPhotoDiary={() => {
+          // Photo diary action — to be wired by wave-3 Fotky sub-issue
+        }}
       />
 
-      {/* Page Content */}
+      {/* Gold-chip tab bar */}
+      <ClientTabBar activeTab={activeTab} onTabChange={setActiveTab} />
+
+      {/* Pane content — scrolls independently */}
       <div className="flex-1 overflow-y-auto">
-        <div className="px-20 py-3">
-          {/* Property List */}
-          <PropertyList items={propertyItems} />
+        <div className="px-20 py-5">
 
-          {/* Questionnaire Answers */}
-          <div className="my-3.5">
-            <QuestionnaireAnswersSection clientId={id!} />
-          </div>
+          {/* ── PŘEHLED PANE ── */}
+          {activeTab === 'prehled' && (
+            <div
+              id="cl-pane-prehled"
+              role="tabpanel"
+              aria-labelledby="cl-tab-prehled"
+              className="tab-content-transition"
+            >
+              {/* Verdict hero card */}
+              {verdictLoading && <VerdictHeroCardSkeleton />}
+              {verdictError && <VerdictHeroCardError />}
+              {verdict && !verdictError && (
+                <VerdictHeroCard verdict={verdict} />
+              )}
 
-          {/* Weekly check-in section */}
-          {/* NOTE: id here is the client's publicId (route param). The backend
-              GET /trainer/clients/{clientUserId}/weekly-check-ins/current
-              expects the ApplicationUser.Id (Guid). Until the backend exposes
-              clientUserId in the client dashboard response, this will return
-              empty results and the section stays hidden. A follow-up task
-              should add clientUserId to GetClientDashboardResponse. */}
-          {id && (
-            <WeeklyCheckInSection clientUserId={id} />
-          )}
+              {/* Active plan cards (nutrition + training side by side) */}
+              <div className="grid grid-cols-2 gap-3.5 mb-4">
+                {activeNutritionPlanSummary ? (
+                  <ActiveNutritionPlanCard
+                    plan={activeNutritionPlanSummary}
+                    globalSettings={activeNutritionPlanDetail?.globalSettings}
+                    targetWeightKg={ob?.targetWeightKg}
+                    goalLabel={ob?.derivedNutritionGoal ?? ob?.primaryGoal}
+                    compliancePercent={client.compliancePercent}
+                    onHistoryClick={() => setActiveTab('plany')}
+                  />
+                ) : (
+                  <PlanCardPlaceholder
+                    type="nutrition"
+                    onCreatePlan={() => navigate(`/nutrition/plans/new?clientId=${id}`)}
+                  />
+                )}
 
-          {/* Divider */}
-          <div className="h-px bg-border my-3.5" />
-
-          {/* Stats Grid */}
-          <StatsGrid stats={statsItems} columns={3} />
-
-          {/* Weight Progress Chart */}
-          {weightChartData && (
-            <div className="mb-4">
-              <div className="text-[11px] text-text3 font-medium uppercase tracking-[0.04em] mb-2">
-                Váhový progres
+                {activeTrainingPlan ? (
+                  <ActiveTrainingPlanCard
+                    plan={activeTrainingPlan}
+                    trainingFrequencyActual={verdict?.trainingFrequencyActual}
+                    trainingFrequencyPrescribed={verdict?.trainingFrequencyPrescribed}
+                    prCountThisMonth={verdict?.prCountThisMonth}
+                    topPr={topPr}
+                    onHistoryClick={() => setActiveTab('plany')}
+                  />
+                ) : (
+                  <PlanCardPlaceholder
+                    type="training"
+                    onCreatePlan={() => navigate(`/training/plans/new?clientId=${id}`)}
+                  />
+                )}
               </div>
-              <div className="flex gap-3">
-                {weightChartData.map((bar) => (
-                  <div key={bar.label} className="flex flex-col items-center gap-1 flex-1">
-                    <div className="text-[11px] text-text2 font-medium">{bar.value} kg</div>
-                    <div className="w-full relative" style={{ height: 80 }}>
-                      <div
-                        className="absolute bottom-0 left-0 right-0 rounded"
-                        style={{
-                          height: `${Math.max(bar.pct, 8)}%`,
-                          backgroundColor: bar.highlight ? 'var(--accent)' : 'var(--bg3)',
-                        }}
-                      />
-                    </div>
-                    <div className="text-[11px] text-text3">{bar.label}</div>
-                  </div>
-                ))}
-              </div>
+
+              {/* Progress snapshot */}
+              <ProgressSnapshot
+                startWeight={startWeight}
+                currentWeight={currentWeight}
+                targetWeight={targetWeight}
+                verdict={verdict ?? null}
+                onAllMeasurementsClick={() => setActiveTab('mereni')}
+              />
             </div>
           )}
 
-          {/* Divider */}
-          <div className="h-px bg-border my-3.5" />
+          {/* ── PLACEHOLDER PANES ── (wave-3 children fill these)
+              NOTE: id="cl-pane-<id>" lives on each placeholder component's root div,
+              not on this wrapper, to avoid duplicate DOM ids. */}
+          {activeTab === 'mereni' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-mereni"
+              className="tab-content-transition"
+            >
+              <MereniTab />
+            </div>
+          )}
 
-          {/* Recent Activity — day-grouped timeline + summary sidebar */}
-          <RecentActivitySection
-            items={timeline?.items ?? []}
-            limit={timelineLimit}
-            onLoadMore={handleTimelineLoadMore}
-            locale={activeLocale}
-          />
+          {activeTab === 'fotky' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-fotky"
+              className="tab-content-transition"
+            >
+              <FotkyTab />
+            </div>
+          )}
+
+          {activeTab === 'aktivita' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-aktivita"
+              className="tab-content-transition"
+            >
+              <AktivitaTab />
+            </div>
+          )}
+
+          {activeTab === 'plany' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-plany"
+              className="tab-content-transition"
+            >
+              <PlanyTab />
+            </div>
+          )}
+
+          {activeTab === 'checkiny' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-checkiny"
+              className="tab-content-transition"
+            >
+              <CheckinyTab />
+            </div>
+          )}
+
+          {activeTab === 'dotazniky' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-dotazniky"
+              className="tab-content-transition"
+            >
+              <DotaznikyTab />
+            </div>
+          )}
+
+          {activeTab === 'poznamky' && (
+            <div
+              role="tabpanel"
+              aria-labelledby="cl-tab-poznamky"
+              className="tab-content-transition"
+            >
+              <PoznamkyTab />
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Edit Client Dialog */}
+      {/* Edit client dialog (unchanged from original) */}
       <Dialog
         open={editDialogOpen}
         onClose={() => setEditDialogOpen(false)}
-        title="Upravit profil"
+        title={t('clients.editProfile')}
         footer={
           <>
             <Button variant="ghost" onClick={() => setEditDialogOpen(false)}>
-              Zrušit
+              {t('common.cancel')}
             </Button>
             <Button variant="primary" onClick={() => setEditDialogOpen(false)}>
-              Uložit
+              {t('common.save')}
             </Button>
           </>
         }
       >
         <div className="space-y-0">
           <Input
-            label="Jméno"
+            label={t('common.name')}
             defaultValue={client?.firstName ?? ''}
-            placeholder="Jméno"
+            placeholder={t('common.name')}
           />
           <Input
-            label="Příjmení"
+            label={t('clientDetail.lastName')}
             defaultValue={client?.lastName ?? ''}
-            placeholder="Příjmení"
+            placeholder={t('clientDetail.lastName')}
           />
           <Input
-            label="Email"
+            label={t('common.email')}
             defaultValue={client?.email ?? ''}
-            placeholder="Email"
+            placeholder={t('common.email')}
             type="email"
           />
           <Input
-            label="Výška (cm)"
+            label={t('clientDetail.heightCm')}
             defaultValue={client?.heightCm?.toString() ?? ''}
             placeholder="168"
             type="number"
           />
           <Input
-            label="Váha (kg)"
+            label={t('clientDetail.weightKg')}
             defaultValue={client?.weightKg?.toString() ?? ''}
             placeholder="63"
             type="number"

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -84,15 +84,16 @@ export default function ClientDetailPage() {
 
   const ob = client?.onboarding;
 
+  const dob = client?.dateOfBirth;
   const clientAge = useMemo(() => {
-    if (!client?.dateOfBirth) return null;
-    const birth = new Date(client.dateOfBirth);
+    if (!dob) return null;
+    const birth = new Date(dob);
     const now = new Date();
     let age = now.getFullYear() - birth.getFullYear();
     const m = now.getMonth() - birth.getMonth();
     if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age--;
     return age;
-  }, [client?.dateOfBirth]);
+  }, [dob]);
 
   const activeNutritionPlanSummary: PlanSummary | null =
     nutritionPlans?.plans?.[0] ?? null;

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -308,7 +308,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-checkiny"
               className="tab-content-transition"
             >
-              <CheckinyTab />
+              <CheckinyTab clientUserId={id!} />
             </div>
           )}
 
@@ -318,7 +318,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-dotazniky"
               className="tab-content-transition"
             >
-              <DotaznikyTab />
+              <DotaznikyTab clientId={id!} />
             </div>
           )}
 

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -288,7 +288,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-aktivita"
               className="tab-content-transition"
             >
-              <AktivitaTab />
+              <AktivitaTab clientId={id!} />
             </div>
           )}
 

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -271,7 +271,14 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-fotky"
               className="tab-content-transition"
             >
-              <FotkyTab />
+              <FotkyTab
+                clientId={id!}
+                clientName={clientName}
+                clientInitials={clientInitials}
+                linkId={client.linkId}
+                activeNutritionPlan={activeNutritionPlanSummary}
+                activeTrainingPlan={activeTrainingPlan}
+              />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
Rebuilt `ClientDetailPage` into a pinned identity strip + gold-chip 8-tab bar (Přehled / Měření / Fotky / Aktivita / Plány / Check-iny / Dotazníky / Poznámky). New backend endpoints `/trainer/clients/{id}/verdict` (#485), `/trainer/clients/{id}/plans` (#490), and TrainerNote CRUD `/trainer/clients/{id}/notes` (#492, MongoDB-backed). Six web tab panes consume existing + new endpoints. `develop` was merged into the epic branch — the Program.cs DI-block conflict was resolved keeping **both** the `ClientVerdictService` and the develop `GoogleTokenVerifier` registrations.

## Sub-issues consolidated in this epic
- Fixes #484 — epic: client-detail redesign
- Fixes #485 — on-track verdict endpoint
- Fixes #486 — Přehled / tabbed shell
- Fixes #487 — Měření tab
- Fixes #488 — Fotky tab
- Fixes #489 — Aktivita tab
- Fixes #490 — Plány tab + list-client-plans endpoint
- Fixes #491 — Check-iny + Dotazníky tabs
- Fixes #492 — Poznámky (private trainer notes, MongoDB CRUD)

## Scope
backend + web

## QA verdict (from qa-tester)
OVERALL ✅ PASS (consolidated, per-sub-issue AC verified across the epic).

## Deliberate decisions (NOT defects)
1. **Hand-written API modules** (`client-verdict.ts`, `measurements.ts`, `client-plans.ts`, `trainer-notes.ts`) consume the 3 new endpoints instead of regenerated `generated.ts` types — consistent with the existing hand-written-module pattern (`client-requests.ts`). A consolidated `regen-api` reconcile is a recommended follow-up; each module was verified against its backend Response DTO during sub-issue review.
2. **Check-iny tab** is reduced-scope (current-week, no weight/mood/history) — the data model lacks those fields; epic #484 explicitly excludes data-model migration. Follow-up #503 tracks exposing `clientUserId` so the pane lights up.
3. **Live-visual prototype-fidelity** vs `docs/prototypes/notion/scenes/client.html` was deferred from each sub-issue to this epic stage (structural parity verified per child).

## Test plan
- [ ] Identity strip pins client name/avatar/status across tab switches
- [ ] 8 gold-chip tabs render and switch without remount jank
- [ ] Přehled: verdict hero + progress snapshot + active plan cards
- [ ] Měření: measurement series renders
- [ ] Fotky: progress-photo grid
- [ ] Aktivita: single-column activity timeline
- [ ] Plány: active nutrition + training plan cards from `/trainer/clients/{id}/plans`
- [ ] Check-iny: current-week reduced-scope pane
- [ ] Dotazníky: assigned-questionnaire answers
- [ ] Poznámky: TrainerNote create/edit/delete/list (trainer-only, client-403)
- [ ] verdict/plans/notes all return 403 for non-owning trainer
- [ ] i18n keys present in cs/en/de

🤖 Generated with [Claude Code](https://claude.com/claude-code)