### PR TITLE
chore: add advisory Claude security-review CI workflow

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,43 @@
+name: Security Review
+
+# Advisory, diff-aware security scan powered by Anthropic's official
+# claude-code-security-review Action. It reviews only the files changed in
+# the PR and posts findings as PR review comments. It is NOT a required
+# status check by default — merge is not hard-blocked. To turn it into a
+# gate, add this job to the branch-protection required checks and/or set a
+# severity threshold in the step config below. See the "Automated security
+# review" section in README.md for how to triage findings.
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+# Least-privilege: read the tree, write PR comments. Nothing else.
+permissions:
+  contents: read
+  pull-requests: write
+
+# One scan per PR; cancel superseded runs to limit per-PR API cost.
+concurrency:
+  group: security-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  security-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - name: Claude Code security review
+        uses: anthropics/claude-code-security-review@main
+        with:
+          # API key comes from a repo secret — never inline it here.
+          # Provision ANTHROPIC_API_KEY in repo Settings → Secrets and
+          # variables → Actions before this workflow's first run; the
+          # job fails silently (no findings) if the secret is absent.
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          comment-pr: true

--- a/README.md
+++ b/README.md
@@ -70,3 +70,41 @@ make web
 - `main` - production
 - `develop` - integration
 - `feature/*` - feature branches
+
+## Automated security review
+
+Every PR targeting `develop` or `main` runs the
+[`anthropics/claude-code-security-review`](https://github.com/anthropics/claude-code-security-review)
+GitHub Action (`.github/workflows/security-review.yml`). It uses Claude to
+review **only the files changed in the PR diff** and looks for the kinds of
+issues SAST tools miss — missing authorization checks, business-logic flaws,
+unsafe blob/upload handling, secret leakage, and attack-path chaining. This
+backstops the manual `gc-sec-review` skill; it does not replace it.
+
+**How to read the findings**
+
+- Findings appear as **review comments on the PR**. Each one names a file,
+  line, severity, and a suggested remediation.
+- The scan is **advisory** — the `Security Review` check is *not* a required
+  status check, so a finding (or a red check) does **not** block merge. Treat
+  the comments as a prompt to think, not an automatic veto.
+- **Triage each finding before acting:** the reviewer is diff-aware but lacks
+  full repo context, so it can flag false positives (e.g. a check that exists
+  in a caller it can't see). Confirm the issue against the real code path
+  before changing anything; resolve/dismiss the comment with a one-line reason
+  if it's a false positive.
+- High-severity findings on auth, invite, ownership, or upload surfaces should
+  be fixed in the same PR. Lower-severity or stylistic findings can become a
+  follow-up issue.
+
+**Setup / cost notes**
+
+- The Action requires the **`ANTHROPIC_API_KEY`** repo secret
+  (Settings → Secrets and variables → Actions). Without it the job runs but
+  produces no findings — it fails quietly rather than erroring.
+- Each PR scan incurs Anthropic API cost. If that becomes a concern, scope the
+  workflow down (e.g. a diff-size filter, or run only on `develop`-targeted
+  PRs) — see the comments at the top of the workflow file.
+- To make it a hard gate instead of advisory, add `Security Review` to the
+  branch-protection required checks and/or configure a severity threshold in
+  the workflow step.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ backstops the manual `gc-sec-review` skill; it does not replace it.
 - Each PR scan incurs Anthropic API cost. If that becomes a concern, scope the
   workflow down (e.g. a diff-size filter, or run only on `develop`-targeted
   PRs) — see the comments at the top of the workflow file.
+- **Public repo / fork PRs:** the Action is not hardened against prompt
+  injection and should only review trusted PRs. The workflow uses the safe
+  `pull_request` trigger (not `pull_request_target`), so fork PRs run with a
+  read-only token and do **not** receive the `ANTHROPIC_API_KEY` secret by
+  default. Keep "Require approval for all external contributors" enabled under
+  Settings → Actions → General so a fork PR's diff is never scanned without a
+  maintainer's go-ahead.
 - To make it a hard gate instead of advisory, add `Security Review` to the
   branch-protection required checks and/or configure a severity threshold in
   the workflow step.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/security-review.yml` — an **advisory, diff-aware** security scan powered by the official `anthropics/claude-code-security-review` Action, triggered on every PR targeting `develop` or `main`.
- The Action reviews only the files changed in the PR diff and posts findings as PR review comments (`comment-pr: true`). It is **not** a required status check — a finding does not hard-block merge. It backstops, not replaces, the manual `gc-sec-review` skill.
- Least-privilege permissions: `contents: read` + `pull-requests: write` only. Per-PR concurrency group cancels superseded runs to cap API cost.
- Adds a README "Automated security review" section documenting how to read/triage findings and the setup/cost notes.

## ⚠️ Manual prerequisite before first run
- The workflow references the **`ANTHROPIC_API_KEY`** repo secret. This secret must be **provisioned manually** in GitHub → **Settings → Secrets and variables → Actions** before the workflow's first run.
- Without it the job runs but **fails quietly** — it produces **no findings** rather than erroring. Do not interpret a green/empty run as "no security issues" until the secret is confirmed present.

## Known supply-chain consideration
- The Action is pinned to a **mutable ref** — `anthropics/claude-code-security-review@main` — which is the upstream README's recommended usage. Flagging as a known supply-chain consideration: a mutable `@main` ref means the executed Action code can change without a diff in this repo. A future hardening step could pin to a commit SHA, at the cost of manual bumps.
- The Action input is `claude-api-key` (confirmed correct upstream input name), wired from `${{ secrets.ANTHROPIC_API_KEY }}` — referenced, never inlined.

## Related issue
Fixes #386

## Scope
docs-infra (touches only `.github/` + `README.md`; no backend/web/mobile changes)

## QA verdict (from qa-tester)
OVERALL ✅ PASS — handoff-qa-386.json.

## Test plan
- [ ] Workflow YAML is valid and parses as a GitHub Actions workflow.
- [ ] Triggers on `pull_request` to `develop` and `main` only.
- [ ] Permissions are least-privilege (`contents: read`, `pull-requests: write`).
- [ ] API key sourced from `secrets.ANTHROPIC_API_KEY`, never inlined.
- [ ] README documents the workflow, the `ANTHROPIC_API_KEY` prerequisite, triage guidance, and cost notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)