### PR TITLE
refactor: reconcile client-detail API to generated types (#506)

### DIFF
--- a/web/src/api/client-plans.ts
+++ b/web/src/api/client-plans.ts
@@ -1,82 +1,26 @@
 import api from '@/lib/api';
+import type {
+  ListClientPlansResponse,
+  ClientPlanItem,
+  ClientPlanResultSummary,
+} from '@/api/generated';
+
+// Re-export generated types so consumers can import from this module unchanged.
+export type { ListClientPlansResponse, ClientPlanItem, ClientPlanResultSummary };
 
 /**
- * Plan type discriminator — mirrors the backend PlanType string.
+ * Plan type discriminator — kept as a local narrowing union because the
+ * generated ClientPlanItem.planType field is typed as `string`. The values
+ * ("Nutrition" | "Training") are stable backend constants, not an emitted enum.
  */
 export type PlanType = 'Nutrition' | 'Training';
 
 /**
- * Plan status discriminator — mirrors the backend plan status strings.
+ * Plan status discriminator — kept as a local narrowing union because the
+ * generated ClientPlanItem.status field is typed as `string`. Used as a
+ * Record key in PlanyTab's StatusChip component.
  */
 export type PlanStatus = 'Draft' | 'Active' | 'Completed' | 'Archived';
-
-/**
- * Per-plan result summary. Fields not applicable to the plan type are null.
- * Mirrors backend ClientPlanResultSummary.
- *
- * Training-plan fields: totalTrainings, prCount.
- * Nutrition-plan fields: compliancePercent, weightDeltaKg.
- */
-export interface ClientPlanResultSummary {
-  /**
-   * Count of completed WorkoutLogs for this plan.
-   * Null for nutrition plans.
-   */
-  totalTrainings: number | null;
-  /**
-   * Count of PersonalRecords achieved within the plan's date window.
-   * Null for nutrition plans or plans without a StartDate.
-   */
-  prCount: number | null;
-  /**
-   * Nutrition compliance percent (0–100) over the plan period.
-   * Null for training plans or plans without a StartDate.
-   */
-  compliancePercent: number | null;
-  /**
-   * Weight delta (kg) from first to last measurement in the plan window.
-   * Positive = weight gained; negative = weight lost.
-   * Null for training plans or when fewer than two measurements exist.
-   */
-  weightDeltaKg: number | null;
-}
-
-/**
- * A single plan entry in the combined client plan list.
- * Mirrors backend ClientPlanItem.
- */
-export interface ClientPlanItem {
-  /** The plan's public ExternalId (Guid). */
-  planId: string;
-  /** Discriminates the plan type: "Nutrition" or "Training". */
-  planType: PlanType;
-  /** Display name of the plan. */
-  name: string;
-  /** ISO 8601 UTC — the Monday when Week 1 begins. Null when not yet set. */
-  periodStart: string | null;
-  /**
-   * ISO 8601 UTC — when the plan was marked completed.
-   * Null for active/draft plans and open-ended plans.
-   */
-  periodEnd: string | null;
-  /** Current plan status: "Draft" | "Active" | "Completed" | "Archived". */
-  status: PlanStatus;
-  /** Per-plan result metrics. */
-  resultSummary: ClientPlanResultSummary;
-}
-
-/**
- * Response from GET /trainer/clients/{clientId}/plans.
- * Mirrors backend ListClientPlansResponse.
- *
- * NOTE: generated.ts does not yet contain this type — regen-api will be run
- * once at the epic-PR stage to reconcile hand-written modules. This is the
- * hand-authored source of truth for the web client until then.
- */
-export interface ListClientPlansResponse {
-  /** All plans (nutrition + training), newest first. */
-  plans: ClientPlanItem[];
-}
 
 /**
  * Fetch the combined plan list (nutrition + training) for a client.

--- a/web/src/api/client-verdict.ts
+++ b/web/src/api/client-verdict.ts
@@ -1,47 +1,13 @@
 import api from '@/lib/api';
-
-/**
- * On-track verdict for a client as assessed by the trainer dashboard.
- * Mirrors backend ClientVerdict enum.
- */
-export type ClientVerdict = 'OnTrack' | 'NeedsAttention' | 'OffTrack';
-
-/**
- * Direction a client's weight is moving relative to their target.
- * Mirrors backend WeightDirection enum.
- */
-export type WeightDirection = 'Towards' | 'Away' | 'Stable';
-
-/**
- * Response from GET /trainer/clients/{clientId}/verdict.
- * NOTE: generated.ts does not yet contain this type — regen-api
- * must be run once the backend is accessible on :5001 (epic branch).
- * Until then this hand-authored mirror of GetClientVerdictResponse.cs
- * is the source of truth for the web client.
- */
-export interface ClientVerdictResponse {
-  verdict: ClientVerdict;
-  /** Nutrition plan compliance percent (0-100), or null when no active plan. */
-  compliancePercent: number | null;
-  /** Delta between current weight and target weight in kg, positive = above target. */
-  weightDeltaToGoal: number | null;
-  /** Direction the weight is moving relative to the goal. */
-  weightDirection: WeightDirection;
-  /** Sessions completed this ISO week, or null when no active training plan. */
-  trainingFrequencyActual: number | null;
-  /** Sessions prescribed per week in active training plan, or null. */
-  trainingFrequencyPrescribed: number | null;
-  /** UTC timestamp of the most recent activity, or null. */
-  lastActiveAt: string | null;
-  /** Number of personal records achieved in the current calendar month. */
-  prCountThisMonth: number;
-}
+import type { GetClientVerdictResponse } from '@/api/generated';
+export { ClientVerdict, WeightDirection } from '@/api/generated';
+export type { GetClientVerdictResponse };
 
 /** Fetch the on-track verdict for a client. */
 export async function getClientVerdict(
   clientId: string,
-): Promise<ClientVerdictResponse> {
-  const { data } = await api.get<ClientVerdictResponse>(
+): Promise<GetClientVerdictResponse> {
+  const { data } = await api.get<GetClientVerdictResponse>(
     `/trainer/clients/${clientId}/verdict`,
   );
   return data;

--- a/web/src/api/generated.ts
+++ b/web/src/api/generated.ts
@@ -164,7 +164,7 @@ export class ApiClient {
     }
 
     /**
-     * Start a workout
+     * Start a workout (create draft log)
      * @return Success
      */
     startWorkoutEndpoint(startWorkoutRequest: StartWorkoutRequest, signal?: AbortSignal): Promise<StartWorkoutResponse> {
@@ -298,6 +298,78 @@ export class ApiClient {
     }
 
     /**
+     * Go live with a workout
+     * @param logId The external ID of the workout log to go live with.
+    Bound from the route segment {logId}.
+     * @return Success
+     */
+    goLiveEndpoint(logId: string, signal?: AbortSignal): Promise<GoLiveResponse> {
+        let url_ = this.baseUrl + "/client/training/logs/{logId}/go-live";
+        if (logId === undefined || logId === null)
+            throw new globalThis.Error("The parameter 'logId' must be defined.");
+        url_ = url_.replace("{logId}", encodeURIComponent("" + logId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGoLiveEndpoint(_response);
+        });
+    }
+
+    protected processGoLiveEndpoint(response: AxiosResponse): Promise<GoLiveResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GoLiveResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GoLiveResponse>(null as any);
+    }
+
+    /**
      * Get exercise progress
      * @param clientId Client's public user identifier.
      * @param exerciseId Exercise's public identifier.
@@ -427,6 +499,78 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<WorkoutLogDetail>(null as any);
+    }
+
+    /**
+     * Abandon a workout
+     * @param logId The external ID of the workout log to abandon.
+    Bound from the route segment {logId}.
+     * @return Success
+     */
+    abandonWorkoutEndpoint(logId: string, signal?: AbortSignal): Promise<AbandonWorkoutResponse> {
+        let url_ = this.baseUrl + "/client/training/logs/{logId}/abandon";
+        if (logId === undefined || logId === null)
+            throw new globalThis.Error("The parameter 'logId' must be defined.");
+        url_ = url_.replace("{logId}", encodeURIComponent("" + logId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAbandonWorkoutEndpoint(_response);
+        });
+    }
+
+    protected processAbandonWorkoutEndpoint(response: AxiosResponse): Promise<AbandonWorkoutResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<AbandonWorkoutResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<AbandonWorkoutResponse>(null as any);
     }
 
     /**
@@ -1910,6 +2054,148 @@ export class ApiClient {
     }
 
     /**
+     * Unlock a training session for editing
+     * @param planId Training plan identifier.
+     * @param sessionId Session identifier to unlock for editing.
+     * @return No Content
+     */
+    unlockTrainingSessionEndpoint(planId: string, sessionId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/training/plans/{planId}/sessions/{sessionId}/unlock";
+        if (planId === undefined || planId === null)
+            throw new globalThis.Error("The parameter 'planId' must be defined.");
+        url_ = url_.replace("{planId}", encodeURIComponent("" + planId));
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUnlockTrainingSessionEndpoint(_response);
+        });
+    }
+
+    protected processUnlockTrainingSessionEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Relock a training session (release the Editing lock)
+     * @param planId Training plan identifier.
+     * @param sessionId Session identifier to relock.
+     * @return No Content
+     */
+    relockTrainingSessionEndpoint(planId: string, sessionId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/training/plans/{planId}/sessions/{sessionId}/relock";
+        if (planId === undefined || planId === null)
+            throw new globalThis.Error("The parameter 'planId' must be defined.");
+        url_ = url_.replace("{planId}", encodeURIComponent("" + planId));
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRelockTrainingSessionEndpoint(_response);
+        });
+    }
+
+    protected processRelockTrainingSessionEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Publish a week of a training plan
      * @param planId Plan identifier.
      * @param weekNumber Week number to publish.
@@ -2201,6 +2487,85 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<TrainingPlanSummaryDto>(null as any);
+    }
+
+    /**
+     * Finish a session on behalf of a client
+     * @param planId The training plan ExternalId (route parameter).
+     * @param sessionId The session identifier within the plan's weeks (route parameter).
+     * @return Success
+     */
+    finishSessionEndpoint(planId: string, sessionId: string, finishSessionRequest: FinishSessionRequest, signal?: AbortSignal): Promise<FinishSessionResponse> {
+        let url_ = this.baseUrl + "/trainer/training/plans/{planId}/sessions/{sessionId}/finish";
+        if (planId === undefined || planId === null)
+            throw new globalThis.Error("The parameter 'planId' must be defined.");
+        url_ = url_.replace("{planId}", encodeURIComponent("" + planId));
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(finishSessionRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processFinishSessionEndpoint(_response);
+        });
+    }
+
+    protected processFinishSessionEndpoint(response: AxiosResponse): Promise<FinishSessionResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<FinishSessionResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<FinishSessionResponse>(null as any);
     }
 
     /**
@@ -2785,6 +3150,77 @@ export class ApiClient {
     }
 
     /**
+     * List client plans
+     * @param clientId The client's PublicId (Guid), as it appears in the route segment.
+     * @return Success
+     */
+    listClientPlansEndpoint(clientId: string, signal?: AbortSignal): Promise<ListClientPlansResponse> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientId}/plans";
+        if (clientId === undefined || clientId === null)
+            throw new globalThis.Error("The parameter 'clientId' must be defined.");
+        url_ = url_.replace("{clientId}", encodeURIComponent("" + clientId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processListClientPlansEndpoint(_response);
+        });
+    }
+
+    protected processListClientPlansEndpoint(response: AxiosResponse): Promise<ListClientPlansResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ListClientPlansResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ListClientPlansResponse>(null as any);
+    }
+
+    /**
      * Invite a client
      * @return Success
      */
@@ -2913,6 +3349,76 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetDashboardSummaryResponse>(null as any);
+    }
+
+    /**
+     * Get client on-track verdict
+     * @return Success
+     */
+    getClientVerdictEndpoint(clientId: string, signal?: AbortSignal): Promise<GetClientVerdictResponse> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientId}/verdict";
+        if (clientId === undefined || clientId === null)
+            throw new globalThis.Error("The parameter 'clientId' must be defined.");
+        url_ = url_.replace("{clientId}", encodeURIComponent("" + clientId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetClientVerdictEndpoint(_response);
+        });
+    }
+
+    protected processGetClientVerdictEndpoint(response: AxiosResponse): Promise<GetClientVerdictResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GetClientVerdictResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GetClientVerdictResponse>(null as any);
     }
 
     /**
@@ -3384,6 +3890,304 @@ export class ApiClient {
         if (status === 204) {
             const _responseText = response.data;
             return Promise.resolve<void>(null as any);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * List trainer notes for a client
+     * @return Success
+     */
+    listNotesEndpoint(clientId: string, page: number, pageSize: number, signal?: AbortSignal): Promise<ListNotesResponse> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientId}/notes?";
+        if (clientId === undefined || clientId === null)
+            throw new globalThis.Error("The parameter 'clientId' must be defined.");
+        url_ = url_.replace("{clientId}", encodeURIComponent("" + clientId));
+        if (page === undefined || page === null)
+            throw new globalThis.Error("The parameter 'page' must be defined and cannot be null.");
+        else
+            url_ += "page=" + encodeURIComponent("" + page) + "&";
+        if (pageSize === undefined || pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' must be defined and cannot be null.");
+        else
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processListNotesEndpoint(_response);
+        });
+    }
+
+    protected processListNotesEndpoint(response: AxiosResponse): Promise<ListNotesResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ListNotesResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ListNotesResponse>(null as any);
+    }
+
+    /**
+     * Create a trainer note for a client
+     * @return Success
+     */
+    createNoteEndpoint(clientId: string, createNoteRequest: CreateNoteRequest, signal?: AbortSignal): Promise<CreateNoteResponse> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientId}/notes";
+        if (clientId === undefined || clientId === null)
+            throw new globalThis.Error("The parameter 'clientId' must be defined.");
+        url_ = url_.replace("{clientId}", encodeURIComponent("" + clientId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(createNoteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processCreateNoteEndpoint(_response);
+        });
+    }
+
+    protected processCreateNoteEndpoint(response: AxiosResponse): Promise<CreateNoteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<CreateNoteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<CreateNoteResponse>(null as any);
+    }
+
+    /**
+     * Edit a trainer note
+     * @return Success
+     */
+    editNoteEndpoint(clientId: string, noteId: string, editNoteRequest: EditNoteRequest, signal?: AbortSignal): Promise<EditNoteResponse> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientId}/notes/{noteId}";
+        if (clientId === undefined || clientId === null)
+            throw new globalThis.Error("The parameter 'clientId' must be defined.");
+        url_ = url_.replace("{clientId}", encodeURIComponent("" + clientId));
+        if (noteId === undefined || noteId === null)
+            throw new globalThis.Error("The parameter 'noteId' must be defined.");
+        url_ = url_.replace("{noteId}", encodeURIComponent("" + noteId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(editNoteRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PATCH",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processEditNoteEndpoint(_response);
+        });
+    }
+
+    protected processEditNoteEndpoint(response: AxiosResponse): Promise<EditNoteResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<EditNoteResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<EditNoteResponse>(null as any);
+    }
+
+    /**
+     * Delete a trainer note
+     * @return No Content
+     */
+    deleteNoteEndpoint(clientId: string, noteId: string, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/trainer/clients/{clientId}/notes/{noteId}";
+        if (clientId === undefined || clientId === null)
+            throw new globalThis.Error("The parameter 'clientId' must be defined.");
+        url_ = url_.replace("{clientId}", encodeURIComponent("" + clientId));
+        if (noteId === undefined || noteId === null)
+            throw new globalThis.Error("The parameter 'noteId' must be defined.");
+        url_ = url_.replace("{noteId}", encodeURIComponent("" + noteId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDeleteNoteEndpoint(_response);
+        });
+    }
+
+    protected processDeleteNoteEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
 
         } else if (status === 401) {
             const _responseText = response.data;
@@ -8385,6 +9189,78 @@ export class ApiClient {
     }
 
     /**
+     * Save photos / note for a training session diary entry
+     * @param sessionId The unique identifier of the training session whose photos/note are being saved.
+    Sourced from the route segment {SessionId}.
+     * @return No Content
+     */
+    saveSessionPhotosEndpoint(sessionId: string, saveSessionPhotosRequest: SaveSessionPhotosRequest, signal?: AbortSignal): Promise<void> {
+        let url_ = this.baseUrl + "/client/training/log/sessions/{sessionId}/photos";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(saveSessionPhotosRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSaveSessionPhotosEndpoint(_response);
+        });
+    }
+
+    protected processSaveSessionPhotosEndpoint(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Mark all training sessions for a day complete
      * @return Success
      */
@@ -9042,6 +9918,82 @@ export class ApiClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<GetFullTrainingPlanResponse>(null as any);
+    }
+
+    /**
+     * Generate training session photo upload URL
+     * @param sessionId The unique identifier of the session the photo will be attached to.
+    Sourced from the route segment {SessionId}.
+     * @return Success
+     */
+    generateSessionPhotoUploadUrlEndpoint(sessionId: string, generateSessionPhotoUploadUrlRequest: GenerateSessionPhotoUploadUrlRequest, signal?: AbortSignal): Promise<GenerateSessionPhotoUploadUrlResponse> {
+        let url_ = this.baseUrl + "/client/training/log/sessions/{sessionId}/photo-upload-url";
+        if (sessionId === undefined || sessionId === null)
+            throw new globalThis.Error("The parameter 'sessionId' must be defined.");
+        url_ = url_.replace("{sessionId}", encodeURIComponent("" + sessionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(generateSessionPhotoUploadUrlRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGenerateSessionPhotoUploadUrlEndpoint(_response);
+        });
+    }
+
+    protected processGenerateSessionPhotoUploadUrlEndpoint(response: AxiosResponse): Promise<GenerateSessionPhotoUploadUrlResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GenerateSessionPhotoUploadUrlResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("Bad Request", status, _responseText, _headers, result400);
+
+        } else if (status === 401) {
+            const _responseText = response.data;
+            return throwException("Unauthorized", status, _responseText, _headers);
+
+        } else if (status === 403) {
+            const _responseText = response.data;
+            return throwException("Forbidden", status, _responseText, _headers);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GenerateSessionPhotoUploadUrlResponse>(null as any);
     }
 
     /**
@@ -11884,6 +12836,69 @@ export class ApiClient {
     }
 
     /**
+     * Google social login
+     * @return Login successful
+     */
+    googleSocialLoginEndpoint(googleSocialLoginRequest: GoogleSocialLoginRequest, signal?: AbortSignal): Promise<GoogleSocialLoginResponse> {
+        let url_ = this.baseUrl + "/auth/social/google";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(googleSocialLoginRequest);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            signal
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGoogleSocialLoginEndpoint(_response);
+        });
+    }
+
+    protected processGoogleSocialLoginEndpoint(response: AxiosResponse): Promise<GoogleSocialLoginResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<GoogleSocialLoginResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("idToken is missing or empty", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<GoogleSocialLoginResponse>(null as any);
+    }
+
+    /**
      * Reset password
      * @return No Content
      */
@@ -12425,7 +13440,7 @@ export interface WodResult {
     repsByRound?: number[] | undefined;
 }
 
-/** A single set actually performed during a workout with recorded values. */
+/** A single set actually performed during a workout with recorded values. Snapshot-planned fields capture the prescribed values at the time the set was first logged; they are immutable after initial persistence so later plan edits do not affect them. */
 export interface WorkoutSet {
     /** Set number within the exercise (1-based). */
     setNumber?: number;
@@ -12443,6 +13458,20 @@ export interface WorkoutSet {
     completedAt?: string | undefined;
     /** Whether this set is a personal record for this exercise. */
     isPR?: boolean;
+    /** Prescribed repetitions at the time this set was first logged. */
+    plannedReps?: number | undefined;
+    /** Prescribed weight (kg) at the time this set was first logged. */
+    plannedWeightKg?: number | undefined;
+    /** Prescribed RPE at the time this set was first logged. */
+    plannedRpe?: number | undefined;
+    /** Prescribed duration (seconds) at the time this set was first logged. */
+    plannedDurationSeconds?: number | undefined;
+    /** Prescribed distance (meters) at the time this set was first logged. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+Always false for legacy sets whose planned fields are all null (backward-compatible default).
+Never stored — derived on read. */
+    isModified?: boolean;
 }
 
 /** Request to progressively update a workout log with exercise data. Designed for offline-first: client sends all exercises/sets accumulated so far. */
@@ -12460,6 +13489,11 @@ Null for Standard workouts or when not yet recorded. */
 
 /** Exercise data in a workout update. */
 export interface UpdateWorkoutExerciseRequest {
+    /** The section this exercise belongs to — must match SectionId
+(and by design the source SectionId).
+Null for requests from legacy clients that do not yet send section context;
+in that case the exercise is stored in the first section of the log (single-section fallback). */
+    sectionId?: string | undefined;
     /** Reference to the exercise document's ExternalId. */
     exerciseExternalId?: string;
     /** Snapshot of the exercise name. */
@@ -12487,6 +13521,16 @@ export interface UpdateWorkoutSetRequest {
     distanceMeters?: number | undefined;
     /** When this set was completed. */
     completedAt?: string | undefined;
+    /** Prescribed repetitions from the plan prescription. */
+    plannedReps?: number | undefined;
+    /** Prescribed weight (kg) from the plan prescription. */
+    plannedWeightKg?: number | undefined;
+    /** Prescribed RPE from the plan prescription. */
+    plannedRpe?: number | undefined;
+    /** Prescribed duration (seconds) from the plan prescription. */
+    plannedDurationSeconds?: number | undefined;
+    /** Prescribed distance (meters) from the plan prescription. */
+    plannedDistanceMeters?: number | undefined;
 }
 
 /** RFC7807 compatible problem details/ error response class. this can be used by configuring startup like so: app.UseFastEndpoints(c => c.Errors.UseProblemDetails()) */
@@ -12527,6 +13571,18 @@ export interface StartWorkoutRequest {
     planId?: string | undefined;
     /** Optional reference to the training session within the plan. */
     sessionId?: string | undefined;
+}
+
+/** Response returned when a workout log transitions to Live state. */
+export interface GoLiveResponse {
+    /** The external ID of the workout log now in Live state. */
+    logId?: string;
+    /** UTC timestamp when the Live lock was acquired. */
+    liveAt?: string;
+}
+
+/** Request to transition an existing draft workout log to Live state. */
+export interface GoLiveRequest {
 }
 
 /** Paginated response with workout log summaries. */
@@ -12601,6 +13657,16 @@ export interface GetExerciseProgressRequest {
 export interface CompleteWorkoutRequest {
 }
 
+/** Response returned when an abandon request is processed (including idempotent no-op case). */
+export interface AbandonWorkoutResponse {
+    /** Whether a Live lock was actually released. False when the lock was already gone (idempotent). */
+    released?: boolean;
+}
+
+/** Request to abandon (discard) a draft workout session and release the Live lock. */
+export interface AbandonWorkoutRequest {
+}
+
 /** Response for POST /client/weekly-check-ins/{id}/respond. */
 export interface RespondToCheckInResponse {
     /** Check-in identifier. */
@@ -12639,12 +13705,14 @@ export interface PutSettingsResponse {
     profession?: string;
     /** Day of the week (0 = Sunday … 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned time of day. */
+    /** Time of day for the reminder. Between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
     /** Optional addendum. */
     defaultAddendum?: string | undefined;
+    /** Hours after dispatch before the check-in expires. */
+    deadlineOffsetHours?: number;
 }
 
 /** Request body for PUT /trainer/weekly-check-ins/settings. */
@@ -12654,12 +13722,16 @@ Accepted values: "Training", "Nutrition". */
     profession: string;
     /** Day of the week on which the reminder fires (0 = Sunday … 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned local time of day for the reminder. Minutes, Seconds, and Milliseconds must all be zero. */
+    /** Local time of day for the reminder. Must be between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
     /** Optional addendum appended to the default reminder message. ≤ 200 characters. */
     defaultAddendum?: string | undefined;
+    /** Number of hours after the check-in is sent before it expires.
+Must be one of: 24, 48, 72, 120, 168.
+Defaults to 72 (3 days) when not specified. */
+    deadlineOffsetHours?: number;
 }
 
 /** Response for PUT /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. */
@@ -12678,18 +13750,23 @@ export interface PutOverrideResponse {
     enabled?: boolean | undefined;
     /** Override addendum. Null = inherit. */
     addendum?: string | undefined;
+    /** Override deadline offset in hours. Null = inherit. */
+    deadlineOffsetHours?: number | undefined;
 }
 
 /** Request model for PUT /trainer/weekly-check-ins/overrides/{clientUserId}/{profession}. Route params identify the override; body provides the values (null = inherit from setting). */
 export interface PutOverrideRequest {
     /** Override day of week (0 = Sunday … 6 = Saturday). Null = inherit. */
     dayOfWeek?: number | undefined;
-    /** Override time of day (hour-aligned). Null = inherit. Minutes/Seconds/Milliseconds must be zero if set. */
+    /** Override time of day. Null = inherit. Must be between 00:00:00 and 23:59:59 if set. */
     timeOfDay?: string | undefined;
     /** Override enabled flag. Null = inherit. */
     enabled?: boolean | undefined;
     /** Override addendum (≤ 200 chars). Null = inherit. */
     addendum?: string | undefined;
+    /** Override deadline offset in hours. Null = inherit from the professional's setting.
+When set, must be one of 24, 48, 72, 120, or 168. */
+    deadlineOffsetHours?: number | undefined;
 }
 
 /** Response for POST /trainer/weekly-check-ins/{id}/mark-reviewed. */
@@ -12734,6 +13811,10 @@ export interface TrainerCheckInDto {
     dismissedByClientAt?: string | undefined;
     /** When the trainer marked this reviewed. Null if not reviewed. */
     reviewedByTrainerAt?: string | undefined;
+    /** Lifecycle status of the check-in. */
+    status?: string;
+    /** UTC deadline by which the client must respond. Null for rows created before v1 deadline feature. */
+    dueAt?: string | undefined;
 }
 
 /** Query parameters for GET /trainer/weekly-check-ins. */
@@ -12754,12 +13835,14 @@ export interface CheckInSettingDto {
     profession?: string;
     /** Day of the week (0 = Sunday, 1 = Monday, …, 6 = Saturday). */
     dayOfWeek?: number;
-    /** Hour-aligned time of day in "HH:mm:ss" format. */
+    /** Time of day for the reminder in "HH:mm:ss" format. Between 00:00:00 and 23:59:59. */
     timeOfDay?: string;
     /** Whether the reminder is enabled. */
     enabled?: boolean;
     /** Optional addendum appended to the default reminder message. */
     defaultAddendum?: string | undefined;
+    /** Hours after dispatch before the check-in expires. */
+    deadlineOffsetHours?: number;
 }
 
 /** Response model for GET /trainer/weekly-check-ins/overrides. */
@@ -12788,6 +13871,8 @@ export interface CheckInOverrideDto {
     enabled?: boolean | undefined;
     /** Override addendum. Null = inherit. */
     addendum?: string | undefined;
+    /** Override deadline offset in hours. Null = inherit. */
+    deadlineOffsetHours?: number | undefined;
 }
 
 /** Response for GET /client/weekly-check-ins/current. Returns 0–2 active (not responded, not dismissed) check-ins for the current ISO week. */
@@ -12871,6 +13956,10 @@ export interface GetCheckInDetailResponse {
     dismissedByClientAt?: string | undefined;
     /** When the trainer marked this reviewed. Null if not reviewed. */
     reviewedByTrainerAt?: string | undefined;
+    /** Lifecycle status of the check-in. */
+    status?: string;
+    /** UTC deadline by which the client must respond. Null for rows created before v1 deadline feature. */
+    dueAt?: string | undefined;
 }
 
 /** Request for GET /trainer/weekly-check-ins/{id}. */
@@ -13016,6 +14105,18 @@ Null if no questionnaire is linked to this plan. */
 Populated by the endpoint after loading the plan; the client side should filter
 to dates that fall within the plan's active weeks. */
     completions?: TrainingPlanCompletionDto[];
+    /** Per-session workout-log execution data for the plan's client.
+One entry per session that has at least one WorkoutLog record.
+Sessions with no log entry are absent (equivalent to all sets being not-yet-reached).
+The web layer uses this together with Completions to render per-set,
+per-exercise, and per-session completed/skipped/unreached state indicators. */
+    sessionExecutions?: SessionExecutionDto[];
+    /** Per-session edit-lock state for all sessions in the plan.
+Only sessions with an active (non-expired) lock appear here; a session absent from
+this list is implicitly Stable.
+The web editor uses this on initial load to show the Live in-progress badge and gate
+the unlock affordance — SignalR events update this state while the page is open. */
+    sessionLockStates?: SessionLockStateDto[];
 }
 
 /** A single week within a training plan. */
@@ -13182,6 +14283,108 @@ completion documents are transparently migrated. */
     version?: number;
 }
 
+/** Per-set execution data returned by the trainer endpoint. Lets the web layer derive completed / skipped / not-yet-reached states without storing those as flags on the document. */
+export interface SessionExecutionDto {
+    /** The SessionId this execution belongs to. */
+    sessionId?: string;
+    /** Whether the workout was finalised by the client (IsCompleted was true). */
+    isSessionFinished?: boolean;
+    /** Per-exercise map of which set numbers were completed (i.e. had a non-null
+CompletedAt). Key = ExerciseExternalId; value = sorted list
+of 1-based set numbers that were stamped as complete in the WorkoutLog.
+An absent key means no sets for that exercise were logged.
+An empty list should not occur but is treated identically to an absent key.
+Deprecated in favour of CompletedSetsBySectionAndExercise.
+Retained for backward compatibility. When a multi-section log has the same exercise
+in two sections, only the last-encountered section's data appears here — use the
+section-aware map for reliable results. */
+    completedSetsByExercise?: { [key: string]: number[]; };
+    /** Section-aware completed sets map. Key = (SectionId, ExerciseExternalId) encoded as
+the string "{sectionId}:{exerciseId}"; value = sorted list of completed set numbers.
+Use this in preference to CompletedSetsByExercise when section context
+is available (i.e. when the plan has multi-section sessions). */
+    completedSetsBySectionAndExercise?: { [key: string]: number[]; };
+    /** Per-exercise map of per-set actual values, snapshot-planned values, and isModified flags.
+Key = ExerciseExternalId; value = list of LoggedSetDto (one per logged set).
+An absent key means no sets for that exercise were logged.
+The web layer uses this together with CompletedSetsByExercise to render
+the actual-vs-planned comparison and the upraveno (modified) indicator per set.
+Deprecated in favour of LoggedSetsBySectionAndExercise.
+Retained for backward compatibility. When a multi-section log has the same exercise
+in two sections, only the last-encountered section's data appears here. */
+    loggedSetsByExercise?: { [key: string]: LoggedSetDto[]; };
+    /** Section-aware logged sets map. Key = (SectionId, ExerciseExternalId) encoded as
+the string "{sectionId}:{exerciseId}"; value = list of LoggedSetDto.
+Use this in preference to LoggedSetsByExercise for multi-section sessions. */
+    loggedSetsBySectionAndExercise?: { [key: string]: LoggedSetDto[]; };
+    /** True when at least one set in any exercise under this session has IsModified == true.
+The web layer uses this to show the upraveno badge at the session-header level.
+Always false when the session has no WorkoutLog (or all logs are legacy without snapshots). */
+    hasModifications?: boolean;
+    /** Per-section finished state for all sections in this session.
+Populated by the endpoint from both WorkoutLog and TrainingCompletion signals.
+A section is finished when IsSessionFinished is true (session-level completion
+implies every section is done), OR when the TrainingCompletion document records that specific
+section as complete.
+Empty for sessions with no completion data.
+The web layer uses this to render the finished label and disable editing on completed sections
+independently of the session-level finished state. */
+    finishedSections?: SectionFinishedStateDto[];
+}
+
+/** Per-set actual values + snapshot-planned values + backend-computed isModified flag, sourced from a WorkoutSet. Used by training-read endpoints that need to surface actual-vs-planned comparison (GetTodaySession, GetFullTrainingPlan, and the trainer GetTrainingPlan). */
+export interface LoggedSetDto {
+    /** 1-based set number within the exercise. */
+    setNumber?: number;
+    /** Actual repetitions logged. Null when the set has not been performed. */
+    actualReps?: number | undefined;
+    /** Actual weight (kg) logged. Null when not performed. */
+    actualWeightKg?: number | undefined;
+    /** Actual RPE logged. Null when not performed. */
+    actualRpe?: number | undefined;
+    /** Actual duration (seconds) logged. Null when not performed. */
+    actualDurationSeconds?: number | undefined;
+    /** Actual distance (meters) logged. Null when not performed. */
+    actualDistanceMeters?: number | undefined;
+    /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+    plannedReps?: number | undefined;
+    /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+    plannedWeightKg?: number | undefined;
+    /** Snapshot-planned RPE at log time. Null for legacy logs. */
+    plannedRpe?: number | undefined;
+    /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+    plannedDurationSeconds?: number | undefined;
+    /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned counterpart.
+Always false for legacy sets (no snapshot → treated as planned == actual). */
+    isModified?: boolean;
+}
+
+/** Per-section finished state for a training session. A section is "finished" when the client has completed it via either the WorkoutLog path (session-level completion) or the TrainingCompletion path (home-checkbox / section-complete). */
+export interface SectionFinishedStateDto {
+    /** The SectionId this finished state belongs to. */
+    sectionId?: string;
+    /** Whether this section is finished.
+True when a completed WorkoutLog exists for the session (all sections done),
+or when the TrainingCompletion document shows this section as complete. */
+    isFinished?: boolean;
+}
+
+/** Per-session edit-lock state projected into the trainer read model. A session with no active lock document reports Stable with a null holder. */
+export interface SessionLockStateDto {
+    /** The SessionId this lock state belongs to. */
+    sessionId?: string;
+    /** Current lock state of this session.
+Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+"Live" (client has an in-progress workout lock).
+Populated via a batch GetStateAsync call on the session lock service. */
+    lockState?: string;
+    /** Who currently holds the lock, if any.
+Possible values: "Coach", "Client", or null when the session is Stable. */
+    lockHolder?: string | undefined;
+}
+
 /** Request for a full-state update of a training plan. */
 export interface UpdateTrainingPlanRequest {
     /** Updated display name. */
@@ -13287,6 +14490,14 @@ export interface UpdateExerciseSetRequest {
     restSeconds?: number | undefined;
 }
 
+/** Request to acquire an Editing lock on a published training session. */
+export interface UnlockTrainingSessionRequest {
+}
+
+/** Request to release the Editing lock on a training session (relock it to Stable). */
+export interface RelockTrainingSessionRequest {
+}
+
 /** Request to publish a specific week of a training plan. */
 export interface PublishTrainingWeekRequest {
     /** Optimistic concurrency version. */
@@ -13355,6 +14566,26 @@ export enum TrainingPlanStatus {
 
 /** Request to retrieve a single training plan. */
 export interface GetTrainingPlanRequest {
+}
+
+/** Response after a trainer successfully finishes a session. */
+export interface FinishSessionResponse {
+    /** The workout log ExternalId that was created or completed. */
+    workoutLogId?: string;
+    /** The plan ExternalId. */
+    planId?: string;
+    /** The session identifier within the plan. */
+    sessionId?: string;
+    /** The instant the session was marked as completed (the effective completedAt value used). */
+    completedAt?: string;
+}
+
+/** Request for the trainer to retroactively finish a skipped or untouched session. */
+export interface FinishSessionRequest {
+    /** Optional backdated completion instant.
+When omitted the server uses UtcNow.
+Must be in the past (or present) and not before the plan's start date. */
+    completedAt?: string | undefined;
 }
 
 /** Request to delete a training plan. */
@@ -13524,6 +14755,52 @@ export interface CreatePendingInviteRequest {
     questionnairePublicId?: string | undefined;
 }
 
+/** Combined list of a client's nutrition and training plans returned by GET /trainer/clients/{clientId}/plans. */
+export interface ListClientPlansResponse {
+    /** All plans (nutrition + training) across all statuses, newest first. */
+    plans?: ClientPlanItem[];
+}
+
+/** A single plan entry in the combined list. */
+export interface ClientPlanItem {
+    /** The plan's public ExternalId (Guid) as stored in MongoDB. */
+    planId?: string;
+    /** Discriminates the plan type: "Nutrition" or "Training". */
+    planType?: string;
+    /** Display name of the plan. */
+    name?: string;
+    /** The Monday when Week 1 begins (UTC). Null for plans where StartDate has not been set. */
+    periodStart?: string | undefined;
+    /** When the plan was marked completed (UTC). Null for active/draft plans and open-ended plans. */
+    periodEnd?: string | undefined;
+    /** Current plan status as a string: "Draft", "Active", "Completed", "Archived". */
+    status?: string;
+    /** Per-plan result summary. Null fields indicate the metric is not applicable
+(e.g. compliance is null for training plans; totalTrainings is null for nutrition plans). */
+    resultSummary?: ClientPlanResultSummary;
+}
+
+/** Per-plan result summary. Fields not applicable to the plan type are null. */
+export interface ClientPlanResultSummary {
+    /** Count of WorkoutLogs where PlanId == plan.ExternalId and IsCompleted == true.
+Null for nutrition plans. */
+    totalTrainings?: number | undefined;
+    /** Count of PersonalRecords with AchievedAt in [plan.StartDate .. plan.DateCompleted ?? now].
+Null for nutrition plans or plans without a StartDate. */
+    prCount?: number | undefined;
+    /** Nutrition compliance % (0-100) over the plan period via IComplianceService.
+Null for training plans, or when the plan has no StartDate. */
+    compliancePercent?: number | undefined;
+    /** Body weight delta (kg) from the first BodyMeasurement on/after plan start
+to the last BodyMeasurement on/before plan end (DateCompleted ?? now).
+Positive = weight gained; negative = weight lost.
+Null for training plans, or when fewer than two measurements exist in the window. */
+    weightDeltaKg?: number | undefined;
+}
+
+export interface ListClientPlansRequest {
+}
+
 /** Response model returned after sending a client invitation. */
 export interface InviteClientResponse {
     /** Confirmation message. */
@@ -13612,6 +14889,42 @@ export interface ClientDashboardItem {
     activeNutritionPlansCount?: number;
     /** Whether the client has an active training plan. */
     hasActiveTrainingPlan?: boolean;
+}
+
+export interface GetClientVerdictResponse {
+    /** Overall on-track verdict for the client. */
+    verdict?: ClientVerdict;
+    /** Nutrition plan compliance percent (0-100), or null when no active nutrition plan. */
+    compliancePercent?: number | undefined;
+    /** Delta between current weight and target weight in kg, or null when no measurements/target. */
+    weightDeltaToGoal?: number | undefined;
+    /** Direction the client's weight is moving relative to their target. */
+    weightDirection?: WeightDirection;
+    /** Number of workout sessions completed in the current ISO week, or null when no active training plan. */
+    trainingFrequencyActual?: number | undefined;
+    /** Number of sessions prescribed per week in the active training plan, or null when no active training plan. */
+    trainingFrequencyPrescribed?: number | undefined;
+    /** UTC timestamp of the most recent activity (workout log, meal log, or measurement), or null. */
+    lastActiveAt?: string | undefined;
+    /** Number of personal records achieved in the current calendar month. */
+    prCountThisMonth?: number;
+}
+
+/** Represents the on-track verdict for a client as assessed by the trainer dashboard. */
+export enum ClientVerdict {
+    OnTrack = "OnTrack",
+    NeedsAttention = "NeedsAttention",
+    OffTrack = "OffTrack",
+}
+
+/** Indicates the direction a client's weight is moving relative to their target. */
+export enum WeightDirection {
+    Towards = "Towards",
+    Away = "Away",
+    Stable = "Stable",
+}
+
+export interface GetClientVerdictRequest {
 }
 
 /** Response returning a client's activity timeline, ordered newest first. */
@@ -13742,6 +15055,10 @@ Used to populate linkId on the photo-diary-request create form. */
     linkId?: number;
     /** The client profile's public ID. */
     clientPublicId?: string;
+    /** The client's ApplicationUser.Id (= ClientProfile.UserId).
+This is the identifier used by the weekly-check-in and schedule-override
+endpoints — it differs from ClientPublicId. */
+    clientUserId?: string;
     /** The client's email address. */
     email?: string;
     /** The client's first name. */
@@ -13897,6 +15214,42 @@ export interface AcceptClientRequestRequest {
     questionnairePublicId?: string | undefined;
     /** Optional statement from the professional (saved for future display in chat). */
     statement?: string | undefined;
+}
+
+export interface ListNotesResponse {
+    notes?: NoteDto[];
+}
+
+export interface NoteDto {
+    noteId?: string;
+    text?: string;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface ListNotesRequest {
+}
+
+export interface EditNoteResponse {
+    noteId?: string;
+    text?: string;
+    updatedAt?: string;
+}
+
+export interface EditNoteRequest {
+    text: string;
+}
+
+export interface DeleteNoteRequest {
+}
+
+export interface CreateNoteResponse {
+    noteId?: string;
+    createdAt?: string;
+}
+
+export interface CreateNoteRequest {
+    text: string;
 }
 
 export interface CancelQuestionnaireRequest {
@@ -14674,6 +16027,14 @@ export interface GetPlanResponse {
     /** Linked questionnaire response (cross-DB reference to PostgreSQL QuestionnaireResponse.PublicId).
 Null if no questionnaire is linked to this plan. */
     questionnaireResponseId?: string | undefined;
+    /** Per-meal eaten state for all MealLog documents associated with this plan.
+One entry per (MealId, LogDate) pair that has a log record; meals without a log entry
+are absent (equivalent to not-touched / no badge).
+Populated by the endpoint after loading the plan. Ownership is guaranteed by the
+plan ownership gate above the MealLog query — filtering by PlanId is safe. */
+    mealLogs?: MealLogDto[];
+    /** Supplement recommendations attached to this plan. */
+    supplements?: SupplementDto[];
 }
 
 /** Global daily nutrition targets for a plan. */
@@ -14761,7 +16122,35 @@ export interface MealRecipe {
     foodCategories?: string[] | undefined;
 }
 
-/** Request for a full-state update of a nutrition plan: replaces name, settings, and all weeks/days/meals/foods. */
+/** Per-meal eaten state derived from a MealLog document. Lets the web layer render eaten/not-touched indicators and lock editing affordances on meals the client has already confirmed as eaten. */
+export interface MealLogDto {
+    /** The MealId this log belongs to. */
+    mealId?: string;
+    /** The calendar date (UTC) this log entry belongs to, as a date-only value.
+Matches LogDate truncated to day precision. */
+    logDate?: string;
+    /** Whether the meal has been confirmed as eaten by the client.
+true iff EatenAt was non-null in the document.
+A log with EatenAt == null is a photo-only or note-only stub —
+it is NOT considered eaten. */
+    isEaten?: boolean;
+    /** When the meal was eaten, if eaten. Null for photo-only / note-only stubs. */
+    eatenAt?: string | undefined;
+}
+
+/** A supplement entry in a nutrition plan response DTO. */
+export interface SupplementDto {
+    /** Stable public identifier for the supplement. */
+    externalId?: string;
+    /** Name of the supplement. */
+    name?: string;
+    /** Optional dosage instruction. */
+    dose?: string | undefined;
+    /** Optional additional notes. */
+    notes?: string | undefined;
+}
+
+/** Request for a full-state update of a nutrition plan: replaces name, settings, weeks/days/meals/foods, and supplements. */
 export interface UpdatePlanRequest {
     /** Updated display name. */
     name: string;
@@ -14774,6 +16163,9 @@ export interface UpdatePlanRequest {
     /** Updated start date. Must be a Monday and not in the past.
 Null clears the start date (only if it hasn't arrived and no weeks are published). */
     startDate?: string | undefined;
+    /** Full supplement list to persist. Replaces all existing supplements.
+Omitting an entry removes that supplement (full-state replace pattern). */
+    supplements?: UpdateSupplementRequest[];
 }
 
 /** Represents a single week submitted in a full-state plan update. */
@@ -14849,6 +16241,20 @@ export interface UpdateMealRecipeRequest {
     note?: string | undefined;
     /** Distinct food categories from the recipe's ingredients (snapshot). */
     foodCategories?: string[] | undefined;
+}
+
+/** Represents a single supplement entry submitted in a full-state plan update. */
+export interface UpdateSupplementRequest {
+    /** Stable public identifier for this supplement. Clients generate this on creation
+and send it back unchanged on subsequent updates so mobile reminder keys survive round-trips.
+When empty, the endpoint generates a new Guid. */
+    externalId?: string | undefined;
+    /** Name of the supplement (e.g. "Vitamin D3"). Required. */
+    name?: string;
+    /** Optional dosage instruction in free text (e.g. "1 capsule with breakfast"). */
+    dose?: string | undefined;
+    /** Optional additional notes for the client. */
+    notes?: string | undefined;
 }
 
 /** Request to publish a specific week of a nutrition plan. */
@@ -15472,6 +16878,28 @@ export interface CreateExerciseRequest {
     techniqueNotes?: string | undefined;
 }
 
+/** Request model for saving the complete photo and note state of a training session diary entry. The Photos list and Note are replaced with exactly what the client sends. */
+export interface SaveSessionPhotosRequest {
+    /** The complete list of photos to persist on the session log.
+Replaces the existing Photos list entirely — pass an empty list to remove all photos.
+Each item carries the blob URL and an optional per-photo caption.
+Existing URLs that are re-submitted keep their original UploadedAt
+timestamp; new URLs receive the current UTC time. */
+    photos?: SessionPhotoInput[];
+    /** Optional free-text note to persist on the session log entry (max 500 chars).
+When non-null, the stored note is replaced with the trimmed value
+(whitespace-only strings are treated as null). When null, the existing note is cleared. */
+    note?: string | undefined;
+}
+
+/** A single photo input in a SaveSessionPhotosRequest. */
+export interface SessionPhotoInput {
+    /** The MinIO blob URL for this photo, as returned by the signed-URL upload helper. */
+    blobUrl?: string;
+    /** Optional per-photo caption (max 500 chars). */
+    note?: string | undefined;
+}
+
 /** Response for marking all training sessions on a day complete. */
 export interface MarkWholeDayCompleteResponse {
     /** The date that was marked complete. */
@@ -15723,6 +17151,48 @@ Empty when no live-training progress has been logged for today.
 Keeps per-set state out of the planning-document tree (Sessions) which
 represents prescription, not actuals. */
     completedSetsBySessionExercise?: { [key: string]: { [key: string]: number[]; }; };
+    /** Per-session lock state, keyed by SessionId.
+Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+"Live" (client has an in-progress workout lock).
+Missing entries are treated as "Stable".
+Populated via a single batch GetStateAsync call on the session lock service. */
+    lockStateBySession?: { [key: string]: string; };
+    /** Per-session lock holder, keyed by SessionId.
+Possible values: "Coach" (trainer/nutritionist holds the lock) or "Client".
+Null / missing when the session is in the Stable state. */
+    lockHolderBySession?: { [key: string]: string; };
+    /** Per-session photo list for today, keyed by SessionId.
+Each value is an ordered list of photos that were saved to the session log for today's date.
+Sourced from the SessionLog MongoDB document for today.
+Empty dictionary when no photos have been saved for any session today (or when no active plan exists). */
+    photosBySession?: { [key: string]: SessionPhotoDto[]; };
+    /** Per-session diary note for today, keyed by SessionId.
+Only populated for sessions whose SessionLog has a non-null, non-empty Note.
+Allows the mobile client to pre-load the existing note into its textarea so a subsequent
+Save does not overwrite it with null (data-loss prevention).
+Empty dictionary when no session has a note today (or when no active plan exists). */
+    notesBySession?: { [key: string]: string; };
+    /** Per-session, per-exercise logged set values for today.
+Keyed by SessionId → ExerciseExternalId → list of LoggedSetDto (one per set).
+Carries actual logged values, snapshot-planned values, and the backend-computed isModified flag.
+Replaces the set-number-only CompletedSetsBySessionExercise for callers that
+need actual vs planned comparison.
+Empty when no live-training progress has been logged for today. */
+    loggedSetsBySessionExercise?: { [key: string]: { [key: string]: LoggedSetDto[]; }; };
+    /** Per-session hasModifications flag for today, keyed by SessionId.
+True when any set under any exercise in the session has IsModified == true in the latest log.
+Missing entries are treated as false (no modifications / no log). */
+    hasModificationsBySession?: { [key: string]: boolean; };
+}
+
+/** A photo attached to a session diary entry, as returned in PhotosBySession. */
+export interface SessionPhotoDto {
+    /** The MinIO blob URL for this photo. */
+    blobUrl?: string;
+    /** UTC timestamp when the photo was uploaded/persisted. */
+    uploadedAt?: string;
+    /** Optional per-photo caption (max 500 chars). Null when none was provided. */
+    note?: string | undefined;
 }
 
 /** Full training plan response for the client mobile view. Contains all published weeks enriched with completion state and muscle group data. */
@@ -15795,6 +17265,17 @@ Schema-on-read: legacy documents with only flat exercises are backfilled into a 
     /** Flat list of all exercises across all sections, in section order.
 Kept for backward-compatibility with callers that don't yet read Sections. */
     exercises?: ExerciseDto[];
+    /** Current lock state of this session.
+Possible values: "Stable" (no active lock), "Editing" (trainer holds an editing lock),
+"Live" (client has an in-progress workout lock).
+Populated via a batch GetStateAsync call on the session lock service. */
+    lockState?: string;
+    /** Who currently holds the lock, if any.
+Possible values: "Coach", "Client", or null when the session is Stable. */
+    lockHolder?: string | undefined;
+    /** True when at least one exercise in this session has HasModifications == true.
+Always false when no workout log exists for this session. */
+    hasModifications?: boolean;
 }
 
 /** An ordered section within a session (e.g. "Hlavní", "Warm-up", "Cool-down"). */
@@ -15849,28 +17330,71 @@ Empty list when the exercise no longer exists in the database. */
     muscleGroups?: MuscleGroup[];
     /** True when every planned set has a completed workout log entry. */
     isCompleted?: boolean;
-    /** Planned sets with per-set completion timestamps. */
+    /** True when at least one set under this exercise has IsModified == true.
+Always false when no workout log exists for this exercise. */
+    hasModifications?: boolean;
+    /** Planned sets with per-set completion timestamps and actual-vs-planned delta. */
     sets?: SetDto[];
 }
 
-/** A planned set with its completion state derived from workout logs. */
+/** A planned set with its completion state and actual-vs-planned delta derived from workout logs. */
 export interface SetDto {
     /** 1-based set number within the exercise. */
     setNumber?: number;
     /** Set type (Normal, Warmup, Dropset, Superset). */
     type?: string;
-    /** Target number of repetitions. */
+    /** Target number of repetitions (from the plan prescription). */
     reps?: number | undefined;
-    /** Target weight in kilograms. */
+    /** Target weight in kilograms (from the plan prescription). */
     weightKg?: number | undefined;
-    /** Target duration in seconds (for timed exercises). */
+    /** Target duration in seconds (from the plan prescription). */
     durationSeconds?: number | undefined;
-    /** Target distance in meters (for distance-based exercises). */
+    /** Target distance in meters (from the plan prescription). */
     distanceMeters?: number | undefined;
     /** Rest time after this set in seconds. */
     restSeconds?: number | undefined;
     /** When this set was completed, or null if not yet done. */
     completedAt?: string | undefined;
+    /** Actual repetitions logged. Null when not yet performed. */
+    actualReps?: number | undefined;
+    /** Actual weight (kg) logged. Null when not yet performed. */
+    actualWeightKg?: number | undefined;
+    /** Actual RPE logged. Null when not yet performed. */
+    actualRpe?: number | undefined;
+    /** Actual duration (seconds) logged. Null when not yet performed. */
+    actualDurationSeconds?: number | undefined;
+    /** Actual distance (meters) logged. Null when not yet performed. */
+    actualDistanceMeters?: number | undefined;
+    /** Snapshot-planned repetitions at log time. Null for legacy logs. */
+    plannedReps?: number | undefined;
+    /** Snapshot-planned weight (kg) at log time. Null for legacy logs. */
+    plannedWeightKg?: number | undefined;
+    /** Snapshot-planned RPE at log time. Null for legacy logs. */
+    plannedRpe?: number | undefined;
+    /** Snapshot-planned duration (seconds) at log time. Null for legacy logs. */
+    plannedDurationSeconds?: number | undefined;
+    /** Snapshot-planned distance (meters) at log time. Null for legacy logs. */
+    plannedDistanceMeters?: number | undefined;
+    /** Backend-computed flag: true when any actual field differs from its snapshot-planned
+counterpart. Always false for legacy sets (no snapshot → treated as planned == actual). */
+    isModified?: boolean;
+}
+
+/** Response for the session photo upload URL generation endpoint. */
+export interface GenerateSessionPhotoUploadUrlResponse {
+    /** Time-limited pre-signed URL the client uses to PUT the image directly to blob storage. */
+    uploadUrl?: string;
+    /** The permanent blob URL to pass to POST /client/training/log/sessions/{sessionId}/photos
+after the upload completes. */
+    blobUrl?: string;
+}
+
+/** Request model for generating a pre-signed training session photo upload URL. */
+export interface GenerateSessionPhotoUploadUrlRequest {
+    /** MIME type of the image file (e.g. "image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"). */
+    contentType: string;
+    /** Declared file size in bytes. Must not exceed 10 MiB. */
+    sizeBytes?: number;
 }
 
 /** Response model returned after sending a client request. */
@@ -15944,6 +17468,7 @@ export enum PlanPhotoCategory {
     Food = "Food",
     Body = "Body",
     FreeForm = "FreeForm",
+    Training = "Training",
 }
 
 /** Identifies whether a PlanPhoto is associated with a nutrition plan or a training plan. */
@@ -16166,7 +17691,7 @@ export interface GetTodayPlanResponse {
 /** Response model for the client's meal log for today. */
 export interface GetTodayLogResponse {
     /** Meals eaten today. */
-    mealsEaten?: MealLogDto[];
+    mealsEaten?: MealLogDto2[];
     /** Total nutrients consumed across all meals today. */
     totalConsumed?: NutrientTotals;
     /** Remaining nutrients to reach the daily target.
@@ -16175,7 +17700,7 @@ Null if the active plan has no global settings. */
 }
 
 /** DTO representing a single logged meal with computed nutrient totals. */
-export interface MealLogDto {
+export interface MealLogDto2 {
     /** Identifier of the meal that was eaten. */
     mealId?: string;
     /** Display name of the meal (resolved from the plan). */
@@ -16279,6 +17804,9 @@ export interface GetFullPlanResponse {
     /** Set of meal IDs that the client has logged as eaten.
 Meal IDs are unique across the plan, so a flat set covers all days. */
     eatenMealIds?: string[];
+    /** Supplement recommendations for this plan. Clients use this list to configure
+local reminder notifications; the list is read-only on the client side. */
+    supplements?: SupplementDto[];
 }
 
 /** A published week with pre-computed start/end dates. */
@@ -16515,11 +18043,11 @@ export interface GetComplianceScoreRequest {
 /** Response containing the client's plans. */
 export interface GetClientPlansResponse {
     /** Plan summaries. */
-    items?: ClientPlanItem[];
+    items?: ClientPlanItem2[];
 }
 
 /** Lightweight plan summary for the client's plan list. */
-export interface ClientPlanItem {
+export interface ClientPlanItem2 {
     /** Plan public identifier. */
     planId?: string;
     /** Display name. */
@@ -16638,6 +18166,26 @@ Null when neither is uploaded. */
 export interface VerifyEmailRequest {
     /** The verification token from the email link. */
     token?: string;
+}
+
+/** Response returned after a successful Google social login. Shape is intentionally identical to LoginResponse so clients can reuse the same token-storage logic. */
+export interface GoogleSocialLoginResponse {
+    /** JWT access token (short-lived, 15 minutes). */
+    accessToken?: string;
+    /** Refresh token for obtaining new access tokens (7 days). */
+    refreshToken?: string;
+    /** Access token expiration time in UTC. */
+    expiresAt?: string;
+    /** Whether the user's email address has been verified.
+Always true for Google-provisioned accounts because Google
+verifies the email before issuing the ID token. */
+    emailConfirmed?: boolean;
+}
+
+/** Request body for POST /auth/social/google. */
+export interface GoogleSocialLoginRequest {
+    /** The Google ID token returned by the Google Identity Services flow on the client. */
+    idToken: string;
 }
 
 /** Request model for completing a password reset using a token. */

--- a/web/src/api/trainer-notes.ts
+++ b/web/src/api/trainer-notes.ts
@@ -1,21 +1,19 @@
 import api from '@/lib/api';
+import type {
+  NoteDto,
+  CreateNoteResponse,
+  EditNoteResponse,
+  ListNotesResponse,
+} from '@/api/generated';
 
-export interface TrainerNote {
-  noteId: string;
-  text: string;
-  createdAt: string;
-  updatedAt: string;
-}
+// Re-export generated types so consumers can import from this module unchanged.
+export type { CreateNoteResponse, EditNoteResponse, ListNotesResponse };
 
-export interface CreateNoteResponse {
-  noteId: string;
-  createdAt: string;
-}
-
-export interface ListNotesResponse {
-  notes: TrainerNote[];
-  totalCount: number;
-}
+/**
+ * Alias for the generated NoteDto — keeps consumer imports stable
+ * (`import type { TrainerNote } from '@/api/trainer-notes'`).
+ */
+export type TrainerNote = NoteDto;
 
 export async function createNote(
   clientId: string,
@@ -32,19 +30,13 @@ export async function listNotes(
   clientId: string,
   page = 1,
   pageSize = 20,
-): Promise<ListNotesResponse> {
-  const { data, headers } = await api.get<{ notes: TrainerNote[] }>(
+): Promise<{ notes: TrainerNote[]; totalCount: number }> {
+  const { data, headers } = await api.get<ListNotesResponse>(
     `/trainer/clients/${clientId}/notes`,
     { params: { page, pageSize } },
   );
   const totalCount = parseInt(headers['x-total-count'] ?? '0', 10);
   return { notes: data.notes ?? [], totalCount };
-}
-
-export interface EditNoteResponse {
-  noteId: string;
-  text: string;
-  updatedAt: string;
 }
 
 export async function updateNote(

--- a/web/src/components/clients/ProgressSnapshot.tsx
+++ b/web/src/components/clients/ProgressSnapshot.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { ClientVerdictResponse } from '@/api/client-verdict';
+import type { GetClientVerdictResponse } from '@/api/client-verdict';
 
 interface WeightBar {
   pct: number;
@@ -11,7 +11,7 @@ interface ProgressSnapshotProps {
   startWeight?: number | null;
   currentWeight?: number | null;
   targetWeight?: number | null;
-  verdict?: ClientVerdictResponse | null;
+  verdict?: GetClientVerdictResponse | null;
   onAllMeasurementsClick: () => void;
 }
 

--- a/web/src/components/clients/VerdictHeroCard.tsx
+++ b/web/src/components/clients/VerdictHeroCard.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from 'react-i18next';
-import type { ClientVerdictResponse } from '@/api/client-verdict';
+import type { GetClientVerdictResponse } from '@/api/client-verdict';
+import { ClientVerdict, WeightDirection } from '@/api/client-verdict';
 
 interface VerdictHeroCardProps {
-  verdict: ClientVerdictResponse;
+  verdict: GetClientVerdictResponse;
 }
 
 export function VerdictHeroCard({ verdict }: VerdictHeroCardProps) {
   const { t } = useTranslation();
 
-  const isOnTrack = verdict.verdict === 'OnTrack';
-  const isNeedsAttention = verdict.verdict === 'NeedsAttention';
+  const isOnTrack = verdict.verdict === ClientVerdict.OnTrack;
+  const isNeedsAttention = verdict.verdict === ClientVerdict.NeedsAttention;
 
   const borderClass = isOnTrack
     ? 'border-green-bg'
@@ -51,7 +52,7 @@ export function VerdictHeroCard({ verdict }: VerdictHeroCardProps) {
 
   // Format weight delta signal
   const weightSignal = verdict.weightDeltaToGoal != null
-    ? `${verdict.weightDeltaToGoal < 0 ? '' : '+'}${verdict.weightDeltaToGoal.toFixed(1)} kg ${verdict.weightDirection === 'Towards' ? '↘' : verdict.weightDirection === 'Away' ? '↗' : '→'}`
+    ? `${verdict.weightDeltaToGoal < 0 ? '' : '+'}${verdict.weightDeltaToGoal.toFixed(1)} kg ${verdict.weightDirection === WeightDirection.Towards ? '↘' : verdict.weightDirection === WeightDirection.Away ? '↗' : '→'}`
     : '—';
 
   // Training frequency signal

--- a/web/src/components/clients/tabs/FotkyTab.tsx
+++ b/web/src/components/clients/tabs/FotkyTab.tsx
@@ -36,6 +36,7 @@ const CATEGORY_EMOJI: Record<PlanPhotoCategory, string> = {
   [PlanPhotoCategory.Food]: '🍽️',
   [PlanPhotoCategory.Body]: '📏',
   [PlanPhotoCategory.FreeForm]: '📷',
+  [PlanPhotoCategory.Training]: '🏋️',
 };
 
 // ── Props ─────────────────────────────────────────────────────────────────────

--- a/web/src/components/clients/tabs/PlanyTab.tsx
+++ b/web/src/components/clients/tabs/PlanyTab.tsx
@@ -11,7 +11,7 @@ interface PlanyTabProps {
 
 // ── Date formatting helpers ───────────────────────────────────────────────────
 
-function formatDate(iso: string | null): string {
+function formatDate(iso: string | null | undefined): string {
   if (!iso) return '';
   return new Date(iso).toLocaleDateString('cs-CZ', {
     day: 'numeric',
@@ -20,7 +20,7 @@ function formatDate(iso: string | null): string {
   });
 }
 
-function formatPeriod(periodStart: string | null, periodEnd: string | null): string {
+function formatPeriod(periodStart: string | null | undefined, periodEnd: string | null | undefined): string {
   const start = formatDate(periodStart);
   const end = formatDate(periodEnd);
   if (!start && !end) return '—';
@@ -32,7 +32,10 @@ function formatPeriod(periodStart: string | null, periodEnd: string | null): str
 // ── Status chip ───────────────────────────────────────────────────────────────
 
 interface StatusChipProps {
-  status: PlanStatus;
+  // Accept string because the generated ClientPlanItem.status field is typed
+  // as `string | undefined`; the modifierMap lookup falls back to 'tag-gray'
+  // for any unrecognised or undefined value.
+  status: string | undefined;
   label: string;
 }
 
@@ -45,8 +48,9 @@ function StatusChip({ status, label }: StatusChipProps) {
     Draft: 'tag-gray',
     Archived: 'tag-gray',
   };
+  const modifier = status != null ? (modifierMap[status as PlanStatus] ?? 'tag-gray') : 'tag-gray';
   return (
-    <span className={`tag ${modifierMap[status] ?? 'tag-gray'}`}>
+    <span className={`tag ${modifier}`}>
       {label}
     </span>
   );
@@ -56,6 +60,9 @@ function StatusChip({ status, label }: StatusChipProps) {
 
 function formatResultSummary(plan: ClientPlanItem, t: TFunction): string {
   const { planType, resultSummary: r } = plan;
+
+  // resultSummary is optional in the generated type; guard before accessing fields.
+  if (!r) return '—';
 
   if (planType === 'Nutrition') {
     const parts: string[] = [];
@@ -102,7 +109,7 @@ function formatResultSummary(plan: ClientPlanItem, t: TFunction): string {
 
 // ── Plan type emoji prefix ────────────────────────────────────────────────────
 
-function planTypeEmoji(planType: string): string {
+function planTypeEmoji(planType: string | undefined): string {
   return planType === 'Nutrition' ? '🥗' : '🏋️';
 }
 
@@ -123,6 +130,7 @@ export function PlanyTab({ clientId }: PlanyTabProps) {
   const isEmpty = !isPending && !isError && plans.length === 0;
 
   function handleRowClick(plan: ClientPlanItem) {
+    if (!plan.planId) return;
     if (plan.planType === 'Nutrition') {
       navigate(`/clients/${clientId}/plans/${plan.planId}`);
     } else {
@@ -192,7 +200,7 @@ export function PlanyTab({ clientId }: PlanyTabProps) {
             <tbody>
               {plans.map((plan) => {
                 const statusLabel = t(
-                  `clientDetail.plany.status.${plan.status.toLowerCase()}`,
+                  `clientDetail.plany.status.${(plan.status ?? '').toLowerCase()}`,
                 );
                 return (
                   <tr
@@ -207,7 +215,7 @@ export function PlanyTab({ clientId }: PlanyTabProps) {
                         handleRowClick(plan);
                       }
                     }}
-                    aria-label={`${t('clientDetail.plany.table.openPlan')} ${plan.name}`}
+                    aria-label={`${t('clientDetail.plany.table.openPlan')} ${plan.name ?? ''}`}
                   >
                     <td className="row-title py-2.5 pr-4 font-medium text-text">
                       <span className="mr-1.5">{planTypeEmoji(plan.planType)}</span>

--- a/web/src/components/clients/tabs/PoznamkyTab.tsx
+++ b/web/src/components/clients/tabs/PoznamkyTab.tsx
@@ -41,10 +41,12 @@ function NoteCard({ note, clientId }: NoteCardProps) {
   const addToast = useToastStore((s) => s.addToast);
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
-  const [editText, setEditText] = useState(note.text);
+  const [editText, setEditText] = useState(note.text ?? '');
 
   const updateMutation = useMutation({
-    mutationFn: (text: string) => updateNote(clientId, note.noteId, text),
+    // NoteDto.noteId is technically optional in the generated type, but the
+    // backend always populates it; the fallback '' is a safety net only.
+    mutationFn: (text: string) => updateNote(clientId, note.noteId ?? '', text),
     onMutate: async (text: string) => {
       await queryClient.cancelQueries({
         queryKey: ['trainer-notes', clientId],
@@ -80,7 +82,9 @@ function NoteCard({ note, clientId }: NoteCardProps) {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => deleteNote(clientId, note.noteId),
+    // NoteDto.noteId is technically optional in the generated type, but the
+    // backend always populates it; the fallback '' is a safety net only.
+    mutationFn: () => deleteNote(clientId, note.noteId ?? ''),
     onMutate: async () => {
       await queryClient.cancelQueries({
         queryKey: ['trainer-notes', clientId],
@@ -126,7 +130,7 @@ function NoteCard({ note, clientId }: NoteCardProps) {
             className="text-[12px] text-text3 px-3 py-1.5 border border-border rounded-[var(--radius-sm)] hover:bg-bg-hover transition-colors"
             onClick={() => {
               setEditing(false);
-              setEditText(note.text);
+              setEditText(note.text ?? '');
             }}
           >
             {t('common.cancel')}
@@ -151,7 +155,7 @@ function NoteCard({ note, clientId }: NoteCardProps) {
         <div className="text-[13px] text-text whitespace-pre-wrap break-words">
           {note.text}
         </div>
-        <div className="text-[11px] text-text3 mt-1">{formatDate(note.createdAt)}</div>
+        <div className="text-[11px] text-text3 mt-1">{note.createdAt ? formatDate(note.createdAt) : ''}</div>
       </div>
       <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
         <button


### PR DESCRIPTION
## Summary
- Regenerated `web/src/api/generated.ts` via NSwag to include epic #484's endpoints (verdict, list-client-plans, TrainerNote CRUD) and DTOs.
- Replaced the four hand-written client-detail API modules' types with generated types, keeping thin wrapper functions and stable re-export aliases so consumer import paths are unchanged.
- Consumers updated: `VerdictHeroCard`/`ProgressSnapshot` use `ClientVerdict`/`WeightDirection` enum members; `PlanyTab` + `PoznamkyTab` null-guard generated-optional fields; `FotkyTab` handles the new `PlanPhotoCategory.Training` member surfaced by the regen.
- Pure type reconcile — no behavior change in any consuming pane.

## Related issue
Fixes #506

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — tsc/build/lint clean; lockfile + package.json untouched (the diff-vs-develop delta on those comes from #497 history below the branch point, not this commit).

## Test plan
- [ ] `regen-api` run against backend so `generated.ts` includes verdict, list-client-plans, trainer-notes endpoints + DTOs.
- [ ] Four hand-written modules source request/response shapes from `generated.ts` (thin wrappers kept).
- [ ] No behavior change in Přehled verdict hero, Plány, Poznámky, Měření panes; `npm run build` clean.
- [ ] Now-redundant hand-written interfaces removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)