### PR TITLE
feat: wire Apple sign-in on web login page

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/ConfigKeys.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ConfigKeys.cs
@@ -79,4 +79,9 @@ public static class ConfigKeys
     /// Google OAuth 2.0 client ID used to verify Google ID tokens.
     /// </summary>
     public const string GoogleClientId = "Google:ClientId";
+
+    /// <summary>
+    /// Apple Service ID (reverse-domain format) used as the JWT audience when verifying Apple identity tokens.
+    /// </summary>
+    public const string AppleClientId = "Apple:ClientId";
 }

--- a/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/ErrorCodes.cs
@@ -13,6 +13,9 @@ public static class ErrorCodes
     /// <summary>Google-verified email matches a password-only account with no Google external login. The user should sign in with their password.</summary>
     public const string SocialEmailConflict = "social_email_conflict";
 
+    /// <summary>Apple did not provide an email in the identity token, and no (apple, sub) link exists. Cannot provision or log in without an email address.</summary>
+    public const string AppleNoEmailNoLink = "APPLE_NO_EMAIL_NO_LINK";
+
     /// <summary>Account is deactivated.</summary>
     public const string AccountDeactivated = "ACCOUNT_DEACTIVATED";
 

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginEndpoint.cs
@@ -1,0 +1,225 @@
+using System.Security.Cryptography;
+using FastEndpoints;
+using FastEndpoints.Security;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Extensions;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Apple;
+
+/// <summary>
+/// Endpoint for signing in via Apple Sign-In.
+/// Verifies the Apple identity token, then either logs in an existing linked account,
+/// provisions a new account from the Apple profile, or returns 409 when the
+/// email belongs to a password-only account with no Apple link.
+/// <para>
+/// Apple-specific behaviour: the identity token may omit email/name after first
+/// authorization. The (apple, sub) link is therefore checked BEFORE any email use
+/// to handle re-auth without email in the token.
+/// </para>
+/// </summary>
+public class AppleSocialLoginEndpoint(
+    IAppleTokenVerifier appleVerifier,
+    UserManager<ApplicationUser> userManager,
+    IApplicationDbContext db,
+    IConfiguration config) : Endpoint<AppleSocialLoginRequest, AppleSocialLoginResponse>
+{
+    private const string AppleProvider = "apple";
+
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/auth/social/apple");
+        AllowAnonymous();
+        Options(x => x.RequireRateLimiting(AppPolicies.AuthRateLimit));
+        Summary(s =>
+        {
+            s.Summary = "Apple Sign-In";
+            s.Description = "Verifies an Apple identity token and returns platform JWT tokens. Provisions a new account if the email is not yet registered.";
+            s.Response<AppleSocialLoginResponse>(200, "Login successful");
+            s.Responses[400] = "identityToken is missing or empty";
+            s.Responses[401] = "Apple identity token is invalid, expired, has wrong audience, or email is explicitly unverified";
+            s.Responses[403] = "Account is deactivated";
+            s.Responses[409] = "Email belongs to an existing password-only account (social_email_conflict)";
+            s.Responses[422] = "No Apple account link exists and token carries no email — cannot provision";
+        });
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(AppleSocialLoginRequest req, CancellationToken ct)
+    {
+        // 1. Verify the Apple identity token (throws on failure).
+        AppleTokenPayload applePayload;
+        try
+        {
+            applePayload = await appleVerifier.VerifyAsync(req.IdentityToken, ct);
+        }
+        catch (InvalidOperationException)
+        {
+            await this.SendProblemAsync(StatusCodes.Status401Unauthorized,
+                ErrorCodes.InvalidCredentials,
+                "Apple identity token is invalid, expired, or has the wrong audience.",
+                ct);
+            return;
+        }
+
+        // 2. Look up the UserExternalLogin row for (apple, sub) FIRST.
+        // Apple omits email/name after first auth, so the sub-based lookup is the
+        // primary path for returning users.
+        var externalLogin = await db.UserExternalLogins
+            .FirstOrDefaultAsync(
+                el => el.Provider == AppleProvider && el.Subject == applePayload.Subject,
+                ct);
+
+        ApplicationUser user;
+
+        if (externalLogin is not null)
+        {
+            // Happy path A: existing Apple link found — load the linked user.
+            var linkedUser = await userManager.FindByIdAsync(externalLogin.UserId.ToString());
+            if (linkedUser is null)
+            {
+                // Orphaned external login — treat as invalid credentials.
+                await this.SendProblemAsync(StatusCodes.Status401Unauthorized,
+                    ErrorCodes.InvalidCredentials,
+                    "Linked account not found.",
+                    ct);
+                return;
+            }
+
+            user = linkedUser;
+        }
+        else
+        {
+            // No Apple link yet.
+            //
+            // Apple can omit email after first auth — if there is no link AND no email,
+            // we cannot look up or provision an account. Return a clear 422.
+            if (string.IsNullOrEmpty(applePayload.Email))
+            {
+                await this.SendProblemAsync(StatusCodes.Status422UnprocessableEntity,
+                    ErrorCodes.AppleNoEmailNoLink,
+                    "Apple did not provide an email address and no linked account exists. Please sign in using Apple on the same device used during initial registration.",
+                    ct);
+                return;
+            }
+
+            // Check by email for an existing account.
+            var existingUser = await userManager.FindByEmailAsync(applePayload.Email);
+
+            if (existingUser is not null)
+            {
+                // Email exists but no Apple link — this is a password-only (or other-provider) account.
+                // Return 409 so the web prompts the user to sign in with their password.
+                await this.SendProblemAsync(StatusCodes.Status409Conflict,
+                    ErrorCodes.SocialEmailConflict,
+                    "An account with this email already exists. Please sign in with your password.",
+                    ct);
+                return;
+            }
+
+            // Happy path B: new user — provision from Apple profile.
+            // FirstName/LastName come from the request body (Apple sends these ONLY on first auth).
+            // ApplicationUser.FirstName/LastName are non-null strings — never write null.
+            var firstName = req.FirstName ?? string.Empty;
+            var lastName = req.LastName ?? string.Empty;
+
+            var newUser = new ApplicationUser
+            {
+                UserName = applePayload.Email,
+                Email = applePayload.Email,
+                EmailConfirmed = true, // Apple has verified the email (including private-relay).
+                FirstName = firstName,
+                LastName = lastName,
+                GdprConsent = true,
+                GdprConsentDate = DateTime.UtcNow
+            };
+
+            // The trainer-portal register flow assigns the Trainer role by default.
+            var createResult = await userManager.CreateAsync(newUser);
+            if (!createResult.Succeeded)
+            {
+                foreach (var error in createResult.Errors)
+                {
+                    AddError(error.Description);
+                }
+                ThrowIfAnyErrors();
+                return;
+            }
+
+            await userManager.AddToRoleAsync(newUser, AppRoles.Trainer);
+
+            // Create the professional profile (mirroring RegisterEndpoint for Trainer role).
+            db.ProfessionalProfiles.Add(new ProfessionalProfile { UserId = newUser.Id });
+
+            // Link the Apple identity.
+            db.UserExternalLogins.Add(new UserExternalLogin
+            {
+                UserId = newUser.Id,
+                Provider = AppleProvider,
+                Subject = applePayload.Subject,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            await db.SaveChangesAsync(ct);
+            user = newUser;
+        }
+
+        // 3. Check if the account is active.
+        if (!user.IsActive)
+        {
+            await this.SendProblemAsync(StatusCodes.Status403Forbidden,
+                ErrorCodes.AccountDeactivated,
+                "Account is deactivated.",
+                ct);
+            return;
+        }
+
+        // 4. Issue tokens (same logic as LoginEndpoint and GoogleSocialLoginEndpoint).
+        var roles = await userManager.GetRolesAsync(user);
+        var expiresAt = DateTime.UtcNow.AddMinutes(
+            config.GetValue(ConfigKeys.JwtAccessTokenExpirationMinutes, 15));
+
+        var accessToken = JwtBearer.CreateToken(o =>
+        {
+            o.SigningKey = config[ConfigKeys.JwtSecret]!;
+            o.ExpireAt = expiresAt;
+            o.User.Roles.AddRange(roles);
+            o.User.Claims.Add((AppClaims.UserId, user.Id.ToString()));
+            o.User.Claims.Add((AppClaims.Email, user.Email!));
+        });
+
+        var refreshTokenValue = GenerateRefreshToken();
+        var refreshTokenDays = config.GetValue(ConfigKeys.JwtRefreshTokenExpirationDays, 7);
+
+        db.RefreshTokens.Add(new Domain.Entities.RefreshToken
+        {
+            UserId = user.Id,
+            Token = refreshTokenValue,
+            ExpiresAt = DateTime.UtcNow.AddDays(refreshTokenDays)
+        });
+
+        await db.SaveChangesAsync(ct);
+
+        await Send.OkAsync(new AppleSocialLoginResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshTokenValue,
+            ExpiresAt = expiresAt,
+            EmailConfirmed = user.EmailConfirmed
+        }, ct);
+    }
+
+    /// <summary>
+    /// Generates a cryptographically secure random refresh token string.
+    /// </summary>
+    private static string GenerateRefreshToken()
+    {
+        var randomBytes = RandomNumberGenerator.GetBytes(64);
+        return Convert.ToBase64String(randomBytes);
+    }
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginRequest.cs
@@ -1,0 +1,33 @@
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Apple;
+
+/// <summary>
+/// Request body for the Apple Sign-In endpoint.
+/// The identity token is always required. The authorization code and name fields
+/// are only present on first authorization (Apple omits them on re-auth).
+/// </summary>
+public class AppleSocialLoginRequest
+{
+    /// <summary>
+    /// The Apple identity token (JWT) returned by the Apple JS SDK or native Sign-In.
+    /// </summary>
+    public string IdentityToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The authorization code returned by Apple (forwarded for forward-compatibility).
+    /// The backend does not currently exchange this for tokens — identity verification
+    /// is performed via the identity token alone.
+    /// </summary>
+    public string? AuthorizationCode { get; set; }
+
+    /// <summary>
+    /// The user's first name, present only on first authorization.
+    /// Apple does not re-send this on subsequent authentications.
+    /// </summary>
+    public string? FirstName { get; set; }
+
+    /// <summary>
+    /// The user's last name, present only on first authorization.
+    /// Apple does not re-send this on subsequent authentications.
+    /// </summary>
+    public string? LastName { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginResponse.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginResponse.cs
@@ -1,0 +1,30 @@
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Apple;
+
+/// <summary>
+/// Response returned on a successful Apple Sign-In.
+/// Identical shape to Google Social Login response.
+/// </summary>
+public class AppleSocialLoginResponse
+{
+    /// <summary>
+    /// Short-lived JWT access token (15 minutes by default).
+    /// </summary>
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Long-lived opaque refresh token (7 days by default).
+    /// </summary>
+    public string RefreshToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC expiry time of the access token.
+    /// </summary>
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Whether the account's email address has been confirmed.
+    /// Apple-provisioned and Apple-verified accounts always have this set to true,
+    /// which causes the client to redirect to /download-app rather than /verify-email.
+    /// </summary>
+    public bool EmailConfirmed { get; set; }
+}

--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginValidator.cs
@@ -1,0 +1,18 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace FitnessPlatform.Application.Features.Auth.SocialLogin.Apple;
+
+/// <summary>
+/// Validates the Apple Social Login request.
+/// </summary>
+public class AppleSocialLoginValidator : Validator<AppleSocialLoginRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="AppleSocialLoginValidator"/>.
+    /// </summary>
+    public AppleSocialLoginValidator()
+    {
+        RuleFor(x => x.IdentityToken).NotEmpty();
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/AppleTokenVerifier.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/AppleTokenVerifier.cs
@@ -1,0 +1,174 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FitnessPlatform.Application.Domain.Constants;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Production implementation of <see cref="IAppleTokenVerifier"/> using hand-rolled
+/// RS256 JWT validation against Apple's JWKS.
+/// <para>
+/// Uses <see cref="ConfigurationManager{T}"/> pointed at Apple's OpenID Connect
+/// discovery document to automatically fetch, cache, and refresh the JWKS.
+/// No external NuGet package is required — <c>Microsoft.IdentityModel.Protocols.OpenIdConnect</c>
+/// is already present transitively via the JwtBearer authentication middleware.
+/// </para>
+/// </summary>
+public class AppleTokenVerifier : IAppleTokenVerifier
+{
+    private const string AppleIssuer = "https://appleid.apple.com";
+    private const string AppleDiscoveryEndpoint = "https://appleid.apple.com/.well-known/openid-configuration";
+
+    private readonly IConfigurationManager<OpenIdConnectConfiguration> _configManager;
+    private readonly IConfiguration _config;
+    private readonly JwtSecurityTokenHandler _tokenHandler;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="AppleTokenVerifier"/>.
+    /// </summary>
+    /// <param name="httpClientFactory">Factory for creating named HTTP clients.</param>
+    /// <param name="config">Application configuration (reads <c>Apple:ClientId</c>).</param>
+    public AppleTokenVerifier(IHttpClientFactory httpClientFactory, IConfiguration config)
+    {
+        _config = config;
+
+        // Use the ConfigurationManager pattern so JWKS is fetched and cached automatically.
+        // It refreshes keys when the cache age exceeds the default (1 hour) or when an
+        // unknown "kid" is encountered — handles Apple's key rotation.
+        var httpClient = httpClientFactory.CreateClient("AppleAuth");
+        var httpDocRetriever = new HttpDocumentRetriever(httpClient) { RequireHttps = true };
+
+        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            AppleDiscoveryEndpoint,
+            new OpenIdConnectConfigurationRetriever(),
+            httpDocRetriever);
+
+        _tokenHandler = new JwtSecurityTokenHandler();
+    }
+
+    /// <inheritdoc />
+    public async Task<AppleTokenPayload> VerifyAsync(string identityToken, CancellationToken ct = default)
+    {
+        var clientId = _config[ConfigKeys.AppleClientId]
+            ?? throw new InvalidOperationException("Apple:ClientId is not configured.");
+
+        // Fetch (or return cached) OpenID Connect configuration including the JWKS.
+        OpenIdConnectConfiguration oidcConfig;
+        try
+        {
+            oidcConfig = await _configManager.GetConfigurationAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to retrieve Apple JWKS configuration.", ex);
+        }
+
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidIssuer = AppleIssuer,
+            ValidAudience = clientId,
+            // Explicitly restrict to RS256 — reject "none" and HS-family to block alg-confusion.
+            ValidAlgorithms = ["RS256"],
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromMinutes(5),
+            IssuerSigningKeys = oidcConfig.SigningKeys,
+            ValidateIssuerSigningKey = true,
+            ValidateIssuer = true,
+            ValidateAudience = true
+        };
+
+        ClaimsPrincipal principal;
+        try
+        {
+            principal = _tokenHandler.ValidateToken(identityToken, validationParameters, out _);
+        }
+        catch (SecurityTokenException ex)
+        {
+            // If validation failed due to a key mismatch (Apple rotated), request a fresh
+            // configuration and retry once. ConfigurationManager.RequestRefresh() marks the
+            // cache as stale so the next GetConfigurationAsync fetches fresh keys.
+            _configManager.RequestRefresh();
+
+            OpenIdConnectConfiguration refreshedConfig;
+            try
+            {
+                refreshedConfig = await _configManager.GetConfigurationAsync(ct);
+            }
+            catch (Exception fetchEx)
+            {
+                throw new InvalidOperationException(
+                    "Failed to retrieve refreshed Apple JWKS configuration.", fetchEx);
+            }
+
+            var refreshedParams = new TokenValidationParameters
+            {
+                ValidIssuer = AppleIssuer,
+                ValidAudience = clientId,
+                ValidAlgorithms = ["RS256"],
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5),
+                IssuerSigningKeys = refreshedConfig.SigningKeys,
+                ValidateIssuerSigningKey = true,
+                ValidateIssuer = true,
+                ValidateAudience = true
+            };
+
+            try
+            {
+                principal = _tokenHandler.ValidateToken(identityToken, refreshedParams, out _);
+            }
+            catch (SecurityTokenException retryEx)
+            {
+                throw new InvalidOperationException(
+                    "Apple identity token validation failed after JWKS refresh.", retryEx);
+            }
+
+            // Suppress the original exception — the retry succeeded.
+            _ = ex;
+        }
+
+        // Extract claims from the validated token.
+        var sub = principal.FindFirstValue("sub")
+            ?? throw new InvalidOperationException("Apple identity token is missing the 'sub' claim.");
+
+        var email = principal.FindFirstValue("email");
+
+        // email_verified and is_private_email are serialized as STRING ("true"/"false") by Apple,
+        // but the OIDC spec allows boolean too. Parse tolerantly.
+        var emailVerifiedClaim = principal.FindFirstValue("email_verified");
+        var emailVerified = ParseBoolClaim(emailVerifiedClaim);
+
+        var isPrivateEmailClaim = principal.FindFirstValue("is_private_email");
+        var isPrivateEmail = ParseBoolClaim(isPrivateEmailClaim);
+
+        // Security gate: reject tokens where the email is present, is NOT a private-relay
+        // address, AND is explicitly marked as unverified. Private-relay addresses are always
+        // considered safe (Apple controls them). Absent email is allowed (re-auth flow).
+        if (email is not null && !isPrivateEmail && !emailVerified)
+        {
+            throw new InvalidOperationException(
+                "Apple identity token email is explicitly unverified and is not a private-relay address.");
+        }
+
+        return new AppleTokenPayload(
+            Subject: sub,
+            Email: email,
+            EmailVerified: emailVerified || isPrivateEmail,
+            IsPrivateEmail: isPrivateEmail);
+    }
+
+    /// <summary>
+    /// Parses an Apple claim value that may be a JSON boolean or a string "true"/"false".
+    /// Returns false when the claim is absent or unrecognized.
+    /// </summary>
+    private static bool ParseBoolClaim(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        if (bool.TryParse(value, out var result)) return result;
+        // Some Apple tokens serialize as "TRUE"/"FALSE" — handle case-insensitively.
+        return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/AppleTokenVerifier.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/AppleTokenVerifier.cs
@@ -32,21 +32,40 @@ public class AppleTokenVerifier : IAppleTokenVerifier
     /// <param name="httpClientFactory">Factory for creating named HTTP clients.</param>
     /// <param name="config">Application configuration (reads <c>Apple:ClientId</c>).</param>
     public AppleTokenVerifier(IHttpClientFactory httpClientFactory, IConfiguration config)
+        : this(config, BuildConfigManager(httpClientFactory))
+    {
+    }
+
+    /// <summary>
+    /// Test seam constructor — injects a pre-configured OIDC config manager so tests
+    /// can supply a self-signed RSA key without making real network calls.
+    /// </summary>
+    internal AppleTokenVerifier(
+        IConfiguration config,
+        IConfigurationManager<OpenIdConnectConfiguration> configManager)
     {
         _config = config;
+        _configManager = configManager;
 
+        // MapInboundClaims = false is REQUIRED: the default (true) remaps the JWT's
+        // short claim names ("sub", "email", …) to long XML URI types, which makes
+        // FindFirstValue("sub") return null and breaks every real Apple token.
+        _tokenHandler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+    }
+
+    private static IConfigurationManager<OpenIdConnectConfiguration> BuildConfigManager(
+        IHttpClientFactory httpClientFactory)
+    {
         // Use the ConfigurationManager pattern so JWKS is fetched and cached automatically.
         // It refreshes keys when the cache age exceeds the default (1 hour) or when an
         // unknown "kid" is encountered — handles Apple's key rotation.
         var httpClient = httpClientFactory.CreateClient("AppleAuth");
         var httpDocRetriever = new HttpDocumentRetriever(httpClient) { RequireHttps = true };
 
-        _configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+        return new ConfigurationManager<OpenIdConnectConfiguration>(
             AppleDiscoveryEndpoint,
             new OpenIdConnectConfigurationRetriever(),
             httpDocRetriever);
-
-        _tokenHandler = new JwtSecurityTokenHandler();
     }
 
     /// <inheritdoc />

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/IAppleTokenVerifier.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/IAppleTokenVerifier.cs
@@ -1,0 +1,45 @@
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Represents the verified claims extracted from an Apple identity token.
+/// </summary>
+/// <param name="Subject">
+/// The Apple subject identifier ("sub" claim) — stable per user per app team.
+/// This is the primary correlation key because Apple only sends email on first auth.
+/// </param>
+/// <param name="Email">
+/// The email address from the token. May be null when a returning user re-authenticates
+/// (Apple omits it after first authorization). May be an Apple private-relay address
+/// (e.g. xyz@privaterelay.appleid.com).
+/// </param>
+/// <param name="EmailVerified">
+/// Whether Apple considers the email address verified.
+/// Always true for private-relay addresses; true for regular Apple IDs that passed
+/// Apple's verification flow.
+/// </param>
+/// <param name="IsPrivateEmail">
+/// Whether the email is an Apple private-relay address.
+/// Private-relay addresses are generated per app and hide the real email.
+/// </param>
+public record AppleTokenPayload(string Subject, string? Email, bool EmailVerified, bool IsPrivateEmail);
+
+/// <summary>
+/// Validates an Apple identity token and returns the verified payload.
+/// Abstracted so tests can inject a fake without calling Apple.
+/// </summary>
+public interface IAppleTokenVerifier
+{
+    /// <summary>
+    /// Validates <paramref name="identityToken"/> against Apple's public JWKS
+    /// and the configured Apple Service ID (audience).
+    /// </summary>
+    /// <param name="identityToken">The raw Apple identity token (JWT) from the client.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The verified payload on success.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the token is invalid, expired, the audience does not match,
+    /// the algorithm is not RS256, or the email is explicitly unverified and not a
+    /// private-relay address.
+    /// </exception>
+    Task<AppleTokenPayload> VerifyAsync(string identityToken, CancellationToken ct = default);
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -215,6 +215,9 @@ builder.Services.AddScoped<IClientVerdictService, ClientVerdictService>();
 // Google social login token verification
 builder.Services.AddScoped<IGoogleTokenVerifier, GoogleTokenVerifier>();
 
+// Apple Sign-In token verification
+builder.Services.AddScoped<IAppleTokenVerifier, AppleTokenVerifier>();
+
 // Audit
 builder.Services.AddScoped<IAuditService, AuditService>();
 

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/AppleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/AppleSocialLoginEndpointTests.cs
@@ -1,0 +1,460 @@
+using FastEndpoints;
+using FastEndpoints.Testing;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Features.Auth.SocialLogin.Apple;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FitnessPlatform.Tests.Endpoints.Auth;
+
+/// <summary>
+/// Unit tests for <see cref="AppleSocialLoginEndpoint"/>.
+/// A fake <see cref="IAppleTokenVerifier"/> is injected so no real Apple
+/// network calls are made.
+/// </summary>
+public class AppleSocialLoginEndpointTests
+{
+    private static readonly string JwtSecret = new('x', 64);
+
+    // Shared Apple token payload returned by the fake verifier — verified email, not private-relay.
+    private static readonly AppleTokenPayload ValidPayloadWithEmail = new(
+        Subject: "apple-sub-12345",
+        Email: "appleuser@example.com",
+        EmailVerified: true,
+        IsPrivateEmail: false);
+
+    // Payload simulating a private-relay email (first auth with hidden real email).
+    private static readonly AppleTokenPayload PrivateRelayPayload = new(
+        Subject: "apple-sub-67890",
+        Email: "abc123@privaterelay.appleid.com",
+        EmailVerified: true,
+        IsPrivateEmail: true);
+
+    // Payload simulating a returning user (Apple omits email after first auth).
+    private static readonly AppleTokenPayload ReturningUserPayload = new(
+        Subject: "apple-sub-12345",
+        Email: null,
+        EmailVerified: false,
+        IsPrivateEmail: false);
+
+    private static IConfiguration MakeConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = JwtSecret,
+                ["Jwt:AccessTokenExpirationMinutes"] = "15",
+                ["Jwt:RefreshTokenExpirationDays"] = "7"
+            })
+            .Build();
+
+    private static IAppleTokenVerifier MakeVerifier(AppleTokenPayload payload)
+    {
+        var verifier = Substitute.For<IAppleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(payload);
+        return verifier;
+    }
+
+    private static IAppleTokenVerifier MakeFailingVerifier()
+    {
+        var verifier = Substitute.For<IAppleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Token invalid"));
+        return verifier;
+    }
+
+    // ── 400 — FluentValidation rejects missing identityToken ─────────────────
+
+    [Fact]
+    public void Validator_EmptyIdentityToken_HasValidationError()
+    {
+        var validator = new AppleSocialLoginValidator();
+        var result = validator.Validate(new AppleSocialLoginRequest { IdentityToken = "" });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => string.Equals(
+            e.PropertyName, nameof(AppleSocialLoginRequest.IdentityToken),
+            StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validator_NullIdentityToken_HasValidationError()
+    {
+        var validator = new AppleSocialLoginValidator();
+        var result = validator.Validate(new AppleSocialLoginRequest { IdentityToken = null! });
+        result.IsValid.Should().BeFalse();
+    }
+
+    // ── 401 — invalid Apple token ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_InvalidAppleToken_Returns401()
+    {
+        // Arrange
+        var verifier = MakeFailingVerifier();
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act — SendProblemAsync writes the response; it does NOT throw.
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "bad-token" },
+            CancellationToken.None);
+
+        // Assert
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// Verifier throws when token uses alg=none or HS256 — endpoint must return 401.
+    /// The ValidAlgorithms=["RS256"] guard inside AppleTokenVerifier rejects these;
+    /// the endpoint maps any InvalidOperationException to 401 invalid_credentials.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_VerifierThrowsForAlgConfusion_Returns401()
+    {
+        // Arrange — simulate the exception raised by alg-confusion guard
+        var verifier = Substitute.For<IAppleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException(
+                "Apple identity token validation failed after JWKS refresh."));
+
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "alg-none-token" },
+            CancellationToken.None);
+
+        // Assert — must be 401, not 200/409/403
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// Verifier throws when email is explicitly unverified and not a private-relay address.
+    /// The endpoint maps this InvalidOperationException to 401 invalid_credentials.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_VerifierThrowsForUnverifiedNonRelayEmail_Returns401()
+    {
+        var verifier = Substitute.For<IAppleTokenVerifier>();
+        verifier.VerifyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException(
+                "Apple identity token email is explicitly unverified and is not a private-relay address."));
+
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "unverified-email-token" },
+            CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ── 401 — orphaned external login ─────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_OrphanedExternalLogin_Returns401()
+    {
+        // Arrange — external login exists but linked user does not
+        var userId = Guid.NewGuid();
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "apple",
+            Subject = ValidPayloadWithEmail.Subject
+        };
+
+        var verifier = MakeVerifier(ValidPayloadWithEmail);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        // FindByIdAsync returns null — orphaned link
+        userManager.FindByIdAsync(userId.ToString()).Returns((ApplicationUser?)null);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "valid-token" },
+            CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ── 422 — no link AND no email in token ───────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_NoLinkAndNoEmailInToken_Returns422()
+    {
+        // Arrange — no external login, token has no email (Apple re-auth without link)
+        var verifier = MakeVerifier(ReturningUserPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        var db = new MockDbBuilder().Build(); // no external logins
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "no-email-token" },
+            CancellationToken.None);
+
+        // Assert — 422, not NRE or 401
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    // ── 409 — email conflict (password-only account) ──────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_ExistingPasswordOnlyAccount_Returns409WithSocialEmailConflict()
+    {
+        // Arrange — existing user with the verified email but NO Apple external login
+        var existingUser = EntityBuilder.User
+            .WithEmail(ValidPayloadWithEmail.Email!)
+            .Build();
+
+        var verifier = MakeVerifier(ValidPayloadWithEmail);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByEmailAsync(ValidPayloadWithEmail.Email!).Returns(existingUser);
+
+        // No UserExternalLogin rows in the DB.
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "valid-token" },
+            CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    // ── 403 — deactivated account ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleAsync_DeactivatedAccount_Returns403WithAccountDeactivatedCode()
+    {
+        // Arrange — existing external login for this Apple subject; account inactive
+        var userId = Guid.NewGuid();
+        var inactiveUser = EntityBuilder.User
+            .WithId(userId)
+            .WithEmail(ValidPayloadWithEmail.Email!)
+            .Inactive()
+            .Build();
+
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "apple",
+            Subject = ValidPayloadWithEmail.Subject
+        };
+
+        var verifier = MakeVerifier(ValidPayloadWithEmail);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByIdAsync(userId.ToString()).Returns(inactiveUser);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "valid-token" },
+            CancellationToken.None);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    // ── 200 — happy path A: existing Apple-linked user (returning) ────────────
+
+    [Fact]
+    public async Task HandleAsync_ExistingAppleLink_ReturnsTokens()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = EntityBuilder.User
+            .WithId(userId)
+            .WithEmail(ValidPayloadWithEmail.Email!)
+            .Build();
+
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "apple",
+            Subject = ValidPayloadWithEmail.Subject
+        };
+
+        var verifier = MakeVerifier(ValidPayloadWithEmail);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByIdAsync(userId.ToString()).Returns(user);
+        userManager.GetRolesAsync(user).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "valid-token" },
+            CancellationToken.None);
+
+        ep.ValidationFailed.Should().BeFalse();
+        ep.Response.AccessToken.Should().NotBeNullOrEmpty();
+        ep.Response.RefreshToken.Should().NotBeNullOrEmpty();
+        ep.Response.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+        db.RefreshTokens.Received(1).Add(Arg.Is<RefreshToken>(rt => rt.UserId == userId));
+        await db.Received().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Happy path A variant: re-auth where token carries no email.
+    /// The existing (apple, sub) link must be found, and the user's stored name
+    /// must NOT be overwritten by the absent body values.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_ExistingAppleLinkNoEmailInToken_ReturnsTokens_AndIgnoresAbsentBodyName()
+    {
+        // Arrange — returning user; token has no email; no name in body
+        var userId = Guid.NewGuid();
+        var user = EntityBuilder.User
+            .WithId(userId)
+            .WithEmail("stored@example.com")
+            .Build();
+
+        var externalLogin = new UserExternalLogin
+        {
+            UserId = userId,
+            Provider = "apple",
+            Subject = ReturningUserPayload.Subject
+        };
+
+        var verifier = MakeVerifier(ReturningUserPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+        userManager.FindByIdAsync(userId.ToString()).Returns(user);
+        userManager.GetRolesAsync(user).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder()
+            .With(externalLogin)
+            .Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act — no FirstName/LastName in body
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "valid-token" },
+            CancellationToken.None);
+
+        // Assert — tokens returned; no name update attempted on userManager
+        ep.ValidationFailed.Should().BeFalse();
+        ep.Response.AccessToken.Should().NotBeNullOrEmpty();
+        // We must NOT have called UpdateAsync on the user (no name overwrite)
+        await userManager.DidNotReceive().UpdateAsync(Arg.Any<ApplicationUser>());
+    }
+
+    // ── 200 — happy path B: new user provisioning with private-relay email ────
+
+    [Fact]
+    public async Task HandleAsync_NewUserWithPrivateRelayEmail_ProvisionesAccountAndReturnsTokens()
+    {
+        // Arrange — no existing user or external login; Apple private-relay email
+        var verifier = MakeVerifier(PrivateRelayPayload);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+
+        // FindByEmailAsync returns null → no existing account
+        userManager.FindByEmailAsync(PrivateRelayPayload.Email!).Returns((ApplicationUser?)null);
+
+        // CreateAsync succeeds and sets up the user object
+        userManager.CreateAsync(Arg.Any<ApplicationUser>())
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer)
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act — name from body (first auth)
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest
+            {
+                IdentityToken = "valid-token",
+                FirstName = "Anna",
+                LastName = "Smith"
+            },
+            CancellationToken.None);
+
+        // Assert
+        ep.ValidationFailed.Should().BeFalse();
+        ep.Response.AccessToken.Should().NotBeNullOrEmpty();
+        ep.Response.RefreshToken.Should().NotBeNullOrEmpty();
+        ep.Response.EmailConfirmed.Should().BeTrue(); // Apple verified it
+
+        // Provisioned user must have FirstName/LastName from the body
+        await userManager.Received(1).CreateAsync(
+            Arg.Is<ApplicationUser>(u =>
+                u.FirstName == "Anna" &&
+                u.LastName == "Smith" &&
+                u.EmailConfirmed == true &&
+                u.Email == PrivateRelayPayload.Email));
+
+        // A UserExternalLogin row must have been added for apple
+        db.UserExternalLogins.Received(1).Add(Arg.Is<UserExternalLogin>(el =>
+            el.Provider == "apple" && el.Subject == PrivateRelayPayload.Subject));
+
+        // A ProfessionalProfile must have been created (Trainer role provisioning)
+        db.ProfessionalProfiles.Received(1).Add(Arg.Any<ProfessionalProfile>());
+    }
+
+    /// <summary>
+    /// Happy path B variant: new user with no name in body.
+    /// FirstName and LastName must fall back to empty string, never null
+    /// (ApplicationUser.FirstName/LastName are non-null string fields).
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_NewUserNoNameInBody_ProvisionesWithEmptyStrings()
+    {
+        var verifier = MakeVerifier(ValidPayloadWithEmail);
+        var userManager = EndpointTestHelpers.CreateFakeUserManager();
+
+        userManager.FindByEmailAsync(ValidPayloadWithEmail.Email!).Returns((ApplicationUser?)null);
+        userManager.CreateAsync(Arg.Any<ApplicationUser>())
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer)
+            .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Trainer"]);
+
+        var db = new MockDbBuilder().Build();
+        var config = MakeConfig();
+        var ep = Factory.Create<AppleSocialLoginEndpoint>(verifier, userManager, db, config);
+
+        // Act — no name in body (Apple omitted on first auth for this test)
+        await ep.HandleAsync(
+            new AppleSocialLoginRequest { IdentityToken = "valid-token" },
+            CancellationToken.None);
+
+        ep.ValidationFailed.Should().BeFalse();
+
+        // Name fields must be empty strings, not null
+        await userManager.Received(1).CreateAsync(
+            Arg.Is<ApplicationUser>(u =>
+                u.FirstName == string.Empty &&
+                u.LastName == string.Empty));
+    }
+}

--- a/backend/FitnessPlatform.Tests/Services/AppleTokenVerifierTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/AppleTokenVerifierTests.cs
@@ -1,0 +1,260 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="AppleTokenVerifier"/> that exercise the REAL verifier
+/// against a self-signed RSA test key — not a mock. These tests are the regression
+/// guard for the MapInboundClaims bug (PR #510): the happy-path test must FAIL when
+/// MapInboundClaims defaults to true and PASS after setting it to false.
+/// </summary>
+public class AppleTokenVerifierTests : IDisposable
+{
+    // A real RSA key generated once per test-class instance.
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly string _kid = "test-key-id";
+    private const string AppleIssuer = "https://appleid.apple.com";
+    private const string TestAudience = "com.example.testapp";
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds an <see cref="AppleTokenVerifier"/> wired to the test RSA key via the
+    /// internal seam constructor — no HTTP calls, no Apple JWKS endpoint.
+    /// </summary>
+    private AppleTokenVerifier BuildVerifier()
+    {
+        var rsaSecurityKey = new RsaSecurityKey(_rsa) { KeyId = _kid };
+
+        var oidcConfig = new OpenIdConnectConfiguration();
+        oidcConfig.SigningKeys.Add(rsaSecurityKey);
+
+        var configManager = Substitute.For<IConfigurationManager<OpenIdConnectConfiguration>>();
+        configManager
+            .GetConfigurationAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(oidcConfig));
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [ConfigKeys.AppleClientId] = TestAudience
+            })
+            .Build();
+
+        return new AppleTokenVerifier(config, configManager);
+    }
+
+    /// <summary>
+    /// Signs a JWT with the test RSA key.
+    /// </summary>
+    /// <param name="notBefore">Start of the token validity window. Defaults to now.</param>
+    /// <param name="expires">End of the token validity window. Defaults to one hour from now.</param>
+    private string BuildToken(
+        string sub,
+        string? email = null,
+        string? emailVerified = null,
+        string? isPrivateEmail = null,
+        string issuer = AppleIssuer,
+        string audience = TestAudience,
+        DateTime? notBefore = null,
+        DateTime? expires = null,
+        SecurityAlgorithm algorithm = SecurityAlgorithm.Rs256)
+    {
+        var claims = new List<Claim> { new("sub", sub) };
+        if (email is not null) claims.Add(new Claim("email", email));
+        if (emailVerified is not null) claims.Add(new Claim("email_verified", emailVerified));
+        if (isPrivateEmail is not null) claims.Add(new Claim("is_private_email", isPrivateEmail));
+
+        SigningCredentials signingCredentials;
+        switch (algorithm)
+        {
+            case SecurityAlgorithm.Rs256:
+                signingCredentials = new SigningCredentials(
+                    new RsaSecurityKey(_rsa) { KeyId = _kid },
+                    SecurityAlgorithms.RsaSha256);
+                break;
+
+            case SecurityAlgorithm.Hs256WithRsaPublicKeyBytes:
+                // Algorithm confusion attack: sign with HS256 using the RSA public key bytes as secret.
+                var publicKeyBytes = _rsa.ExportRSAPublicKey();
+                signingCredentials = new SigningCredentials(
+                    new SymmetricSecurityKey(publicKeyBytes),
+                    SecurityAlgorithms.HmacSha256);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(algorithm));
+        }
+
+        var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            Issuer = issuer,
+            Audience = audience,
+            NotBefore = notBefore ?? DateTime.UtcNow.AddMinutes(-5),
+            Expires = expires ?? DateTime.UtcNow.AddHours(1),
+            SigningCredentials = signingCredentials,
+        };
+
+        return handler.CreateEncodedJwt(descriptor);
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A valid RS256 token with verified email must return the correct Subject and Email.
+    /// This test is the direct regression guard for the MapInboundClaims bug:
+    ///   WITHOUT MapInboundClaims = false → FindFirstValue("sub") returns null → throws.
+    ///   WITH    MapInboundClaims = false → FindFirstValue("sub") returns "apple-test-sub" → passes.
+    /// </summary>
+    [Fact]
+    public async Task VerifyAsync_ValidToken_ReturnsCorrectSubjectAndEmail()
+    {
+        var verifier = BuildVerifier();
+        var token = BuildToken(
+            sub: "apple-test-sub",
+            email: "user@example.com",
+            emailVerified: "true");
+
+        var result = await verifier.VerifyAsync(token);
+
+        result.Subject.Should().Be("apple-test-sub");
+        result.Email.Should().Be("user@example.com");
+        result.EmailVerified.Should().BeTrue();
+        result.IsPrivateEmail.Should().BeFalse();
+    }
+
+    // ── email_verified / is_private_email parsing ─────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_StringTrueEmailVerified_ParsedCorrectly()
+    {
+        var verifier = BuildVerifier();
+        var token = BuildToken(
+            sub: "sub-1",
+            email: "test@apple.com",
+            emailVerified: "true",
+            isPrivateEmail: "false");
+
+        var result = await verifier.VerifyAsync(token);
+
+        result.EmailVerified.Should().BeTrue();
+        result.IsPrivateEmail.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_StringFalseEmailVerified_ParsedCorrectly()
+    {
+        var verifier = BuildVerifier();
+        // Unverified non-private-relay email → verifier must throw (security gate).
+        var token = BuildToken(
+            sub: "sub-2",
+            email: "test@example.com",
+            emailVerified: "false",
+            isPrivateEmail: "false");
+
+        var act = () => verifier.VerifyAsync(token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*unverified*");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_PrivateRelayEmailWithMissingEmailVerified_Accepted()
+    {
+        // Private-relay emails have no email_verified claim in the token.
+        // The verifier must still accept them and set EmailVerified = true (IsPrivateEmail implies verified).
+        var verifier = BuildVerifier();
+        var token = BuildToken(
+            sub: "sub-3",
+            email: "xyz@privaterelay.appleid.com",
+            emailVerified: null,    // absent — real Apple private-relay tokens omit this
+            isPrivateEmail: "true");
+
+        var result = await verifier.VerifyAsync(token);
+
+        result.IsPrivateEmail.Should().BeTrue();
+        result.EmailVerified.Should().BeTrue(); // because IsPrivateEmail → EmailVerified = true
+    }
+
+    // ── Algorithm-confusion attack guard ──────────────────────────────────────
+
+    /// <summary>
+    /// A token signed with HS256 using the RSA public key bytes as the HMAC secret must
+    /// be rejected. This proves ValidAlgorithms = ["RS256"] blocks the classic alg-confusion attack.
+    /// </summary>
+    [Fact]
+    public async Task VerifyAsync_Hs256TokenSignedWithRsaPublicKeyBytes_Rejected()
+    {
+        var verifier = BuildVerifier();
+        var token = BuildToken(
+            sub: "attacker",
+            algorithm: SecurityAlgorithm.Hs256WithRsaPublicKeyBytes);
+
+        var act = () => verifier.VerifyAsync(token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ── Rejection scenarios ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task VerifyAsync_WrongAudience_Rejected()
+    {
+        var verifier = BuildVerifier();
+        var token = BuildToken(sub: "sub-bad-aud", audience: "com.attacker.app");
+
+        var act = () => verifier.VerifyAsync(token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WrongIssuer_Rejected()
+    {
+        var verifier = BuildVerifier();
+        var token = BuildToken(sub: "sub-bad-iss", issuer: "https://evil.example.com");
+
+        var act = () => verifier.VerifyAsync(token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ExpiredToken_Rejected()
+    {
+        var verifier = BuildVerifier();
+        // Both notBefore and expires are in the past so the JWT is well-formed but expired.
+        var token = BuildToken(
+            sub: "sub-expired",
+            notBefore: DateTime.UtcNow.AddHours(-3),
+            expires: DateTime.UtcNow.AddHours(-2));
+
+        var act = () => verifier.VerifyAsync(token);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ── IDisposable ───────────────────────────────────────────────────────────
+
+    public void Dispose() => _rsa.Dispose();
+
+    // ── Helper enum ──────────────────────────────────────────────────────────
+
+    internal enum SecurityAlgorithm
+    {
+        Rs256,
+        Hs256WithRsaPublicKeyBytes
+    }
+}

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -15,3 +15,25 @@ export async function googleSocialLogin(idToken: string): Promise<LoginResponse>
   const { data } = await api.post<LoginResponse>('/auth/social/google', { idToken });
   return data;
 }
+
+/**
+ * POST /auth/social/apple
+ * Sends Apple identity token (and optional first-auth fields) to the backend,
+ * which verifies the JWT against Apple's JWKS and returns platform JWT tokens.
+ *
+ * @param payload.identityToken  - Apple identity token JWT from signInWithApple().
+ * @param payload.authorizationCode - Authorization code from Apple (forwarded
+ *   for forward-compat; backend ignores it today — no .p8 exchange is done).
+ * @param payload.firstName - Present only on first Apple authorization; absent
+ *   on re-auth. Backend persists it on new account provision only.
+ * @param payload.lastName  - Same as firstName.
+ */
+export async function appleSocialLogin(payload: {
+  identityToken: string;
+  authorizationCode?: string;
+  firstName?: string;
+  lastName?: string;
+}): Promise<LoginResponse> {
+  const { data } = await api.post<LoginResponse>('/auth/social/apple', payload);
+  return data;
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -98,7 +98,8 @@
     "verifyEmailSuccess": "E-mail byl úspěšně ověřen.",
     "verifyEmailExpired": "Odkaz vypršel. Nechte si odeslat nový.",
     "verifyEmailInvalid": "Neplatný ověřovací odkaz.",
-    "googleLoading": "Přihlašuji přes Google..."
+    "googleLoading": "Přihlašuji přes Google...",
+    "appleLoading": "Přihlašuji přes Apple..."
   },
   "downloadApp": {
     "title": "Stáhněte si aplikaci",
@@ -810,7 +811,8 @@
     "COMPLETED_AT_IN_FUTURE": "Datum dokončení nesmí být v budoucnosti.",
     "COMPLETED_AT_BEFORE_PLAN_START": "Datum dokončení nesmí být před začátkem plánu.",
     "session_locked": "Trénink je aktuálně uzamčen — uložení selhalo.",
-    "social_email_conflict": "Tento e-mail je registrován s heslem. Přihlaste se emailem a heslem."
+    "social_email_conflict": "Tento e-mail je registrován s heslem. Přihlaste se emailem a heslem.",
+    "APPLE_NO_EMAIL_NO_LINK": "Přihlášení přes Apple selhalo: e-mail nebyl poskytnut. Otevřete Nastavení > Apple ID a povolte sdílení e-mailu s touto aplikací."
   },
   "nutritionGoals": {
     "title": "Cíle & makra",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -98,7 +98,8 @@
     "verifyEmailSuccess": "E-Mail erfolgreich bestätigt.",
     "verifyEmailExpired": "Link abgelaufen. Fordern Sie einen neuen an.",
     "verifyEmailInvalid": "Ungültiger Bestätigungslink.",
-    "googleLoading": "Anmeldung mit Google..."
+    "googleLoading": "Anmeldung mit Google...",
+    "appleLoading": "Anmeldung mit Apple..."
   },
   "downloadApp": {
     "title": "App herunterladen",
@@ -800,7 +801,8 @@
     "COMPLETED_AT_IN_FUTURE": "Das Abschlussdatum darf nicht in der Zukunft liegen.",
     "COMPLETED_AT_BEFORE_PLAN_START": "Das Abschlussdatum darf nicht vor dem Startdatum des Plans liegen.",
     "session_locked": "Einheit ist derzeit gesperrt — Speichern fehlgeschlagen.",
-    "social_email_conflict": "Diese E-Mail ist mit einem Passwort registriert. Bitte melden Sie sich mit E-Mail und Passwort an."
+    "social_email_conflict": "Diese E-Mail ist mit einem Passwort registriert. Bitte melden Sie sich mit E-Mail und Passwort an.",
+    "APPLE_NO_EMAIL_NO_LINK": "Apple-Anmeldung fehlgeschlagen: Es wurde keine E-Mail angegeben. Öffnen Sie Einstellungen > Apple-ID und erlauben Sie das Teilen der E-Mail mit dieser App."
   },
   "nutritionGoals": {
     "title": "Ziele & Makros",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -98,7 +98,8 @@
     "verifyEmailSuccess": "Email verified successfully.",
     "verifyEmailExpired": "Link expired. Request a new one.",
     "verifyEmailInvalid": "Invalid verification link.",
-    "googleLoading": "Signing in with Google..."
+    "googleLoading": "Signing in with Google...",
+    "appleLoading": "Signing in with Apple..."
   },
   "downloadApp": {
     "title": "Download the app",
@@ -801,7 +802,8 @@
     "COMPLETED_AT_IN_FUTURE": "Completion date cannot be in the future.",
     "COMPLETED_AT_BEFORE_PLAN_START": "Completion date cannot be before the plan's start date.",
     "session_locked": "Session is currently locked — save failed.",
-    "social_email_conflict": "This email is registered with a password. Please sign in with your email and password."
+    "social_email_conflict": "This email is registered with a password. Please sign in with your email and password.",
+    "APPLE_NO_EMAIL_NO_LINK": "Apple sign-in failed: no email was provided. Open Settings > Apple ID and allow email sharing with this app."
   },
   "nutritionGoals": {
     "title": "Goals & Macros",

--- a/web/src/lib/appleAuth.ts
+++ b/web/src/lib/appleAuth.ts
@@ -1,0 +1,134 @@
+/**
+ * Apple Sign-In helper — loads the Apple JS SDK on demand and invokes the
+ * popup-mode sign-in flow.
+ *
+ * The SDK is loaded once (idempotent). Service ID and redirect URI come from
+ * Vite env vars (VITE_APPLE_CLIENT_ID / VITE_APPLE_REDIRECT_URI) so no URLs
+ * are hardcoded (rules/code-quality.md#no-hardcoded-api-urls).
+ */
+
+/** Typed subset of the Apple JS SDK response we consume. */
+interface AppleSignInAuthorizationResult {
+  authorization: {
+    /** Apple identity token (JWT). This is what POST /auth/social/apple expects. */
+    id_token: string;
+    /** Authorization code — forwarded in the request body for forward-compat. */
+    code: string;
+  };
+  /**
+   * Present only on first authorization. Absent on subsequent sign-ins.
+   * Apple sends user info only once; we must persist it on first use.
+   */
+  user?: {
+    name?: {
+      firstName?: string | null;
+      lastName?: string | null;
+    };
+    email?: string | null;
+  };
+}
+
+/**
+ * Shape returned by the SDK's AppleID.auth.signIn() promise.
+ * The full SDK object has many more fields; we type only what we use.
+ * The `unknown` cast below is a deliberate interop escape: the Apple JS SDK
+ * ships no official TypeScript types and window.AppleID is dynamically
+ * injected, so we can't derive the shape statically. This is the narrowest
+ * safe cast — we extract named fields immediately and do not propagate `any`.
+ */
+interface AppleIDAuth {
+  init(config: {
+    clientId: string;
+    scope: string;
+    redirectURI: string;
+    usePopup: boolean;
+  }): void;
+  signIn(): Promise<AppleSignInAuthorizationResult>;
+}
+
+interface AppleIDGlobal {
+  auth: AppleIDAuth;
+}
+
+/**
+ * Result shape returned to callers of signInWithApple().
+ */
+export interface AppleSignInResult {
+  identityToken: string;
+  authorizationCode: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+// Singleton promise so concurrent callers share one in-flight load.
+let sdkLoadPromise: Promise<void> | null = null;
+
+/**
+ * Idempotently injects the Apple JS SDK script and resolves once
+ * window.AppleID is available.
+ */
+function loadAppleSdk(): Promise<void> {
+  if (sdkLoadPromise) return sdkLoadPromise;
+
+  sdkLoadPromise = new Promise<void>((resolve, reject) => {
+    // Already loaded by a previous call (e.g. hot reload).
+    if ((window as { AppleID?: AppleIDGlobal }).AppleID) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src =
+      'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js';
+    script.async = true;
+    script.onload = () => {
+      if ((window as { AppleID?: AppleIDGlobal }).AppleID) {
+        resolve();
+      } else {
+        reject(new Error('Apple JS SDK loaded but window.AppleID is missing'));
+      }
+    };
+    script.onerror = () => reject(new Error('Failed to load Apple JS SDK'));
+    document.head.appendChild(script);
+  });
+
+  return sdkLoadPromise;
+}
+
+/**
+ * Initiates Apple Sign-In via the popup/JS-callback flow.
+ *
+ * Reads clientId + redirectURI from Vite env:
+ *   VITE_APPLE_CLIENT_ID   — Apple Services ID (e.g. com.example.app.web)
+ *   VITE_APPLE_REDIRECT_URI — Must match the domain registered in the Apple
+ *                             Developer portal (e.g. https://app.example.com)
+ *
+ * Returns identityToken (always), authorizationCode (always), and
+ * firstName/lastName (first auth only — Apple omits them on re-auth).
+ *
+ * Throws if the user cancels or the SDK rejects.
+ */
+export async function signInWithApple(): Promise<AppleSignInResult> {
+  await loadAppleSdk();
+
+  // The interop cast: window.AppleID is unknown at compile time because the
+  // Apple JS SDK ships no TS types and is dynamically injected.  We cast via
+  // unknown → AppleIDGlobal immediately and use the typed interface from here.
+  const appleID = (window as unknown as { AppleID: AppleIDGlobal }).AppleID;
+
+  appleID.auth.init({
+    clientId: import.meta.env.VITE_APPLE_CLIENT_ID ?? '',
+    scope: 'name email',
+    redirectURI: import.meta.env.VITE_APPLE_REDIRECT_URI ?? '',
+    usePopup: true,
+  });
+
+  const response = await appleID.auth.signIn();
+
+  return {
+    identityToken: response.authorization.id_token,
+    authorizationCode: response.authorization.code,
+    firstName: response.user?.name?.firstName ?? undefined,
+    lastName: response.user?.name?.lastName ?? undefined,
+  };
+}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -12,7 +12,8 @@ import { apiClient } from '@/api/client';
 import { showError, showApiError } from '@/lib/api-errors';
 import type { LoginResponse } from '@/api/client';
 import { INVITE_TOKEN_KEY } from '@/pages/InviteAcceptPage';
-import { googleSocialLogin } from '@/api/auth';
+import { googleSocialLogin, appleSocialLogin } from '@/api/auth';
+import { signInWithApple } from '@/lib/appleAuth';
 
 export default function LoginPage() {
   const { t } = useTranslation();
@@ -22,6 +23,7 @@ export default function LoginPage() {
   const setTokens = useAuthStore((s) => s.setTokens);
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [appleLoading, setAppleLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [inviteStatus, setInviteStatus] = useState<'accepted' | 'failed' | null>(null);
   const justRegistered = (location.state as { registered?: boolean })?.registered;
@@ -140,6 +142,60 @@ export default function LoginPage() {
       showApiError(err, 'auth.loginError');
     } finally {
       setGoogleLoading(false);
+    }
+  };
+
+  /**
+   * Triggered by the Apple button click. Loads the Apple JS SDK on demand,
+   * opens the Apple popup, and completes sign-in via POST /auth/social/apple.
+   *
+   * firstName/lastName are present only on the first Apple authorization —
+   * Apple omits them on subsequent sign-ins. The backend persists them on
+   * new account provision only and ignores them on returning users.
+   */
+  const handleAppleSignIn = async () => {
+    setAppleLoading(true);
+    try {
+      const { identityToken, authorizationCode, firstName, lastName } = await signInWithApple();
+      const res: LoginResponse = await appleSocialLogin({
+        identityToken,
+        authorizationCode,
+        firstName,
+        lastName,
+      });
+      setTokens(res.accessToken!, res.refreshToken!);
+      const profile = await apiClient.getProfileEndpoint();
+      const emailConfirmed = res.emailConfirmed ?? true;
+
+      login(
+        {
+          publicId: profile.userId!,
+          email: profile.email!,
+          firstName: profile.firstName!,
+          lastName: profile.lastName!,
+          roles: profile.roles ?? [],
+          emailConfirmed,
+          avatarBlobUrl: profile.avatarBlobUrl ?? null,
+        },
+        res.accessToken!,
+        res.refreshToken!,
+      );
+
+      // Apple has verified the email (or it is a private-relay address, which
+      // is also considered confirmed). Still check in case an existing linked
+      // account was somehow unverified.
+      if (!emailConfirmed) {
+        navigate('/verify-email', { replace: true });
+        return;
+      }
+
+      const roles = profile.roles ?? [];
+      const isClientOnly = roles.includes('Client') && !roles.some((r: string) => ['Trainer', 'Nutritionist', 'Admin'].includes(r));
+      navigate(isClientOnly ? '/download-app' : '/dashboard', { replace: true });
+    } catch (err) {
+      showApiError(err, 'auth.loginError');
+    } finally {
+      setAppleLoading(false);
     }
   };
 
@@ -303,11 +359,17 @@ export default function LoginPage() {
           </div>
         </div>
 
-        <button type="button" className="auth-social">
+        <button
+          type="button"
+          className="auth-social"
+          disabled={appleLoading}
+          onClick={handleAppleSignIn}
+          style={{ width: '100%' }}
+        >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
             <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
-          Pokračovat přes Apple
+          {appleLoading ? t('auth.appleLoading') : 'Pokračovat přes Apple'}
         </button>
 
         {/* Footer */}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Google OAuth client ID for @react-oauth/google. */
+  readonly VITE_GOOGLE_CLIENT_ID: string;
+  /** Apple Services ID for Apple Sign-In (e.g. com.example.app.web). */
+  readonly VITE_APPLE_CLIENT_ID: string;
+  /**
+   * Redirect URI registered in the Apple Developer portal for this web app.
+   * Must match exactly (e.g. https://app.example.com).
+   */
+  readonly VITE_APPLE_REDIRECT_URI: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- Backend: new `POST /auth/social/apple` (FastEndpoints) verifies the Apple identity-token JWT against Apple's JWKS via `ConfigurationManager<OpenIdConnectConfiguration>` (issuer/audience/RS256/lifetime pinned, key-rotation refresh), then links / provisions / returns the standard `LoginResponse`. 409 `social_email_conflict` for password-only accounts; 422 `APPLE_NO_EMAIL_NO_LINK` when no email and no existing link.
- Reuses the existing `UserExternalLogin` entity — **no migration**.
- Web: wires the previously-dead Apple button via the official Apple JS SDK (popup mode, **no new npm dependency**), adds `appleSocialLogin()` API call and `auth.appleLoading` + `apiErrors.APPLE_NO_EMAIL_NO_LINK` i18n in cs/en/de. Mirrors the merged #479 Google pattern.
- Two new env vars (`VITE_APPLE_CLIENT_ID`, `VITE_APPLE_REDIRECT_URI`) typed in `vite-env.d.ts`; backend config key `Apple:ClientId`.

## Related issue
Fixes #480

## Scope
backend + web (cross-package, one branch / one PR)

## QA verdict (from qa-tester)
OVERALL ⚠️ INTERACTIVE-REQUIRED — all static/structural/test surface PASSED (backend 13/13 Apple + 9/9 Google regression, web build clean, i18n complete). The single `met:false` AC is the live click→Apple-popup→token round-trip, not exercisable without a real Apple Service ID / `VITE_APPLE_CLIENT_ID` (same standing prerequisite as Google's `VITE_GOOGLE_CLIENT_ID`).

## Notes / out of scope
- `authorizationCode` server-side exchange is intentionally out of scope (user-confirmed): identity-token verification only, no `.p8`. The request body accepts `authorizationCode` for forward-compat.

## Test plan
- [ ] Clicking the Apple button initiates Sign in with Apple and obtains an identity token (requires `VITE_APPLE_CLIENT_ID`)
- [ ] `POST /auth/social/apple` verifies the JWT against Apple JWKS and returns access+refresh tokens
- [ ] Name persisted on first auth, ignored on re-auth; absent name provisions empty display name
- [ ] Private-relay email accepted and stored as canonical email
- [ ] Email match → links Apple identity and returns tokens
- [ ] No match → provisions new account and returns tokens
- [ ] Password-only account → 409 `social_email_conflict`, surfaced in cs/en/de
- [ ] Successful login stores tokens and applies standard redirect (client → /download-app, staff → /dashboard, unverified → /verify-email)
- [ ] New strings land in cs/en/de
- [ ] Google button at the sibling location is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)