### PR TITLE
refactor: move goal & target-weight ownership to plan documents (#493)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Documents/NutritionPlan.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/NutritionPlan.cs
@@ -67,6 +67,23 @@ public class NutritionPlan
     public List<Supplement> Supplements { get; set; } = [];
 
     /// <summary>
+    /// Primary fitness goal for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    [BsonElement("goal")]
+    [BsonIgnoreIfNull]
+    [BsonRepresentation(BsonType.String)]
+    public PrimaryGoal? Goal { get; set; }
+
+    /// <summary>
+    /// Target body weight in kilograms for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    [BsonElement("targetWeightKg")]
+    [BsonIgnoreIfNull]
+    public decimal? TargetWeightKg { get; set; }
+
+    /// <summary>
     /// Optimistic concurrency version. Incremented on each update.
     /// </summary>
     [BsonElement("version")]

--- a/backend/FitnessPlatform.Application/Domain/Documents/NutritionPlan.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/NutritionPlan.cs
@@ -23,7 +23,7 @@ public class NutritionPlan
     public Guid ExternalId { get; set; }
 
     /// <summary>
-    /// The client this plan belongs to (matches ApplicationUser.Id).
+    /// The client this plan belongs to (matches <c>ClientProfile.PublicId</c>, NOT <c>ApplicationUser.Id</c>).
     /// </summary>
     [BsonElement("clientId")]
     public Guid ClientId { get; set; }

--- a/backend/FitnessPlatform.Application/Domain/Documents/TrainingPlan.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/TrainingPlan.cs
@@ -23,7 +23,7 @@ public class TrainingPlan
     public Guid ExternalId { get; set; }
 
     /// <summary>
-    /// The client this plan belongs to (matches ApplicationUser.Id).
+    /// The client this plan belongs to (matches <c>ClientProfile.PublicId</c>, NOT <c>ApplicationUser.Id</c>).
     /// </summary>
     [BsonElement("clientId")]
     public Guid ClientId { get; set; }

--- a/backend/FitnessPlatform.Application/Domain/Documents/TrainingPlan.cs
+++ b/backend/FitnessPlatform.Application/Domain/Documents/TrainingPlan.cs
@@ -61,6 +61,23 @@ public class TrainingPlan
     public List<TrainingWeek> Weeks { get; set; } = [];
 
     /// <summary>
+    /// Primary fitness goal for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    [BsonElement("goal")]
+    [BsonIgnoreIfNull]
+    [BsonRepresentation(BsonType.String)]
+    public PrimaryGoal? Goal { get; set; }
+
+    /// <summary>
+    /// Target body weight in kilograms for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    [BsonElement("targetWeightKg")]
+    [BsonIgnoreIfNull]
+    public decimal? TargetWeightKg { get; set; }
+
+    /// <summary>
     /// Optimistic concurrency version. Incremented on each update.
     /// </summary>
     [BsonElement("version")]

--- a/backend/FitnessPlatform.Application/Features/ClientMeasurements/GetMeasurementStats/GetMeasurementStatsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientMeasurements/GetMeasurementStats/GetMeasurementStatsEndpoint.cs
@@ -62,12 +62,12 @@ public class GetMeasurementStatsEndpoint(IApplicationDbContext db, IMongoContext
 
         // Query the active NutritionPlan to source targetWeightKg plan-first.
         // Fallback to OnboardingData only when the plan value is null.
-        // Key: plan.ClientId == clientProfile.UserId (the ApplicationUser.Id Guid, NOT PublicId).
+        // Key: plan.ClientId == clientProfile.PublicId (the ClientProfile.PublicId Guid, NOT UserId).
         decimal? planTargetWeightKg = null;
         try
         {
             var planFilter = Builders<NutritionPlan>.Filter.And(
-                Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientId),
+                Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientProfile.PublicId),
                 Builders<NutritionPlan>.Filter.Eq(p => p.Status, NutritionPlanStatus.Active));
 
             using var planCursor = await mongo.NutritionPlans.FindAsync(
@@ -77,9 +77,10 @@ public class GetMeasurementStatsEndpoint(IApplicationDbContext db, IMongoContext
             var activePlan = await planCursor.FirstOrDefaultAsync(ct);
             planTargetWeightKg = activePlan?.TargetWeightKg;
         }
-        catch
+        catch (MongoDB.Driver.MongoException ex)
         {
-            // Active plan query is optional — fall back to onboarding if Mongo is unavailable
+            // Active plan query is optional — log and fall back to onboarding if Mongo is unavailable
+            Logger.LogWarning(ex, "Mongo query for active NutritionPlan failed for client {ClientPublicId}; falling back to onboarding data", clientProfile.PublicId);
         }
 
         // Plan-first: prefer plan's targetWeightKg; fall back to onboarding baseline.

--- a/backend/FitnessPlatform.Application/Features/ClientMeasurements/GetMeasurementStats/GetMeasurementStatsEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/ClientMeasurements/GetMeasurementStats/GetMeasurementStatsEndpoint.cs
@@ -1,8 +1,12 @@
 using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.ClientMeasurements.GetMeasurementStats;
 
@@ -10,7 +14,8 @@ namespace FitnessPlatform.Application.Features.ClientMeasurements.GetMeasurement
 /// Returns aggregated weight statistics for the authenticated client's measurements.
 /// </summary>
 /// <param name="db">Database context.</param>
-public class GetMeasurementStatsEndpoint(IApplicationDbContext db) : EndpointWithoutRequest<MeasurementStatsResponse>
+/// <param name="mongo">MongoDB context for reading target weight from the active nutrition plan.</param>
+public class GetMeasurementStatsEndpoint(IApplicationDbContext db, IMongoContext mongo) : EndpointWithoutRequest<MeasurementStatsResponse>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -55,7 +60,30 @@ public class GetMeasurementStatsEndpoint(IApplicationDbContext db) : EndpointWit
 
         var hasWeightData = await weightMeasurements.AnyAsync(ct);
 
-        var targetWeightKg = clientProfile.OnboardingData?.TargetWeightKg;
+        // Query the active NutritionPlan to source targetWeightKg plan-first.
+        // Fallback to OnboardingData only when the plan value is null.
+        // Key: plan.ClientId == clientProfile.UserId (the ApplicationUser.Id Guid, NOT PublicId).
+        decimal? planTargetWeightKg = null;
+        try
+        {
+            var planFilter = Builders<NutritionPlan>.Filter.And(
+                Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientId),
+                Builders<NutritionPlan>.Filter.Eq(p => p.Status, NutritionPlanStatus.Active));
+
+            using var planCursor = await mongo.NutritionPlans.FindAsync(
+                planFilter,
+                new FindOptions<NutritionPlan> { Sort = Builders<NutritionPlan>.Sort.Descending(p => p.DateCreated), Limit = 1 },
+                ct);
+            var activePlan = await planCursor.FirstOrDefaultAsync(ct);
+            planTargetWeightKg = activePlan?.TargetWeightKg;
+        }
+        catch
+        {
+            // Active plan query is optional — fall back to onboarding if Mongo is unavailable
+        }
+
+        // Plan-first: prefer plan's targetWeightKg; fall back to onboarding baseline.
+        var targetWeightKg = planTargetWeightKg ?? clientProfile.OnboardingData?.TargetWeightKg;
 
         if (!hasWeightData)
         {

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/CreatePlan/CreatePlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/CreatePlan/CreatePlanEndpoint.cs
@@ -81,6 +81,8 @@ public class CreatePlanEndpoint(IMongoContext mongo, NutritionAuthHelper authHel
             Status = NutritionPlanStatus.Draft,
             GlobalSettings = req.GlobalSettings,
             QuestionnaireResponseId = req.QuestionnaireResponseId,
+            Goal = req.Goal,
+            TargetWeightKg = req.TargetWeightKg,
             Weeks = Enumerable.Range(1, req.WeekCount).Select(w => new PlanWeek
             {
                 WeekNumber = w,

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/CreatePlan/CreatePlanRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/CreatePlan/CreatePlanRequest.cs
@@ -1,4 +1,5 @@
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
 
 namespace FitnessPlatform.Application.Features.NutritionPlans.CreatePlan;
 
@@ -38,4 +39,16 @@ public class CreatePlanRequest
     /// Must be a submitted response owned by this professional for the same client.
     /// </summary>
     public Guid? QuestionnaireResponseId { get; set; }
+
+    /// <summary>
+    /// Optional primary fitness goal for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    public PrimaryGoal? Goal { get; set; }
+
+    /// <summary>
+    /// Optional target body weight in kilograms for this plan period.
+    /// Must be greater than zero when provided.
+    /// </summary>
+    public decimal? TargetWeightKg { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/CreatePlan/CreatePlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/CreatePlan/CreatePlanValidator.cs
@@ -34,5 +34,15 @@ public class CreatePlanValidator : Validator<CreatePlanRequest>
             .WithErrorCode(Domain.Constants.ErrorCodes.StartDateInPast)
             .WithMessage("Start date cannot be in the past.")
             .When(x => x.StartDate.HasValue);
+
+        RuleFor(x => x.TargetWeightKg)
+            .GreaterThan(0)
+            .WithMessage("TargetWeightKg must be greater than zero.")
+            .When(x => x.TargetWeightKg.HasValue);
+
+        RuleFor(x => x.Goal)
+            .IsInEnum()
+            .WithMessage("Goal must be a valid PrimaryGoal value.")
+            .When(x => x.Goal.HasValue);
     }
 }

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanEndpoint.cs
@@ -129,8 +129,13 @@ public class UpdatePlanEndpoint(IMongoContext mongo, IMacroCalculatorService mac
         plan.Name = req.Name;
         plan.StartDate = req.StartDate.HasValue ? DateTime.SpecifyKind(req.StartDate.Value.Date, DateTimeKind.Utc) : null;
         plan.GlobalSettings = req.GlobalSettings;
-        plan.Goal = req.Goal;
-        plan.TargetWeightKg = req.TargetWeightKg;
+        // Transitional guard: web/mobile clients built against the pre-#493 Swagger do not
+        // yet send Goal/TargetWeightKg in their update payloads, so the fields arrive as
+        // null. Blindly assigning would clobber a goal set at create-time or via the
+        // backfill migration. Preserve the stored value whenever the caller omits the field.
+        // Explicit clear-to-null will be supported once regen-api ships the updated contract.
+        if (req.Goal.HasValue) plan.Goal = req.Goal;
+        if (req.TargetWeightKg.HasValue) plan.TargetWeightKg = req.TargetWeightKg;
         plan.Weeks = req.Weeks.Select(rw =>
         {
             var existing = existingWeeks.GetValueOrDefault(rw.WeekNumber);

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanEndpoint.cs
@@ -129,6 +129,8 @@ public class UpdatePlanEndpoint(IMongoContext mongo, IMacroCalculatorService mac
         plan.Name = req.Name;
         plan.StartDate = req.StartDate.HasValue ? DateTime.SpecifyKind(req.StartDate.Value.Date, DateTimeKind.Utc) : null;
         plan.GlobalSettings = req.GlobalSettings;
+        plan.Goal = req.Goal;
+        plan.TargetWeightKg = req.TargetWeightKg;
         plan.Weeks = req.Weeks.Select(rw =>
         {
             var existing = existingWeeks.GetValueOrDefault(rw.WeekNumber);

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanRequest.cs
@@ -1,4 +1,5 @@
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
 
 namespace FitnessPlatform.Application.Features.NutritionPlans.UpdatePlan;
 
@@ -43,6 +44,18 @@ public class UpdatePlanRequest
     /// Omitting an entry removes that supplement (full-state replace pattern).
     /// </summary>
     public List<UpdateSupplementRequest> Supplements { get; set; } = [];
+
+    /// <summary>
+    /// Optional primary fitness goal for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    public PrimaryGoal? Goal { get; set; }
+
+    /// <summary>
+    /// Optional target body weight in kilograms for this plan period.
+    /// Must be greater than zero when provided.
+    /// </summary>
+    public decimal? TargetWeightKg { get; set; }
 }
 
 /// <summary>

--- a/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/NutritionPlans/UpdatePlan/UpdatePlanValidator.cs
@@ -20,6 +20,16 @@ public class UpdatePlanValidator : Validator<UpdatePlanRequest>
         RuleFor(x => x.Version)
             .GreaterThanOrEqualTo(1);
 
+        RuleFor(x => x.TargetWeightKg)
+            .GreaterThan(0)
+            .WithMessage("TargetWeightKg must be greater than zero.")
+            .When(x => x.TargetWeightKg.HasValue);
+
+        RuleFor(x => x.Goal)
+            .IsInEnum()
+            .WithMessage("Goal must be a valid PrimaryGoal value.")
+            .When(x => x.Goal.HasValue);
+
         RuleForEach(x => x.Supplements).ChildRules(supplement =>
         {
             supplement.RuleFor(s => s.Name)

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
@@ -1,11 +1,14 @@
 using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.Trainers.GetClientDashboard;
 
@@ -16,7 +19,8 @@ namespace FitnessPlatform.Application.Features.Trainers.GetClientDashboard;
 /// <param name="db">Database context.</param>
 /// <param name="audit">Audit logging service.</param>
 /// <param name="complianceService">Service for calculating compliance metrics.</param>
-public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService audit, IComplianceService complianceService)
+/// <param name="mongo">MongoDB context for reading active plan goal/macros.</param>
+public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService audit, IComplianceService complianceService, IMongoContext mongo)
     : Endpoint<GetClientDashboardRequest, GetClientDashboardResponse>
 {
     /// <inheritdoc />
@@ -152,15 +156,40 @@ public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService 
             questionnaireResponsePublicId = qResponse.PublicId;
         }
 
+        // Query the active NutritionPlan to source goal + targetWeightKg plan-first.
+        // Fallback to OnboardingData only when the plan value is null.
+        // Key: plan.ClientId == clientProfile.UserId (the ApplicationUser.Id Guid, NOT PublicId).
+        NutritionPlan? activePlan = null;
+        try
+        {
+            var planFilter = Builders<NutritionPlan>.Filter.And(
+                Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientProfile.UserId),
+                Builders<NutritionPlan>.Filter.Eq(p => p.Status, NutritionPlanStatus.Active));
+
+            using var planCursor = await mongo.NutritionPlans.FindAsync(
+                planFilter,
+                new FindOptions<NutritionPlan> { Sort = Builders<NutritionPlan>.Sort.Descending(p => p.DateCreated), Limit = 1 },
+                ct);
+            activePlan = await planCursor.FirstOrDefaultAsync(ct);
+        }
+        catch
+        {
+            // Active plan query is optional — fall back to onboarding if Mongo is unavailable
+        }
+
         OnboardingDataDto? onboarding = null;
         if (clientProfile.OnboardingData is { } od)
         {
+            // Plan-first: prefer plan's goal and targetWeightKg; fall back to onboarding baseline.
+            var effectiveTargetWeightKg = activePlan?.TargetWeightKg ?? od.TargetWeightKg;
+            var effectivePrimaryGoal = activePlan?.Goal?.ToString() ?? od.PrimaryGoal.ToString();
+
             onboarding = new OnboardingDataDto
             {
                 Sex = od.Sex.ToString(),
-                TargetWeightKg = od.TargetWeightKg,
+                TargetWeightKg = effectiveTargetWeightKg,
                 BodyType = od.BodyType.ToString(),
-                PrimaryGoal = od.PrimaryGoal.ToString(),
+                PrimaryGoal = effectivePrimaryGoal,
                 TimeHorizon = od.TimeHorizon.ToString(),
                 JobType = od.JobType.ToString(),
                 SleepHours = od.SleepHours,

--- a/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/GetClientDashboard/GetClientDashboardEndpoint.cs
@@ -158,12 +158,12 @@ public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService 
 
         // Query the active NutritionPlan to source goal + targetWeightKg plan-first.
         // Fallback to OnboardingData only when the plan value is null.
-        // Key: plan.ClientId == clientProfile.UserId (the ApplicationUser.Id Guid, NOT PublicId).
+        // Key: plan.ClientId == clientProfile.PublicId (the ClientProfile.PublicId Guid, NOT UserId).
         NutritionPlan? activePlan = null;
         try
         {
             var planFilter = Builders<NutritionPlan>.Filter.And(
-                Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientProfile.UserId),
+                Builders<NutritionPlan>.Filter.Eq(p => p.ClientId, clientProfile.PublicId),
                 Builders<NutritionPlan>.Filter.Eq(p => p.Status, NutritionPlanStatus.Active));
 
             using var planCursor = await mongo.NutritionPlans.FindAsync(
@@ -172,9 +172,10 @@ public class GetClientDashboardEndpoint(IApplicationDbContext db, IAuditService 
                 ct);
             activePlan = await planCursor.FirstOrDefaultAsync(ct);
         }
-        catch
+        catch (MongoDB.Driver.MongoException ex)
         {
-            // Active plan query is optional — fall back to onboarding if Mongo is unavailable
+            // Active plan query is optional — log and fall back to onboarding if Mongo is unavailable
+            Logger.LogWarning(ex, "Mongo query for active NutritionPlan failed for client {ClientPublicId}; falling back to onboarding data", clientProfile.PublicId);
         }
 
         OnboardingDataDto? onboarding = null;

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/CreateTrainingPlan/CreateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/CreateTrainingPlan/CreateTrainingPlanEndpoint.cs
@@ -81,6 +81,8 @@ public class CreateTrainingPlanEndpoint(IMongoContext mongo, ProfessionalAuthHel
             Description = req.Description?.Trim(),
             Status = TrainingPlanStatus.Draft,
             QuestionnaireResponseId = req.QuestionnaireResponseId,
+            Goal = req.Goal,
+            TargetWeightKg = req.TargetWeightKg,
             Weeks = Enumerable.Range(1, req.WeekCount).Select(w => new TrainingWeek
             {
                 WeekNumber = w,

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/CreateTrainingPlan/CreateTrainingPlanRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/CreateTrainingPlan/CreateTrainingPlanRequest.cs
@@ -1,3 +1,5 @@
+using FitnessPlatform.Application.Domain.Enums;
+
 namespace FitnessPlatform.Application.Features.TrainingPlans.CreateTrainingPlan;
 
 /// <summary>
@@ -35,4 +37,16 @@ public class CreateTrainingPlanRequest
     /// Must be a submitted response owned by this professional for the same client.
     /// </summary>
     public Guid? QuestionnaireResponseId { get; set; }
+
+    /// <summary>
+    /// Optional primary fitness goal for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    public PrimaryGoal? Goal { get; set; }
+
+    /// <summary>
+    /// Optional target body weight in kilograms for this plan period.
+    /// Must be greater than zero when provided.
+    /// </summary>
+    public decimal? TargetWeightKg { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/CreateTrainingPlan/CreateTrainingPlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/CreateTrainingPlan/CreateTrainingPlanValidator.cs
@@ -38,5 +38,15 @@ public class CreateTrainingPlanValidator : Validator<CreateTrainingPlanRequest>
             .WithErrorCode(Domain.Constants.ErrorCodes.StartDateInPast)
             .WithMessage("Start date cannot be in the past.")
             .When(x => x.StartDate.HasValue);
+
+        RuleFor(x => x.TargetWeightKg)
+            .GreaterThan(0)
+            .WithMessage("TargetWeightKg must be greater than zero.")
+            .When(x => x.TargetWeightKg.HasValue);
+
+        RuleFor(x => x.Goal)
+            .IsInEnum()
+            .WithMessage("Goal must be a valid PrimaryGoal value.")
+            .When(x => x.Goal.HasValue);
     }
 }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
@@ -323,8 +323,13 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService
         plan.Name = req.Name;
         plan.StartDate = req.StartDate.HasValue ? DateTime.SpecifyKind(req.StartDate.Value.Date, DateTimeKind.Utc) : null;
         plan.Description = req.Description?.Trim();
-        plan.Goal = req.Goal;
-        plan.TargetWeightKg = req.TargetWeightKg;
+        // Transitional guard: web/mobile clients built against the pre-#493 Swagger do not
+        // yet send Goal/TargetWeightKg in their update payloads, so the fields arrive as
+        // null. Blindly assigning would clobber a goal set at create-time or via the
+        // backfill migration. Preserve the stored value whenever the caller omits the field.
+        // Explicit clear-to-null will be supported once regen-api ships the updated contract.
+        if (req.Goal.HasValue) plan.Goal = req.Goal;
+        if (req.TargetWeightKg.HasValue) plan.TargetWeightKg = req.TargetWeightKg;
         plan.Weeks = req.Weeks.Select(rw =>
         {
             var existing = existingWeeks.GetValueOrDefault(rw.WeekNumber);

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanEndpoint.cs
@@ -323,6 +323,8 @@ public class UpdateTrainingPlanEndpoint(IMongoContext mongo, ISessionLockService
         plan.Name = req.Name;
         plan.StartDate = req.StartDate.HasValue ? DateTime.SpecifyKind(req.StartDate.Value.Date, DateTimeKind.Utc) : null;
         plan.Description = req.Description?.Trim();
+        plan.Goal = req.Goal;
+        plan.TargetWeightKg = req.TargetWeightKg;
         plan.Weeks = req.Weeks.Select(rw =>
         {
             var existing = existingWeeks.GetValueOrDefault(rw.WeekNumber);

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanRequest.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanRequest.cs
@@ -1,3 +1,5 @@
+using FitnessPlatform.Application.Domain.Enums;
+
 namespace FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
 
 /// <summary>
@@ -34,4 +36,16 @@ public class UpdateTrainingPlanRequest
     /// Updated start date. Must be a Monday and not in the past.
     /// </summary>
     public DateTime? StartDate { get; set; }
+
+    /// <summary>
+    /// Optional primary fitness goal for this plan period.
+    /// When set, read sites prefer this value over the client's onboarding baseline.
+    /// </summary>
+    public PrimaryGoal? Goal { get; set; }
+
+    /// <summary>
+    /// Optional target body weight in kilograms for this plan period.
+    /// Must be greater than zero when provided.
+    /// </summary>
+    public decimal? TargetWeightKg { get; set; }
 }

--- a/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
+++ b/backend/FitnessPlatform.Application/Features/TrainingPlans/UpdateTrainingPlan/UpdateTrainingPlanValidator.cs
@@ -26,6 +26,16 @@ public class UpdateTrainingPlanValidator : Validator<UpdateTrainingPlanRequest>
             .MaximumLength(2000)
             .When(x => x.Description is not null);
 
+        RuleFor(x => x.TargetWeightKg)
+            .GreaterThan(0)
+            .WithMessage("TargetWeightKg must be greater than zero.")
+            .When(x => x.TargetWeightKg.HasValue);
+
+        RuleFor(x => x.Goal)
+            .IsInEnum()
+            .WithMessage("Goal must be a valid PrimaryGoal value.")
+            .When(x => x.Goal.HasValue);
+
         RuleFor(x => x.Weeks)
             .NotEmpty().WithMessage("At least one week is required.")
             .Must(weeks => weeks.Count <= 52).WithMessage("A plan may not exceed 52 weeks.")

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PlanGoalBackfillService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PlanGoalBackfillService.cs
@@ -26,10 +26,10 @@ namespace FitnessPlatform.Application.Infrastructure.Services;
 /// </para>
 ///
 /// <para>
-/// Join key: <c>plan.ClientId</c> is the <c>ClientProfile.UserId</c> (the
-/// <c>ApplicationUser.Id</c> Guid). It is <strong>NOT</strong> the
-/// <c>ClientProfile.PublicId</c>. The Mongo side stores <c>UserId</c>, not
-/// <c>PublicId</c>, so the join must resolve via <c>ClientProfile.UserId</c>.
+/// Join key: <c>plan.ClientId</c> is the <c>ClientProfile.PublicId</c> Guid.
+/// It is <strong>NOT</strong> <c>ClientProfile.UserId</c> (the ApplicationUser.Id).
+/// <c>CreatePlanEndpoint</c> writes <c>plan.ClientId = clientProfile.PublicId</c>,
+/// so the join must resolve via <c>ClientProfile.PublicId</c>.
 /// </para>
 /// </summary>
 public class PlanGoalBackfillService(
@@ -77,27 +77,27 @@ public class PlanGoalBackfillService(
             "Pass A (nutrition plans): found {Count} candidate plans to inspect",
             candidates.Count);
 
-        // Collect all unique ClientIds (which are UserId Guids) from the candidate plans.
+        // Collect all unique ClientIds (which are ClientProfile.PublicId Guids) from the candidate plans.
         var clientIds = candidates.Select(p => p.ClientId).Distinct().ToList();
 
-        // Resolve ClientProfile.UserId -> OnboardingData in a single Postgres query.
-        // CRITICAL: plan.ClientId == ClientProfile.UserId (NOT ClientProfile.PublicId).
-        var onboardingByUserId = await db.ClientProfiles
+        // Resolve ClientProfile.PublicId -> OnboardingData in a single Postgres query.
+        // CRITICAL: plan.ClientId == ClientProfile.PublicId (NOT ClientProfile.UserId).
+        var onboardingByPublicId = await db.ClientProfiles
             .AsNoTracking()
-            .Where(cp => clientIds.Contains(cp.UserId) && cp.OnboardingData != null)
+            .Where(cp => clientIds.Contains(cp.PublicId) && cp.OnboardingData != null)
             .Select(cp => new
             {
-                cp.UserId,
+                cp.PublicId,
                 cp.OnboardingData!.PrimaryGoal,
                 cp.OnboardingData.TargetWeightKg
             })
-            .ToDictionaryAsync(cp => cp.UserId, ct);
+            .ToDictionaryAsync(cp => cp.PublicId, ct);
 
         var updatedCount = 0;
 
         foreach (var plan in candidates)
         {
-            if (!onboardingByUserId.TryGetValue(plan.ClientId, out var od))
+            if (!onboardingByPublicId.TryGetValue(plan.ClientId, out var od))
                 continue;
 
             // PrimaryGoal is a non-nullable enum so we always have a value to write.
@@ -150,23 +150,23 @@ public class PlanGoalBackfillService(
 
         var clientIds = candidates.Select(p => p.ClientId).Distinct().ToList();
 
-        // CRITICAL: plan.ClientId == ClientProfile.UserId (NOT ClientProfile.PublicId).
-        var onboardingByUserId = await db.ClientProfiles
+        // CRITICAL: plan.ClientId == ClientProfile.PublicId (NOT ClientProfile.UserId).
+        var onboardingByPublicId = await db.ClientProfiles
             .AsNoTracking()
-            .Where(cp => clientIds.Contains(cp.UserId) && cp.OnboardingData != null)
+            .Where(cp => clientIds.Contains(cp.PublicId) && cp.OnboardingData != null)
             .Select(cp => new
             {
-                cp.UserId,
+                cp.PublicId,
                 cp.OnboardingData!.PrimaryGoal,
                 cp.OnboardingData.TargetWeightKg
             })
-            .ToDictionaryAsync(cp => cp.UserId, ct);
+            .ToDictionaryAsync(cp => cp.PublicId, ct);
 
         var updatedCount = 0;
 
         foreach (var plan in candidates)
         {
-            if (!onboardingByUserId.TryGetValue(plan.ClientId, out var od))
+            if (!onboardingByPublicId.TryGetValue(plan.ClientId, out var od))
                 continue;
 
             var update = Builders<TrainingPlan>.Update

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PlanGoalBackfillService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PlanGoalBackfillService.cs
@@ -1,4 +1,5 @@
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
 using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using Microsoft.EntityFrameworkCore;
@@ -99,12 +100,11 @@ public class PlanGoalBackfillService(
             if (!onboardingByUserId.TryGetValue(plan.ClientId, out var od))
                 continue;
 
-            // Only backfill if we have at least one value to write.
-            if (od.PrimaryGoal is null && od.TargetWeightKg is null)
-                continue;
-
+            // PrimaryGoal is a non-nullable enum so we always have a value to write.
+            // Only skip if onboarding data has no target weight AND goal is unset
+            // (the goal is always set since it is required on the onboarding form).
             var update = Builders<NutritionPlan>.Update
-                .Set(p => p.Goal, od.PrimaryGoal)
+                .Set(p => p.Goal, (PrimaryGoal?)od.PrimaryGoal)
                 .Set(p => p.TargetWeightKg, od.TargetWeightKg);
 
             // Idempotent guard: only update documents still null in both fields.
@@ -169,11 +169,8 @@ public class PlanGoalBackfillService(
             if (!onboardingByUserId.TryGetValue(plan.ClientId, out var od))
                 continue;
 
-            if (od.PrimaryGoal is null && od.TargetWeightKg is null)
-                continue;
-
             var update = Builders<TrainingPlan>.Update
-                .Set(p => p.Goal, od.PrimaryGoal)
+                .Set(p => p.Goal, (PrimaryGoal?)od.PrimaryGoal)
                 .Set(p => p.TargetWeightKg, od.TargetWeightKg);
 
             var idempotentFilter = Builders<TrainingPlan>.Filter.And(

--- a/backend/FitnessPlatform.Application/Infrastructure/Services/PlanGoalBackfillService.cs
+++ b/backend/FitnessPlatform.Application/Infrastructure/Services/PlanGoalBackfillService.cs
@@ -1,0 +1,195 @@
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace FitnessPlatform.Application.Infrastructure.Services;
+
+/// <summary>
+/// One-shot, idempotent backfill that copies goal and targetWeightKg from each
+/// client's <see cref="Domain.Entities.ClientOnboardingData"/> onto existing
+/// <see cref="NutritionPlan"/> and <see cref="TrainingPlan"/> documents that
+/// were created before the plan-level goal fields were introduced.
+///
+/// <para>
+/// Safety guarantees:
+/// <list type="bullet">
+///   <item>Only plans with a <c>null</c> Goal <strong>AND</strong> null TargetWeightKg are
+///     touched — documents that already have either field set are never overwritten.</item>
+///   <item>Running the method twice in a row is a no-op the second time (idempotent).</item>
+///   <item>PostgreSQL is read-only — no EF writes are made.</item>
+///   <item>No schema changes or EF migrations are required.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Join key: <c>plan.ClientId</c> is the <c>ClientProfile.UserId</c> (the
+/// <c>ApplicationUser.Id</c> Guid). It is <strong>NOT</strong> the
+/// <c>ClientProfile.PublicId</c>. The Mongo side stores <c>UserId</c>, not
+/// <c>PublicId</c>, so the join must resolve via <c>ClientProfile.UserId</c>.
+/// </para>
+/// </summary>
+public class PlanGoalBackfillService(
+    IApplicationDbContext db,
+    IMongoContext mongo,
+    ILogger<PlanGoalBackfillService> logger)
+{
+    /// <summary>
+    /// Runs both backfill passes (nutrition plans then training plans) and
+    /// returns a summary of how many documents were updated.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A tuple with the count of nutrition plans and training plans updated.
+    /// </returns>
+    public async Task<(int NutritionPlansUpdated, int TrainingPlansUpdated)> BackfillAsync(
+        CancellationToken ct = default)
+    {
+        var nutritionCount = await BackfillNutritionPlansAsync(ct);
+        var trainingCount  = await BackfillTrainingPlansAsync(ct);
+        return (nutritionCount, trainingCount);
+    }
+
+    // ── Pass A — NutritionPlans ──────────────────────────────────────────────
+
+    private async Task<int> BackfillNutritionPlansAsync(CancellationToken ct)
+    {
+        // Find all NutritionPlan documents where both Goal and TargetWeightKg are null.
+        // These are plans that pre-date the plan-level goal feature.
+        var filter = Builders<NutritionPlan>.Filter.And(
+            Builders<NutritionPlan>.Filter.Eq(p => p.Goal, null),
+            Builders<NutritionPlan>.Filter.Eq(p => p.TargetWeightKg, null));
+
+        using var cursor = await mongo.NutritionPlans.FindAsync(filter, cancellationToken: ct);
+        var candidates = await cursor.ToListAsync(ct);
+
+        if (candidates.Count == 0)
+        {
+            logger.LogInformation(
+                "Pass A (nutrition plans): no candidates found (all plans already have Goal or TargetWeightKg set), skipping");
+            return 0;
+        }
+
+        logger.LogInformation(
+            "Pass A (nutrition plans): found {Count} candidate plans to inspect",
+            candidates.Count);
+
+        // Collect all unique ClientIds (which are UserId Guids) from the candidate plans.
+        var clientIds = candidates.Select(p => p.ClientId).Distinct().ToList();
+
+        // Resolve ClientProfile.UserId -> OnboardingData in a single Postgres query.
+        // CRITICAL: plan.ClientId == ClientProfile.UserId (NOT ClientProfile.PublicId).
+        var onboardingByUserId = await db.ClientProfiles
+            .AsNoTracking()
+            .Where(cp => clientIds.Contains(cp.UserId) && cp.OnboardingData != null)
+            .Select(cp => new
+            {
+                cp.UserId,
+                cp.OnboardingData!.PrimaryGoal,
+                cp.OnboardingData.TargetWeightKg
+            })
+            .ToDictionaryAsync(cp => cp.UserId, ct);
+
+        var updatedCount = 0;
+
+        foreach (var plan in candidates)
+        {
+            if (!onboardingByUserId.TryGetValue(plan.ClientId, out var od))
+                continue;
+
+            // Only backfill if we have at least one value to write.
+            if (od.PrimaryGoal is null && od.TargetWeightKg is null)
+                continue;
+
+            var update = Builders<NutritionPlan>.Update
+                .Set(p => p.Goal, od.PrimaryGoal)
+                .Set(p => p.TargetWeightKg, od.TargetWeightKg);
+
+            // Idempotent guard: only update documents still null in both fields.
+            var idempotentFilter = Builders<NutritionPlan>.Filter.And(
+                Builders<NutritionPlan>.Filter.Eq(p => p.ExternalId, plan.ExternalId),
+                Builders<NutritionPlan>.Filter.Eq(p => p.Goal, null),
+                Builders<NutritionPlan>.Filter.Eq(p => p.TargetWeightKg, null));
+
+            var result = await mongo.NutritionPlans.UpdateOneAsync(idempotentFilter, update, cancellationToken: ct);
+            if (result.ModifiedCount > 0)
+                updatedCount++;
+        }
+
+        logger.LogInformation(
+            "Pass A (nutrition plans): backfilled {Count} plans with goal/targetWeightKg from onboarding data",
+            updatedCount);
+
+        return updatedCount;
+    }
+
+    // ── Pass B — TrainingPlans ───────────────────────────────────────────────
+
+    private async Task<int> BackfillTrainingPlansAsync(CancellationToken ct)
+    {
+        // Find all TrainingPlan documents where both Goal and TargetWeightKg are null.
+        var filter = Builders<TrainingPlan>.Filter.And(
+            Builders<TrainingPlan>.Filter.Eq(p => p.Goal, null),
+            Builders<TrainingPlan>.Filter.Eq(p => p.TargetWeightKg, null));
+
+        using var cursor = await mongo.TrainingPlans.FindAsync(filter, cancellationToken: ct);
+        var candidates = await cursor.ToListAsync(ct);
+
+        if (candidates.Count == 0)
+        {
+            logger.LogInformation(
+                "Pass B (training plans): no candidates found (all plans already have Goal or TargetWeightKg set), skipping");
+            return 0;
+        }
+
+        logger.LogInformation(
+            "Pass B (training plans): found {Count} candidate plans to inspect",
+            candidates.Count);
+
+        var clientIds = candidates.Select(p => p.ClientId).Distinct().ToList();
+
+        // CRITICAL: plan.ClientId == ClientProfile.UserId (NOT ClientProfile.PublicId).
+        var onboardingByUserId = await db.ClientProfiles
+            .AsNoTracking()
+            .Where(cp => clientIds.Contains(cp.UserId) && cp.OnboardingData != null)
+            .Select(cp => new
+            {
+                cp.UserId,
+                cp.OnboardingData!.PrimaryGoal,
+                cp.OnboardingData.TargetWeightKg
+            })
+            .ToDictionaryAsync(cp => cp.UserId, ct);
+
+        var updatedCount = 0;
+
+        foreach (var plan in candidates)
+        {
+            if (!onboardingByUserId.TryGetValue(plan.ClientId, out var od))
+                continue;
+
+            if (od.PrimaryGoal is null && od.TargetWeightKg is null)
+                continue;
+
+            var update = Builders<TrainingPlan>.Update
+                .Set(p => p.Goal, od.PrimaryGoal)
+                .Set(p => p.TargetWeightKg, od.TargetWeightKg);
+
+            var idempotentFilter = Builders<TrainingPlan>.Filter.And(
+                Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, plan.ExternalId),
+                Builders<TrainingPlan>.Filter.Eq(p => p.Goal, null),
+                Builders<TrainingPlan>.Filter.Eq(p => p.TargetWeightKg, null));
+
+            var result = await mongo.TrainingPlans.UpdateOneAsync(idempotentFilter, update, cancellationToken: ct);
+            if (result.ModifiedCount > 0)
+                updatedCount++;
+        }
+
+        logger.LogInformation(
+            "Pass B (training plans): backfilled {Count} plans with goal/targetWeightKg from onboarding data",
+            updatedCount);
+
+        return updatedCount;
+    }
+}

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -290,6 +290,24 @@ if (args.Contains("--backfill-photo-descriptions"))
     return;
 }
 
+// One-shot backfill: copy goal + targetWeightKg from ClientOnboardingData onto existing
+// NutritionPlan and TrainingPlan MongoDB documents that were created before the plan-level
+// goal fields were introduced.
+// Usage: dotnet run -- --backfill-plan-goals
+if (args.Contains("--backfill-plan-goals"))
+{
+    using var scope = app.Services.CreateScope();
+    var db     = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+    var mongoc = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+    var logFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+    var svc = new FitnessPlatform.Application.Infrastructure.Services.PlanGoalBackfillService(
+        db, mongoc, logFactory.CreateLogger<FitnessPlatform.Application.Infrastructure.Services.PlanGoalBackfillService>());
+    var (nutritionCount, trainingCount) = await svc.BackfillAsync();
+    Console.WriteLine($"Nutrition plans updated: {nutritionCount}");
+    Console.WriteLine($"Training plans updated:  {trainingCount}");
+    return;
+}
+
 // Auto-apply pending EF Core migrations — OPT-IN via Database:RunMigrationsOnStartup=true.
 //
 // This flag is intentionally OFF by default. It must be set explicitly in the

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientMeasurements/GetMeasurementStatsEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientMeasurements/GetMeasurementStatsEndpointTests.cs
@@ -4,7 +4,9 @@ using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Features.ClientMeasurements.GetMeasurementStats;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
 
 namespace FitnessPlatform.Tests.Endpoints.ClientMeasurements;
 
@@ -14,6 +16,12 @@ namespace FitnessPlatform.Tests.Endpoints.ClientMeasurements;
 public class GetMeasurementStatsEndpointTests
 {
     private readonly Guid _clientId = Guid.NewGuid();
+
+    // Helper: returns a mock IMongoContext with empty NutritionPlans collection
+    // (no active plan) — ensures the plan-first read path falls back gracefully
+    // without affecting the assertion being tested.
+    private static IMongoContext CreateEmptyMongo() =>
+        PlanTestHelpers.CreateMockMongo();
 
     [Fact]
     public async Task HandleAsync_WithWeightData_ReturnsStats()
@@ -59,7 +67,7 @@ public class GetMeasurementStatsEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            db);
+            db, CreateEmptyMongo());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -102,7 +110,7 @@ public class GetMeasurementStatsEndpointTests
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
-            db);
+            db, CreateEmptyMongo());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 
@@ -122,7 +130,7 @@ public class GetMeasurementStatsEndpointTests
         var ep = Factory.Create<GetMeasurementStatsEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity()),
-            db);
+            db, CreateEmptyMongo());
 
         await ep.HandleAsync(TestContext.Current.CancellationToken);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientMeasurements/GetMeasurementStatsPlanGoalTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientMeasurements/GetMeasurementStatsPlanGoalTests.cs
@@ -21,7 +21,8 @@ namespace FitnessPlatform.Tests.Endpoints.ClientMeasurements;
 /// </summary>
 public class GetMeasurementStatsPlanGoalTests
 {
-    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();       // ApplicationUser.Id (JWT claim)
+    private readonly Guid _clientPublicId = Guid.NewGuid(); // ClientProfile.PublicId (plan join key)
 
     private static ClientOnboardingData BuildOnboarding(long clientProfileId, decimal? targetWeightKg) =>
         new()
@@ -56,6 +57,7 @@ public class GetMeasurementStatsPlanGoalTests
     {
         var clientProfile = EntityBuilder.ClientProfile
             .WithUserId(_clientId)
+            .WithPublicId(_clientPublicId)
             .WithId(20)
             .Build();
 
@@ -65,9 +67,9 @@ public class GetMeasurementStatsPlanGoalTests
             .With(clientProfile)
             .Build();
 
-        // Active plan with different target weight
+        // Active plan — seeded with PublicId (what CreatePlanEndpoint writes)
         var activePlan = PlanTestHelpers.CreatePlan(
-            clientId: _clientId,
+            clientId: _clientPublicId,
             status: NutritionPlanStatus.Active);
         activePlan.TargetWeightKg = 72.5m;  // plan = 72.5
 
@@ -95,6 +97,7 @@ public class GetMeasurementStatsPlanGoalTests
     {
         var clientProfile = EntityBuilder.ClientProfile
             .WithUserId(_clientId)
+            .WithPublicId(_clientPublicId)
             .WithId(21)
             .Build();
 
@@ -129,6 +132,7 @@ public class GetMeasurementStatsPlanGoalTests
     {
         var clientProfile = EntityBuilder.ClientProfile
             .WithUserId(_clientId)
+            .WithPublicId(_clientPublicId)
             .WithId(22)
             .Build();
 
@@ -138,9 +142,9 @@ public class GetMeasurementStatsPlanGoalTests
             .With(clientProfile)
             .Build();
 
-        // Active plan exists but has no target weight (pre-migration document)
+        // Active plan exists but has no target weight (pre-migration document) — seeded with PublicId
         var activePlan = PlanTestHelpers.CreatePlan(
-            clientId: _clientId,
+            clientId: _clientPublicId,
             status: NutritionPlanStatus.Active);
         activePlan.TargetWeightKg = null;
 
@@ -168,6 +172,7 @@ public class GetMeasurementStatsPlanGoalTests
     {
         var clientProfile = EntityBuilder.ClientProfile
             .WithUserId(_clientId)
+            .WithPublicId(_clientPublicId)
             .WithId(23)
             .Build();
 

--- a/backend/FitnessPlatform.Tests/Endpoints/ClientMeasurements/GetMeasurementStatsPlanGoalTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/ClientMeasurements/GetMeasurementStatsPlanGoalTests.cs
@@ -1,0 +1,192 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Features.ClientMeasurements.GetMeasurementStats;
+using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+
+namespace FitnessPlatform.Tests.Endpoints.ClientMeasurements;
+
+/// <summary>
+/// Tests for the plan-first <c>TargetWeightKg</c> sourcing in
+/// <see cref="GetMeasurementStatsEndpoint"/> (Phase 3 of #493).
+///
+/// The endpoint reads <c>TargetWeightKg</c> from the most-recent active
+/// <c>NutritionPlan</c> for the client, falling back to
+/// <c>ClientOnboardingData.TargetWeightKg</c> when no active plan exists.
+/// </summary>
+public class GetMeasurementStatsPlanGoalTests
+{
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private static ClientOnboardingData BuildOnboarding(long clientProfileId, decimal? targetWeightKg) =>
+        new()
+        {
+            Id = clientProfileId,
+            ClientProfileId = clientProfileId,
+            PrimaryGoal = PrimaryGoal.LoseFat,
+            TargetWeightKg = targetWeightKg,
+            Sex = BiologicalSex.Female,
+            HeightCm = 165,
+            WeightKg = 70,
+            BodyType = BodyType.Mesomorph,
+            TimeHorizon = TimeHorizon.SixMonths,
+            JobType = JobType.Sedentary,
+            SleepHours = 8,
+            StressLevel = 2,
+            CurrentTrainingFrequency = CurrentTrainingFrequency.Regular,
+            DesiredTrainingFrequency = DesiredTrainingFrequency.ThreePerWeek,
+            FitnessRating = 6,
+            MealsPerDay = MealsPerDay.TwoToThree,
+            DietaryStyle = DietaryStyle.Standard,
+            PlanExperience = PlanExperience.TriedFailed,
+            PrimaryMotivation = PrimaryMotivation.Health,
+        };
+
+    /// <summary>
+    /// When an active NutritionPlan has <c>TargetWeightKg</c> set, the stats
+    /// response prefers the plan value over the onboarding data.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_ActivePlanHasTargetWeight_ResponseUsesPlanValue()
+    {
+        var clientProfile = EntityBuilder.ClientProfile
+            .WithUserId(_clientId)
+            .WithId(20)
+            .Build();
+
+        clientProfile.OnboardingData = BuildOnboarding(20, targetWeightKg: 60.0m); // onboarding = 60
+
+        var db = new MockDbBuilder()
+            .With(clientProfile)
+            .Build();
+
+        // Active plan with different target weight
+        var activePlan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            status: NutritionPlanStatus.Active);
+        activePlan.TargetWeightKg = 72.5m;  // plan = 72.5
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [activePlan]);
+
+        var ep = Factory.Create<GetMeasurementStatsEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, mongo);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        // Plan value must win over onboarding
+        ep.Response.TargetWeightKg.Should().Be(72.5m);
+    }
+
+    /// <summary>
+    /// When no active NutritionPlan exists, the stats response falls back to
+    /// the <c>ClientOnboardingData.TargetWeightKg</c>.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_NoPlan_FallsBackToOnboarding()
+    {
+        var clientProfile = EntityBuilder.ClientProfile
+            .WithUserId(_clientId)
+            .WithId(21)
+            .Build();
+
+        clientProfile.OnboardingData = BuildOnboarding(21, targetWeightKg: 58.0m);
+
+        var db = new MockDbBuilder()
+            .With(clientProfile)
+            .Build();
+
+        // No active plans
+        var mongo = PlanTestHelpers.CreateMockMongo();
+
+        var ep = Factory.Create<GetMeasurementStatsEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, mongo);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        // Onboarding fallback value
+        ep.Response.TargetWeightKg.Should().Be(58.0m);
+    }
+
+    /// <summary>
+    /// When the active plan has <c>TargetWeightKg = null</c>, the response
+    /// falls back to the onboarding data.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_ActivePlanWithNullTargetWeight_FallsBackToOnboarding()
+    {
+        var clientProfile = EntityBuilder.ClientProfile
+            .WithUserId(_clientId)
+            .WithId(22)
+            .Build();
+
+        clientProfile.OnboardingData = BuildOnboarding(22, targetWeightKg: 62.0m);
+
+        var db = new MockDbBuilder()
+            .With(clientProfile)
+            .Build();
+
+        // Active plan exists but has no target weight (pre-migration document)
+        var activePlan = PlanTestHelpers.CreatePlan(
+            clientId: _clientId,
+            status: NutritionPlanStatus.Active);
+        activePlan.TargetWeightKg = null;
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [activePlan]);
+
+        var ep = Factory.Create<GetMeasurementStatsEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, mongo);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        // Plan null → onboarding fallback
+        ep.Response.TargetWeightKg.Should().Be(62.0m);
+    }
+
+    /// <summary>
+    /// When neither active plan nor onboarding data provides a target weight,
+    /// <c>TargetWeightKg</c> is null in the response (no crash).
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_NoTargetWeightAnywhere_ReturnsNullTargetWeight()
+    {
+        var clientProfile = EntityBuilder.ClientProfile
+            .WithUserId(_clientId)
+            .WithId(23)
+            .Build();
+
+        // No onboarding data
+        var db = new MockDbBuilder()
+            .With(clientProfile)
+            .Build();
+
+        var mongo = PlanTestHelpers.CreateMockMongo();
+
+        var ep = Factory.Create<GetMeasurementStatsEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_clientId, AppRoles.Client))),
+            db, mongo);
+
+        await ep.HandleAsync(TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.TargetWeightKg.Should().BeNull();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
@@ -176,8 +176,14 @@ public class PlanGoalFieldsTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// Regression test for #493: the pre-regen web/mobile client omits Goal and
+    /// TargetWeightKg from update payloads (both arrive as null). The endpoint must
+    /// preserve the stored values rather than clobbering them with null. This guards
+    /// against the transitional period before regen-api ships the updated contract.
+    /// </summary>
     [Fact]
-    public async Task UpdatePlan_ClearsGoalToNull_PersistsNull()
+    public async Task UpdatePlan_OmitsGoalAndTarget_PreservesStoredValues()
     {
         var planId = Guid.NewGuid();
         var plan = PlanTestHelpers.CreatePlan(
@@ -200,23 +206,28 @@ public class PlanGoalFieldsTests
             new MockDbBuilder().Build(),
             Substitute.For<IRealtimeNotifier>());
 
+        // Simulate a legacy client payload: Goal and TargetWeightKg are null (omitted)
+        // while another field (Name) is legitimately updated.
         var req = new UpdatePlanRequest
         {
             PlanId = planId,
-            Name = "Plan Without Goal",
+            Name = "Renamed Plan",
             Version = 1,
-            Goal = null,
-            TargetWeightKg = null,
+            Goal = null,          // omitted by old client — must NOT clear the stored goal
+            TargetWeightKg = null, // omitted by old client — must NOT clear the stored weight
             Weeks = []
         };
 
         await ep.HandleAsync(req, TestContext.Current.CancellationToken);
 
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The persisted document must still carry the original Goal and TargetWeightKg.
         await mongo.NutritionPlans.Received(1).ReplaceOneAsync(
             Arg.Any<FilterDefinition<NutritionPlan>>(),
             Arg.Is<NutritionPlan>(p =>
-                p.Goal == null &&
-                p.TargetWeightKg == null),
+                p.Goal == PrimaryGoal.LoseFat &&
+                p.TargetWeightKg == 70.0m),
             Arg.Any<ReplaceOptions>(),
             Arg.Any<CancellationToken>());
     }

--- a/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
@@ -110,7 +110,7 @@ public class PlanGoalFieldsTests
         var result = validator.Validate(request);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(CreatePlanRequest.TargetWeightKg)));
+        result.Errors.Should().Contain(e => e.ErrorMessage == "TargetWeightKg must be greater than zero.");
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class PlanGoalFieldsTests
         var result = validator.Validate(request);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(CreatePlanRequest.TargetWeightKg)));
+        result.Errors.Should().Contain(e => e.ErrorMessage == "TargetWeightKg must be greater than zero.");
     }
 
     // ── UpdatePlan ────────────────────────────────────────────────────────────

--- a/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
@@ -1,0 +1,321 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.NutritionPlans.CreatePlan;
+using FitnessPlatform.Application.Features.NutritionPlans.UpdatePlan;
+using FluentValidation;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.NutritionPlans;
+
+/// <summary>
+/// Tests verifying that <c>Goal</c> and <c>TargetWeightKg</c> fields are
+/// correctly persisted when creating and updating nutrition plans.
+/// </summary>
+public class PlanGoalFieldsTests
+{
+    private readonly Guid _nutritionistId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    // ── CreatePlan ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreatePlan_WithGoalAndTargetWeight_PersistsFields()
+    {
+        var mongo = PlanTestHelpers.CreateMockMongo();
+        var authHelper = CreateAuthHelper(hasLink: true);
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<CreatePlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, authHelper, db);
+
+        var request = new CreatePlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Weight Loss Plan",
+            WeekCount = 1,
+            Goal = PrimaryGoal.LoseFat,
+            TargetWeightKg = 75.5m
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.NutritionPlans.Received(1).InsertOneAsync(
+            Arg.Is<NutritionPlan>(p =>
+                p.Goal == PrimaryGoal.LoseFat &&
+                p.TargetWeightKg == 75.5m),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreatePlan_WithoutGoalAndTargetWeight_PersistsNullFields()
+    {
+        var mongo = PlanTestHelpers.CreateMockMongo();
+        var authHelper = CreateAuthHelper(hasLink: true);
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<CreatePlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo, authHelper, db);
+
+        var request = new CreatePlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Basic Plan",
+            WeekCount = 1
+            // Goal and TargetWeightKg omitted — should be null on the document
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.NutritionPlans.Received(1).InsertOneAsync(
+            Arg.Is<NutritionPlan>(p =>
+                p.Goal == null &&
+                p.TargetWeightKg == null),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void CreatePlan_Validator_WithZeroTargetWeight_FailsValidation()
+    {
+        var validator = new CreatePlanValidator();
+        var request = new CreatePlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Bad Plan",
+            WeekCount = 1,
+            TargetWeightKg = 0m   // must be > 0
+        };
+
+        var result = validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreatePlanRequest.TargetWeightKg));
+    }
+
+    [Fact]
+    public void CreatePlan_Validator_WithNegativeTargetWeight_FailsValidation()
+    {
+        var validator = new CreatePlanValidator();
+        var request = new CreatePlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Bad Plan",
+            WeekCount = 1,
+            TargetWeightKg = -5m  // must be > 0
+        };
+
+        var result = validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreatePlanRequest.TargetWeightKg));
+    }
+
+    // ── UpdatePlan ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdatePlan_WithGoalAndTargetWeight_PersistsFields()
+    {
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            nutritionistId: _nutritionistId,
+            weekCount: 1,
+            version: 1);
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        var macroCalc = Substitute.For<IMacroCalculatorService>();
+
+        var ep = Factory.Create<UpdatePlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo,
+            macroCalc,
+            new MockDbBuilder().Build(),
+            Substitute.For<IRealtimeNotifier>());
+
+        var req = new UpdatePlanRequest
+        {
+            PlanId = planId,
+            Name = "Updated Plan",
+            Version = 1,
+            Goal = PrimaryGoal.GainMuscle,
+            TargetWeightKg = 90.0m,
+            Weeks = []
+        };
+
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await mongo.NutritionPlans.Received(1).ReplaceOneAsync(
+            Arg.Any<FilterDefinition<NutritionPlan>>(),
+            Arg.Is<NutritionPlan>(p =>
+                p.Goal == PrimaryGoal.GainMuscle &&
+                p.TargetWeightKg == 90.0m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdatePlan_ClearsGoalToNull_PersistsNull()
+    {
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            nutritionistId: _nutritionistId,
+            weekCount: 1,
+            version: 1);
+        plan.Goal = PrimaryGoal.LoseFat;
+        plan.TargetWeightKg = 70.0m;
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        var macroCalc = Substitute.For<IMacroCalculatorService>();
+
+        var ep = Factory.Create<UpdatePlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo,
+            macroCalc,
+            new MockDbBuilder().Build(),
+            Substitute.For<IRealtimeNotifier>());
+
+        var req = new UpdatePlanRequest
+        {
+            PlanId = planId,
+            Name = "Plan Without Goal",
+            Version = 1,
+            Goal = null,
+            TargetWeightKg = null,
+            Weeks = []
+        };
+
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        await mongo.NutritionPlans.Received(1).ReplaceOneAsync(
+            Arg.Any<FilterDefinition<NutritionPlan>>(),
+            Arg.Is<NutritionPlan>(p =>
+                p.Goal == null &&
+                p.TargetWeightKg == null),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdatePlan_StaleConcurrencyVersion_Returns409()
+    {
+        var planId = Guid.NewGuid();
+        var plan = PlanTestHelpers.CreatePlan(
+            externalId: planId,
+            nutritionistId: _nutritionistId,
+            weekCount: 1,
+            version: 3);   // server is at version 3
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [plan]);
+        var macroCalc = Substitute.For<IMacroCalculatorService>();
+
+        var ep = Factory.Create<UpdatePlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_nutritionistId, AppRoles.Nutritionist))),
+            mongo,
+            macroCalc,
+            new MockDbBuilder().Build(),
+            Substitute.For<IRealtimeNotifier>());
+
+        var req = new UpdatePlanRequest
+        {
+            PlanId = planId,
+            Name = "Updated Plan",
+            Version = 1,  // stale — client thinks it is still at 1
+            Goal = PrimaryGoal.LoseFat,
+            TargetWeightKg = 75.0m,
+            Weeks = []
+        };
+
+        await ep.HandleAsync(req, TestContext.Current.CancellationToken);
+
+        // Version mismatch must return 409, not 200
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    // ── Bson round-trip: fields survive serialize → deserialize ───────────────
+
+    [Fact]
+    public void NutritionPlanDocument_GoalAndTargetWeightKg_RoundTripViaBson()
+    {
+        var original = new NutritionPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            NutritionistId = Guid.NewGuid(),
+            Name = "Bson Test Plan",
+            Goal = PrimaryGoal.GainMuscle,
+            TargetWeightKg = 82.5m,
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var bsonDoc = original.ToBsonDocument();
+        var deserialized = MongoDB.Bson.Serialization.BsonSerializer
+            .Deserialize<NutritionPlan>(bsonDoc);
+
+        deserialized.Goal.Should().Be(PrimaryGoal.GainMuscle);
+        deserialized.TargetWeightKg.Should().Be(82.5m);
+    }
+
+    [Fact]
+    public void NutritionPlanDocument_NullGoalAndTargetWeightKg_RoundTripViaBson()
+    {
+        var original = new NutritionPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            NutritionistId = Guid.NewGuid(),
+            Name = "Bson Null Test Plan",
+            Goal = null,
+            TargetWeightKg = null,
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var bsonDoc = original.ToBsonDocument();
+        var deserialized = MongoDB.Bson.Serialization.BsonSerializer
+            .Deserialize<NutritionPlan>(bsonDoc);
+
+        deserialized.Goal.Should().BeNull();
+        deserialized.TargetWeightKg.Should().BeNull();
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static NutritionAuthHelper CreateAuthHelper(bool hasLink)
+    {
+        var db = Substitute.For<IApplicationDbContext>();
+        var helper = Substitute.ForPartsOf<NutritionAuthHelper>(db);
+        helper.HasActiveLinkAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(hasLink);
+        return helper;
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/NutritionPlans/PlanGoalFieldsTests.cs
@@ -110,7 +110,7 @@ public class PlanGoalFieldsTests
         var result = validator.Validate(request);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreatePlanRequest.TargetWeightKg));
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(CreatePlanRequest.TargetWeightKg)));
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class PlanGoalFieldsTests
         var result = validator.Validate(request);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreatePlanRequest.TargetWeightKg));
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(CreatePlanRequest.TargetWeightKg)));
     }
 
     // ── UpdatePlan ────────────────────────────────────────────────────────────

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardEndpointTests.cs
@@ -4,7 +4,9 @@ using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
 using FitnessPlatform.Application.Domain.Interfaces;
 using FitnessPlatform.Application.Features.Trainers.GetClientDashboard;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
 using NSubstitute;
 
 namespace FitnessPlatform.Tests.Endpoints.Trainers;
@@ -14,6 +16,10 @@ public class GetClientDashboardEndpointTests
     private readonly Guid _trainerId = Guid.NewGuid();
     private readonly IAuditService _audit = Substitute.For<IAuditService>();
     private readonly IComplianceService _complianceService = Substitute.For<IComplianceService>();
+
+    // Returns a mock IMongoContext with no active plans — plan-first path
+    // falls back to onboarding data without affecting the assertion.
+    private static IMongoContext EmptyMongo() => PlanTestHelpers.CreateMockMongo();
 
     [Fact]
     public async Task HandleAsync_LinkedClient_ReturnsDashboard()
@@ -38,7 +44,7 @@ public class GetClientDashboardEndpointTests
             ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
                 new System.Security.Claims.ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            db, _audit, _complianceService);
+            db, _audit, _complianceService, EmptyMongo());
 
         await ep.HandleAsync(new GetClientDashboardRequest
         {
@@ -81,7 +87,7 @@ public class GetClientDashboardEndpointTests
             ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
                 new System.Security.Claims.ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            db, _audit, _complianceService);
+            db, _audit, _complianceService, EmptyMongo());
 
         await ep.HandleAsync(new GetClientDashboardRequest
         {
@@ -110,7 +116,7 @@ public class GetClientDashboardEndpointTests
             ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
                 new System.Security.Claims.ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            db, _audit, _complianceService);
+            db, _audit, _complianceService, EmptyMongo());
 
         await ep.HandleAsync(new GetClientDashboardRequest
         {
@@ -130,7 +136,7 @@ public class GetClientDashboardEndpointTests
             ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
                 new System.Security.Claims.ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            db, _audit, _complianceService);
+            db, _audit, _complianceService, EmptyMongo());
 
         await ep.HandleAsync(new GetClientDashboardRequest
         {
@@ -144,7 +150,7 @@ public class GetClientDashboardEndpointTests
     public async Task HandleAsync_NoClaims_Returns401()
     {
         var db = new MockDbBuilder().Build();
-        var ep = Factory.Create<GetClientDashboardEndpoint>(db, _audit, _complianceService);
+        var ep = Factory.Create<GetClientDashboardEndpoint>(db, _audit, _complianceService, EmptyMongo());
 
         await ep.HandleAsync(new GetClientDashboardRequest
         {
@@ -176,7 +182,7 @@ public class GetClientDashboardEndpointTests
             ctx => ctx.Request.HttpContext.User = new System.Security.Claims.ClaimsPrincipal(
                 new System.Security.Claims.ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            db, _audit, _complianceService);
+            db, _audit, _complianceService, EmptyMongo());
 
         await ep.HandleAsync(new GetClientDashboardRequest
         {

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardPlanGoalTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardPlanGoalTests.cs
@@ -1,0 +1,244 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.Trainers.GetClientDashboard;
+using FitnessPlatform.Tests.Builders;
+using FitnessPlatform.Tests.Endpoints.NutritionPlans;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+/// <summary>
+/// Tests for the plan-first goal/targetWeightKg sourcing in
+/// <see cref="GetClientDashboardEndpoint"/> (Phase 3 of #493).
+///
+/// The endpoint reads <c>Goal</c> and <c>TargetWeightKg</c> from the most-recent
+/// active <c>NutritionPlan</c> for the client, falling back to
+/// <c>ClientOnboardingData</c> when no active plan is found.
+/// </summary>
+public class GetClientDashboardPlanGoalTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly IAuditService _audit = Substitute.For<IAuditService>();
+    private readonly IComplianceService _complianceService = Substitute.For<IComplianceService>();
+
+    /// <summary>
+    /// When an active NutritionPlan has <c>Goal</c> and <c>TargetWeightKg</c> set,
+    /// the dashboard response prefers the plan values over onboarding data.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_ActivePlanHasGoal_ResponseUsesPlanGoal()
+    {
+        var clientUser = EntityBuilder.User.WithEmail("client@test.com").Build();
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(1).WithUser(clientUser).Build();
+
+        // Attach onboarding data with a DIFFERENT goal than the plan
+        clientProfile.OnboardingData = new ClientOnboardingData
+        {
+            Id = 1,
+            ClientProfileId = 1,
+            PrimaryGoal = PrimaryGoal.LoseFat,       // onboarding says WeightLoss
+            TargetWeightKg = 70.0m,                     // onboarding target
+            // required fields
+            Sex = BiologicalSex.Male,
+            HeightCm = 175,
+            WeightKg = 80,
+            BodyType = BodyType.Mesomorph,
+            TimeHorizon = TimeHorizon.SixMonths,
+            JobType = JobType.Sedentary,
+            SleepHours = 7,
+            StressLevel = 3,
+            CurrentTrainingFrequency = CurrentTrainingFrequency.Regular,
+            DesiredTrainingFrequency = DesiredTrainingFrequency.FourPerWeek,
+            FitnessRating = 6,
+            MealsPerDay = MealsPerDay.FourToFive,
+            DietaryStyle = DietaryStyle.Standard,
+            PlanExperience = PlanExperience.TriedFailed,
+            PrimaryMotivation = PrimaryMotivation.Appearance,
+        };
+
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(10)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        // Active NutritionPlan with DIFFERENT goal
+        var activePlan = PlanTestHelpers.CreatePlan(
+            clientId: clientProfile.UserId,
+            status: NutritionPlanStatus.Active);
+        activePlan.Goal = PrimaryGoal.GainMuscle;       // plan says MuscleGain
+        activePlan.TargetWeightKg = 85.0m;              // plan target
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [activePlan]);
+
+        var ep = Factory.Create<GetClientDashboardEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db, _audit, _complianceService, mongo);
+
+        await ep.HandleAsync(new GetClientDashboardRequest
+        {
+            ClientId = clientProfile.PublicId
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Onboarding.Should().NotBeNull();
+        // Plan values must win
+        ep.Response.Onboarding!.PrimaryGoal.Should().Be(PrimaryGoal.GainMuscle.ToString());
+        ep.Response.Onboarding!.TargetWeightKg.Should().Be(85.0m);
+    }
+
+    /// <summary>
+    /// When no active NutritionPlan exists for the client, the dashboard
+    /// response falls back to the <c>ClientOnboardingData</c> values.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_NoPlan_ResponseFallsBackToOnboarding()
+    {
+        var clientUser = EntityBuilder.User.WithEmail("client2@test.com").Build();
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(2).WithUserId(_trainerId).Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(2).WithUser(clientUser).Build();
+
+        clientProfile.OnboardingData = new ClientOnboardingData
+        {
+            Id = 2,
+            ClientProfileId = 2,
+            PrimaryGoal = PrimaryGoal.LoseFat,
+            TargetWeightKg = 68.0m,
+            Sex = BiologicalSex.Female,
+            HeightCm = 165,
+            WeightKg = 72,
+            BodyType = BodyType.Mesomorph,
+            TimeHorizon = TimeHorizon.SixMonths,
+            JobType = JobType.Sedentary,
+            SleepHours = 8,
+            StressLevel = 2,
+            CurrentTrainingFrequency = CurrentTrainingFrequency.Regular,
+            DesiredTrainingFrequency = DesiredTrainingFrequency.ThreePerWeek,
+            FitnessRating = 5,
+            MealsPerDay = MealsPerDay.TwoToThree,
+            DietaryStyle = DietaryStyle.Standard,
+            PlanExperience = PlanExperience.TriedFailed,
+            PrimaryMotivation = PrimaryMotivation.Health,
+        };
+
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(11)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        // Empty mongo — no active plans
+        var mongo = PlanTestHelpers.CreateMockMongo();
+
+        var ep = Factory.Create<GetClientDashboardEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db, _audit, _complianceService, mongo);
+
+        await ep.HandleAsync(new GetClientDashboardRequest
+        {
+            ClientId = clientProfile.PublicId
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Onboarding.Should().NotBeNull();
+        // Onboarding fallback values must appear
+        ep.Response.Onboarding!.PrimaryGoal.Should().Be(PrimaryGoal.LoseFat.ToString());
+        ep.Response.Onboarding!.TargetWeightKg.Should().Be(68.0m);
+    }
+
+    /// <summary>
+    /// When the active plan has <c>Goal = null</c> and <c>TargetWeightKg = null</c>,
+    /// the response falls back to the onboarding data for both fields.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_ActivePlanWithNullGoal_FallsBackToOnboarding()
+    {
+        var clientUser = EntityBuilder.User.WithEmail("client3@test.com").Build();
+        var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(3).WithUserId(_trainerId).Build();
+        var clientProfile = EntityBuilder.ClientProfile.WithId(3).WithUser(clientUser).Build();
+
+        clientProfile.OnboardingData = new ClientOnboardingData
+        {
+            Id = 3,
+            ClientProfileId = 3,
+            PrimaryGoal = PrimaryGoal.LoseFat,
+            TargetWeightKg = 65.0m,
+            Sex = BiologicalSex.Female,
+            HeightCm = 162,
+            WeightKg = 70,
+            BodyType = BodyType.Mesomorph,
+            TimeHorizon = TimeHorizon.ThreeMonths,
+            JobType = JobType.Sedentary,
+            SleepHours = 7,
+            StressLevel = 3,
+            CurrentTrainingFrequency = CurrentTrainingFrequency.Occasional,
+            DesiredTrainingFrequency = DesiredTrainingFrequency.TwoPerWeek,
+            FitnessRating = 4,
+            MealsPerDay = MealsPerDay.TwoToThree,
+            DietaryStyle = DietaryStyle.Standard,
+            PlanExperience = PlanExperience.Never,
+            PrimaryMotivation = PrimaryMotivation.Health,
+        };
+
+        var link = EntityBuilder.ClientProfessionalLink
+            .WithId(12)
+            .WithClientProfile(clientProfile)
+            .WithProfessionalProfile(trainerProfile)
+            .Build();
+
+        var db = new MockDbBuilder()
+            .With(trainerProfile)
+            .With(clientProfile)
+            .With(link)
+            .Build();
+
+        // Active plan but goal fields are null (pre-migration document)
+        var activePlan = PlanTestHelpers.CreatePlan(
+            clientId: clientProfile.UserId,
+            status: NutritionPlanStatus.Active);
+        activePlan.Goal = null;
+        activePlan.TargetWeightKg = null;
+
+        var mongo = PlanTestHelpers.CreateMockMongo(plans: [activePlan]);
+
+        var ep = Factory.Create<GetClientDashboardEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            db, _audit, _complianceService, mongo);
+
+        await ep.HandleAsync(new GetClientDashboardRequest
+        {
+            ClientId = clientProfile.PublicId
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+        ep.Response.Onboarding.Should().NotBeNull();
+        // Plan nulls → onboarding fallback
+        ep.Response.Onboarding!.PrimaryGoal.Should().Be(PrimaryGoal.LoseFat.ToString());
+        ep.Response.Onboarding!.TargetWeightKg.Should().Be(65.0m);
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardPlanGoalTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/GetClientDashboardPlanGoalTests.cs
@@ -75,9 +75,9 @@ public class GetClientDashboardPlanGoalTests
             .With(link)
             .Build();
 
-        // Active NutritionPlan with DIFFERENT goal
+        // Active NutritionPlan with DIFFERENT goal — seeded with PublicId (what CreatePlanEndpoint writes)
         var activePlan = PlanTestHelpers.CreatePlan(
-            clientId: clientProfile.UserId,
+            clientId: clientProfile.PublicId,
             status: NutritionPlanStatus.Active);
         activePlan.Goal = PrimaryGoal.GainMuscle;       // plan says MuscleGain
         activePlan.TargetWeightKg = 85.0m;              // plan target
@@ -215,9 +215,9 @@ public class GetClientDashboardPlanGoalTests
             .With(link)
             .Build();
 
-        // Active plan but goal fields are null (pre-migration document)
+        // Active plan but goal fields are null (pre-migration document) — seeded with PublicId
         var activePlan = PlanTestHelpers.CreatePlan(
-            clientId: clientProfile.UserId,
+            clientId: clientProfile.PublicId,
             status: NutritionPlanStatus.Active);
         activePlan.Goal = null;
         activePlan.TargetWeightKg = null;

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
@@ -116,7 +116,7 @@ public class TrainingPlanGoalFieldsTests
         var result = validator.Validate(request);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateTrainingPlanRequest.TargetWeightKg));
+        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(CreateTrainingPlanRequest.TargetWeightKg)));
     }
 
     // ── UpdateTrainingPlan ────────────────────────────────────────────────────

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
@@ -162,6 +162,57 @@ public class TrainingPlanGoalFieldsTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// Regression test for #493: the pre-regen web/mobile client omits Goal and
+    /// TargetWeightKg from update payloads (both arrive as null). The endpoint must
+    /// preserve the stored values rather than clobbering them with null.
+    /// </summary>
+    [Fact]
+    public async Task UpdateTrainingPlan_OmitsGoalAndTarget_PreservesStoredValues()
+    {
+        var planId = Guid.NewGuid();
+        var plan = TrainingPlanTestHelpers.CreatePlan(
+            externalId: planId,
+            trainerId: _trainerId,
+            weekCount: 1,
+            version: 1);
+        plan.Goal = PrimaryGoal.GainMuscle;
+        plan.TargetWeightKg = 88.5m;
+
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubLockService(), Substitute.For<IRealtimeNotifier>());
+
+        // Simulate a legacy client payload: Goal and TargetWeightKg are null (omitted)
+        // while another field (Name) is legitimately updated.
+        var request = new UpdateTrainingPlanRequest
+        {
+            PlanId = planId,
+            Name = "Renamed Block",
+            Version = 1,
+            Goal = null,           // omitted by old client — must NOT clear the stored goal
+            TargetWeightKg = null, // omitted by old client — must NOT clear the stored weight
+            Weeks = [new UpdateTrainingWeekRequest { WeekNumber = 1, Sessions = [] }]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        // The persisted document must still carry the original Goal and TargetWeightKg.
+        await mongo.TrainingPlans.Received(1).ReplaceOneAsync(
+            Arg.Any<FilterDefinition<TrainingPlan>>(),
+            Arg.Is<TrainingPlan>(p =>
+                p.Goal == PrimaryGoal.GainMuscle &&
+                p.TargetWeightKg == 88.5m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task UpdateTrainingPlan_StaleConcurrencyVersion_Returns409()
     {

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
@@ -1,0 +1,246 @@
+using System.Security.Claims;
+using FastEndpoints;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Features.TrainingPlans.CreateTrainingPlan;
+using FitnessPlatform.Application.Features.TrainingPlans.UpdateTrainingPlan;
+using FluentValidation;
+using FitnessPlatform.Tests.Builders;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace FitnessPlatform.Tests.Endpoints.TrainingPlans;
+
+/// <summary>
+/// Tests verifying that <c>Goal</c> and <c>TargetWeightKg</c> fields are
+/// correctly persisted when creating and updating training plans.
+/// </summary>
+public class TrainingPlanGoalFieldsTests
+{
+    private readonly Guid _trainerId = Guid.NewGuid();
+    private readonly Guid _clientId = Guid.NewGuid();
+
+    private static ISessionLockService StubLockService()
+    {
+        var svc = Substitute.For<ISessionLockService>();
+        svc.GetStateAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<SessionLock>());
+        return svc;
+    }
+
+    // ── CreateTrainingPlan ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateTrainingPlan_WithGoalAndTargetWeight_PersistsFields()
+    {
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo();
+        var authHelper = TrainingPlanTestHelpers.CreateMockAuthHelper(true);
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<CreateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, authHelper, db);
+
+        var request = new CreateTrainingPlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Strength Block",
+            WeekCount = 4,
+            Goal = PrimaryGoal.GainMuscle,
+            TargetWeightKg = 88.0m
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.TrainingPlans.Received(1).InsertOneAsync(
+            Arg.Is<TrainingPlan>(p =>
+                p.Goal == PrimaryGoal.GainMuscle &&
+                p.TargetWeightKg == 88.0m),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateTrainingPlan_WithoutGoal_PersistsNullFields()
+    {
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo();
+        var authHelper = TrainingPlanTestHelpers.CreateMockAuthHelper(true);
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<CreateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, authHelper, db);
+
+        var request = new CreateTrainingPlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Basic Block",
+            WeekCount = 2
+            // Goal and TargetWeightKg omitted
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(201);
+
+        await mongo.TrainingPlans.Received(1).InsertOneAsync(
+            Arg.Is<TrainingPlan>(p =>
+                p.Goal == null &&
+                p.TargetWeightKg == null),
+            Arg.Any<InsertOneOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void CreateTrainingPlan_Validator_WithZeroTargetWeight_FailsValidation()
+    {
+        var validator = new CreateTrainingPlanValidator();
+        var request = new CreateTrainingPlanRequest
+        {
+            ClientId = _clientId,
+            Name = "Bad Plan",
+            WeekCount = 1,
+            TargetWeightKg = 0m  // must be > 0
+        };
+
+        var result = validator.Validate(request);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(CreateTrainingPlanRequest.TargetWeightKg));
+    }
+
+    // ── UpdateTrainingPlan ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateTrainingPlan_WithGoalAndTargetWeight_PersistsFields()
+    {
+        var planId = Guid.NewGuid();
+        var plan = TrainingPlanTestHelpers.CreatePlan(
+            externalId: planId,
+            trainerId: _trainerId,
+            weekCount: 1,
+            version: 1);
+
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubLockService(), Substitute.For<IRealtimeNotifier>());
+
+        var request = new UpdateTrainingPlanRequest
+        {
+            PlanId = planId,
+            Name = "Updated Block",
+            Version = 1,
+            Goal = PrimaryGoal.LoseFat,
+            TargetWeightKg = 75.0m,
+            Weeks = [new UpdateTrainingWeekRequest { WeekNumber = 1, Sessions = [] }]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(200);
+
+        await mongo.TrainingPlans.Received(1).ReplaceOneAsync(
+            Arg.Any<FilterDefinition<TrainingPlan>>(),
+            Arg.Is<TrainingPlan>(p =>
+                p.Goal == PrimaryGoal.LoseFat &&
+                p.TargetWeightKg == 75.0m),
+            Arg.Any<ReplaceOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateTrainingPlan_StaleConcurrencyVersion_Returns409()
+    {
+        var planId = Guid.NewGuid();
+        var plan = TrainingPlanTestHelpers.CreatePlan(
+            externalId: planId,
+            trainerId: _trainerId,
+            weekCount: 1,
+            version: 5);   // server is at version 5
+
+        var mongo = TrainingPlanTestHelpers.CreateMockMongo(plan);
+
+        var ep = Factory.Create<UpdateTrainingPlanEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, StubLockService(), Substitute.For<IRealtimeNotifier>());
+
+        var request = new UpdateTrainingPlanRequest
+        {
+            PlanId = planId,
+            Name = "Updated Block",
+            Version = 1,  // stale
+            Goal = PrimaryGoal.GainMuscle,
+            TargetWeightKg = 90.0m,
+            Weeks = [new UpdateTrainingWeekRequest { WeekNumber = 1, Sessions = [] }]
+        };
+
+        await ep.HandleAsync(request, TestContext.Current.CancellationToken);
+
+        // Version mismatch must return 409, not 200
+        ep.HttpContext.Response.StatusCode.Should().Be(409);
+    }
+
+    // ── Bson round-trip: fields survive serialize → deserialize ───────────────
+
+    [Fact]
+    public void TrainingPlanDocument_GoalAndTargetWeightKg_RoundTripViaBson()
+    {
+        var original = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = Guid.NewGuid(),
+            Name = "Bson Test Training Plan",
+            Goal = PrimaryGoal.LoseFat,
+            TargetWeightKg = 70.0m,
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var bsonDoc = original.ToBsonDocument();
+        var deserialized = MongoDB.Bson.Serialization.BsonSerializer
+            .Deserialize<TrainingPlan>(bsonDoc);
+
+        deserialized.Goal.Should().Be(PrimaryGoal.LoseFat);
+        deserialized.TargetWeightKg.Should().Be(70.0m);
+    }
+
+    [Fact]
+    public void TrainingPlanDocument_NullGoalAndTargetWeightKg_RoundTripViaBson()
+    {
+        var original = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId = Guid.NewGuid(),
+            TrainerId = Guid.NewGuid(),
+            Name = "Bson Null Training Plan",
+            Goal = null,
+            TargetWeightKg = null,
+            Version = 1,
+            DateCreated = DateTime.UtcNow
+        };
+
+        var bsonDoc = original.ToBsonDocument();
+        var deserialized = MongoDB.Bson.Serialization.BsonSerializer
+            .Deserialize<TrainingPlan>(bsonDoc);
+
+        deserialized.Goal.Should().BeNull();
+        deserialized.TargetWeightKg.Should().BeNull();
+    }
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/TrainingPlans/TrainingPlanGoalFieldsTests.cs
@@ -116,7 +116,7 @@ public class TrainingPlanGoalFieldsTests
         var result = validator.Validate(request);
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.PropertyName.StartsWith(nameof(CreateTrainingPlanRequest.TargetWeightKg)));
+        result.Errors.Should().Contain(e => e.ErrorMessage == "TargetWeightKg must be greater than zero.");
     }
 
     // ── UpdateTrainingPlan ────────────────────────────────────────────────────

--- a/backend/FitnessPlatform.Tests/Services/PlanGoalBackfillServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/PlanGoalBackfillServiceTests.cs
@@ -1,0 +1,398 @@
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+using Npgsql;
+using Testcontainers.MongoDb;
+using Testcontainers.PostgreSql;
+
+namespace FitnessPlatform.Tests.Services;
+
+/// <summary>
+/// Testcontainers integration tests for <see cref="PlanGoalBackfillService"/>.
+///
+/// Boots real PostgreSQL (all EF migrations applied) and MongoDB containers,
+/// seeds minimal data, then verifies that the backfill correctly copies
+/// <c>PrimaryGoal</c> and <c>TargetWeightKg</c> from
+/// <c>ClientOnboardingData</c> into <c>NutritionPlan</c> and
+/// <c>TrainingPlan</c> documents, and that a second run is a no-op.
+///
+/// Join key: <c>plan.ClientId</c> == <c>ClientProfile.UserId</c> (the
+/// <c>ApplicationUser.Id</c> Guid) — NOT <c>ClientProfile.PublicId</c>.
+/// </summary>
+public class PlanGoalBackfillServiceTests : IAsyncLifetime
+{
+    // Wide timeout to tolerate Docker contention on the dev machine (see #336).
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(180);
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16").Build();
+    private readonly MongoDbContainer   _mongo    = new MongoDbBuilder("mongo:7").Build();
+
+    private ApplicationDbContext _db       = null!;
+    private IMongoContext        _mongoCtx = null!;
+
+    // ── IAsyncLifetime ────────────────────────────────────────────────────────
+
+    public async ValueTask InitializeAsync()
+    {
+        using var cts = new CancellationTokenSource(StartupTimeout);
+        await Task.WhenAll(_postgres.StartAsync(cts.Token), _mongo.StartAsync(cts.Token));
+
+        _db = BuildDbContext(_postgres.GetConnectionString());
+        await _db.Database.MigrateAsync(TestContext.Current.CancellationToken);
+
+        var mongoClient = new MongoClient(_mongo.GetConnectionString());
+        var mongoDb     = mongoClient.GetDatabase("fitness_plan_goal_backfill_test");
+        _mongoCtx = new MongoContext(mongoDb);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _db.DisposeAsync();
+        await Task.WhenAll(
+            _postgres.DisposeAsync().AsTask(),
+            _mongo.DisposeAsync().AsTask());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static ApplicationDbContext BuildDbContext(string connectionString)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(connectionString)
+            .UseSnakeCaseNamingConvention()
+            .ConfigureWarnings(w =>
+                w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning))
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    /// <summary>
+    /// Inserts a minimal user + client_profile + client_onboarding_data row via raw SQL.
+    /// Returns (userId, clientProfileId) so callers can seed Mongo plans with the
+    /// correct <c>plan.ClientId = userId</c>.
+    /// </summary>
+    private async Task<(Guid UserId, long ClientProfileId)> SeedUserWithOnboardingAsync(
+        PrimaryGoal goal,
+        decimal? targetWeightKg)
+    {
+        var ct     = TestContext.Current.CancellationToken;
+        var userId = Guid.NewGuid();
+
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(ct);
+
+        // Insert user
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = @"
+                INSERT INTO users (
+                    id, user_name, normalized_user_name,
+                    email, normalized_email, email_confirmed,
+                    password_hash, security_stamp, concurrency_stamp,
+                    phone_number_confirmed, two_factor_enabled,
+                    lockout_enabled, access_failed_count,
+                    first_name, last_name, is_active, date_created,
+                    gdpr_consent, verification_emails_sent, time_zone
+                ) VALUES (
+                    @id, @email, @emailUpper,
+                    @email, @emailUpper, true,
+                    '', gen_random_uuid()::text, gen_random_uuid()::text,
+                    false, false,
+                    true, 0,
+                    'Test', 'User', true, now(),
+                    true, 0, 'Europe/Prague'
+                )";
+            cmd.Parameters.AddWithValue("id",         userId);
+            cmd.Parameters.AddWithValue("email",      $"{userId:N}@goal-backfill-test.com");
+            cmd.Parameters.AddWithValue("emailUpper", $"{userId:N}@GOAL-BACKFILL-TEST.COM");
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        // Insert client_profile
+        long clientProfileId;
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = @"
+                INSERT INTO client_profiles (user_id, public_id, date_created, is_onboarding_complete)
+                VALUES (@userId, @publicId, now(), true)
+                RETURNING id";
+            cmd.Parameters.AddWithValue("userId",   userId);
+            cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+            clientProfileId = (long)(await cmd.ExecuteScalarAsync(ct))!;
+        }
+
+        // Insert client_onboarding_data (many NOT NULL columns)
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = @"
+                INSERT INTO client_onboarding_data (
+                    client_profile_id, date_of_birth, sex, height_cm, weight_kg,
+                    body_type, primary_goal, time_horizon, job_type, sleep_hours,
+                    stress_level, current_training_frequency, desired_training_frequency,
+                    fitness_rating, gym_access, preferred_activities, injuries,
+                    meals_per_day, dietary_style, allergies, diet_rating,
+                    plan_experience, past_blockers, primary_motivation,
+                    derived_activity_level, derived_nutrition_goal,
+                    bmr, tdee, adjusted_kcal, protein_grams, carbs_grams, fat_grams,
+                    target_weight_kg, date_created
+                ) VALUES (
+                    @clientProfileId, '2000-01-01', 0, 175, 75,
+                    0, @goal, 0, 0, 7,
+                    3, 0, 0,
+                    6, 0, 'strength', 'none',
+                    0, 0, 'none', 3,
+                    0, 'none', 0,
+                    0, 0,
+                    1800, 2200, 2000, 150, 220, 60,
+                    @targetWeightKg, now()
+                )";
+            cmd.Parameters.AddWithValue("clientProfileId", clientProfileId);
+            cmd.Parameters.AddWithValue("goal",            (int)goal);
+            cmd.Parameters.AddWithValue("targetWeightKg",
+                targetWeightKg.HasValue ? (object)targetWeightKg.Value : DBNull.Value);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        return (userId, clientProfileId);
+    }
+
+    private PlanGoalBackfillService BuildSut()
+    {
+        // Rebuild DbContext for a clean tracked-entity cache each call.
+        _db.Dispose();
+        _db = BuildDbContext(_postgres.GetConnectionString());
+
+        return new PlanGoalBackfillService(
+            _db,
+            _mongoCtx,
+            NullLogger<PlanGoalBackfillService>.Instance);
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A NutritionPlan with null Goal/TargetWeightKg and a matching client
+    /// onboarding entry → backfill populates both fields, second run is a no-op.
+    /// Join key is UserId (not PublicId).
+    /// </summary>
+    [Fact]
+    public async Task BackfillAsync_NutritionPlan_CopiesGoalAndTarget_AndIsIdempotent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var (userId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.LoseFat, 70.0m);
+
+        // Insert a NutritionPlan with null goal/targetWeightKg. plan.ClientId = userId.
+        var plan = new NutritionPlan
+        {
+            ExternalId    = Guid.NewGuid(),
+            ClientId      = userId,          // CRITICAL: must equal ClientProfile.UserId
+            NutritionistId = Guid.NewGuid(),
+            Name          = "Backfill Test Plan",
+            Status        = NutritionPlanStatus.Draft,
+            Goal          = null,
+            TargetWeightKg = null,
+            Weeks         = [],
+            Version       = 1,
+            DateCreated   = DateTime.UtcNow
+        };
+        await _mongoCtx.NutritionPlans.InsertOneAsync(plan, cancellationToken: ct);
+
+        // First backfill
+        var sut = BuildSut();
+        var (nutrition1, training1) = await sut.BackfillAsync(ct);
+
+        nutrition1.Should().Be(1, "one nutrition plan should be updated");
+        training1.Should().Be(0, "no training plans to update");
+
+        // Verify the Mongo document was updated
+        var filter  = Builders<NutritionPlan>.Filter.Eq(p => p.ExternalId, plan.ExternalId);
+        var updated = await _mongoCtx.NutritionPlans.Find(filter).FirstOrDefaultAsync(ct);
+
+        updated.Should().NotBeNull();
+        updated!.Goal.Should().Be(PrimaryGoal.LoseFat);
+        updated.TargetWeightKg.Should().Be(70.0m);
+
+        // Idempotency: second run must not touch the already-backfilled document
+        var sut2 = BuildSut();
+        var (nutrition2, training2) = await sut2.BackfillAsync(ct);
+
+        nutrition2.Should().Be(0, "already backfilled — second run must be a no-op");
+        training2.Should().Be(0);
+
+        // Document values unchanged
+        var afterSecond = await _mongoCtx.NutritionPlans.Find(filter).FirstOrDefaultAsync(ct);
+        afterSecond!.Goal.Should().Be(PrimaryGoal.LoseFat);
+        afterSecond.TargetWeightKg.Should().Be(70.0m);
+    }
+
+    /// <summary>
+    /// A TrainingPlan with null Goal/TargetWeightKg and a matching onboarding
+    /// entry → backfill populates both fields, second run is a no-op.
+    /// </summary>
+    [Fact]
+    public async Task BackfillAsync_TrainingPlan_CopiesGoalAndTarget_AndIsIdempotent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var (userId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.GainMuscle, 85.0m);
+
+        var plan = new TrainingPlan
+        {
+            ExternalId = Guid.NewGuid(),
+            ClientId   = userId,
+            TrainerId  = Guid.NewGuid(),
+            Name       = "Backfill Training Plan",
+            Status     = TrainingPlanStatus.Draft,
+            Goal       = null,
+            TargetWeightKg = null,
+            Weeks      = [],
+            Version    = 1,
+            DateCreated = DateTime.UtcNow
+        };
+        await _mongoCtx.TrainingPlans.InsertOneAsync(plan, cancellationToken: ct);
+
+        // First backfill
+        var sut = BuildSut();
+        var (nutrition1, training1) = await sut.BackfillAsync(ct);
+
+        training1.Should().Be(1, "one training plan should be updated");
+        // nutrition1 may be 0 or higher from other parallel test seeding — we only care about training
+
+        // Verify document
+        var filter  = Builders<TrainingPlan>.Filter.Eq(p => p.ExternalId, plan.ExternalId);
+        var updated = await _mongoCtx.TrainingPlans.Find(filter).FirstOrDefaultAsync(ct);
+
+        updated.Should().NotBeNull();
+        updated!.Goal.Should().Be(PrimaryGoal.GainMuscle);
+        updated.TargetWeightKg.Should().Be(85.0m);
+
+        // Idempotency
+        var sut2 = BuildSut();
+        var (_, training2) = await sut2.BackfillAsync(ct);
+
+        training2.Should().Be(0, "already backfilled");
+    }
+
+    /// <summary>
+    /// A plan whose client has no onboarding data must be skipped (no crash,
+    /// no update).
+    /// </summary>
+    [Fact]
+    public async Task BackfillAsync_NoOnboardingData_SkipsPlan()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Insert user+profile but NO onboarding data
+        var userId = Guid.NewGuid();
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync(ct);
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = @"
+                INSERT INTO users (
+                    id, user_name, normalized_user_name,
+                    email, normalized_email, email_confirmed,
+                    password_hash, security_stamp, concurrency_stamp,
+                    phone_number_confirmed, two_factor_enabled,
+                    lockout_enabled, access_failed_count,
+                    first_name, last_name, is_active, date_created,
+                    gdpr_consent, verification_emails_sent, time_zone
+                ) VALUES (
+                    @id, @email, @emailUpper,
+                    @email, @emailUpper, true,
+                    '', gen_random_uuid()::text, gen_random_uuid()::text,
+                    false, false, true, 0,
+                    'No', 'Onboarding', true, now(),
+                    true, 0, 'Europe/Prague'
+                )";
+            cmd.Parameters.AddWithValue("id",         userId);
+            cmd.Parameters.AddWithValue("email",      $"{userId:N}@no-onboarding.com");
+            cmd.Parameters.AddWithValue("emailUpper", $"{userId:N}@NO-ONBOARDING.COM");
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = @"
+                INSERT INTO client_profiles (user_id, public_id, date_created, is_onboarding_complete)
+                VALUES (@userId, @publicId, now(), false)";
+            cmd.Parameters.AddWithValue("userId",   userId);
+            cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        // Plan with null goal for this client
+        var plan = new NutritionPlan
+        {
+            ExternalId     = Guid.NewGuid(),
+            ClientId       = userId,
+            NutritionistId = Guid.NewGuid(),
+            Name           = "No-onboarding Plan",
+            Status         = NutritionPlanStatus.Draft,
+            Goal           = null,
+            TargetWeightKg = null,
+            Weeks          = [],
+            Version        = 1,
+            DateCreated    = DateTime.UtcNow
+        };
+        await _mongoCtx.NutritionPlans.InsertOneAsync(plan, cancellationToken: ct);
+
+        var sut = BuildSut();
+        await sut.BackfillAsync(ct);
+
+        // Document must remain untouched (still null)
+        var filter  = Builders<NutritionPlan>.Filter.Eq(p => p.ExternalId, plan.ExternalId);
+        var fetched = await _mongoCtx.NutritionPlans.Find(filter).FirstOrDefaultAsync(ct);
+
+        fetched.Should().NotBeNull();
+        fetched!.Goal.Should().BeNull("no onboarding data means nothing to copy");
+        fetched.TargetWeightKg.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A plan that already has both Goal and TargetWeightKg set must be
+    /// skipped entirely — backfill never overwrites existing data.
+    /// </summary>
+    [Fact]
+    public async Task BackfillAsync_AlreadyBackfilled_DoesNotOverwrite()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var (userId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.LoseFat, 60.0m);
+
+        // Plan already has goal set — should not be touched
+        var plan = new NutritionPlan
+        {
+            ExternalId     = Guid.NewGuid(),
+            ClientId       = userId,
+            NutritionistId = Guid.NewGuid(),
+            Name           = "Pre-backfilled Plan",
+            Status         = NutritionPlanStatus.Active,
+            Goal           = PrimaryGoal.GainMuscle,   // already set
+            TargetWeightKg = 90.0m,                    // already set
+            Weeks          = [],
+            Version        = 1,
+            DateCreated    = DateTime.UtcNow
+        };
+        await _mongoCtx.NutritionPlans.InsertOneAsync(plan, cancellationToken: ct);
+
+        var sut = BuildSut();
+        await sut.BackfillAsync(ct);
+
+        // Values must remain as-is (not overwritten by onboarding WeightLoss/60.0)
+        var filter  = Builders<NutritionPlan>.Filter.Eq(p => p.ExternalId, plan.ExternalId);
+        var fetched = await _mongoCtx.NutritionPlans.Find(filter).FirstOrDefaultAsync(ct);
+
+        fetched.Should().NotBeNull();
+        fetched!.Goal.Should().Be(PrimaryGoal.GainMuscle, "pre-existing value must not be overwritten");
+        fetched.TargetWeightKg.Should().Be(90.0m, "pre-existing value must not be overwritten");
+    }
+}

--- a/backend/FitnessPlatform.Tests/Services/PlanGoalBackfillServiceTests.cs
+++ b/backend/FitnessPlatform.Tests/Services/PlanGoalBackfillServiceTests.cs
@@ -22,8 +22,9 @@ namespace FitnessPlatform.Tests.Services;
 /// <c>ClientOnboardingData</c> into <c>NutritionPlan</c> and
 /// <c>TrainingPlan</c> documents, and that a second run is a no-op.
 ///
-/// Join key: <c>plan.ClientId</c> == <c>ClientProfile.UserId</c> (the
-/// <c>ApplicationUser.Id</c> Guid) — NOT <c>ClientProfile.PublicId</c>.
+/// Join key: <c>plan.ClientId</c> == <c>ClientProfile.PublicId</c> — NOT
+/// <c>ClientProfile.UserId</c> (ApplicationUser.Id). Plans are written by
+/// <c>CreatePlanEndpoint</c> with <c>plan.ClientId = clientProfile.PublicId</c>.
 /// </summary>
 public class PlanGoalBackfillServiceTests : IAsyncLifetime
 {
@@ -74,15 +75,16 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
 
     /// <summary>
     /// Inserts a minimal user + client_profile + client_onboarding_data row via raw SQL.
-    /// Returns (userId, clientProfileId) so callers can seed Mongo plans with the
-    /// correct <c>plan.ClientId = userId</c>.
+    /// Returns (UserId, PublicId, ClientProfileId) so callers can seed Mongo plans with
+    /// the correct <c>plan.ClientId = publicId</c> (matching what CreatePlanEndpoint writes).
     /// </summary>
-    private async Task<(Guid UserId, long ClientProfileId)> SeedUserWithOnboardingAsync(
+    private async Task<(Guid UserId, Guid PublicId, long ClientProfileId)> SeedUserWithOnboardingAsync(
         PrimaryGoal goal,
         decimal? targetWeightKg)
     {
-        var ct     = TestContext.Current.CancellationToken;
-        var userId = Guid.NewGuid();
+        var ct       = TestContext.Current.CancellationToken;
+        var userId   = Guid.NewGuid();
+        var publicId = Guid.NewGuid();
 
         await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
         await conn.OpenAsync(ct);
@@ -114,7 +116,7 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
             await cmd.ExecuteNonQueryAsync(ct);
         }
 
-        // Insert client_profile
+        // Insert client_profile — capture the generated public_id
         long clientProfileId;
         await using (var cmd = conn.CreateCommand())
         {
@@ -123,7 +125,7 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
                 VALUES (@userId, @publicId, now(), true)
                 RETURNING id";
             cmd.Parameters.AddWithValue("userId",   userId);
-            cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+            cmd.Parameters.AddWithValue("publicId", publicId);
             clientProfileId = (long)(await cmd.ExecuteScalarAsync(ct))!;
         }
 
@@ -159,7 +161,7 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
             await cmd.ExecuteNonQueryAsync(ct);
         }
 
-        return (userId, clientProfileId);
+        return (userId, publicId, clientProfileId);
     }
 
     private PlanGoalBackfillService BuildSut()
@@ -179,20 +181,21 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
     /// <summary>
     /// A NutritionPlan with null Goal/TargetWeightKg and a matching client
     /// onboarding entry → backfill populates both fields, second run is a no-op.
-    /// Join key is UserId (not PublicId).
+    /// Join key is PublicId (not UserId).
     /// </summary>
     [Fact]
     public async Task BackfillAsync_NutritionPlan_CopiesGoalAndTarget_AndIsIdempotent()
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var (userId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.LoseFat, 70.0m);
+        var (_, publicId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.LoseFat, 70.0m);
 
-        // Insert a NutritionPlan with null goal/targetWeightKg. plan.ClientId = userId.
+        // Insert a NutritionPlan with null goal/targetWeightKg.
+        // plan.ClientId = publicId, matching what CreatePlanEndpoint writes.
         var plan = new NutritionPlan
         {
             ExternalId    = Guid.NewGuid(),
-            ClientId      = userId,          // CRITICAL: must equal ClientProfile.UserId
+            ClientId      = publicId,        // CRITICAL: must equal ClientProfile.PublicId
             NutritionistId = Guid.NewGuid(),
             Name          = "Backfill Test Plan",
             Status        = NutritionPlanStatus.Draft,
@@ -241,12 +244,12 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var (userId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.GainMuscle, 85.0m);
+        var (_, publicId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.GainMuscle, 85.0m);
 
         var plan = new TrainingPlan
         {
             ExternalId = Guid.NewGuid(),
-            ClientId   = userId,
+            ClientId   = publicId,   // CRITICAL: must equal ClientProfile.PublicId
             TrainerId  = Guid.NewGuid(),
             Name       = "Backfill Training Plan",
             Status     = TrainingPlanStatus.Draft,
@@ -319,21 +322,22 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
             await cmd.ExecuteNonQueryAsync(ct);
         }
 
+        var noOnboardingPublicId = Guid.NewGuid();
         await using (var cmd = conn.CreateCommand())
         {
             cmd.CommandText = @"
                 INSERT INTO client_profiles (user_id, public_id, date_created, is_onboarding_complete)
                 VALUES (@userId, @publicId, now(), false)";
             cmd.Parameters.AddWithValue("userId",   userId);
-            cmd.Parameters.AddWithValue("publicId", Guid.NewGuid());
+            cmd.Parameters.AddWithValue("publicId", noOnboardingPublicId);
             await cmd.ExecuteNonQueryAsync(ct);
         }
 
-        // Plan with null goal for this client
+        // Plan with null goal for this client — seeded with PublicId as the join key
         var plan = new NutritionPlan
         {
             ExternalId     = Guid.NewGuid(),
-            ClientId       = userId,
+            ClientId       = noOnboardingPublicId,   // PublicId join key, no onboarding data
             NutritionistId = Guid.NewGuid(),
             Name           = "No-onboarding Plan",
             Status         = NutritionPlanStatus.Draft,
@@ -366,13 +370,13 @@ public class PlanGoalBackfillServiceTests : IAsyncLifetime
     {
         var ct = TestContext.Current.CancellationToken;
 
-        var (userId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.LoseFat, 60.0m);
+        var (_, publicId, _) = await SeedUserWithOnboardingAsync(PrimaryGoal.LoseFat, 60.0m);
 
         // Plan already has goal set — should not be touched
         var plan = new NutritionPlan
         {
             ExternalId     = Guid.NewGuid(),
-            ClientId       = userId,
+            ClientId       = publicId,   // PublicId join key
             NutritionistId = Guid.NewGuid(),
             Name           = "Pre-backfilled Plan",
             Status         = NutritionPlanStatus.Active,


### PR DESCRIPTION
## Summary
- New top-level `Goal` (PrimaryGoal enum) + `TargetWeightKg` fields on both `NutritionPlan` and `TrainingPlan` documents.
- Create/update endpoints (nutrition + training) accept `Goal` + `TargetWeightKg`, with `TargetWeightKg > 0` validation when present.
- `GetClientDashboard` + `GetMeasurementStats` now read goal/target plan-first (from the active NutritionPlan) and fall back to onboarding only when the plan value is null.
- One-shot idempotent `PlanGoalBackfillService` (`dotnet run -- --backfill-plan-goals`) copies goal/target from `ClientOnboardingData` onto pre-existing plan docs, joined via `ClientProfile.PublicId` (plan documents store `ClientId = ClientProfile.PublicId`, NOT `ApplicationUser.Id`).
- Onboarding fields retained as transitional fallback (nothing deleted). No API wire-shape change; `regen-api` intentionally deferred.

## Related issue
Fixes #493

## Scope
backend

## QA verdict (from qa-tester)
OVERALL ✅ PASS — dotnet build clean, full test suite green (the read sites + backfill join on `ClientProfile.PublicId`; the plan-goal tests now seed `ClientId = PublicId` distinct from `UserId` and assert the PLAN value is surfaced, genuinely guarding the join).

## Rework since first review
A blind second-pass reviewer caught a BLOCKING defect — the cross-DB join used `ClientProfile.UserId` while plan documents store `ClientProfile.PublicId`, making the feature a silent no-op. Fixed:
- `cd0349f` — join on `PublicId` at all 3 sites (`GetClientDashboard`, `GetMeasurementStats`, `PlanGoalBackfillService` both passes); replaced bare `catch{}` fallbacks with typed `MongoException` + `LogWarning`; re-pointed test fixtures to seed `ClientId = PublicId`.
- `e8f5ada` — hardened `TargetWeightKg` validator assertions against a FluentValidation nullable-name concurrency flake.

## ⚠️ Merge constraint
This PR adds a MongoDB data-mutation backfill (`PlanGoalBackfillService` + `--backfill-plan-goals`), which is on the merge **exclusion list** (rules/merge-strategy.md#exclusion-list). It is **human-merged** regardless of tier — `pr-reviewer` will not auto-merge it.

## Test plan
- [ ] NutritionPlan & TrainingPlan documents have plan-level goal + targetWeightKg fields.
- [ ] Plan create/update accept goal + targetWeightKg; targetWeightKg > 0 enforced.
- [ ] Dashboard + measurement-stats read plan-first, onboarding-fallback.
- [ ] Backfill copies goal/target from onboarding via ClientProfile.PublicId, idempotent (null-only guard).
- [ ] Optimistic concurrency preserved on plan update.
- [ ] dotnet build clean; full dotnet test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
