### PR TITLE
refactor(web): move login social-button labels into i18n

### DIFF
--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -99,7 +99,9 @@
     "verifyEmailExpired": "Odkaz vypršel. Nechte si odeslat nový.",
     "verifyEmailInvalid": "Neplatný ověřovací odkaz.",
     "googleLoading": "Přihlašuji přes Google...",
-    "appleLoading": "Přihlašuji přes Apple..."
+    "appleLoading": "Přihlašuji přes Apple...",
+    "continueWithGoogle": "Pokračovat přes Google",
+    "continueWithApple": "Pokračovat přes Apple"
   },
   "downloadApp": {
     "title": "Stáhněte si aplikaci",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -99,7 +99,9 @@
     "verifyEmailExpired": "Link abgelaufen. Fordern Sie einen neuen an.",
     "verifyEmailInvalid": "Ungültiger Bestätigungslink.",
     "googleLoading": "Anmeldung mit Google...",
-    "appleLoading": "Anmeldung mit Apple..."
+    "appleLoading": "Anmeldung mit Apple...",
+    "continueWithGoogle": "Mit Google fortfahren",
+    "continueWithApple": "Mit Apple fortfahren"
   },
   "downloadApp": {
     "title": "App herunterladen",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -99,7 +99,9 @@
     "verifyEmailExpired": "Link expired. Request a new one.",
     "verifyEmailInvalid": "Invalid verification link.",
     "googleLoading": "Signing in with Google...",
-    "appleLoading": "Signing in with Apple..."
+    "appleLoading": "Signing in with Apple...",
+    "continueWithGoogle": "Continue with Google",
+    "continueWithApple": "Continue with Apple"
   },
   "downloadApp": {
     "title": "Download the app",

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -335,7 +335,7 @@ export default function LoginPage() {
               <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
               <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
             </svg>
-            {googleLoading ? t('auth.googleLoading') : 'Pokračovat přes Google'}
+            {googleLoading ? t('auth.googleLoading') : t('auth.continueWithGoogle')}
           </button>
           {/* Invisible GoogleLogin overlay — renders a 0-opacity button that
               fills the same space. When clicked it opens Google's credential
@@ -369,7 +369,7 @@ export default function LoginPage() {
           <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
             <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
-          {appleLoading ? t('auth.appleLoading') : 'Pokračovat přes Apple'}
+          {appleLoading ? t('auth.appleLoading') : t('auth.continueWithApple')}
         </button>
 
         {/* Footer */}


### PR DESCRIPTION
## Summary
- Replaces the two hardcoded Czech default-label literals on the login social sign-in buttons ("Pokračovat přes Google" / "Pokračovat přes Apple") with i18n keys `auth.continueWithGoogle` / `auth.continueWithApple`, read via the project's `t()` hook.
- Adds both keys to all three locale files (`cs`, `en`, `de`), with `cs` as the primary (values byte-identical to the prior literals — no rendered-copy change).
- No behavior, styling, or logic change on the login page; loading-state bindings (`auth.googleLoading` / `auth.appleLoading`) are untouched.

## Related issue
Fixes #512

## Scope
web

## QA verdict (from qa-tester)
OVERALL ✅ PASS — web build clean, all three locales carry both keys, web-only, no `generated.ts` touched.

## Test plan
- [ ] "Pokračovat přes Apple" is replaced by an i18n key (`auth.continueWithApple`) read via the translation hook.
- [ ] "Pokračovat přes Google" is replaced by an i18n key (`auth.continueWithGoogle`).
- [ ] Both keys added to `cs.json`, `en.json`, `de.json`, with `cs` as primary.
- [ ] No other behavior, styling, or logic change on the login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)