### PR TITLE
fix(qa-seed): key seeded nutrition plan NutritionistId on user id (#553)

### DIFF
--- a/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
+++ b/backend/FitnessPlatform.Application/Seed/QaSeedRunner.cs
@@ -294,7 +294,7 @@ public static class QaSeedRunner
             // RECIPE_NOT_OWNED (HTTP 400) when the e2e flow calls the upload-url endpoint.
             await EnsureFoodsAsync(mongo, NutriUserId, logger);
             await EnsureRecipesAsync(mongo, NutriUserId, logger);
-            await EnsureNutritionPlanAsync(mongo, clientProfile.PublicId, nutriProfile.PublicId, logger);
+            await EnsureNutritionPlanAsync(mongo, clientProfile.PublicId, NutriUserId, logger);
 
             // Image blobs in MinIO — idempotent, bucket created if absent.
             await EnsureAvatarAsync(sp, logger);
@@ -1568,7 +1568,7 @@ public static class QaSeedRunner
     private static async Task EnsureNutritionPlanAsync(
         IMongoContext mongo,
         Guid clientProfilePublicId,
-        Guid nutriProfilePublicId,
+        Guid nutriUserId,
         ILogger logger)
     {
         var existing = await mongo.NutritionPlans
@@ -1588,7 +1588,7 @@ public static class QaSeedRunner
         {
             ExternalId     = QaNutritionPlanExternalId,
             ClientId       = clientProfilePublicId,
-            NutritionistId = nutriProfilePublicId,
+            NutritionistId = nutriUserId,
             Name           = "QA Test Nutrition Plan",
             Status         = NutritionPlanStatus.Active,
             DateCreated    = now,

--- a/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
+++ b/backend/FitnessPlatform.Tests/Seed/QaSeedRunnerTests.cs
@@ -543,7 +543,8 @@ public class QaSeedRunnerTests : IAsyncLifetime
         plan.Should().NotBeNull("QaSeedRunner must create the QA nutrition plan");
         plan!.ClientId.Should().Be(QaSeedRunner.ClientProfilePublicId,
             "NutritionPlan.ClientId must be keyed on ClientProfile.PublicId, not ApplicationUser.Id");
-        plan.NutritionistId.Should().Be(QaSeedRunner.NutriProfilePublicId);
+        plan.NutritionistId.Should().Be(QaSeedRunner.NutriUserId,
+            "NutritionPlan.NutritionistId must be keyed on ApplicationUser.Id (NutriUserId), not the professional profile PublicId, so nutritionist endpoint filters match AppClaims.UserId");
         plan.Status.Should().Be(FitnessPlatform.Application.Domain.Enums.NutritionPlanStatus.Active);
 
         plan.Weeks.Should().HaveCount(1);

--- a/docs/testing/e2e-fixtures.md
+++ b/docs/testing/e2e-fixtures.md
@@ -232,7 +232,7 @@ All three recipes are owned by the QA Nutri, visibility `Public`.
 | ---------------------------- | -------------------------------------- | -------------------------------------------------- |
 | `QaNutritionPlanExternalId`  | `dddddddd-eeee-ffff-0000-111111111111` | The plan's `ExternalId`                            |
 | `ClientProfilePublicId`      | `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa` | `NutritionPlan.ClientId` (profile public id)       |
-| `NutriProfilePublicId`       | `cccccccc-cccc-cccc-cccc-cccccccccccc` | `NutritionPlan.NutritionistId`                     |
+| `NutriUserId`                | `33333333-3333-3333-3333-333333333333` | `NutritionPlan.NutritionistId` (nutritionist user id) |
 
 Plan shape:
 


### PR DESCRIPTION
Fixes #553. The QA seed wrote `NutritionPlan.NutritionistId = nutriProfile.PublicId`, but production and every nutritionist endpoint filter key on `ApplicationUser.Id` (NutriUserId) — so the seeded plan was invisible (404) to publish/update/get as qa.nutri. Now passes `NutriUserId`, mirroring the food seed. `ClientId` left unchanged (correctly keyed on profile PublicId for client-facing reads). QaSeedRunnerTests assertion + e2e-fixtures.md doc corrected. QA-fixture-only; no production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)