### PR TITLE
fix(auth): default new Google social-login users to Client role (#533)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Google/GoogleSocialLoginEndpoint.cs
@@ -154,7 +154,11 @@ public class GoogleSocialLoginEndpoint(
                 GdprConsentDate = DateTime.UtcNow
             };
 
-            // The trainer-portal register flow assigns the Trainer role by default.
+            // New Google social-login users default to the Client role.
+            // The client-facing mobile app is the social-login consumer; trainers are
+            // provisioned via the password register flow only. Defaulting to Trainer here
+            // would allow any anonymous caller with a valid Google token to gain Trainer
+            // privileges — a privilege escalation on an anonymous endpoint.
             var createResult = await userManager.CreateAsync(newUser);
             if (!createResult.Succeeded)
             {
@@ -166,10 +170,10 @@ public class GoogleSocialLoginEndpoint(
                 return;
             }
 
-            await userManager.AddToRoleAsync(newUser, AppRoles.Trainer);
+            await userManager.AddToRoleAsync(newUser, AppRoles.Client);
 
-            // Create the professional profile (mirroring RegisterEndpoint for Trainer role).
-            db.ProfessionalProfiles.Add(new ProfessionalProfile { UserId = newUser.Id });
+            // Create the client profile (mirroring RegisterEndpoint for Client role).
+            db.ClientProfiles.Add(new ClientProfile { UserId = newUser.Id });
 
             // Link the Google identity.
             db.UserExternalLogins.Add(new UserExternalLogin

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/GoogleSocialLoginEndpointTests.cs
@@ -430,11 +430,11 @@ public class GoogleSocialLoginEndpointTests
         userManager.CreateAsync(Arg.Any<ApplicationUser>())
             .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
 
-        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer)
+        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Client)
             .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
 
         // GetRolesAsync needs to return roles for token creation
-        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Trainer"]);
+        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Client"]);
 
         var db = new MockDbBuilder()
             .With(MakeValidNonce())
@@ -457,8 +457,17 @@ public class GoogleSocialLoginEndpointTests
         db.UserExternalLogins.Received(1).Add(Arg.Is<UserExternalLogin>(el =>
             el.Provider == "google" && el.Subject == ValidPayload.Subject));
 
-        // A ProfessionalProfile must have been created (Trainer role provisioning)
-        db.ProfessionalProfiles.Received(1).Add(Arg.Any<ProfessionalProfile>());
+        // New user must be provisioned with the Client role — NOT Trainer.
+        // Assigning Trainer here would allow any anonymous caller with a valid
+        // Google token to gain Trainer privileges (privilege escalation).
+        await userManager.Received(1).AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Client);
+        await userManager.DidNotReceive().AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer);
+
+        // A ClientProfile must have been created (mirroring RegisterEndpoint for Client role).
+        db.ClientProfiles.Received(1).Add(Arg.Any<ClientProfile>());
+
+        // ProfessionalProfile must NOT be created for a new Google social-login user.
+        db.ProfessionalProfiles.DidNotReceive().Add(Arg.Any<ProfessionalProfile>());
     }
 
     // ── 200 — email matches existing google-linked account (returning user) ──


### PR DESCRIPTION
## Summary

Fixes #533 — privilege escalation on the anonymous `POST /auth/social/google` endpoint.

New-user provisioning hardcoded `AppRoles.Trainer` + a `ProfessionalProfile` for **every** new Google OAuth account, letting any caller with a valid Google token self-provision as a Trainer.

## Change

`GoogleSocialLoginEndpoint` new-user branch now assigns **`AppRoles.Client`** and creates a **`ClientProfile`** (mirroring the password register flow for clients). Misleading "Trainer role" comments corrected with a security note.

## Why default to Client

There is a single configured `Google:ClientId`, so the endpoint cannot distinguish mobile-client from web-trainer callers by audience. Google social sign-in is **login-only** on the web/trainer portal and **client-facing** on mobile — no trainer-via-Google signup path exists anywhere. So all new Google social-login users correctly default to the least-privileged Client role. Trainers/nutritionists are still provisioned only via the password register flow.

## Tests

`GoogleSocialLoginEndpointTests` updated: asserts Client role + ClientProfile created, with regression assertions that Trainer role and ProfessionalProfile are **not** created. Auth namespace 71/71 green; build clean.

## Out of scope

The identical hole in `AppleSocialLoginEndpoint.cs` is intentionally left for a separate follow-up issue (this PR is pinned to #533 / Google).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
