### PR TITLE
fix(checkins): fold ownership into RespondToCheckIn query predicate (#534)

### DIFF
--- a/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInEndpoint.cs
+++ b/backend/FitnessPlatform.Application/Features/WeeklyCheckIns/RespondToCheckIn/RespondToCheckInEndpoint.cs
@@ -47,9 +47,9 @@ public class RespondToCheckInEndpoint(
         var clientUserId = Guid.Parse(userId);
 
         var checkIn = await db.WeeklyCheckIns
-            .FirstOrDefaultAsync(c => c.Id == req.Id, ct);
+            .FirstOrDefaultAsync(c => c.Id == req.Id && c.ClientUserId == clientUserId, ct);
 
-        if (checkIn is null || checkIn.ClientUserId != clientUserId)
+        if (checkIn is null)
         {
             await Send.NotFoundAsync(ct);
             return;


### PR DESCRIPTION
Fixes #534. RespondToCheckIn loaded the check-in by PK then checked ownership post-load — an existence oracle (a non-owner could probe whether an ID exists). Ownership is now folded into the load predicate (`&& c.ClientUserId == clientUserId`), so non-owned and non-existent IDs both return 404 from the same null path (indistinguishable). Existing 404 test stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)