### PR TITLE
fix: mobile auth single-flight token refresh + distinct 429 handling

### DIFF
--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import { getLocales } from 'expo-localization';
 import { useAuthStore } from '../stores/auth';
+import { executeRefresh } from '../lib/refresh';
+import { Toast } from '../lib/toast';
+import i18n from '../i18n';
 
 // `EXPO_PUBLIC_API_BASE_URL` lets QA dev builds point at the compose-exposed
 // API (https://localhost:5001) without rebuilding. Inlined at bundle time by
@@ -37,30 +40,64 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// On 401: attempt token refresh, then retry
+/**
+ * Returns true if the error is an Axios 429 response.
+ * Extracted so both the top-level 429 guard and the refresh catch share the
+ * same logic — the refresh call itself can also be rate-limited.
+ */
+function isRateLimited(error: unknown): boolean {
+  const err = error as import('axios').AxiosError;
+  return err?.response?.status === 429;
+}
+
+/**
+ * Show the rate-limit toast and return a rejected promise.
+ * Does NOT call logout() — the user session remains valid.
+ */
+function rejectWithRateLimit(error: unknown): Promise<never> {
+  Toast.show(i18n.t('errors.rateLimit'));
+  return Promise.reject(error);
+}
+
+// On 401: use the shared single-flight refresh, then retry original request once.
+// On 429: surface a toast and reject — do NOT logout.
 api.interceptors.response.use(
   (response) => response,
-  async (error) => {
+  async (error: import('axios').AxiosError & { config: import('axios').InternalAxiosRequestConfig & { _retry?: boolean } }) => {
     const original = error.config;
+
+    // 429 on the original request — surface toast, keep the user logged in.
+    if (isRateLimited(error)) {
+      return rejectWithRateLimit(error);
+    }
+
     if (error.response?.status === 401 && !original._retry) {
       original._retry = true;
-      const { refreshToken, setTokens, logout } = useAuthStore.getState();
+
+      const { refreshToken, logout } = useAuthStore.getState();
       if (!refreshToken) {
         logout();
         return Promise.reject(error);
       }
+
       try {
-        const { data } = await axios.post(`${API_BASE_URL}/auth/refresh`, {
-          refreshToken,
-        });
-        setTokens(data.accessToken, data.refreshToken);
-        original.headers.Authorization = `Bearer ${data.accessToken}`;
+        // executeRefresh() is single-flight: concurrent 401s await the same promise.
+        const newAccessToken = await executeRefresh();
+        original.headers.Authorization = `Bearer ${newAccessToken}`;
         return api(original);
-      } catch {
+      } catch (refreshError) {
+        // If the /auth/refresh call itself was rate-limited, show the toast
+        // and keep the user logged in — same as a top-level 429.
+        if (isRateLimited(refreshError)) {
+          return rejectWithRateLimit(refreshError);
+        }
+        // Any other refresh failure (expired/invalid token, network error) →
+        // the session cannot be recovered; logout.
         logout();
         return Promise.reject(error);
       }
     }
+
     return Promise.reject(error);
   }
 );

--- a/mobile/src/i18n/locales/cs.json
+++ b/mobile/src/i18n/locales/cs.json
@@ -189,6 +189,9 @@
     "previous": "Předchozí",
     "next": "Další"
   },
+  "errors": {
+    "rateLimit": "Příliš mnoho požadavků. Zkuste to prosím za chvíli."
+  },
   "imagePicker": {
     "sourceTitle": "Vyberte zdroj",
     "sourceCamera": "Vyfotit",

--- a/mobile/src/i18n/locales/de.json
+++ b/mobile/src/i18n/locales/de.json
@@ -189,6 +189,9 @@
     "previous": "Zurück",
     "next": "Weiter"
   },
+  "errors": {
+    "rateLimit": "Zu viele Anfragen. Bitte versuchen Sie es in einem Moment erneut."
+  },
   "imagePicker": {
     "sourceTitle": "Quelle auswählen",
     "sourceCamera": "Foto aufnehmen",

--- a/mobile/src/i18n/locales/en.json
+++ b/mobile/src/i18n/locales/en.json
@@ -189,6 +189,9 @@
     "previous": "Previous",
     "next": "Next"
   },
+  "errors": {
+    "rateLimit": "Too many requests. Please try again in a moment."
+  },
   "imagePicker": {
     "sourceTitle": "Select source",
     "sourceCamera": "Take photo",

--- a/mobile/src/lib/refresh.ts
+++ b/mobile/src/lib/refresh.ts
@@ -1,0 +1,58 @@
+/**
+ * Single-flight token refresh helper.
+ *
+ * Both the Axios 401 interceptor (api/client.ts) and the session-restore path
+ * (stores/auth.ts) share this module so they can never race each other with
+ * the same refresh token. Only one /auth/refresh call can be in-flight at a
+ * time; concurrent callers wait for the same promise and reuse its result.
+ */
+
+import axios from 'axios';
+import { useAuthStore } from '../stores/auth';
+
+// Mirror the same base-URL resolution as client.ts so the refresh call hits
+// the same host. EXPO_PUBLIC_API_BASE_URL is inlined at bundle time.
+const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ??
+  (__DEV__
+    ? 'https://localhost:5001'
+    : 'https://api.gfplatform.com');
+
+/** Resolves to the new access token, or rejects on failure. */
+type RefreshResult = string;
+
+let inFlight: Promise<RefreshResult> | null = null;
+
+/**
+ * Execute a /auth/refresh call, coalescing concurrent calls into a single
+ * in-flight request. When the promise settles the slot is cleared so the
+ * next genuine expiry starts a fresh call.
+ *
+ * Uses a plain axios.post — NOT the shared api instance — to avoid
+ * recursively triggering the 401 interceptor and to keep the import graph
+ * acyclic (api/client.ts imports this module; this module must not import
+ * api/client.ts).
+ *
+ * Returns the new access token on success.
+ * Throws on failure (caller is responsible for logging out when appropriate).
+ */
+export function executeRefresh(): Promise<RefreshResult> {
+  if (inFlight) return inFlight;
+
+  inFlight = (async (): Promise<RefreshResult> => {
+    const { refreshToken, setTokens } = useAuthStore.getState();
+
+    if (!refreshToken) {
+      throw new Error('no_refresh_token');
+    }
+
+    // Plain axios — not the api instance — to avoid interceptor recursion.
+    const { data } = await axios.post(`${API_BASE_URL}/auth/refresh`, { refreshToken });
+    setTokens(data.accessToken as string, data.refreshToken as string);
+    return data.accessToken as string;
+  })().finally(() => {
+    inFlight = null;
+  });
+
+  return inFlight;
+}

--- a/mobile/src/stores/auth.ts
+++ b/mobile/src/stores/auth.ts
@@ -177,14 +177,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return;
     }
     try {
-      // Dynamic import to avoid circular dependency
-      const api = (await import('../api/client')).default;
-      const { data: tokens } = await api.post('/auth/refresh', { refreshToken });
-      const newAccessToken = tokens.accessToken as string;
-      const newRefreshToken = tokens.refreshToken as string;
-      storage.set('refreshToken', newRefreshToken);
-      set({ accessToken: newAccessToken, refreshToken: newRefreshToken });
+      // Dynamic import to avoid circular dependency:
+      // auth.ts → lib/refresh.ts → auth.ts (via useAuthStore.getState()).
+      // The single-flight lock in executeRefresh() is shared with the 401
+      // interceptor in api/client.ts so both callers coalesce onto the same
+      // /auth/refresh request if they race at startup.
+      const { executeRefresh } = await import('../lib/refresh');
+      await executeRefresh();
 
+      // At this point setTokens() has already been called by executeRefresh,
+      // so get() now returns the new access token.
+      const api = (await import('../api/client')).default;
       const { data: profile } = await api.get('/users/me');
       set({
         user: {


### PR DESCRIPTION
## Summary
- Adds a shared, module-level single-flight `executeRefresh()` in `mobile/src/lib/refresh.ts`, used by **both** the `api/client.ts` 401 interceptor and the `stores/auth.ts` session-restore path — so concurrent 401s coalesce onto exactly one `/auth/refresh` POST and waiters reuse the rotated token (no more revoked-token re-POST → spurious logout).
- Handles `429` distinctly from `401`: a rate-limited response surfaces the mobile toast (`errors.rateLimit`) and rejects **without** calling `logout()`. This applies both to a top-level 429 on the original request and to a 429 on the `/auth/refresh` call itself.
- Removes the previously uncoordinated refresh in `restoreSession()` (its own `api.post('/auth/refresh')` + manual `storage.set`), routing it through the shared single-flight lock instead — token persistence now flows through `setTokens()`.
- Mirrors the web fix from #521 / PR #522 (`web/src/lib/refresh.ts` + distinct 429 handling in `web/src/lib/api.ts`); same backend root cause (`/auth/refresh` rotates+revokes the refresh token on first use).

## Related issue
Fixes #523

(Related: #521 — the web fix for the same root cause. This PR is the mobile follow-up only; it is NOT part of an epic.)

## Scope
mobile

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all 6 acceptance criteria met; `npx tsc --noEmit` clean (exit 0); `expo-doctor` advisory is pre-existing on develop (no package.json/lock change). No regressions.

## Files changed (6)
- `mobile/src/lib/refresh.ts` (new) — single-flight `executeRefresh()`
- `mobile/src/api/client.ts` — interceptor uses `executeRefresh()`; 429 handled distinctly from 401
- `mobile/src/stores/auth.ts` — session-restore routes through the shared single-flight lock
- `mobile/src/i18n/locales/{cs,en,de}.json` — new `errors.rateLimit` key (all three locales)

## Test plan
- [ ] Concurrent 401s on the mobile client trigger exactly ONE `/auth/refresh` call (single-flight); waiters reuse its result.
- [ ] The single-flight lock is shared between `client.ts`'s interceptor and `stores/auth.ts` session restore (no two uncoordinated refresh callers).
- [ ] A 429 response is handled distinctly from a 401 — it does NOT force `logout()`; surfaced via the mobile toast.
- [ ] After token expiry with several parallel queries in flight, the user stays logged in (no spurious logout).
- [ ] i18n: new user-facing copy lands in all three locale files: `mobile/src/i18n/locales/{cs,en,de}.json`.
- [ ] `npx tsc --noEmit` clean; no `any` / `@ts-ignore`; use design tokens, no hardcoded colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
