### PR TITLE
fix(auth): default new Apple social-login users to Client role (#563)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/Auth/SocialLogin/Apple/AppleSocialLoginEndpoint.cs
@@ -175,7 +175,11 @@ public class AppleSocialLoginEndpoint(
                 GdprConsentDate = DateTime.UtcNow
             };
 
-            // The trainer-portal register flow assigns the Trainer role by default.
+            // New Apple social-login users default to the Client role.
+            // The client-facing mobile app is the social-login consumer; trainers are
+            // provisioned via the password register flow only. Defaulting to Trainer here
+            // would allow any anonymous caller with a valid Apple token to gain Trainer
+            // privileges — a privilege escalation on an anonymous endpoint.
             var createResult = await userManager.CreateAsync(newUser);
             if (!createResult.Succeeded)
             {
@@ -187,10 +191,10 @@ public class AppleSocialLoginEndpoint(
                 return;
             }
 
-            await userManager.AddToRoleAsync(newUser, AppRoles.Trainer);
+            await userManager.AddToRoleAsync(newUser, AppRoles.Client);
 
-            // Create the professional profile (mirroring RegisterEndpoint for Trainer role).
-            db.ProfessionalProfiles.Add(new ProfessionalProfile { UserId = newUser.Id });
+            // Create the client profile (mirroring RegisterEndpoint for Client role).
+            db.ClientProfiles.Add(new ClientProfile { UserId = newUser.Id });
 
             // Link the Apple identity.
             db.UserExternalLogins.Add(new UserExternalLogin

--- a/backend/FitnessPlatform.Tests/Endpoints/Auth/AppleSocialLoginEndpointTests.cs
+++ b/backend/FitnessPlatform.Tests/Endpoints/Auth/AppleSocialLoginEndpointTests.cs
@@ -554,10 +554,10 @@ public class AppleSocialLoginEndpointTests
         userManager.CreateAsync(Arg.Any<ApplicationUser>())
             .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
 
-        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer)
+        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Client)
             .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
 
-        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Trainer"]);
+        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Client"]);
 
         var db = new MockDbBuilder()
             .With(MakeValidNonce())
@@ -594,8 +594,17 @@ public class AppleSocialLoginEndpointTests
         db.UserExternalLogins.Received(1).Add(Arg.Is<UserExternalLogin>(el =>
             el.Provider == "apple" && el.Subject == PrivateRelayPayload.Subject));
 
-        // A ProfessionalProfile must have been created (Trainer role provisioning)
-        db.ProfessionalProfiles.Received(1).Add(Arg.Any<ProfessionalProfile>());
+        // New user must be provisioned with the Client role — NOT Trainer.
+        // Assigning Trainer here would allow any anonymous caller with a valid
+        // Apple token to gain Trainer privileges (privilege escalation).
+        await userManager.Received(1).AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Client);
+        await userManager.DidNotReceive().AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer);
+
+        // A ClientProfile must have been created (mirroring RegisterEndpoint for Client role).
+        db.ClientProfiles.Received(1).Add(Arg.Any<ClientProfile>());
+
+        // ProfessionalProfile must NOT be created for a new Apple social-login user.
+        db.ProfessionalProfiles.DidNotReceive().Add(Arg.Any<ProfessionalProfile>());
     }
 
     /// <summary>
@@ -612,9 +621,9 @@ public class AppleSocialLoginEndpointTests
         userManager.FindByEmailAsync(ValidPayloadWithEmail.Email!).Returns((ApplicationUser?)null);
         userManager.CreateAsync(Arg.Any<ApplicationUser>())
             .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
-        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer)
+        userManager.AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Client)
             .Returns(Microsoft.AspNetCore.Identity.IdentityResult.Success);
-        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Trainer"]);
+        userManager.GetRolesAsync(Arg.Any<ApplicationUser>()).Returns(["Client"]);
 
         var db = new MockDbBuilder()
             .With(MakeValidNonce())
@@ -634,5 +643,17 @@ public class AppleSocialLoginEndpointTests
             Arg.Is<ApplicationUser>(u =>
                 u.FirstName == string.Empty &&
                 u.LastName == string.Empty));
+
+        // New user must be provisioned with the Client role — NOT Trainer.
+        // Assigning Trainer here would allow any anonymous caller with a valid
+        // Apple token to gain Trainer privileges (privilege escalation).
+        await userManager.Received(1).AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Client);
+        await userManager.DidNotReceive().AddToRoleAsync(Arg.Any<ApplicationUser>(), AppRoles.Trainer);
+
+        // A ClientProfile must have been created (mirroring RegisterEndpoint for Client role).
+        db.ClientProfiles.Received(1).Add(Arg.Any<ClientProfile>());
+
+        // ProfessionalProfile must NOT be created for a new Apple social-login user.
+        db.ProfessionalProfiles.DidNotReceive().Add(Arg.Any<ProfessionalProfile>());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #563 — privilege escalation on the anonymous `POST /auth/social/apple` endpoint. Direct sibling of #533 (Google), fixed by the same pattern (commit `8298d6e`).

New-user provisioning hardcoded `AppRoles.Trainer` + a `ProfessionalProfile` for **every** new Apple OAuth account, letting any caller with a valid Apple identity token self-provision as a Trainer.

## Change

`AppleSocialLoginEndpoint` new-user branch now assigns **`AppRoles.Client`** and creates a **`ClientProfile`** (mirroring the password register flow for clients). Misleading "Trainer role" comments corrected with a security note.

The `(apple, sub)`-first lookup ordering and the 422 (no-email-no-link) / 409 / 401 / 403 error paths are unchanged.

## Why default to Client

Same rationale as #533: a single configured Apple client id means the endpoint can't distinguish caller apps by audience, and no trainer-via-Apple signup path exists anywhere. New social-login users default to the least-privileged Client role; trainers/nutritionists are provisioned only via the password register flow.

## Tests

Both new-user provisioning tests in `AppleSocialLoginEndpointTests` flipped: assert Client role + ClientProfile created, with regression assertions that Trainer role and ProfessionalProfile are **not** created. Returning-user tests unchanged. Apple tests 19/19, Auth namespace 71/71, full suite 1498/1498 green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
