### PR TITLE
fix: use correct PublicId/UserId join keys for client plans + exercise progress (#528, #529)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Trainers/ListClientPlans/ListClientPlansEndpoint.cs
@@ -83,16 +83,18 @@ public class ListClientPlansEndpoint(
             return;
         }
 
-        // clientProfile.UserId is ApplicationUser.Id (Guid) — used by all Mongo documents
-        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId)
+        // NutritionPlan.ClientId and TrainingPlan.ClientId store ClientProfile.PublicId.
+        // WorkoutLog.ClientId and PersonalRecord.ClientId store ApplicationUser.Id (UserId).
+        // clientProfile.Id is the long PK used by BodyMeasurement (keyed on ClientProfileId).
+        var clientPublicId = clientProfile.PublicId;
         var clientUserId = clientProfile.UserId;
         var clientProfileId = clientProfile.Id;
 
-        // Load all plans from Mongo in parallel
+        // Load all plans from Mongo in parallel — keyed on PublicId
         var nutritionFilter = Builders<Domain.Documents.NutritionPlan>.Filter
-            .Eq(p => p.ClientId, clientUserId);
+            .Eq(p => p.ClientId, clientPublicId);
         var trainingFilter = Builders<Domain.Documents.TrainingPlan>.Filter
-            .Eq(p => p.ClientId, clientUserId);
+            .Eq(p => p.ClientId, clientPublicId);
 
         var nutritionTask = mongo.NutritionPlans
             .Find(nutritionFilter)

--- a/backend/FitnessPlatform.Application/Features/WorkoutLogs/GetExerciseProgress/GetExerciseProgressEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WorkoutLogs/GetExerciseProgress/GetExerciseProgressEndpoint.cs
@@ -2,8 +2,10 @@ using System.Security.Claims;
 using FastEndpoints;
 using FitnessPlatform.Application.Domain.Constants;
 using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Infrastructure.Data;
 using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
 using FitnessPlatform.Application.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
 using MongoDB.Driver;
 
 namespace FitnessPlatform.Application.Features.WorkoutLogs.GetExerciseProgress;
@@ -13,7 +15,8 @@ namespace FitnessPlatform.Application.Features.WorkoutLogs.GetExerciseProgress;
 /// </summary>
 /// <param name="mongo">MongoDB context.</param>
 /// <param name="authHelper">Validates trainer-client relationship.</param>
-public class GetExerciseProgressEndpoint(IMongoContext mongo, ProfessionalAuthHelper authHelper)
+/// <param name="db">PostgreSQL context — used to resolve ClientProfile.UserId from the public id.</param>
+public class GetExerciseProgressEndpoint(IMongoContext mongo, ProfessionalAuthHelper authHelper, IApplicationDbContext db)
     : Endpoint<GetExerciseProgressRequest, GetExerciseProgressResponse>
 {
     /// <inheritdoc />
@@ -48,8 +51,20 @@ public class GetExerciseProgressEndpoint(IMongoContext mongo, ProfessionalAuthHe
             return;
         }
 
+        // req.ClientId is ClientProfile.PublicId; WorkoutLog.ClientId stores ApplicationUser.Id (UserId).
+        // Resolve the client's UserId before filtering Mongo.
+        var clientProfile = await db.ClientProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cp => cp.PublicId == req.ClientId, ct);
+
+        if (clientProfile is null)
+        {
+            await Send.NotFoundAsync(ct);
+            return;
+        }
+
         // Find all completed workout logs for this client
-        var filter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, req.ClientId)
+        var filter = Builders<WorkoutLog>.Filter.Eq(w => w.ClientId, clientProfile.UserId)
                      & Builders<WorkoutLog>.Filter.Eq(w => w.IsCompleted, true);
 
         var options = new FindOptions<WorkoutLog>

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansIntegrationTests.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+
+namespace FitnessPlatform.Tests.Endpoints.Trainers;
+
+/// <summary>
+/// Integration tests for GET /trainer/clients/{clientId}/plans — issue #528.
+///
+/// Root cause: ListClientPlansEndpoint was filtering NutritionPlan.ClientId and
+/// TrainingPlan.ClientId by clientProfile.UserId, but those fields store
+/// clientProfile.PublicId. The result was always an empty list.
+///
+/// These tests use real PostgreSQL + MongoDB (Testcontainers) to validate
+/// that plans are only found when ClientId == PublicId — not when it equals UserId.
+/// A mock-based test cannot catch this bug because mocks ignore the filter value.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class ListClientPlansIntegrationTests(FitnessApiFactory factory)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static string UniqueEmail(string tag) => $"{Guid.NewGuid():N}@listplans-{tag}.com";
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, long ProfessionalProfileId)> SetupTrainerAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer");
+
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Test", "Trainer", "Trainer");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var user = await db.Users.FirstAsync(
+            u => u.Email == email, TestContext.Current.CancellationToken);
+        var profile = await db.ProfessionalProfiles.FirstAsync(
+            p => p.UserId == user.Id, TestContext.Current.CancellationToken);
+
+        return (http, profile.Id);
+    }
+
+    private async Task<(Guid ClientPublicId, long ClientProfileId, Guid ClientUserId)>
+        SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Test", "Client", "Client");
+        await TestHelpers.LoginAsync(http, email, "TestPass1!");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var user = await db.Users.FirstAsync(
+            u => u.Email == email, TestContext.Current.CancellationToken);
+        var profile = await db.ClientProfiles.FirstAsync(
+            cp => cp.UserId == user.Id, TestContext.Current.CancellationToken);
+
+        return (profile.PublicId, profile.Id, user.Id);
+    }
+
+    private async Task LinkTrainerToClientAsync(long trainerProfileId, long clientProfileId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        db.ClientProfessionalLinks.Add(new ClientProfessionalLink
+        {
+            PublicId = Guid.NewGuid(),
+            ProfessionalProfileId = trainerProfileId,
+            ClientProfileId = clientProfileId,
+            ProfessionalRole = UserRole.Trainer,
+            IsActive = true,
+            CanViewTrainingPlans = true,
+            CanViewNutritionPlans = true,
+            DateCreated = DateTime.UtcNow,
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── regression guard tests ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Regression guard for #528: when a NutritionPlan is seeded with
+    /// ClientId = clientProfile.PublicId (the correct key), the endpoint returns it.
+    /// A test seeding with UserId would pass green even with the broken filter —
+    /// this test would fail with the broken filter and pass with the fix.
+    /// </summary>
+    [Fact]
+    public async Task Plans_SeededWithPublicId_AreReturnedByTrainer()
+    {
+        var (trainerHttp, trainerProfileId) = await SetupTrainerAsync();
+        var (clientPublicId, clientProfileId, _) = await SetupClientAsync();
+        await LinkTrainerToClientAsync(trainerProfileId, clientProfileId);
+
+        // Seed a NutritionPlan with ClientId = PublicId (the correct key)
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.NutritionPlans.InsertOneAsync(new NutritionPlan
+            {
+                Id = ObjectId.GenerateNewId(),
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientPublicId,   // ← MUST be PublicId, not UserId
+                NutritionistId = Guid.NewGuid(),
+                Name = "Test Plan PublicId",
+                Status = NutritionPlanStatus.Active,
+                StartDate = DateTime.UtcNow.AddDays(-7),
+                Weeks = [],
+                Version = 1,
+                DateCreated = DateTime.UtcNow,
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        var response = await trainerHttp.GetAsync(
+            $"/trainer/clients/{clientPublicId}/plans",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PlansResponse>(
+            JsonOptions, cancellationToken: TestContext.Current.CancellationToken);
+
+        body!.Plans.Should().HaveCountGreaterThanOrEqualTo(1,
+            "the plan seeded with ClientId = PublicId must appear in the list");
+        body.Plans.Should().Contain(p => p.Name == "Test Plan PublicId");
+    }
+
+    /// <summary>
+    /// Regression guard for #528: a plan seeded with ClientId = UserId (the WRONG key,
+    /// the old bug) must NOT appear in the response. Without this guard, a test
+    /// seeding with UserId would still pass green while production (which uses PublicId)
+    /// would silently return zero plans.
+    /// </summary>
+    [Fact]
+    public async Task Plans_SeededWithUserIdInsteadOfPublicId_AreNotReturned()
+    {
+        var (trainerHttp, trainerProfileId) = await SetupTrainerAsync();
+        var (clientPublicId, clientProfileId, clientUserId) = await SetupClientAsync();
+        await LinkTrainerToClientAsync(trainerProfileId, clientProfileId);
+
+        // Seed a NutritionPlan with ClientId = UserId (wrong key — the old bug)
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.NutritionPlans.InsertOneAsync(new NutritionPlan
+            {
+                Id = ObjectId.GenerateNewId(),
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientUserId,   // ← WRONG: UserId not PublicId
+                NutritionistId = Guid.NewGuid(),
+                Name = "WrongKey Plan UserId",
+                Status = NutritionPlanStatus.Active,
+                StartDate = DateTime.UtcNow.AddDays(-7),
+                Weeks = [],
+                Version = 1,
+                DateCreated = DateTime.UtcNow,
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        var response = await trainerHttp.GetAsync(
+            $"/trainer/clients/{clientPublicId}/plans",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PlansResponse>(
+            JsonOptions, cancellationToken: TestContext.Current.CancellationToken);
+
+        body!.Plans.Should().NotContain(p => p.Name == "WrongKey Plan UserId",
+            "a plan whose ClientId is UserId (not PublicId) must not match the filter");
+    }
+
+    // ── DTOs for deserialization ──────────────────────────────────────────────
+
+    private record PlansResponse(List<PlanItem> Plans);
+
+    private record PlanItem(
+        Guid PlanId,
+        string PlanType,
+        string Name,
+        string Status,
+        DateTime? PeriodStart,
+        DateTime? PeriodEnd,
+        ResultSummary ResultSummary);
+
+    private record ResultSummary(
+        int? TotalTrainings,
+        int? PrCount,
+        decimal? CompliancePercent,
+        decimal? WeightDeltaKg);
+}

--- a/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Trainers/ListClientPlansTests.cs
@@ -29,13 +29,14 @@ public class ListClientPlansTests
     public async Task List_BothPlanTypes_ReturnsCombinedListNewestFirst()
     {
         var (db, clientProfile) = BuildLinkedClientSetup();
-        var clientUserId = clientProfile.UserId;
+        // NutritionPlan.ClientId and TrainingPlan.ClientId store ClientProfile.PublicId (not UserId).
+        var clientPublicId = clientProfile.PublicId;
 
         var olderStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);  // Monday
         var newerStart = new DateTime(2025, 6, 2, 0, 0, 0, DateTimeKind.Utc);  // Monday
 
-        var nutritionPlan = CreateNutritionPlan(clientUserId, startDate: olderStart, name: "Old Nutrition Plan");
-        var trainingPlan = CreateTrainingPlan(clientUserId, startDate: newerStart, name: "New Training Plan");
+        var nutritionPlan = CreateNutritionPlan(clientPublicId, startDate: olderStart, name: "Old Nutrition Plan");
+        var trainingPlan = CreateTrainingPlan(clientPublicId, startDate: newerStart, name: "New Training Plan");
 
         var mongo = BuildMongo(
             nutritionPlans: [nutritionPlan],
@@ -65,15 +66,16 @@ public class ListClientPlansTests
     public async Task List_AllStatuses_ReturnsDraftActiveCompleted()
     {
         var (db, clientProfile) = BuildLinkedClientSetup();
-        var clientUserId = clientProfile.UserId;
+        // NutritionPlan.ClientId and TrainingPlan.ClientId store ClientProfile.PublicId (not UserId).
+        var clientPublicId = clientProfile.PublicId;
 
         var start1 = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
         var start2 = new DateTime(2025, 3, 3, 0, 0, 0, DateTimeKind.Utc);
         var start3 = new DateTime(2025, 5, 5, 0, 0, 0, DateTimeKind.Utc);
 
-        var draftPlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Draft, startDate: start1, name: "Draft Plan");
-        var activePlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Active, startDate: start2, name: "Active Plan");
-        var completedPlan = CreateTrainingPlan(clientUserId, status: TrainingPlanStatus.Completed, startDate: start3, name: "Completed Plan");
+        var draftPlan = CreateTrainingPlan(clientPublicId, status: TrainingPlanStatus.Draft, startDate: start1, name: "Draft Plan");
+        var activePlan = CreateTrainingPlan(clientPublicId, status: TrainingPlanStatus.Active, startDate: start2, name: "Active Plan");
+        var completedPlan = CreateTrainingPlan(clientPublicId, status: TrainingPlanStatus.Completed, startDate: start3, name: "Completed Plan");
 
         var mongo = BuildMongo(
             trainingPlans: [draftPlan, activePlan, completedPlan],
@@ -99,14 +101,17 @@ public class ListClientPlansTests
     public async Task List_TrainingPlan_ResultSummaryIncludesTotalTrainingsAndPrCount()
     {
         var (db, clientProfile) = BuildLinkedClientSetup();
+        // NutritionPlan.ClientId and TrainingPlan.ClientId store ClientProfile.PublicId (not UserId).
+        // WorkoutLog.ClientId and PersonalRecord.ClientId store UserId.
+        var clientPublicId = clientProfile.PublicId;
         var clientUserId = clientProfile.UserId;
 
         var planStart = new DateTime(2025, 1, 6, 0, 0, 0, DateTimeKind.Utc);
         var planId = Guid.NewGuid();
 
-        var trainingPlan = CreateTrainingPlan(clientUserId, externalId: planId, startDate: planStart, name: "Hypertrophy Plan");
+        var trainingPlan = CreateTrainingPlan(clientPublicId, externalId: planId, startDate: planStart, name: "Hypertrophy Plan");
 
-        // 3 completed logs for this plan
+        // 3 completed logs for this plan — keyed on UserId (WorkoutLog convention)
         var log1 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
         var log2 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
         var log3 = CreateWorkoutLog(clientUserId, planId, isCompleted: true);
@@ -115,7 +120,7 @@ public class ListClientPlansTests
         // 1 completed but for a different plan (should not be counted)
         var log5 = CreateWorkoutLog(clientUserId, Guid.NewGuid(), isCompleted: true);
 
-        // 2 PRs in the plan window
+        // 2 PRs in the plan window — keyed on UserId (PersonalRecord convention)
         var pr1 = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(10));
         var pr2 = CreatePersonalRecord(clientUserId, achievedAt: planStart.AddDays(20));
         // 1 PR before plan start (should not be counted)
@@ -143,11 +148,12 @@ public class ListClientPlansTests
     public async Task List_TrainingPlanNoStartDate_PrCountIsNull()
     {
         var (db, clientProfile) = BuildLinkedClientSetup();
+        var clientPublicId = clientProfile.PublicId;
         var clientUserId = clientProfile.UserId;
 
         var planId = Guid.NewGuid();
-        // No StartDate set — Draft plan
-        var trainingPlan = CreateTrainingPlan(clientUserId, externalId: planId, startDate: null, name: "Draft Plan");
+        // No StartDate set — Draft plan — ClientId is PublicId for plans
+        var trainingPlan = CreateTrainingPlan(clientPublicId, externalId: planId, startDate: null, name: "Draft Plan");
 
         var pr = CreatePersonalRecord(clientUserId, achievedAt: DateTime.UtcNow.AddDays(-5));
 
@@ -175,15 +181,16 @@ public class ListClientPlansTests
         var planEnd = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc);
         var clientUserId = Guid.NewGuid();
 
-        var nutritionPlan = CreateNutritionPlan(
-            clientUserId,
-            startDate: planStart,
-            dateCompleted: planEnd,
-            name: "Weight Loss Plan");
-
         var trainerProfile = EntityBuilder.ProfessionalProfile.WithId(1).WithUserId(_trainerId).Build();
         var clientUser = EntityBuilder.User.WithId(clientUserId).Build();
         var clientProfile = EntityBuilder.ClientProfile.WithId(10).WithUser(clientUser).Build();
+
+        // NutritionPlan.ClientId stores ClientProfile.PublicId (not UserId).
+        var nutritionPlan = CreateNutritionPlan(
+            clientProfile.PublicId,
+            startDate: planStart,
+            dateCompleted: planEnd,
+            name: "Weight Loss Plan");
         var link = EntityBuilder.ClientProfessionalLink
             .WithId(42)
             .WithClientProfile(clientProfile)
@@ -244,9 +251,9 @@ public class ListClientPlansTests
     public async Task List_NutritionPlanNoStartDate_ComplianceAndWeightDeltaAreNull()
     {
         var (db, clientProfile) = BuildLinkedClientSetup();
-        var clientUserId = clientProfile.UserId;
+        var clientPublicId = clientProfile.PublicId;
 
-        var nutritionPlan = CreateNutritionPlan(clientUserId, startDate: null, name: "Draft Nutrition Plan");
+        var nutritionPlan = CreateNutritionPlan(clientPublicId, startDate: null, name: "Draft Nutrition Plan");
 
         var mongo = BuildMongo(nutritionPlans: [nutritionPlan], workoutLogs: [], personalRecords: []);
 

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/GetExerciseProgressEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/GetExerciseProgressEndpointTests.cs
@@ -2,8 +2,12 @@ using System.Security.Claims;
 using FastEndpoints;
 using FluentAssertions;
 using FitnessPlatform.Application.Domain.Constants;
+using FitnessPlatform.Application.Domain.Entities;
 using FitnessPlatform.Application.Features.WorkoutLogs.GetExerciseProgress;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Tests.Builders;
 using FitnessPlatform.Tests.Endpoints;
+using NSubstitute;
 
 namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 
@@ -13,23 +17,27 @@ namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
 public class GetExerciseProgressEndpointTests
 {
     private readonly Guid _trainerId = Guid.NewGuid();
-    private readonly Guid _clientId = Guid.NewGuid();
+    private readonly Guid _clientPublicId = Guid.NewGuid();
+    private readonly Guid _clientUserId = Guid.NewGuid();
 
     [Fact]
     public async Task HandleAsync_ValidRequest_Returns200()
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
         var authHelper = WorkoutLogTestHelpers.CreateMockAuthHelper(true);
+        // After fix #529: the endpoint loads ClientProfile to resolve UserId.
+        // Provide a mock db that returns a matching ClientProfile.
+        var db = BuildMockDbWithClientProfile(_clientPublicId, _clientUserId);
 
         var ep = Factory.Create<GetExerciseProgressEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, authHelper);
+            mongo, authHelper, db);
 
         await ep.HandleAsync(new GetExerciseProgressRequest
         {
-            ClientId = _clientId,
+            ClientId = _clientPublicId,
             ExerciseId = Guid.NewGuid()
         }, TestContext.Current.CancellationToken);
 
@@ -41,19 +49,60 @@ public class GetExerciseProgressEndpointTests
     {
         var mongo = WorkoutLogTestHelpers.CreateMockMongo();
         var authHelper = WorkoutLogTestHelpers.CreateMockAuthHelper(false);
+        var db = new MockDbBuilder().Build();
 
         var ep = Factory.Create<GetExerciseProgressEndpoint>(
             ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
                 new ClaimsIdentity(
                     EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
-            mongo, authHelper);
+            mongo, authHelper, db);
 
         await ep.HandleAsync(new GetExerciseProgressRequest
         {
-            ClientId = _clientId,
+            ClientId = _clientPublicId,
             ExerciseId = Guid.NewGuid()
         }, TestContext.Current.CancellationToken);
 
         ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ClientProfileNotFound_Returns404()
+    {
+        // authHelper says "link exists" but the ClientProfile row is missing (data integrity gap).
+        var mongo = WorkoutLogTestHelpers.CreateMockMongo();
+        var authHelper = WorkoutLogTestHelpers.CreateMockAuthHelper(true);
+        // Empty db — no ClientProfile matching the PublicId
+        var db = new MockDbBuilder().Build();
+
+        var ep = Factory.Create<GetExerciseProgressEndpoint>(
+            ctx => ctx.Request.HttpContext.User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    EndpointTestHelpers.FakeUserClaims(_trainerId, AppRoles.Trainer))),
+            mongo, authHelper, db);
+
+        await ep.HandleAsync(new GetExerciseProgressRequest
+        {
+            ClientId = _clientPublicId,
+            ExerciseId = Guid.NewGuid()
+        }, TestContext.Current.CancellationToken);
+
+        ep.HttpContext.Response.StatusCode.Should().Be(404);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static IApplicationDbContext BuildMockDbWithClientProfile(Guid publicId, Guid userId)
+    {
+        var clientUser = EntityBuilder.User.WithId(userId).Build();
+        var clientProfile = EntityBuilder.ClientProfile
+            .WithId(1)
+            .WithPublicId(publicId)
+            .WithUser(clientUser)
+            .Build();
+
+        return new MockDbBuilder()
+            .With(clientProfile)
+            .Build();
     }
 }

--- a/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/GetExerciseProgressIntegrationTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/WorkoutLogs/GetExerciseProgressIntegrationTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FitnessPlatform.Application.Domain.Documents;
+using FitnessPlatform.Application.Domain.Entities;
+using FitnessPlatform.Application.Domain.Enums;
+using FitnessPlatform.Application.Infrastructure.Data;
+using FitnessPlatform.Application.Infrastructure.Data.MongoDb;
+using FitnessPlatform.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Bson;
+
+namespace FitnessPlatform.Tests.Endpoints.WorkoutLogs;
+
+/// <summary>
+/// Integration tests for GET /training/clients/{clientId}/progress/{exerciseId} — issue #529.
+///
+/// Root cause: GetExerciseProgressEndpoint filtered WorkoutLog.ClientId == req.ClientId
+/// (a PublicId), but WorkoutLog.ClientId stores ApplicationUser.Id (UserId). The result
+/// was always an empty data-points list.
+///
+/// These tests use real PostgreSQL + MongoDB (Testcontainers) to validate
+/// that data points are returned only when the workout log is keyed on UserId —
+/// not when it is keyed on PublicId (the wrong key). A mock-based test cannot
+/// catch this because mocks ignore the filter value.
+/// </summary>
+[Collection(TestCollection.Name)]
+public class GetExerciseProgressIntegrationTests(FitnessApiFactory factory)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static string UniqueEmail(string tag) => $"{Guid.NewGuid():N}@exprogress-{tag}.com";
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<(HttpClient Http, long ProfessionalProfileId)> SetupTrainerAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("trainer");
+
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Test", "Trainer", "Trainer");
+        var (token, _) = await TestHelpers.LoginAsync(http, email, "TestPass1!");
+        TestHelpers.SetBearerToken(http, token);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var user = await db.Users.FirstAsync(
+            u => u.Email == email, TestContext.Current.CancellationToken);
+        var profile = await db.ProfessionalProfiles.FirstAsync(
+            p => p.UserId == user.Id, TestContext.Current.CancellationToken);
+
+        return (http, profile.Id);
+    }
+
+    private async Task<(Guid ClientPublicId, long ClientProfileId, Guid ClientUserId)>
+        SetupClientAsync()
+    {
+        var http = factory.CreateClient();
+        var email = UniqueEmail("client");
+
+        await TestHelpers.RegisterAsync(http, email, "TestPass1!", "Test", "Client", "Client");
+        await TestHelpers.LoginAsync(http, email, "TestPass1!");
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var user = await db.Users.FirstAsync(
+            u => u.Email == email, TestContext.Current.CancellationToken);
+        var profile = await db.ClientProfiles.FirstAsync(
+            cp => cp.UserId == user.Id, TestContext.Current.CancellationToken);
+
+        return (profile.PublicId, profile.Id, user.Id);
+    }
+
+    private async Task LinkTrainerToClientAsync(long trainerProfileId, long clientProfileId)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        db.ClientProfessionalLinks.Add(new ClientProfessionalLink
+        {
+            PublicId = Guid.NewGuid(),
+            ProfessionalProfileId = trainerProfileId,
+            ClientProfileId = clientProfileId,
+            ProfessionalRole = UserRole.Trainer,
+            IsActive = true,
+            CanViewTrainingPlans = true,
+            CanViewNutritionPlans = true,
+            DateCreated = DateTime.UtcNow,
+        });
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // ── regression guard tests ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Regression guard for #529: when a WorkoutLog is seeded with
+    /// ClientId = clientProfile.UserId (the correct key), the endpoint returns data points.
+    /// With the old buggy filter (ClientId == req.ClientId == PublicId), this would
+    /// return zero data points.
+    /// </summary>
+    [Fact]
+    public async Task ExerciseProgress_WorkoutLogSeededWithUserId_ReturnsDataPoints()
+    {
+        var (trainerHttp, trainerProfileId) = await SetupTrainerAsync();
+        var (clientPublicId, clientProfileId, clientUserId) = await SetupClientAsync();
+        await LinkTrainerToClientAsync(trainerProfileId, clientProfileId);
+
+        var exerciseId = Guid.NewGuid();
+        var exerciseName = "Deadlift";
+
+        // Seed a completed WorkoutLog with ClientId = UserId (the correct key)
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.WorkoutLogs.InsertOneAsync(new WorkoutLog
+            {
+                Id = ObjectId.GenerateNewId(),
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientUserId,    // ← MUST be UserId, not PublicId
+                StartedAt = DateTime.UtcNow.AddDays(-3),
+                CompletedAt = DateTime.UtcNow.AddDays(-3).AddHours(1),
+                IsCompleted = true,
+                Sections =
+                [
+                    new WorkoutSection
+                    {
+                        SectionId = Guid.NewGuid(),
+                        Name = "Main",
+                        Exercises =
+                        [
+                            new WorkoutExercise
+                            {
+                                ExerciseExternalId = exerciseId,
+                                ExerciseName = exerciseName,
+                                Sets =
+                                [
+                                    new WorkoutSet
+                                    {
+                                        SetNumber = 1,
+                                        WeightKg = 140m,
+                                        Reps = 5,
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                DateCreated = DateTime.UtcNow,
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        var response = await trainerHttp.GetAsync(
+            $"/training/clients/{clientPublicId}/progress/{exerciseId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ExerciseProgressResponse>(
+            JsonOptions, cancellationToken: TestContext.Current.CancellationToken);
+
+        body!.DataPoints.Should().HaveCountGreaterThanOrEqualTo(1,
+            "the workout log seeded with ClientId = UserId must produce a data point");
+        body.ExerciseName.Should().Be(exerciseName);
+    }
+
+    /// <summary>
+    /// Regression guard for #529: a WorkoutLog seeded with ClientId = PublicId
+    /// (the WRONG key, the old bug's side-effect) must NOT produce data points.
+    /// This confirms the endpoint now correctly resolves UserId before filtering.
+    /// </summary>
+    [Fact]
+    public async Task ExerciseProgress_WorkoutLogSeededWithPublicId_ReturnsNoDataPoints()
+    {
+        var (trainerHttp, trainerProfileId) = await SetupTrainerAsync();
+        var (clientPublicId, clientProfileId, _) = await SetupClientAsync();
+        await LinkTrainerToClientAsync(trainerProfileId, clientProfileId);
+
+        var exerciseId = Guid.NewGuid();
+
+        // Seed a completed WorkoutLog with ClientId = PublicId (wrong key — pre-fix bug)
+        using (var scope = factory.Services.CreateScope())
+        {
+            var mongo = scope.ServiceProvider.GetRequiredService<IMongoContext>();
+            await mongo.WorkoutLogs.InsertOneAsync(new WorkoutLog
+            {
+                Id = ObjectId.GenerateNewId(),
+                ExternalId = Guid.NewGuid(),
+                ClientId = clientPublicId,   // ← WRONG: PublicId stored where UserId expected
+                StartedAt = DateTime.UtcNow.AddDays(-3),
+                CompletedAt = DateTime.UtcNow.AddDays(-3).AddHours(1),
+                IsCompleted = true,
+                Sections =
+                [
+                    new WorkoutSection
+                    {
+                        SectionId = Guid.NewGuid(),
+                        Name = "Main",
+                        Exercises =
+                        [
+                            new WorkoutExercise
+                            {
+                                ExerciseExternalId = exerciseId,
+                                ExerciseName = "Squat",
+                                Sets =
+                                [
+                                    new WorkoutSet
+                                    {
+                                        SetNumber = 1,
+                                        WeightKg = 100m,
+                                        Reps = 5,
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                DateCreated = DateTime.UtcNow,
+            }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+
+        var response = await trainerHttp.GetAsync(
+            $"/training/clients/{clientPublicId}/progress/{exerciseId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ExerciseProgressResponse>(
+            JsonOptions, cancellationToken: TestContext.Current.CancellationToken);
+
+        body!.DataPoints.Should().BeEmpty(
+            "a workout log whose ClientId is PublicId (not UserId) must not be returned");
+    }
+
+    // ── DTOs for deserialization ──────────────────────────────────────────────
+
+    private record ExerciseProgressResponse(string ExerciseName, List<DataPoint> DataPoints);
+
+    private record DataPoint(
+        DateTime Date,
+        decimal? BestWeightKg,
+        int? BestReps,
+        decimal TotalVolume,
+        bool HasPR);
+}


### PR DESCRIPTION
## Summary
- **#528** — `ListClientPlansEndpoint` was filtering `NutritionPlan.ClientId` / `TrainingPlan.ClientId` by `clientProfile.UserId`, but both plan documents store `ClientProfile.PublicId`. The trainer's client-plans list was always empty. Switched both plan filters to `clientProfile.PublicId`; corrected the misleading comment. The `WorkoutLog` / `PersonalRecord` filters in the same file are left on `UserId` (they key on `ApplicationUser.Id` — correct as-is).
- **#529** — `GetExerciseProgressEndpoint` was filtering `WorkoutLog.ClientId` by `req.ClientId` (a `PublicId`), but `WorkoutLog.ClientId` stores `ApplicationUser.Id` (UserId). The progress chart always returned zero data points. The endpoint now resolves `ClientProfile` from `req.ClientId` (PublicId) via Postgres, then filters `WorkoutLog` by `clientProfile.UserId` — mirroring the established `GetTodaySessionEndpoint` pattern. Returns `404` (Problem Details) when the profile cannot be resolved.

> Note for reviewers: the two fixes deliberately move in **opposite directions** on the join key. This is correct, not a copy-paste error — `NutritionPlan`/`TrainingPlan` key on `ClientProfile.PublicId`, while `WorkoutLog`/`PersonalRecord` key on `ApplicationUser.Id` (UserId). The canonical reference is `GetTodaySessionEndpoint` (TrainingPlan/SessionLog → PublicId at lines 66/380; WorkoutLog → UserId at line 245 with an explicit warning comment).

## Related issues
Fixes #528
Fixes #529

## Scope
backend

## QA verdict (from qa-tester)
OVERALL ✅ PASS — all 4 acceptance criteria met. `dotnet build` clean; Trainers namespace 85/85, WorkoutLogs namespace 86/86; new Testcontainers integration tests (real Mongo + Postgres) confirm both fixes plus regression guards.

## Test plan
- [ ] #528: A trainer opening a client's plans page sees that client's nutrition and training plans listed correctly.
- [ ] #528: `WorkoutLog`/`PersonalRecord` filters in `ListClientPlansEndpoint` are NOT touched (they correctly key on `UserId`).
- [ ] #529: A trainer's exercise-progress chart shows the client's completed workout history (no longer zero data points).
- [ ] #529: `WorkoutLog` is filtered by `ApplicationUser.Id` (UserId), not `ClientProfile.PublicId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
