### PR TITLE
chore(web): add generate-api:e2e for unattended client regen via the e2e harness

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "generate-api": "cd ../backend && curl -sk https://localhost:5001/swagger/v1/swagger.json -o swagger.json && dotnet nswag run nswag.json && sed -i '' 's|/\\* eslint-disable \\*/|/* eslint-disable */\\n// @ts-nocheck|' ../web/src/api/generated.ts",
+    "generate-api:e2e": "cd ../backend && curl -sk \"$(../scripts/test-env ports | jq -r .api_url)/swagger/v1/swagger.json\" -o swagger.json && dotnet nswag run nswag.json && sed -i '' 's|/\\* eslint-disable \\*/|/* eslint-disable */\\n// @ts-nocheck|' ../web/src/api/generated.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },


### PR DESCRIPTION
## What
Adds a `generate-api:e2e` npm script in `web/package.json` alongside the existing `generate-api`.

## Why
`generate-api` curls the dev API on `https://localhost:5001`, which requires the developer's local dev secrets (POSTGRES_PASSWORD / MONGO_PASSWORD / JWT_SECRET / MinIO) to boot — so an agent can't regenerate the client unattended without harvesting secrets (correctly blocked by the safety classifier).

`generate-api:e2e` instead points at the **self-contained e2e compose harness**, whose secrets are baked into docker-compose. It resolves the harness's ephemeral API port at runtime via `scripts/test-env ports` (JSON `.api_url`) — no hardcoded port (the harness deliberately avoids :5001 so it can coexist with the dev API).

## Usage
```bash
npm run e2e:up                 # self-contained backend, no manual secrets
cd web && npm run generate-api:e2e
npm run e2e:down
```

## Notes
- One-line, dev-tooling only. No app/runtime code, no generated.ts in this PR.
- The script body mirrors `generate-api` (curl → nswag → sed); only the swagger source URL changes.
- Wired against the verified `scripts/test-env ports` interface; the full harness-up → regen path should be smoke-tested on the next real regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)