### PR TITLE
fix: auth concurrent-refresh logout race + shared login/refresh rate-limit lockout (#521)

### DIFF
--- a/backend/FitnessPlatform.Application/Domain/Constants/AppPolicies.cs
+++ b/backend/FitnessPlatform.Application/Domain/Constants/AppPolicies.cs
@@ -6,9 +6,19 @@ namespace FitnessPlatform.Application.Domain.Constants;
 public static class AppPolicies
 {
     /// <summary>
-    /// Rate limiting policy for authentication endpoints.
+    /// Rate limiting policy for authentication endpoints (login, register, password reset, social login, etc.).
+    /// 10 requests per 15 minutes per IP.
     /// </summary>
     public const string AuthRateLimit = "auth";
+
+    /// <summary>
+    /// Rate limiting policy for the token refresh endpoint.
+    /// A separate, higher-limit policy so transparent background refresh calls
+    /// cannot exhaust the shared login budget.
+    /// 120 requests per 15 minutes per IP — bounding flood abuse while allowing
+    /// normal client behaviour (multiple tabs, background refresh, concurrent requests).
+    /// </summary>
+    public const string RefreshRateLimit = "auth-refresh";
 
     /// <summary>
     /// CORS policy for the web application.

--- a/backend/FitnessPlatform.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/RefreshToken/RefreshTokenEndpoint.cs
@@ -26,7 +26,7 @@ public class RefreshTokenEndpoint(
     {
         Post("/auth/refresh");
         AllowAnonymous();
-        Options(x => x.RequireRateLimiting(AppPolicies.AuthRateLimit));
+        Options(x => x.RequireRateLimiting(AppPolicies.RefreshRateLimit));
         Summary(s =>
         {
             s.Summary = "Refresh access token";

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -1,5 +1,6 @@
 using System.Threading.RateLimiting;
 using FastEndpoints;
+using Microsoft.AspNetCore.HttpOverrides;
 using FastEndpoints.Security;
 using FastEndpoints.Swagger;
 using FitnessPlatform.Application.Domain.Constants;
@@ -124,17 +125,46 @@ var rateLimitingDisabled = builder.Configuration.GetValue<bool>("RateLimiting:Di
 
 builder.Services.AddRateLimiter(options =>
 {
+    // Resolve the client IP from the request context.
+    // Behind a trusted reverse proxy (Render edge), X-Forwarded-For has already
+    // been resolved into HttpContext.Connection.RemoteIpAddress by UseForwardedHeaders.
+    // If RemoteIpAddress is still null (should not happen in production because
+    // UseForwardedHeaders is registered before UseRateLimiter), fall back to the
+    // connection id — a per-connection unique string — so we never collapse all
+    // anonymous connections into a single shared "unknown" bucket that one flood
+    // could exhaust for everyone.
+    static string GetPartitionKey(HttpContext context) =>
+        context.Connection.RemoteIpAddress?.ToString()
+        ?? context.Connection.Id;
+
     options.AddPolicy(AppPolicies.AuthRateLimit, context =>
         rateLimitingDisabled
             ? RateLimitPartition.GetNoLimiter("disabled")
             : RateLimitPartition.GetFixedWindowLimiter(
-                partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                partitionKey: GetPartitionKey(context),
                 factory: _ => new FixedWindowRateLimiterOptions
                 {
                     PermitLimit = 10,
                     Window = TimeSpan.FromMinutes(15),
                     QueueLimit = 0
                 }));
+
+    // Separate policy for the refresh endpoint so background token rotation
+    // does not consume the shared login/register budget.
+    // 120 permits per 15 min per IP: bounds flood abuse while comfortably
+    // accommodating normal transparent refresh (multiple tabs, concurrent requests).
+    options.AddPolicy(AppPolicies.RefreshRateLimit, context =>
+        rateLimitingDisabled
+            ? RateLimitPartition.GetNoLimiter("disabled")
+            : RateLimitPartition.GetFixedWindowLimiter(
+                partitionKey: GetPartitionKey(context),
+                factory: _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = 120,
+                    Window = TimeSpan.FromMinutes(15),
+                    QueueLimit = 0
+                }));
+
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 });
 
@@ -337,6 +367,41 @@ if (runMigrationsOnStartup)
 
 // Middleware pipeline
 app.UseExceptionHandler();
+
+// Resolve the true client IP from X-Forwarded-For when the app runs behind
+// the Render edge proxy (or any trusted reverse proxy).
+//
+// SECURITY: blanket trust (ForwardedHeadersOptions with no KnownProxies /
+// KnownNetworks configured) lets any client spoof X-Forwarded-For and forge
+// its own rate-limit partition key.  We restrict trust to:
+//   • RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+//   • IPv6 loopback / link-local (::1, fc00::/7, fe80::/10)
+//
+// Render's internal routing places the edge proxy on a private IP relative
+// to the application container, so these ranges cover the production topology
+// while preventing a public client from injecting an arbitrary forwarded IP.
+//
+// Must run BEFORE UseRateLimiter so the rate-limiter already sees the resolved
+// IP in HttpContext.Connection.RemoteIpAddress.
+app.UseForwardedHeaders(new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor,
+    KnownIPNetworks =
+    {
+        // 10.0.0.0/8  (RFC 1918)
+        new System.Net.IPNetwork(System.Net.IPAddress.Parse("10.0.0.0"), 8),
+        // 172.16.0.0/12  (RFC 1918)
+        new System.Net.IPNetwork(System.Net.IPAddress.Parse("172.16.0.0"), 12),
+        // 192.168.0.0/16  (RFC 1918)
+        new System.Net.IPNetwork(System.Net.IPAddress.Parse("192.168.0.0"), 16),
+        // ::1/128  (IPv6 loopback)
+        new System.Net.IPNetwork(System.Net.IPAddress.IPv6Loopback, 128),
+        // fc00::/7  (IPv6 unique local)
+        new System.Net.IPNetwork(System.Net.IPAddress.Parse("fc00::"), 7),
+        // fe80::/10  (IPv6 link-local)
+        new System.Net.IPNetwork(System.Net.IPAddress.Parse("fe80::"), 10),
+    }
+});
 
 // Health endpoints — registered before HTTPS redirect / auth so they remain
 // reachable on plain HTTP (Render terminates TLS at the edge) and don't

--- a/backend/FitnessPlatform.Application/Program.cs
+++ b/backend/FitnessPlatform.Application/Program.cs
@@ -386,6 +386,9 @@ app.UseExceptionHandler();
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedFor,
+    // ForwardLimit defaults to 1 — assumes exactly ONE trusted hop (the Render edge proxy).
+    // If the deployment topology ever adds a second trusted hop (e.g. an internal LB behind
+    // Render), bump this to 2 and add the LB's network to KnownIPNetworks.
     KnownIPNetworks =
     {
         // 10.0.0.0/8  (RFC 1918)

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/RateLimitPolicyTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/RateLimitPolicyTests.cs
@@ -6,7 +6,9 @@ using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
 using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,12 +19,46 @@ using Testcontainers.PostgreSql;
 namespace FitnessPlatform.Tests.Endpoints.Auth;
 
 /// <summary>
-/// Rate-limit integration tests that use a dedicated factory with rate limiting
-/// RE-ENABLED (overriding FitnessApiFactory's default RateLimiting:Disabled=true).
+/// IStartupFilter that prepends a middleware reading X-Test-Client-IP and
+/// writing the parsed address into Connection.RemoteIpAddress.  This gives
+/// the rate-limiter a stable, controllable partition key under TestServer
+/// (which otherwise sets RemoteIpAddress = null because there is no real TCP
+/// socket, causing the fallback to per-request Connection.Id and making the
+/// FixedWindow buckets never exhaustible from a test).
 ///
-/// These tests verify:
-/// (a) /auth/refresh is on its own policy and does NOT exhaust the /auth/login budget.
-/// (b) The X-Forwarded-For partition key is respected when injected (trusted proxy scenario).
+/// Registered only by <see cref="RateLimitEnabledFactory"/>; production code
+/// never references this class.
+/// </summary>
+internal sealed class TestClientIpStartupFilter : IStartupFilter
+{
+    public const string Header = "X-Test-Client-IP";
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            app.Use(async (context, nextMiddleware) =>
+            {
+                if (context.Request.Headers.TryGetValue(Header, out var ipValue)
+                    && !string.IsNullOrWhiteSpace(ipValue))
+                {
+                    if (System.Net.IPAddress.TryParse(ipValue!, out var parsed))
+                        context.Connection.RemoteIpAddress = parsed;
+                }
+
+                await nextMiddleware(context);
+            });
+
+            next(app);
+        };
+    }
+}
+
+/// <summary>
+/// WebApplicationFactory override that:
+/// (a) re-enables rate limiting (overrides FitnessApiFactory's RateLimiting:Disabled=true), and
+/// (b) registers <see cref="TestClientIpStartupFilter"/> so tests can steer the rate-limit
+///     partition key via an X-Test-Client-IP request header.
 /// </summary>
 public class RateLimitEnabledFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
@@ -41,7 +77,7 @@ public class RateLimitEnabledFactory : WebApplicationFactory<Program>, IAsyncLif
         builder.UseSetting("MINIO_SECRET_KEY", "test");
         builder.UseSetting("JWT_SECRET", new string('x', 64));
 
-        // KEY DIFFERENCE: rate limiting is enabled for this factory
+        // KEY DIFFERENCE from FitnessApiFactory: rate limiting is ENABLED
         builder.UseSetting("RateLimiting:Disabled", "false");
 
         builder.UseSetting("ConnectionStrings:PostgreSQl",
@@ -51,6 +87,10 @@ public class RateLimitEnabledFactory : WebApplicationFactory<Program>, IAsyncLif
 
         builder.ConfigureServices(services =>
         {
+            // Prepend the test IP middleware via IStartupFilter so we can control
+            // Connection.RemoteIpAddress (partition key) from test code.
+            services.AddSingleton<IStartupFilter, TestClientIpStartupFilter>();
+
             // Replace DbContext with testcontainer PostgreSQL
             var descriptor = services.SingleOrDefault(
                 d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
@@ -128,138 +168,255 @@ public class RateLimitEnabledFactory : WebApplicationFactory<Program>, IAsyncLif
 
 /// <summary>
 /// Integration tests for the split rate-limit policy introduced in issue #521.
-/// Uses <see cref="RateLimitEnabledFactory"/> which keeps rate limiting active.
+/// Uses <see cref="RateLimitEnabledFactory"/> which keeps rate limiting active and
+/// allows tests to steer the partition key via the X-Test-Client-IP header.
+///
+/// Each test uses a dedicated client that always sends a fixed X-Test-Client-IP so all
+/// requests from that client land in the SAME rate-limit bucket — making exhaustion
+/// assertions meaningful and deterministic.
 /// </summary>
 public class RateLimitPolicyTests : IAsyncLifetime
 {
     private readonly RateLimitEnabledFactory _factory = new();
-    private HttpClient _client = null!;
 
-    public async ValueTask InitializeAsync()
-    {
-        await _factory.InitializeAsync();
-        _client = _factory.CreateClient(new WebApplicationFactoryClientOptions
-        {
-            // Do not follow redirects so we can inspect 429 responses directly
-            AllowAutoRedirect = false
-        });
-    }
+    // Three stable "virtual IPs" used to isolate test buckets from each other.
+    // They are in the 10.0.0.0/8 private range which is trusted by UseForwardedHeaders
+    // (KnownIPNetworks in Program.cs).
+    private const string Ip1 = "10.0.1.1";
+    private const string Ip2 = "10.0.1.2";
+    private const string Ip3 = "10.0.1.3";
+
+    // These IPs are NOT in any KnownIPNetworks range — useful for the untrusted-proxy test.
+    private const string UntrustedIp = "203.0.113.5";
+
+    public async ValueTask InitializeAsync() => await _factory.InitializeAsync();
 
     public async ValueTask DisposeAsync()
     {
-        _client.Dispose();
+        // Do NOT call _factory.Dispose() — that calls base.Dispose() which disposes
+        // the root IServiceProvider, clearing FastEndpoints' process-global
+        // ServiceResolver.Provider and causing ObjectDisposedException in concurrent tests.
+        // See the same comment in FitnessApiFactory.DisposeAsync for the full explanation.
         await _factory.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Creates an HttpClient that stamps every request with a fixed X-Test-Client-IP so
+    /// all requests from this client share the same rate-limit partition.
+    /// </summary>
+    private HttpClient CreateClientWithIp(string ip)
+    {
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+        client.DefaultRequestHeaders.Add(TestClientIpStartupFilter.Header, ip);
+        return client;
     }
 
     private static string UniqueEmail() => $"{Guid.NewGuid():N}@ratelimit-test.com";
 
+    // ---------------------------------------------------------------------------
+    // AC-4: /auth/refresh on its own policy cannot exhaust the /auth/login budget
+    // ---------------------------------------------------------------------------
+
     /// <summary>
-    /// Registers a user and returns a valid refresh token so tests can call /auth/refresh.
+    /// Proves that the FixedWindow limiter can actually be exhausted when all requests
+    /// share the same IP partition.  If the IP is controllable, 10 login attempts from
+    /// the same IP must yield a 429 on the 11th call.
+    ///
+    /// This is the baseline assertion that confirms the TestServer partition-key injection
+    /// is working.  Without it, every request lands in its own unique bucket (fallback
+    /// Connection.Id) and the limiter NEVER triggers — making all subsequent tests vacuous.
     /// </summary>
-    private async Task<string> GetValidRefreshTokenAsync(string email, string password)
+    [Fact]
+    public async Task LoginBudget_IsExhaustedAfter10Attempts_SameIp()
     {
-        await TestHelpers.RegisterAsync(_client, email, password, "Rate", "Tester", "Client");
-        var (_, refreshToken) = await TestHelpers.LoginAsync(_client, email, password);
-        return refreshToken;
+        using var client = CreateClientWithIp(Ip1);
+
+        // Exhaust the login budget: PermitLimit = 10 for AppPolicies.AuthRateLimit.
+        // We use 10 different emails so we don't hit a 401 (wrong-password) that might
+        // confuse the assertion.  The /auth/login endpoint does not require the user to
+        // exist for the rate limiter to decrement the permit — the limiter runs BEFORE
+        // the handler validates credentials.
+        for (var i = 0; i < 10; i++)
+        {
+            var response = await client.PostAsJsonAsync("/auth/login", new
+            {
+                Email = $"bogus-{i}@exhaustion-test.com",
+                Password = "anything"
+            });
+            // Anything except 429 is acceptable here (401, 400, etc.)
+            response.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
+                $"login attempt #{i + 1} should not be rate-limited yet (budget = 10)");
+        }
+
+        // The 11th attempt from the same IP must be blocked.
+        var rateLimitedResponse = await client.PostAsJsonAsync("/auth/login", new
+        {
+            Email = "bogus-final@exhaustion-test.com",
+            Password = "anything"
+        });
+
+        rateLimitedResponse.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "the 11th /auth/login from the same IP must be rate-limited (budget = 10 per 15 min)");
     }
 
     /// <summary>
-    /// AC-4 regression: /auth/refresh is on its own policy (auth-refresh) and cannot
-    /// exhaust the /auth/login budget (auth policy, PermitLimit=10).
+    /// AC-4 regression: /auth/refresh lives on the 'auth-refresh' policy (PermitLimit=120),
+    /// NOT the 'auth' policy (PermitLimit=10).
     ///
-    /// We issue 11 refresh calls from the same "IP" (loopback, which test clients use).
-    /// The 11th call MAY be rate-limited on the refresh policy (PermitLimit=120 — will
-    /// NOT be hit in 11 calls), but MORE IMPORTANTLY /auth/login must still return 200,
-    /// proving the refresh calls did not consume the login budget.
+    /// We issue 10 /auth/refresh calls from IP2, then verify that /auth/login from IP2 is
+    /// still allowed — proving the refresh calls did NOT consume the login budget.
+    ///
+    /// Without the policy split (i.e. if refresh were on AppPolicies.AuthRateLimit), the
+    /// 10 refresh calls would exhaust the 10-permit login bucket and the login would 429.
     /// </summary>
     [Fact]
     public async Task RefreshCalls_DoNotExhaustLoginBudget()
     {
+        using var client = CreateClientWithIp(Ip2);
+
+        // Register + login to obtain a valid refresh token chain.
+        // Registration calls /auth/register which is on the 'auth' policy —
+        // that consumes 1 permit from Ip2's login bucket.
         var email = UniqueEmail();
         const string password = "TestPass1!";
+        var registerResponse = await TestHelpers.RegisterAsync(client, email, password, "Rate", "Tester", "Client");
+        registerResponse.IsSuccessStatusCode.Should().BeTrue("registration must succeed");
 
-        // Get initial refresh token via registration + login (1 permit from auth budget)
-        var refreshToken = await GetValidRefreshTokenAsync(email, password);
+        var (_, refreshToken) = await TestHelpers.LoginAsync(client, email, password);
+        // 2 permits consumed from Ip2's login budget (register + login).
 
-        // Issue 10 more refresh calls (each rotates the token — well within the
-        // refresh policy's 120-permit budget, but would exceed the 10-permit login
-        // budget if they were sharing it)
-        for (var i = 0; i < 10; i++)
+        // Issue 8 more /auth/refresh calls — each rotates the token.
+        // If refresh were sharing the 'auth' budget, 8 more + 2 earlier = 10 total,
+        // leaving 0 permits for the final login check.
+        for (var i = 0; i < 8; i++)
         {
-            var response = await _client.PostAsJsonAsync("/auth/refresh", new { RefreshToken = refreshToken });
+            var refreshResponse = await client.PostAsJsonAsync("/auth/refresh", new { RefreshToken = refreshToken });
+            refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+                $"refresh call #{i + 1} must succeed — auth-refresh policy has 120-permit budget");
 
-            // Each refresh call should succeed (200)
-            if (response.IsSuccessStatusCode)
-            {
-                // Rotate the refresh token for the next iteration
-                var body = await response.Content.ReadFromJsonAsync<RefreshResult>();
-                refreshToken = body!.RefreshToken;
-            }
-            else
-            {
-                // A 429 here would mean the refresh policy kicked in early — fail the test
-                response.StatusCode.Should().Be(HttpStatusCode.OK,
-                    $"refresh call #{i + 1} should succeed; got {(int)response.StatusCode}");
-                break;
-            }
+            var body = await refreshResponse.Content.ReadFromJsonAsync<RefreshResult>();
+            refreshToken = body!.RefreshToken;
         }
+        // 10 total requests against 'auth' budget if policies were shared —
+        // the next /auth/login would 429.
 
-        // Now try /auth/login. If refresh calls had been sharing the auth budget we
-        // would have exhausted it (10 permits: 1 from registration login + 10 from
-        // refresh = 11 > 10). With the split policy the login budget still has room.
-        var loginResponse = await _client.PostAsJsonAsync("/auth/login", new
+        // Now try /auth/login. With the split policy the login budget has 8 permits
+        // remaining (only the register + initial login consumed from it), so this must succeed.
+        var loginResponse = await client.PostAsJsonAsync("/auth/login", new
         {
             Email = email,
             Password = password
         });
 
         loginResponse.StatusCode.Should().Be(HttpStatusCode.OK,
-            "login must succeed after many refresh calls — refresh uses its own rate-limit bucket");
+            "login must succeed after 8 refresh calls — /auth/refresh uses its OWN budget (auth-refresh), not the login budget (auth)");
     }
 
     /// <summary>
-    /// AC-5 regression: the partition key is resolved from a trusted X-Forwarded-For
-    /// header when the source IP is in a known-proxy network (loopback qualifies
-    /// because the test client connects via loopback).
+    /// Complementary AC-4 assertion: /auth/login does NOT exhaust the /auth/refresh budget.
     ///
-    /// We issue two requests with different X-Forwarded-For values from the same
-    /// underlying connection. Both should succeed independently — they are partitioned
-    /// by their declared forwarded IP, not by the shared connection IP — demonstrating
-    /// that UseForwardedHeaders correctly rewrites RemoteIpAddress per request.
+    /// We exhaust Ip3's login budget (10 calls) then verify that /auth/refresh from Ip3
+    /// is NOT blocked by the login exhaustion — the refresh endpoint is on a separate policy.
+    /// </summary>
+    [Fact]
+    public async Task ExhaustedLoginBudget_DoesNotBlock_RefreshEndpoint()
+    {
+        using var client = CreateClientWithIp(Ip3);
+
+        // Seed a user and obtain a refresh token BEFORE exhausting the budget.
+        var email = UniqueEmail();
+        const string password = "TestPass1!";
+        var registerResponse = await TestHelpers.RegisterAsync(client, email, password, "Rate", "Seed", "Client");
+        registerResponse.IsSuccessStatusCode.Should().BeTrue("registration must succeed");
+
+        var (_, refreshToken) = await TestHelpers.LoginAsync(client, email, password);
+        // 2 of 10 permits consumed.
+
+        // Exhaust the remaining 8 permits on the login budget.
+        for (var i = 0; i < 8; i++)
+        {
+            await client.PostAsJsonAsync("/auth/login", new
+            {
+                Email = $"bogus-{i}@exhaust-budget.com",
+                Password = "anything"
+            });
+        }
+        // Now Ip3's login bucket is fully exhausted.
+
+        // Confirm the login bucket is indeed exhausted.
+        var blockedLogin = await client.PostAsJsonAsync("/auth/login", new
+        {
+            Email = email,
+            Password = password
+        });
+        blockedLogin.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "Ip3's login bucket must be exhausted (10 permits used)");
+
+        // /auth/refresh must NOT be blocked — it is on the separate 'auth-refresh' policy.
+        var refreshResponse = await client.PostAsJsonAsync("/auth/refresh", new { RefreshToken = refreshToken });
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            "/auth/refresh must succeed even when the login budget is exhausted — it is on the 'auth-refresh' policy, not the 'auth' policy");
+    }
+
+    // ---------------------------------------------------------------------------
+    // AC-5: per-IP partitioning via trusted X-Forwarded-For
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// AC-5: Two distinct X-Forwarded-For values from the SAME underlying TestServer
+    /// connection are treated as SEPARATE rate-limit partitions.
     ///
-    /// Note: this test verifies that two distinct forwarded IPs are treated as distinct
-    /// partitions (neither exhausts the other's budget). It does not attempt to exhaust
-    /// a bucket, as doing so would require 10+ requests per IP.
+    /// We exhaust the login budget from forwardedIp1 (10 calls → 429), then confirm
+    /// that a login from forwardedIp2 — a DIFFERENT forwarded IP — is still allowed.
+    /// This proves that the partition key is the resolved IP, not a shared fallback.
+    ///
+    /// For UseForwardedHeaders to honor the X-Forwarded-For header, the immediate peer
+    /// (Connection.RemoteIpAddress as set by TestClientIpStartupFilter) must be in a
+    /// KnownIPNetworks range in Program.cs.  We use 10.0.2.1 (inside 10.0.0.0/8) as
+    /// the trusted proxy IP so the header is actually applied.
     /// </summary>
     [Fact]
     public async Task ForwardedFor_DifferentIPs_ArePartitionedSeparately()
     {
-        const string password = "TestPass1!";
+        // Use a trusted proxy IP as the immediate peer — 10.0.0.0/8 is in KnownIPNetworks.
+        const string trustedProxyIp = "10.0.2.1";
+        const string forwardedIp1   = "203.0.113.10"; // public "client IP" #1
+        const string forwardedIp2   = "203.0.113.11"; // public "client IP" #2
 
-        var email1 = UniqueEmail();
-        var email2 = UniqueEmail();
+        // Client whose underlying TestServer connection looks like it's coming from
+        // the trusted proxy. Every request also carries an X-Forwarded-For header that
+        // UseForwardedHeaders will rewrite Connection.RemoteIpAddress with.
+        using var client = CreateClientWithIp(trustedProxyIp);
 
-        // Register both users
-        await TestHelpers.RegisterAsync(_client, email1, password, "Rate", "One", "Client");
-        await TestHelpers.RegisterAsync(_client, email2, password, "Rate", "Two", "Client");
+        // Helper: send a login from a specific forwarded IP.
+        async Task<HttpResponseMessage> LoginFromIp(string forwarded, string email, string pw)
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Post, "/auth/login");
+            req.Headers.Add("X-Forwarded-For", forwarded);
+            req.Content = JsonContent.Create(new { Email = email, Password = pw });
+            return await client.SendAsync(req);
+        }
 
-        // Login from two different forwarded IPs (simulated via X-Forwarded-For header)
-        using var request1 = new HttpRequestMessage(HttpMethod.Post, "/auth/login");
-        request1.Headers.Add("X-Forwarded-For", "10.0.0.1");
-        request1.Content = JsonContent.Create(new { Email = email1, Password = password });
+        // Exhaust forwardedIp1's login budget: 10 attempts.
+        for (var i = 0; i < 10; i++)
+        {
+            var response = await LoginFromIp(forwardedIp1, $"bogus-fwd-{i}@partition-test.com", "anything");
+            response.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
+                $"attempt #{i + 1} from {forwardedIp1} must not be rate-limited yet");
+        }
 
-        using var request2 = new HttpRequestMessage(HttpMethod.Post, "/auth/login");
-        request2.Headers.Add("X-Forwarded-For", "10.0.0.2");
-        request2.Content = JsonContent.Create(new { Email = email2, Password = password });
+        // Confirm forwardedIp1 is now exhausted.
+        var blockedResponse = await LoginFromIp(forwardedIp1, "extra@partition-test.com", "anything");
+        blockedResponse.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            $"the 11th attempt from {forwardedIp1} must be rate-limited (budget = 10)");
 
-        var response1 = await _client.SendAsync(request1);
-        var response2 = await _client.SendAsync(request2);
-
-        // Both should succeed — they are in separate partitions
-        response1.StatusCode.Should().Be(HttpStatusCode.OK,
-            "login from 10.0.0.1 should succeed");
-        response2.StatusCode.Should().Be(HttpStatusCode.OK,
-            "login from 10.0.0.2 should succeed in its own partition");
+        // forwardedIp2 has its own independent bucket — must still be allowed.
+        var allowedResponse = await LoginFromIp(forwardedIp2, "other@partition-test.com", "anything");
+        allowedResponse.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
+            $"login from {forwardedIp2} must succeed — it has its own partition independent of {forwardedIp1}");
     }
 
     private record RefreshResult(string AccessToken, string RefreshToken, DateTime ExpiresAt);

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/RateLimitPolicyTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/RateLimitPolicyTests.cs
@@ -1,0 +1,266 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Interfaces;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Application.Infrastructure.Services;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Testcontainers.MongoDb;
+using Testcontainers.PostgreSql;
+
+namespace FitnessPlatform.Tests.Endpoints.Auth;
+
+/// <summary>
+/// Rate-limit integration tests that use a dedicated factory with rate limiting
+/// RE-ENABLED (overriding FitnessApiFactory's default RateLimiting:Disabled=true).
+///
+/// These tests verify:
+/// (a) /auth/refresh is on its own policy and does NOT exhaust the /auth/login budget.
+/// (b) The X-Forwarded-For partition key is respected when injected (trusted proxy scenario).
+/// </summary>
+public class RateLimitEnabledFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:16")
+        .Build();
+
+    private readonly MongoDbContainer _mongo = new MongoDbBuilder("mongo:7")
+        .Build();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Provide required secrets
+        builder.UseSetting("POSTGRES_PASSWORD", "test");
+        builder.UseSetting("MONGO_PASSWORD", "test");
+        builder.UseSetting("MINIO_ACCESS_KEY", "test");
+        builder.UseSetting("MINIO_SECRET_KEY", "test");
+        builder.UseSetting("JWT_SECRET", new string('x', 64));
+
+        // KEY DIFFERENCE: rate limiting is enabled for this factory
+        builder.UseSetting("RateLimiting:Disabled", "false");
+
+        builder.UseSetting("ConnectionStrings:PostgreSQl",
+            "Host=localhost;Database=placeholder;Username=postgres");
+        builder.UseSetting("ConnectionStrings:MongoDB",
+            "mongodb://localhost:27017");
+
+        builder.ConfigureServices(services =>
+        {
+            // Replace DbContext with testcontainer PostgreSQL
+            var descriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor is not null)
+                services.Remove(descriptor);
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseNpgsql(_postgres.GetConnectionString())
+                    .ConfigureWarnings(w => w.Ignore(
+                        Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning)));
+
+            // Replace MongoDB with testcontainer
+            var mongoDbDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoDatabase));
+            if (mongoDbDescriptor is not null)
+                services.Remove(mongoDbDescriptor);
+
+            var mongoContextDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMongoContext));
+            if (mongoContextDescriptor is not null)
+                services.Remove(mongoContextDescriptor);
+
+            services.AddSingleton<IMongoDatabase>(_ =>
+            {
+                var client = new MongoClient(_mongo.GetConnectionString());
+                return client.GetDatabase("fitness_ratelimit_test");
+            });
+            services.AddSingleton<IMongoContext, MongoContext>();
+
+            // Replace email service with fake
+            var emailDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IEmailService));
+            if (emailDescriptor is not null)
+                services.Remove(emailDescriptor);
+            services.AddScoped<IEmailService, FakeEmailService>();
+
+            // Replace blob storage with fake
+            var blobDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IBlobStorageService));
+            if (blobDescriptor is not null)
+                services.Remove(blobDescriptor);
+            services.AddSingleton<IBlobStorageService, FakeBlobStorageService>();
+
+            // Replace realtime notifier with fake
+            var notifierDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IRealtimeNotifier));
+            if (notifierDescriptor is not null)
+                services.Remove(notifierDescriptor);
+            services.AddSingleton<FakeRealtimeNotifier>();
+            services.AddSingleton<IRealtimeNotifier>(sp => sp.GetRequiredService<FakeRealtimeNotifier>());
+
+            // Replace push notifications with fake
+            var pushDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IPushNotificationService));
+            if (pushDescriptor is not null)
+                services.Remove(pushDescriptor);
+            services.AddSingleton<FakePushNotificationService>();
+            services.AddSingleton<IPushNotificationService>(
+                sp => sp.GetRequiredService<FakePushNotificationService>());
+        });
+
+        builder.UseEnvironment("Development");
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await Task.WhenAll(
+            _postgres.StartAsync(),
+            _mongo.StartAsync());
+
+        await ApplicationDbContextSeed.SeedAsync(Services);
+    }
+
+    public new async ValueTask DisposeAsync()
+    {
+        await Task.WhenAll(
+            _postgres.DisposeAsync().AsTask(),
+            _mongo.DisposeAsync().AsTask());
+    }
+}
+
+/// <summary>
+/// Integration tests for the split rate-limit policy introduced in issue #521.
+/// Uses <see cref="RateLimitEnabledFactory"/> which keeps rate limiting active.
+/// </summary>
+public class RateLimitPolicyTests : IAsyncLifetime
+{
+    private readonly RateLimitEnabledFactory _factory = new();
+    private HttpClient _client = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _factory.InitializeAsync();
+        _client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            // Do not follow redirects so we can inspect 429 responses directly
+            AllowAutoRedirect = false
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        await _factory.DisposeAsync();
+    }
+
+    private static string UniqueEmail() => $"{Guid.NewGuid():N}@ratelimit-test.com";
+
+    /// <summary>
+    /// Registers a user and returns a valid refresh token so tests can call /auth/refresh.
+    /// </summary>
+    private async Task<string> GetValidRefreshTokenAsync(string email, string password)
+    {
+        await TestHelpers.RegisterAsync(_client, email, password, "Rate", "Tester", "Client");
+        var (_, refreshToken) = await TestHelpers.LoginAsync(_client, email, password);
+        return refreshToken;
+    }
+
+    /// <summary>
+    /// AC-4 regression: /auth/refresh is on its own policy (auth-refresh) and cannot
+    /// exhaust the /auth/login budget (auth policy, PermitLimit=10).
+    ///
+    /// We issue 11 refresh calls from the same "IP" (loopback, which test clients use).
+    /// The 11th call MAY be rate-limited on the refresh policy (PermitLimit=120 — will
+    /// NOT be hit in 11 calls), but MORE IMPORTANTLY /auth/login must still return 200,
+    /// proving the refresh calls did not consume the login budget.
+    /// </summary>
+    [Fact]
+    public async Task RefreshCalls_DoNotExhaustLoginBudget()
+    {
+        var email = UniqueEmail();
+        const string password = "TestPass1!";
+
+        // Get initial refresh token via registration + login (1 permit from auth budget)
+        var refreshToken = await GetValidRefreshTokenAsync(email, password);
+
+        // Issue 10 more refresh calls (each rotates the token — well within the
+        // refresh policy's 120-permit budget, but would exceed the 10-permit login
+        // budget if they were sharing it)
+        for (var i = 0; i < 10; i++)
+        {
+            var response = await _client.PostAsJsonAsync("/auth/refresh", new { RefreshToken = refreshToken });
+
+            // Each refresh call should succeed (200)
+            if (response.IsSuccessStatusCode)
+            {
+                // Rotate the refresh token for the next iteration
+                var body = await response.Content.ReadFromJsonAsync<RefreshResult>();
+                refreshToken = body!.RefreshToken;
+            }
+            else
+            {
+                // A 429 here would mean the refresh policy kicked in early — fail the test
+                response.StatusCode.Should().Be(HttpStatusCode.OK,
+                    $"refresh call #{i + 1} should succeed; got {(int)response.StatusCode}");
+                break;
+            }
+        }
+
+        // Now try /auth/login. If refresh calls had been sharing the auth budget we
+        // would have exhausted it (10 permits: 1 from registration login + 10 from
+        // refresh = 11 > 10). With the split policy the login budget still has room.
+        var loginResponse = await _client.PostAsJsonAsync("/auth/login", new
+        {
+            Email = email,
+            Password = password
+        });
+
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK,
+            "login must succeed after many refresh calls — refresh uses its own rate-limit bucket");
+    }
+
+    /// <summary>
+    /// AC-5 regression: the partition key is resolved from a trusted X-Forwarded-For
+    /// header when the source IP is in a known-proxy network (loopback qualifies
+    /// because the test client connects via loopback).
+    ///
+    /// We issue two requests with different X-Forwarded-For values from the same
+    /// underlying connection. Both should succeed independently — they are partitioned
+    /// by their declared forwarded IP, not by the shared connection IP — demonstrating
+    /// that UseForwardedHeaders correctly rewrites RemoteIpAddress per request.
+    ///
+    /// Note: this test verifies that two distinct forwarded IPs are treated as distinct
+    /// partitions (neither exhausts the other's budget). It does not attempt to exhaust
+    /// a bucket, as doing so would require 10+ requests per IP.
+    /// </summary>
+    [Fact]
+    public async Task ForwardedFor_DifferentIPs_ArePartitionedSeparately()
+    {
+        const string password = "TestPass1!";
+
+        var email1 = UniqueEmail();
+        var email2 = UniqueEmail();
+
+        // Register both users
+        await TestHelpers.RegisterAsync(_client, email1, password, "Rate", "One", "Client");
+        await TestHelpers.RegisterAsync(_client, email2, password, "Rate", "Two", "Client");
+
+        // Login from two different forwarded IPs (simulated via X-Forwarded-For header)
+        using var request1 = new HttpRequestMessage(HttpMethod.Post, "/auth/login");
+        request1.Headers.Add("X-Forwarded-For", "10.0.0.1");
+        request1.Content = JsonContent.Create(new { Email = email1, Password = password });
+
+        using var request2 = new HttpRequestMessage(HttpMethod.Post, "/auth/login");
+        request2.Headers.Add("X-Forwarded-For", "10.0.0.2");
+        request2.Content = JsonContent.Create(new { Email = email2, Password = password });
+
+        var response1 = await _client.SendAsync(request1);
+        var response2 = await _client.SendAsync(request2);
+
+        // Both should succeed — they are in separate partitions
+        response1.StatusCode.Should().Be(HttpStatusCode.OK,
+            "login from 10.0.0.1 should succeed");
+        response2.StatusCode.Should().Be(HttpStatusCode.OK,
+            "login from 10.0.0.2 should succeed in its own partition");
+    }
+
+    private record RefreshResult(string AccessToken, string RefreshToken, DateTime ExpiresAt);
+}

--- a/web/src/i18n/locales/cs.json
+++ b/web/src/i18n/locales/cs.json
@@ -1885,5 +1885,8 @@
       "deleteAriaLabel": "Smazat poznámku",
       "errorLoading": "Poznámky se nepodařilo načíst"
     }
+  },
+  "errors": {
+    "rateLimitRefresh": "Příliš mnoho pokusů — zkuste to za chvíli znovu"
   }
 }

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -1857,5 +1857,8 @@
       "deleteAriaLabel": "Notiz löschen",
       "errorLoading": "Notizen konnten nicht geladen werden"
     }
+  },
+  "errors": {
+    "rateLimitRefresh": "Zu viele Versuche — bitte versuchen Sie es in Kürze erneut"
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1858,5 +1858,8 @@
       "deleteAriaLabel": "Delete note",
       "errorLoading": "Failed to load notes"
     }
+  },
+  "errors": {
+    "rateLimitRefresh": "Too many attempts — please try again shortly"
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import i18n from '@/i18n';
 import { useAuthStore } from '@/stores/auth';
+import { useToastStore } from '@/stores/toast';
+import { executeRefresh } from '@/lib/refresh';
 
 const api = axios.create({
   baseURL: '/',
@@ -31,26 +33,34 @@ function attachToken(config: import('axios').InternalAxiosRequestConfig) {
   return config;
 }
 
-// On 401: attempt token refresh, then retry original request once
+// On 401: use the shared single-flight refresh, then retry original request once.
+// On 429: surface a toast and reject — do NOT logout.
 function handleRefresh(instance: import('axios').AxiosInstance) {
   return async (error: unknown) => {
     const err = error as import('axios').AxiosError & { config: { _retry?: boolean } };
     const original = err.config;
+
+    // 429 — rate limited. Surface toast, keep the user logged in.
+    if (err.response?.status === 429) {
+      useToastStore
+        .getState()
+        .addToast(i18n.t('errors.rateLimitRefresh'), 'error');
+      return Promise.reject(error);
+    }
+
     if (err.response?.status === 401 && !original._retry) {
       original._retry = true;
 
-      const { refreshToken, setTokens, logout } = useAuthStore.getState();
+      const { refreshToken, logout } = useAuthStore.getState();
       if (!refreshToken) {
         logout();
         return Promise.reject(error);
       }
 
       try {
-        const { data } = await axios.post('/auth/refresh', {
-          refreshToken,
-        });
-        setTokens(data.accessToken, data.refreshToken);
-        original.headers.Authorization = `Bearer ${data.accessToken}`;
+        // executeRefresh() is single-flight: concurrent 401s await the same promise.
+        const newAccessToken = await executeRefresh();
+        original.headers.Authorization = `Bearer ${newAccessToken}`;
         return instance(original);
       } catch {
         logout();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -35,17 +35,36 @@ function attachToken(config: import('axios').InternalAxiosRequestConfig) {
 
 // On 401: use the shared single-flight refresh, then retry original request once.
 // On 429: surface a toast and reject — do NOT logout.
+
+/**
+ * Returns true if the error is an Axios 429 response.
+ * Extracted so both the top-level 429 guard and the refresh catch share the
+ * same logic — the refresh call itself can also be rate-limited.
+ */
+function isRateLimited(error: unknown): boolean {
+  const err = error as import('axios').AxiosError;
+  return err?.response?.status === 429;
+}
+
+/**
+ * Show the rate-limit toast and return a rejected promise.
+ * Does NOT call logout() — the user session remains valid.
+ */
+function rejectWithRateLimit(error: unknown): Promise<never> {
+  useToastStore
+    .getState()
+    .addToast(i18n.t('errors.rateLimitRefresh'), 'error');
+  return Promise.reject(error);
+}
+
 function handleRefresh(instance: import('axios').AxiosInstance) {
   return async (error: unknown) => {
     const err = error as import('axios').AxiosError & { config: { _retry?: boolean } };
     const original = err.config;
 
-    // 429 — rate limited. Surface toast, keep the user logged in.
-    if (err.response?.status === 429) {
-      useToastStore
-        .getState()
-        .addToast(i18n.t('errors.rateLimitRefresh'), 'error');
-      return Promise.reject(error);
+    // 429 on the original request — surface toast, keep the user logged in.
+    if (isRateLimited(error)) {
+      return rejectWithRateLimit(error);
     }
 
     if (err.response?.status === 401 && !original._retry) {
@@ -62,7 +81,14 @@ function handleRefresh(instance: import('axios').AxiosInstance) {
         const newAccessToken = await executeRefresh();
         original.headers.Authorization = `Bearer ${newAccessToken}`;
         return instance(original);
-      } catch {
+      } catch (refreshError) {
+        // If the /auth/refresh call itself was rate-limited, show the toast
+        // and keep the user logged in — same as a top-level 429.
+        if (isRateLimited(refreshError)) {
+          return rejectWithRateLimit(refreshError);
+        }
+        // Any other refresh failure (expired/invalid token, network error) →
+        // the session cannot be recovered; logout.
         logout();
         return Promise.reject(error);
       }

--- a/web/src/lib/refresh.ts
+++ b/web/src/lib/refresh.ts
@@ -1,0 +1,46 @@
+/**
+ * Single-flight token refresh helper.
+ *
+ * Both the Axios 401 interceptor (api.ts) and the session-restore path
+ * (stores/auth.ts) share this module so they can never race each other with
+ * the same refresh token. Only one /auth/refresh call can be in-flight at a
+ * time; concurrent callers wait for the same promise and reuse its result.
+ */
+
+import axios from 'axios';
+import { useAuthStore } from '@/stores/auth';
+
+/** Resolves to the new access token, or rejects on failure. */
+type RefreshResult = string;
+
+let inFlight: Promise<RefreshResult> | null = null;
+
+/**
+ * Execute a /auth/refresh call, coalescing concurrent calls into a single
+ * in-flight request. When the promise settles the slot is cleared so the
+ * next genuine expiry starts a fresh call.
+ *
+ * Returns the new access token on success.
+ * Throws on failure (caller is responsible for logging out when appropriate).
+ */
+export function executeRefresh(): Promise<RefreshResult> {
+  if (inFlight) return inFlight;
+
+  inFlight = (async (): Promise<RefreshResult> => {
+    const { refreshToken, setTokens } = useAuthStore.getState();
+
+    if (!refreshToken) {
+      throw new Error('no_refresh_token');
+    }
+
+    // Use the plain axios instance — NOT the api instance — to avoid
+    // triggering the 401 interceptor recursively.
+    const { data } = await axios.post('/auth/refresh', { refreshToken });
+    setTokens(data.accessToken as string, data.refreshToken as string);
+    return data.accessToken as string;
+  })().finally(() => {
+    inFlight = null;
+  });
+
+  return inFlight;
+}

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { create } from 'zustand';
+import { executeRefresh } from '@/lib/refresh';
 
 interface User {
   publicId: string;
@@ -67,12 +68,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       }
 
       try {
-        const { data: tokens } = await axios.post('/auth/refresh', { refreshToken });
-        const newAccessToken = tokens.accessToken as string;
-        const newRefreshToken = tokens.refreshToken as string;
-
-        localStorage.setItem('refreshToken', newRefreshToken);
-        set({ accessToken: newAccessToken, refreshToken: newRefreshToken });
+        // Use the shared single-flight helper so an app-start refresh and a
+        // concurrent interceptor refresh cannot both fire with the same token.
+        const newAccessToken = await executeRefresh();
 
         const { data: profile } = await axios.get('/users/me', {
           headers: { Authorization: `Bearer ${newAccessToken}` },


### PR DESCRIPTION
## Summary

Fixes the auth concurrent-refresh logout bug and the shared login/refresh rate-limit lockout. Two slices on one branch:

- **Web (primary):** single-flight token refresh — concurrent 401s now await one shared `/auth/refresh` promise instead of each rotating the (single-use) refresh token, eliminating the revoked-token storm that forced logout. A 429 is now handled distinctly from a 401 (toast, no `logout()`) — including a 429 on the `/auth/refresh` call itself.
- **Backend (companion):** split `/auth/refresh` into its own `auth-refresh` rate-limit policy (120/15min) off the shared `auth` login bucket (10/15min), so transparent refresh can no longer exhaust the login budget. Added `UseForwardedHeaders` so the per-IP partition key is correct behind the prod reverse proxy and never collapses to `unknown`.

## Root cause

1. **Refresh-token rotation race (web):** `web/src/lib/api.ts` had no single-flight guard on its 401 refresh interceptor. On access-token expiry, multiple in-flight queries each hit 401 and each called `/auth/refresh` with the same token. The backend rotates+revokes on first use, so every sibling call arrived with a revoked token, failed, and the catch ran `logout()`.
2. **Shared rate-limit bucket (backend):** the `auth` FixedWindow policy (10 permits / 15 min, per-IP) was applied to both `/auth/login` and `/auth/refresh`. The refresh storm plus retry-logins exhausted the shared IP partition, so further logins returned 429 until backend restart. Latent: partition key collapsed to the literal `unknown` when `RemoteIpAddress` was null (no `UseForwardedHeaders`).

## The fix (two slices)

- Web: `web/src/lib/refresh.ts` (new single-flight `executeRefresh`), `api.ts` (interceptor reuses it; distinct 429 branch — including a 429 on the refresh call itself, which now toasts + rejects without logout), `stores/auth.ts` (`restoreSession` reuses it), i18n `errors.rateLimitRefresh` in cs/en/de.
- Backend: `AppPolicies.cs` (new `RefreshRateLimit`), `RefreshTokenEndpoint.cs` (binds new policy), `Program.cs` (`auth-refresh` policy + `UseForwardedHeaders` with restricted `KnownIPNetworks`, ordered before `UseRateLimiter`), regression test `RateLimitPolicyTests.cs`.

## Related issue

Fixes #521

## Scope

cross-cut (web primary + backend companion) — one branch, one PR.

## QA verdict (from qa-tester)

OVERALL ✅ PASS — all 7 ACs met (re-verified after the two review fixes below). Backend: Auth namespace **71/71** passed, `RateLimitPolicyTests` **4/4** (`LoginBudget_IsExhaustedAfter10Attempts_SameIp`, `RefreshCalls_DoNotExhaustLoginBudget`, `ExhaustedLoginBudget_DoesNotBlock_RefreshEndpoint`, `ForwardedFor_DifferentIPs_ArePartitionedSeparately`). Web: `npm run build` clean. i18n complete (cs/en/de). `gc-sec-review` run by backend agent: PASS, no blocking findings.

### Review findings (fixed + re-verified)

- **B1 (was BLOCKING):** `RateLimitPolicyTests` were vacuous (TestServer null `RemoteIpAddress` → per-request `Connection.Id` partition; X-Forwarded-For never trusted from a null peer). Fixed in `e3809a8`: a **test-only** `IStartupFilter` (in the Tests project, registered only by `RateLimitEnabledFactory`; production `Program.cs` untouched) injects a stable client IP via `X-Test-Client-IP`. Tests now assert a real 429 on the 11th login and genuinely exhaust both buckets to prove the policy split + forwarded-IP partitioning.
- **M1 (was MAJOR):** a 429 on the `/auth/refresh` call itself still triggered logout. Fixed in `b131317`: the `api.ts` 401-branch catch now routes a 429 via `isRateLimited`/`rejectWithRateLimit` (toast + reject, no logout); genuine refresh failures still logout.

## Test plan

- [ ] Concurrent 401s on the web client trigger exactly one `/auth/refresh` call (single-flight); all waiters reuse its result.
- [ ] A 429 response on the web client is handled distinctly from a 401 — it does NOT force `logout()` (including a 429 on the refresh call itself).
- [ ] After access-token expiry with several parallel queries in flight, the user stays logged in (no spurious logout).
- [ ] `/auth/refresh` is no longer rate-limited under the same bucket as `/auth/login` — split into its own policy.
- [ ] Backend trusts forwarded headers (`UseForwardedHeaders`) so the per-IP rate-limit partition key is correct behind the prod reverse proxy and never collapses to `unknown`.
- [ ] Regression coverage: backend test for the rate-limit policy split / refresh behavior; web change verified by build and the concurrent-refresh code path.
- [ ] i18n: new user-facing copy lands in cs, en, and de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
