### PR TITLE
chore: periodically reap expired/consumed social-login nonce rows

### DIFF
--- a/backend/FitnessPlatform.Application/Infrastructure/Services/SocialLoginNonceReaperService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/SocialLoginNonceReaperService.cs
@@ -1,0 +1,129 @@
+using System.Runtime.CompilerServices;
+using FitnessPlatform.Application.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+[assembly: InternalsVisibleTo("FitnessPlatform.Tests")]
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// Background service that periodically reaps stale <c>SocialLoginNonce</c> rows from
+/// the database to prevent unbounded table growth.
+///
+/// <para><b>Deletion predicate (honours the audit grace window):</b></para>
+/// <list type="bullet">
+///   <item>Expired unconsumed nonces: <c>ExpiresAt &lt; now</c></item>
+///   <item>Consumed nonces past the grace window: <c>ConsumedAt &lt; now - grace</c></item>
+/// </list>
+/// <para>Still-valid unconsumed nonces and recently-consumed nonces within the grace
+/// window are never deleted.</para>
+///
+/// <para><b>Configuration keys (with defaults):</b></para>
+/// <list type="bullet">
+///   <item><c>Auth:NonceReapIntervalMinutes</c> — how often the sweep runs (default: 60)</item>
+///   <item><c>Auth:NonceConsumedGraceHours</c> — how long to retain consumed nonces after
+///     consumption for audit purposes (default: 1)</item>
+/// </list>
+/// </summary>
+public class SocialLoginNonceReaperService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<SocialLoginNonceReaperService> logger,
+    IConfiguration configuration) : BackgroundService
+{
+    /// <summary>
+    /// Default sweep interval in minutes. Override via <c>Auth:NonceReapIntervalMinutes</c>
+    /// in configuration (primarily for tests that need deterministic ticks).
+    /// </summary>
+    internal const int DefaultReapIntervalMinutes = 60;
+
+    /// <summary>
+    /// Default grace window in hours for consumed nonces. Override via
+    /// <c>Auth:NonceConsumedGraceHours</c> in configuration.
+    /// </summary>
+    internal const int DefaultConsumedGraceHours = 1;
+
+    // Exposed for unit/integration tests — drive the sweeper with a virtual clock.
+    internal DateTime? OverrideNow { get; set; }
+
+    private TimeSpan ReapInterval =>
+        TimeSpan.FromMinutes(
+            configuration.GetValue("Auth:NonceReapIntervalMinutes", DefaultReapIntervalMinutes));
+
+    private TimeSpan ConsumedGrace =>
+        TimeSpan.FromHours(
+            configuration.GetValue("Auth:NonceConsumedGraceHours", DefaultConsumedGraceHours));
+
+    /// <summary>
+    /// Entry point used by tests: execute one sweep cycle treating <paramref name="now"/>
+    /// as the current UTC time.
+    /// </summary>
+    internal async Task SweepAsync(DateTime now, CancellationToken ct = default)
+    {
+        var grace = ConsumedGrace;
+        var consumedCutoff = now - grace;
+
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+
+        var deleted = await db.SocialLoginNonces
+            .Where(n => n.ExpiresAt < now
+                        || (n.ConsumedAt != null && n.ConsumedAt < consumedCutoff))
+            .ExecuteDeleteAsync(ct);
+
+        if (deleted > 0)
+        {
+            logger.LogInformation(
+                "SocialLoginNonceReaperService: reaped {Count} stale nonce row(s) at {Now:u}. " +
+                "Predicate: ExpiresAt < {Now:u} OR (ConsumedAt < {ConsumedCutoff:u}).",
+                deleted, now, now, consumedCutoff);
+        }
+        else
+        {
+            logger.LogDebug(
+                "SocialLoginNonceReaperService: sweep at {Now:u} — no stale rows found.", now);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = ReapInterval;
+
+        logger.LogInformation(
+            "SocialLoginNonceReaperService: starting with interval={Interval}, consumedGrace={Grace}.",
+            interval, ConsumedGrace);
+
+        using var timer = new PeriodicTimer(interval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var now = OverrideNow ?? DateTime.UtcNow;
+            logger.LogDebug("SocialLoginNonceReaperService: tick at {Now:u}.", now);
+
+            try
+            {
+                await SweepAsync(now, stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogError(ex,
+                    "SocialLoginNonceReaperService: unhandled error on sweep at {Now:u}.", now);
+            }
+
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        logger.LogInformation("SocialLoginNonceReaperService: stopped.");
+    }
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -201,6 +201,11 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<WeeklyCheckInSched
 builder.Services.AddSingleton<PhotoDiaryReminderScheduler>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<PhotoDiaryReminderScheduler>());
 
+// Social login nonce reaper — periodically deletes expired/consumed nonce rows.
+// Registered as singleton (for test access via IServiceProvider) and hosted service.
+builder.Services.AddSingleton<SocialLoginNonceReaperService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<SocialLoginNonceReaperService>());
+
 // Session lock service — mutual exclusion for trainer-edit vs client-live sessions
 builder.Services.Configure<TrainingLockOptions>(
     builder.Configuration.GetSection(TrainingLockOptions.SectionName));

--- a/backend/FitnessPlatform.Tests/Infrastructure/Services/SocialLoginNonceReaperServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Infrastructure/Services/SocialLoginNonceReaperServiceTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FitnessPlatform.Tests.Infrastructure.Services;
+
+/// <summary>
+/// Integration tests for <see cref="SocialLoginNonceReaperService"/> using a virtual clock.
+/// Uses Testcontainers PostgreSQL (Docker required).
+/// </summary>
+[Collection(TestCollection.Name)]
+public class SocialLoginNonceReaperServiceTests(FitnessApiFactory factory)
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static DateTime Utc(int daysOffset = 0, int hoursOffset = 0) =>
+        DateTime.UtcNow.AddDays(daysOffset).AddHours(hoursOffset);
+
+    /// <summary>
+    /// Inserts a <see cref="SocialLoginNonce"/> row directly and returns its id.
+    /// </summary>
+    private async Task<int> InsertNonceAsync(
+        DateTime expiresAt,
+        DateTime? consumedAt = null)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var nonce = new SocialLoginNonce
+        {
+            Nonce = Guid.NewGuid().ToString("N"), // 32-char hex unique value (within MaxLength(64))
+            ExpiresAt = expiresAt,
+            ConsumedAt = consumedAt,
+            CreatedAt = DateTime.UtcNow
+        };
+        db.SocialLoginNonces.Add(nonce);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return nonce.Id;
+    }
+
+    private async Task<SocialLoginNonce?> LoadNonceAsync(int id)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return await db.SocialLoginNonces
+            .AsNoTracking()
+            .FirstOrDefaultAsync(n => n.Id == id, TestContext.Current.CancellationToken);
+    }
+
+    private SocialLoginNonceReaperService GetReaper() =>
+        factory.Services.GetRequiredService<SocialLoginNonceReaperService>();
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Sweep_DeletesExpiredUnconsumedNonce()
+    {
+        // Arrange: expired nonce (ExpiresAt is 2 hours in the past, never consumed).
+        var id = await InsertNonceAsync(expiresAt: Utc(hoursOffset: -2));
+        var reaper = GetReaper();
+
+        // Act: sweep at "now".
+        var now = DateTime.UtcNow;
+        await reaper.SweepAsync(now, TestContext.Current.CancellationToken);
+
+        // Assert: row is gone.
+        var row = await LoadNonceAsync(id);
+        row.Should().BeNull("expired unconsumed nonces must be reaped");
+    }
+
+    [Fact]
+    public async Task Sweep_DeletesConsumedNoncePastGraceWindow()
+    {
+        // Arrange: consumed nonce whose ConsumedAt is 3 hours ago
+        // (default grace = 1 h → cutoff = now - 1 h → 3 h ago is past the cutoff).
+        var consumedAt = Utc(hoursOffset: -3);
+        // ExpiresAt in the future so it wouldn't be reaped by the expiry arm alone.
+        var id = await InsertNonceAsync(
+            expiresAt: Utc(hoursOffset: +1),
+            consumedAt: consumedAt);
+
+        var reaper = GetReaper();
+        var now = DateTime.UtcNow;
+        await reaper.SweepAsync(now, TestContext.Current.CancellationToken);
+
+        var row = await LoadNonceAsync(id);
+        row.Should().BeNull(
+            "consumed nonces past the grace window must be reaped even if not yet technically expired");
+    }
+
+    [Fact]
+    public async Task Sweep_KeepsValidUnconsumedNonce()
+    {
+        // Arrange: nonce that expires 10 minutes in the future, never consumed.
+        var id = await InsertNonceAsync(expiresAt: Utc(hoursOffset: 0).AddMinutes(10));
+        var reaper = GetReaper();
+
+        var now = DateTime.UtcNow;
+        await reaper.SweepAsync(now, TestContext.Current.CancellationToken);
+
+        var row = await LoadNonceAsync(id);
+        row.Should().NotBeNull("still-valid unconsumed nonces must not be deleted");
+    }
+
+    [Fact]
+    public async Task Sweep_KeepsConsumedNonceWithinGraceWindow()
+    {
+        // Arrange: nonce consumed 10 minutes ago — well within the default 1-hour grace.
+        // ExpiresAt also in the future to rule out the expiry arm.
+        var consumedAt = DateTime.UtcNow.AddMinutes(-10);
+        var id = await InsertNonceAsync(
+            expiresAt: Utc(hoursOffset: +1),
+            consumedAt: consumedAt);
+
+        var reaper = GetReaper();
+        var now = DateTime.UtcNow;
+        await reaper.SweepAsync(now, TestContext.Current.CancellationToken);
+
+        var row = await LoadNonceAsync(id);
+        row.Should().NotBeNull(
+            "consumed nonces within the grace window must be retained for audit purposes");
+    }
+
+    [Fact]
+    public async Task Sweep_IsIdempotent_RunningTwiceDoesNotAffectKeptRows()
+    {
+        // Arrange: one expired nonce (to be reaped), one valid nonce (to be kept).
+        var expiredId = await InsertNonceAsync(expiresAt: Utc(hoursOffset: -1));
+        var validId = await InsertNonceAsync(expiresAt: Utc(hoursOffset: +1));
+
+        var reaper = GetReaper();
+        var now = DateTime.UtcNow;
+
+        // Act: sweep twice.
+        await reaper.SweepAsync(now, TestContext.Current.CancellationToken);
+        await reaper.SweepAsync(now, TestContext.Current.CancellationToken);
+
+        // Assert: expired row gone, valid row still present.
+        var expiredRow = await LoadNonceAsync(expiredId);
+        expiredRow.Should().BeNull("expired row must be reaped on first sweep");
+
+        var validRow = await LoadNonceAsync(validId);
+        validRow.Should().NotBeNull(
+            "second sweep must leave valid rows intact (idempotent)");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SocialLoginNonceReaperService` (`BackgroundService`) that runs on an hourly `PeriodicTimer` and bulk-deletes stale `SocialLoginNonce` rows via `ExecuteDeleteAsync`.
- Delete predicate: `ExpiresAt < now` OR (`ConsumedAt != null` AND `ConsumedAt < now - grace`). Still-valid unconsumed nonces and recently-consumed (within grace) nonces are never deleted.
- Config keys with zero-config safe defaults: `Auth:NonceReapIntervalMinutes` (60) and `Auth:NonceConsumedGraceHours` (1).
- Registered in `Program.cs` via the same dual `AddSingleton` + `AddHostedService` idiom as `WeeklyCheckInScheduler` / `PhotoDiaryReminderScheduler`. Follow-up from #511.

## Related issue
Fixes #515

## Scope
backend

## QA verdict (from qa-tester)
OVERALL ✅ PASS — 5/5 AC; `SocialLoginNonceReaperServiceTests` 5/5 green; build clean. Caveat: local runtime-startup not confirmable in the QA sandbox (unset POSTGRES_PASSWORD) — CI's compose-harness boot (playwright job) is the definitive startup check; PR must show playwright green before merge.

## Test plan
- [ ] A `BackgroundService` runs on a configurable interval (default hourly) and bulk-deletes stale `SocialLoginNonce` rows.
- [ ] The delete predicate is correct: still-valid unconsumed nonces within TTL are NOT deleted.
- [ ] Registered in `Program.cs` alongside existing schedulers; idempotent (running the sweep repeatedly yields the same result).
- [ ] Tests assert: expired nonces deleted, consumed-past-grace nonces deleted, still-valid unconsumed nonce untouched.
- [ ] No change to `POST /auth/social/nonce`, `/auth/social/apple`, `/auth/social/google`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)