### PR TITLE
fix: Check-iny tab always empty — expose clientUserId on client dashboard (#503)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
@@ -192,6 +192,7 @@ public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService 
         {
             LinkId = link.Id,
             ClientPublicId = clientProfile.PublicId,
+            ClientUserId = clientProfile.UserId,
             Email = clientProfile.User.Email!,
             FirstName = clientProfile.User.FirstName,
             LastName = clientProfile.User.LastName,

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardResponse.cs
@@ -17,6 +17,13 @@ public class GetClientDashboardResponse
     public Guid ClientPublicId { get; set; }
 
     /// <summary>
+    /// The client's <c>ApplicationUser.Id</c> (= <c>ClientProfile.UserId</c>).
+    /// This is the identifier used by the weekly-check-in and schedule-override
+    /// endpoints — it differs from <see cref="ClientPublicId"/>.
+    /// </summary>
+    public Guid ClientUserId { get; set; }
+
+    /// <summary>
     /// The client's email address.
     /// </summary>
     public string Email { get; set; } = string.Empty;

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardEndpointTests.cs
@@ -52,6 +52,45 @@ public class GetClientDashboardEndpointTests
         ep.Response.TotalMeasurements.Should().Be(0);
         ep.Response.TotalProgressPhotos.Should().Be(0);
         ep.Response.LinkId.Should().Be(99);
+        ep.Response.ClientUserId.Should().Be(clientUser.Id);
+    }
+
+    [Fact]
+    public async Task HandleAsync_LinkedClient_ReturnsClientUserId_MatchingApplicationUserId()
+    {
+        // ClientUserId must equal the ApplicationUser.Id (the FK on ClientProfile),
+        // which differs from ClientPublicId. This is the identifier the weekly-check-in
+        // endpoint filters on.
+        var clientUser = EntityBuilder.User.WithEmail("checkin@test.com")
+            .WithFirstName("Check").WithLastName("In").Build();
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(2).WithUserId(_trainerId).Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(2).WithUser(clientUser).Build();
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(100)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        var ep = Factory.Create<GetClientDashboardEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
+                new System.Security.Claims.ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db, _audit, _complianceService);
+
+        await ep.HandleAsync(new GetClientDashboardRequest
+        {
+            ClientId = clientProfile.PublicId
+        }, TestContext.Current.CancellationToken);
+
+        ep.Response.ClientUserId.Should().Be(clientUser.Id);
+        ep.Response.ClientPublicId.Should().Be(clientProfile.PublicId);
+        ep.Response.ClientUserId.Should().NotBe(clientProfile.PublicId);
     }
 
     [Fact]

--- a/web/src/api/nutrition-goals.ts
+++ b/web/src/api/nutrition-goals.ts
@@ -66,6 +66,8 @@ export interface OnboardingData {
 
 export interface ClientDashboard {
   clientPublicId: string;
+  /** ApplicationUser.Id for the client. Used for weekly check-in queries. */
+  clientUserId: string;
   /** Internal integer PK of the ClientProfessionalLink row. Used for diary requests. */
   linkId?: number | null;
   email: string;

--- a/web/src/pages/ClientDetailPage.tsx
+++ b/web/src/pages/ClientDetailPage.tsx
@@ -309,7 +309,7 @@ export default function ClientDetailPage() {
               aria-labelledby="cl-tab-checkiny"
               className="tab-content-transition"
             >
-              <CheckinyTab clientUserId={id!} />
+              <CheckinyTab clientUserId={client.clientUserId} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- The trainer client-detail **Check-iny** tab called the weekly-check-in endpoint with the route `id` (= `ClientProfile.PublicId`), but that endpoint filters by `ApplicationUser.Id` (`WeeklyCheckIn.ClientUserId`) — a different Guid — so it always returned empty.
- Fix exposes `clientUserId` (= `ClientProfile.UserId` / `ApplicationUser.Id`) on `GetClientDashboardResponse` and wires `ClientDetailPage` to pass `client.clientUserId` to `CheckinyTab` (which already consumed `clientUserId` for both the current-check-in query and the OverrideDialog).
- No EF migration — response field only.

## Related issue
Fixes #503

## Scope
cross-cut (backend + web — one branch, one PR)

## QA verdict (from qa-tester)
Backend + web static/test all green (GetClientDashboardEndpointTests 6/6, full Trainers namespace 80/80, web build + lint 0 errors). Runtime check-in render AC flagged INTERACTIVE-REQUIRED; root cause statically proven, covered by full CI suite + Netlify deploy preview per orchestrator decision.

## Test plan
- [ ] `GetClientDashboardResponse` (and its TS type in `web/src/api/nutrition-goals.ts`) exposes the client's `ApplicationUser.Id` as `clientUserId`, sourced from `ClientProfile.UserId`.
- [ ] `CheckinyTab` is passed `clientUserId` (not the route `PublicId`) for `getClientCurrentCheckIn` and the `OverrideDialog`.
- [ ] The current-week check-in renders for a client who has one; the empty state only appears when the client genuinely has none.
- [ ] Backend: `dotnet build` clean; `GetClientDashboard` test asserts the new `clientUserId` field.
- [ ] Web: `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)