### PR TITLE
chore(verification): add web lint step to dev/QA verification surface

### DIFF
--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -503,7 +503,7 @@ scope appears on the issue — don't cherry-pick.
 | Scope       | Commands (run in order, fail fast)                                                                                                                          |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `backend`   | `cd backend && dotnet build` then `dotnet test`. Testcontainers require Docker — if Docker isn't available, mark ⚠️ UNVERIFIED with the reason; do not PASS. |
-| `web`       | `cd web && npm ci` (only if `node_modules` is missing or `package-lock.json` changed) then `npm run build` (typecheck lives in the build). If `npm test` ever appears, run it. |
+| `web`       | `cd web && npm ci` (only if `node_modules` is missing or `package-lock.json` changed) then `npm run build` (typecheck lives in the build) **and `npm run lint`** (`eslint .` — NOT part of the build; lint-only errors like `react-hooks` setState-in-effect pass the build but fail CI's `build-and-lint`). Lint must be **0 errors** to PASS (pre-existing warnings OK). If `npm test` ever appears, run it. |
 | `mobile`    | `cd mobile && npm ci` (same condition) then `npx tsc --noEmit` and `npx expo-doctor`. No test suite exists yet — if one appears, run it. |
 | `docs-infra`| File-level diff review, `gh workflow view <file>` or `yamllint` for any changed `.github/workflows/*.yml`, scene-anchor existence for prototype changes.     |
 
@@ -841,8 +841,8 @@ For each dev server in step 3b marked "started by qa-tester":
 - `git fetch`, `git checkout`, `git diff`, `git log`, `git show` (all
   read-only).
 - `dotnet build`, `dotnet test`, `dotnet run` (for boot in step 3b).
-- `npm ci`, `npm run build`, `npm run dev`, `npm test` (if it exists),
-  `npx tsc --noEmit`, `npx expo-doctor`,
+- `npm ci`, `npm run build`, `npm run lint`, `npm run dev`,
+  `npm test` (if it exists), `npx tsc --noEmit`, `npx expo-doctor`,
   `npx expo start --web`.
 - `npm run e2e:up`, `npm run e2e:down`, `npm run e2e:health`,
   `npm run e2e:logs` and the underlying

--- a/.claude/agents/web-react.md
+++ b/.claude/agents/web-react.md
@@ -40,7 +40,7 @@ it to run design-review first (Rule 5.5).
 - [`rules/code-quality.md#no-any-in-typescript`](../rules/code-quality.md#no-any-in-typescript) — strict-mode TS.
 - [`rules/code-quality.md#generated-files-are-write-locked`](../rules/code-quality.md#generated-files-are-write-locked) — `web/src/api/generated.ts` is write-locked; use `regen-api`.
 - [`rules/i18n.md#supported-languages`](../rules/i18n.md#supported-languages) — cs/en/de in same PR.
-- [`rules/verification.md#web`](../rules/verification.md#web) — `npm run build`.
+- [`rules/verification.md#web`](../rules/verification.md#web) — `npm run build` **and** `npm run lint` (lint is separate from the build).
 
 ## Stack
 - React 19, TypeScript (strict), Vite 7
@@ -93,7 +93,11 @@ src/
 ## Commands
 - Dev: `npm run dev` (proxies to `https://localhost:5001`)
 - Type-check: `npx tsc --noEmit` (no test suite exists today)
-- Build: `npm run build`
+- Build: `npm run build` (runs `tsc -b && vite build` — does NOT run ESLint)
+- Lint: `npm run lint` (`eslint .`) — **required, separate from the build.**
+  Must be 0 errors before you report done; lint-only errors (e.g.
+  `react-hooks` setState-in-effect) pass `npm run build` but fail CI's
+  `build-and-lint` job. Pre-existing warnings are OK; don't add new errors.
 - Regenerate API client: `npm run generate-api` (run from `/web`, requires
   backend running on 5001)
 
@@ -158,7 +162,12 @@ Before returning control to the orchestrator, write
 ```
 
 Use `verification.tool: "web-build"` (covers typecheck) or
-`"web-typecheck"` for typecheck-only runs. The `gate-check.sh`
+`"web-typecheck"` for typecheck-only runs. Always **also** run
+`npm run lint` (0 errors) before reporting — the `verification` field
+holds one tool, so report `"web-lint"` when lint is the gating check
+you want recorded and note the build result in your summary, or report
+`"web-build"` and state in your summary that lint passed too. Either
+way both must be green. The `gate-check.sh`
 SubagentStop hook validates before control returns; a malformed
 handoff exits non-zero so you can self-correct.
 

--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -27,6 +27,14 @@ Both can run simultaneously (different ports + DBs).
 
 - `npm ci` when the lockfile changed.
 - `npm run build` — typecheck is part of the build.
+- `npm run lint` (`eslint .`) — **required, and distinct from the build.**
+  `npm run build` runs only `tsc -b && vite build`; it does NOT run
+  ESLint, so lint-only **errors** (e.g. `react-hooks` rule violations like
+  setState-in-effect) pass the local build and the QA gate but fail the
+  CI `build-and-lint` job. Dev agents and `qa-tester` must run `npm run
+  lint` and confirm **0 errors** (pre-existing warnings are acceptable;
+  do not introduce new errors). This mirrors the CI `build-and-lint` job
+  so lint regressions are caught before push, not on the PR.
 
 For interactive AC checks `qa-tester` boots `npm run dev:e2e` on `:5173`
 (the Vite variant whose proxy points at the compose harness on `:5101`)
@@ -73,9 +81,14 @@ JSON's `verification` field — see
 shape is constrained:
 
 - `tool` — one of `dotnet-build`, `dotnet-test`, `web-build`,
-  `web-typecheck`, `mobile-typecheck`, `mobile-prebuild-check` (now
-  maps to `npx expo-doctor` after #314; schema enum value kept stable
-  so archived handoffs still validate).
+  `web-lint`, `web-typecheck`, `mobile-typecheck`,
+  `mobile-prebuild-check` (the last now maps to `npx expo-doctor` after
+  #314; schema enum value kept stable so archived handoffs still
+  validate). `web-lint` maps to `npm run lint` (`eslint .`) and is a
+  **separate** required check from `web-build` — the verification field
+  holds one `tool`, so a web change that needs both reports `web-lint`
+  as its declared check after confirming `web-build` also passed (note
+  the build result in `notes`/summary). Lint must be **0 errors**.
 - `filter` — optional, regex-validated **fully-qualified class name**
   for `dotnet-test` (no quotes/whitespace/shell metacharacters). Used
   with xUnit v3 + Microsoft.Testing.Platform's `--filter-class`

--- a/.claude/schemas/dev-handoff.v1.json
+++ b/.claude/schemas/dev-handoff.v1.json
@@ -44,7 +44,7 @@
       "description": "Constrained verification shape — no raw shell strings. Orchestrator/QA substitutes into a fixed template.",
       "required": ["tool"],
       "properties": {
-        "tool": { "enum": ["dotnet-test", "dotnet-build", "web-build", "web-typecheck", "mobile-typecheck", "mobile-prebuild-check"] },
+        "tool": { "enum": ["dotnet-test", "dotnet-build", "web-build", "web-lint", "web-typecheck", "mobile-typecheck", "mobile-prebuild-check"] },
         "filter": {
           "type": "string",
           "pattern": "^[A-Za-z0-9._~-]+$",


### PR DESCRIPTION
## What

Makes `npm run lint` (`eslint .`) a **required, build-distinct** check across the web verification surface.

## Why

`npm run build` runs only `tsc -b && vite build` — it never invokes ESLint. So lint-only errors (e.g. the `react-hooks` setState-in-effect rule) pass the local build **and** the QA gate, then fail CI's `build-and-lint` job. This is exactly how a lint error slipped past local checks on PR #560 (#540) and only surfaced in CI.

## Changes

- **`rules/verification.md`** — Web section now requires `npm run lint` (0 errors) as a check separate from the build; handoff-reporting note documents the new `web-lint` tool.
- **`schemas/dev-handoff.v1.json`** — add `web-lint` to the `verification.tool` enum (additive; archived handoffs still validate).
- **`agents/qa-tester.md`** — web static-verification row runs `npm run lint` after the build.
- **`agents/web-react.md`** — commands, rule citation, and handoff guidance mandate `npm run lint` before reporting done.

## Verified, not assumed

- Bash allowlist hook already permits `npm run lint` for both `web-react` and `qa-tester` — no hook change needed.
- `dev-handoff.v1.json` still parses as valid JSON with `web-lint` in the enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
